### PR TITLE
Race page audit round 2: aliases, FAQ schema, countdown

### DIFF
--- a/tests/test_neo_brutalist.py
+++ b/tests/test_neo_brutalist.py
@@ -466,6 +466,11 @@ class TestSections:
         assert "gg-countdown" in html
         assert "2026-06-15" in html
 
+    def test_countdown_shows_date_not_dashes(self, normalized_data):
+        html = build_training(normalized_data, "https://example.com")
+        assert "--" not in html
+        assert "June 15, 2026" in html
+
     def test_visible_faq_renders(self, normalized_data):
         html = build_visible_faq(normalized_data)
         assert "gg-faq-item" in html
@@ -530,6 +535,14 @@ class TestLinkify:
     def test_aliases_work(self):
         result = linkify_alternatives("Try Unbound for a bigger field.", [])
         assert 'href="/race/unbound-200/"' in result
+
+    def test_bwr_alias(self):
+        result = linkify_alternatives("Try BWR for California gravel.", [])
+        assert 'href="/race/bwr-california/"' in result
+
+    def test_big_sugar_alias(self):
+        result = linkify_alternatives("Try Big Sugar in the fall.", [])
+        assert 'href="/race/big-sugar/"' in result
 
     def test_empty_text(self):
         assert linkify_alternatives("", []) == ""

--- a/wordpress/generate_methodology.py
+++ b/wordpress/generate_methodology.py
@@ -316,8 +316,8 @@ def build_methodology_css() -> str:
 
 
 def build_jsonld() -> str:
-    """Build WebPage JSON-LD for the methodology page."""
-    jsonld = {
+    """Build WebPage + FAQPage JSON-LD for the methodology page."""
+    webpage = {
         "@context": "https://schema.org",
         "@type": "WebPage",
         "name": "How We Rate Gravel Races — Gravel God Methodology",
@@ -333,7 +333,55 @@ def build_jsonld() -> str:
             "cssSelector": [".gg-hero-tagline", "#formula .gg-section-body"],
         },
     }
-    return f'<script type="application/ld+json">\n{json.dumps(jsonld, indent=2)}\n</script>'
+    faq = {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "Who rates the races?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "All ratings are produced by our editorial team. We research each race using official sources, rider reports, community forums, and our own race experience. Every dimension is scored and explained by a human editor.",
+                },
+            },
+            {
+                "@type": "Question",
+                "name": "Can race organizers influence their score?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "No. We do not accept payment, sponsorship, or partnership in exchange for tier placement or score adjustments. Ratings are editorially independent.",
+                },
+            },
+            {
+                "@type": "Question",
+                "name": "How often are scores updated?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "We review scores annually before each race season and make ad-hoc updates when significant changes occur (new ownership, course redesign, series affiliation changes).",
+                },
+            },
+            {
+                "@type": "Question",
+                "name": "Why isn't my favorite race rated higher?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Our rubric prioritizes consistency. A race might be incredible for a specific niche but score lower on logistics, field depth, or global prestige. The 14-dimension breakdown shows exactly where a race excels and where it loses points.",
+                },
+            },
+            {
+                "@type": "Question",
+                "name": "What about mountain bike races?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "We include a small number of iconic MTB events (like Leadville and Chequamegon) that are culturally significant to the gravel community. These are tagged with an MTB discipline label. The same 14-dimension rubric applies.",
+                },
+            },
+        ],
+    }
+    wp_tag = f'<script type="application/ld+json">\n{json.dumps(webpage, indent=2)}\n</script>'
+    faq_tag = f'<script type="application/ld+json">\n{json.dumps(faq, indent=2)}\n</script>'
+    return f'{wp_tag}\n  {faq_tag}'
 
 
 # ── Assemble page ──────────────────────────────────────────────

--- a/wordpress/generate_neo_brutalist.py
+++ b/wordpress/generate_neo_brutalist.py
@@ -147,7 +147,7 @@ QUESTIONNAIRE_SLUGS = {
     'unbound-gravel-200': 'unbound-200',
     'mid-south': 'mid-south',
     'sbt-grvl': 'sbt-grvl',
-    'belgian-waffle-ride': 'bwr',
+    'bwr-california': 'bwr',
     'leadville-trail-100-mtb': 'leadville-100',
     'the-rift-iceland': 'rift-iceland',
     'gravel-worlds': 'gravel-worlds',
@@ -514,7 +514,7 @@ document.querySelectorAll('.gg-accordion-trigger').forEach(function(trigger) {
   });
 });
 
-// Race day countdown
+// Race day countdown (HTML shows date for crawlers; JS replaces with day count)
 (function() {
   var cd = document.querySelector('.gg-countdown');
   if (!cd) return;
@@ -526,6 +526,14 @@ document.querySelectorAll('.gg-accordion-trigger').forEach(function(trigger) {
   var el = document.getElementById('gg-days-left');
   if (el && diff > 0) {
     el.textContent = diff;
+    // Replace "RACE NAME" with "DAYS UNTIL RACE NAME"
+    var textNodes = cd.childNodes;
+    for (var i = 0; i < textNodes.length; i++) {
+      if (textNodes[i].nodeType === 3 && textNodes[i].textContent.trim()) {
+        textNodes[i].textContent = ' DAYS UNTIL' + textNodes[i].textContent;
+        break;
+      }
+    }
   } else if (el && diff <= 0) {
     cd.style.display = 'none';
   }
@@ -1298,7 +1306,9 @@ def build_training(rd: dict, q_url: str) -> str:
         year, month_name, day = date_match.groups()
         month_num = MONTH_NUMBERS.get(month_name.lower(), "01")
         iso_date = f"{year}-{month_num}-{int(day):02d}"
-        countdown_html = f'<div class="gg-countdown" data-date="{iso_date}"><span class="gg-countdown-num" id="gg-days-left">--</span> DAYS UNTIL {esc(race_name.upper())}</div>'
+        # Show formatted date for no-JS/crawlers; JS replaces with day count
+        display_date = f"{month_name} {int(day)}, {year}"
+        countdown_html = f'<div class="gg-countdown" data-date="{iso_date}"><span class="gg-countdown-num" id="gg-days-left">{esc(display_date)}</span> {esc(race_name.upper())}</div>'
 
     return f'''<section id="training" class="gg-section gg-fade-section">
     <div class="gg-section-header">
@@ -1484,7 +1494,9 @@ def linkify_alternatives(alt_text: str, race_index: list) -> str:
     aliases = {
         'Unbound': 'unbound-200',
         'Unbound Gravel': 'unbound-200',
-        'BWR': 'belgian-waffle-ride',
+        'BWR': 'bwr-california',
+        'Belgian Waffle Ride': 'bwr-california',
+        'Big Sugar': 'big-sugar',
         'Land Run': 'mid-south',
         'Leadville': 'leadville-trail-100-mtb',
     }


### PR DESCRIPTION
## Summary
- **Fix BWR alias**: `belgian-waffle-ride` (404) → `bwr-california` (correct slug). Add `Belgian Waffle Ride` and `Big Sugar` as aliases.
- **Fix QUESTIONNAIRE_SLUGS**: `belgian-waffle-ride` key → `bwr-california`
- **Add FAQPage JSON-LD** to methodology page (5 FAQ items). Race pages had this; methodology was missing it.
- **Fix countdown placeholder**: `--` → actual date (e.g., "June 6, 2026") for crawlers/no-JS. JS still animates to day count.
- **3 new tests** (98 total): BWR alias, Big Sugar alias, countdown shows date not dashes

## Deployed
All 328 race pages + methodology regenerated and deployed via tar+ssh.

## Test plan
- [x] `pytest tests/test_neo_brutalist.py -v` → 98 passed
- [x] `pytest tests/ -q` → 566 passed, 1 skipped
- [x] Verified on server: `Race Rating` x4 in unbound-200, countdown shows date, FAQPage in methodology

🤖 Generated with [Claude Code](https://claude.com/claude-code)