### PR TITLE
fix: resolve parked handover items — cultural_impact parity, orphaned training-form mu-plugin

### DIFF
--- a/.claude/skills/deploy-safely/SKILL.md
+++ b/.claude/skills/deploy-safely/SKILL.md
@@ -72,12 +72,16 @@ mu-plugin syncs (section 3) or article SCP sync. Run those separately —
 
 Source: `wordpress/mu-plugins/` (8 files): `gg-ab.php`, `gg-cookie-consent.php`,
 `gg-ga4.php`, `gg-header.php`, `gg-meta-descriptions.php`, `gg-noindex.php`,
-`gg-race-ctas.php`, `gg-training-form.php`. Seven have a dedicated
+`gg-race-ctas.php`, `gg-training-form.php`. Each has a dedicated
 `push_wordpress.py` SCP flag (`--sync-ab`, `--sync-consent`, `--sync-ga4`,
-`--sync-header`, `--sync-meta-descriptions`, `--sync-noindex`, `--sync-ctas`);
-`--deploy-all` includes all seven. `gg-training-form.php` has **no sync flag
-anywhere in `push_wordpress.py`** and is not in `--deploy-all` — verify its
-deploy path before assuming a local edit is live.
+`--sync-header`, `--sync-meta-descriptions`, `--sync-noindex`, `--sync-ctas`,
+`--sync-training-form`); `--deploy-all` includes all eight. War story (Jul
+2026): `gg-training-form.php` — the questionnaire's Submit & Pay JS loader —
+sat UNTRACKED in a working tree for four months, deployed only by a manual
+March SCP; it had no sync flag and existed in no commit. A revenue-critical
+file whose only copies are a laptop and the server is one disk failure from
+gone; if you add a mu-plugin, its sync flag and its commit land in the same
+change.
 
 `gg-header.php` must be kept in manual sync with `shared_header.py`'s
 `get_site_header_html/css/js()` — no shared source of truth between Python

--- a/race-data/5-mila-marche-gran-fondo.json
+++ b/race-data/5-mila-marche-gran-fondo.json
@@ -102,7 +102,7 @@
         "explanation": "Total event costs include registration fees (€139-220 for circuit passes), accommodation in Porto Recanati or surrounding Marche towns, and travel to the Adriatic coast. Italy's moderate accommodation and dining costs keep overall expenses reasonable for European participants."
       },
       "cultural_impact": {
-        "score": 2,
+        "score": 0,
         "explanation": "The 5 Mila Marche functions as a regional cycling festival promoting the Marche territory through cycling tourism. The event has established significance within Italian amateur cycling circles but remains primarily a regional rather than national cultural phenomenon."
       },
       "overall_score": 56,

--- a/race-data/cyprus-gran-fondo.json
+++ b/race-data/cyprus-gran-fondo.json
@@ -129,7 +129,7 @@
         "explanation": "Travel to Cyprus and potential package upgrades like bronze/silver/gold entries add moderate costs, balanced by local lodging but higher for international participants.[5]"
       },
       "cultural_impact": {
-        "score": 4,
+        "score": 3,
         "explanation": ""
       }
     },

--- a/race-data/korea-epic-ride.json
+++ b/race-data/korea-epic-ride.json
@@ -98,7 +98,7 @@
         "explanation": "Low fees for paved road event near Incheon Airport minimize travel costs. Wild camping options slash Gangwon lodging expenses. Great value for 2500ft elevation challenge."
       },
       "cultural_impact": {
-        "score": 2,
+        "score": 0,
         "explanation": "Regional draw in South Korea's Incheon-Gangwon corridor promotes cycling tourism. Gran Fondo World Tour spot highlights local paved routes. Engages domestic community since 2018 founding."
       },
       "overall_score": 56,

--- a/scripts/push_wordpress.py
+++ b/scripts/push_wordpress.py
@@ -1867,6 +1867,44 @@ def sync_ctas():
         return False
 
 
+def sync_training_form():
+    """Deploy the training-form mu-plugin to WordPress.
+
+    Uploads gg-training-form.php to wp-content/mu-plugins/ via SCP.
+    Enqueues training-plans-form.js on the questionnaire page (ID 5017);
+    without it the Submit & Pay button does nothing. The JS itself deploys
+    separately via --sync-training.
+    """
+    ssh = get_ssh_credentials()
+    if not ssh:
+        return False
+    host, user, port = ssh
+
+    project_root = Path(__file__).resolve().parent.parent
+    plugin_file = project_root / "wordpress" / "mu-plugins" / "gg-training-form.php"
+    if not plugin_file.exists():
+        print(f"✗ mu-plugin not found: {plugin_file}")
+        return False
+
+    remote_path = "~/www/gravelgodcycling.com/public_html/wp-content/mu-plugins"
+
+    try:
+        subprocess.run(
+            [
+                "scp", "-i", str(SSH_KEY), "-P", port,
+                str(plugin_file),
+                f"{user}@{host}:{remote_path}/gg-training-form.php",
+            ],
+            capture_output=True, text=True, timeout=15, check=True,
+        )
+        print("✓ Deployed gg-training-form.php mu-plugin")
+        print("  Questionnaire page JS loader (Submit & Pay path)")
+        return True
+    except Exception as e:
+        print(f"✗ Failed to deploy training-form mu-plugin: {e}")
+        return False
+
+
 def sync_ga4():
     """Deploy the GA4 analytics mu-plugin to WordPress.
 
@@ -3343,6 +3381,10 @@ if __name__ == "__main__":
         help="Deploy race CTA mu-plugin to wp-content/mu-plugins/"
     )
     parser.add_argument(
+        "--sync-training-form", action="store_true",
+        help="Deploy training-form mu-plugin (questionnaire JS loader) to wp-content/mu-plugins/"
+    )
+    parser.add_argument(
         "--sync-ga4", action="store_true",
         help="Deploy GA4 analytics mu-plugin to wp-content/mu-plugins/"
     )
@@ -3493,6 +3535,7 @@ if __name__ == "__main__":
         args.sync_redirects = True
         args.sync_noindex = True
         args.sync_ctas = True
+        args.sync_training_form = True
         args.sync_ga4 = True
         args.sync_prep_kits = True
         args.sync_tire_guides = True
@@ -3520,7 +3563,7 @@ if __name__ == "__main__":
                       args.sync_coaching, args.sync_coaching_apply, args.sync_consulting,
                       args.sync_training_plans, args.sync_success, args.sync_pages,
                       args.sync_sitemap, args.sync_redirects,
-                      args.sync_noindex, args.sync_ctas, args.sync_ga4, args.sync_header, args.sync_prep_kits, args.sync_plan_pages, args.sync_tire_guides,
+                      args.sync_noindex, args.sync_ctas, args.sync_training_form, args.sync_ga4, args.sync_header, args.sync_prep_kits, args.sync_plan_pages, args.sync_tire_guides,
                       args.sync_series, args.sync_blog,
                       args.sync_blog_index, args.sync_photos, args.sync_ab, args.sync_courses,
                       args.sync_meta_descriptions, args.sync_mission_control,
@@ -3582,6 +3625,8 @@ if __name__ == "__main__":
         _run("sync-noindex", sync_noindex)
     if args.sync_ctas:
         _run("sync-ctas", sync_ctas)
+    if args.sync_training_form:
+        _run("sync-training-form", sync_training_form)
     if args.sync_ga4:
         _run("sync-ga4", sync_ga4)
     if args.sync_header:

--- a/wordpress/mu-plugins/gg-training-form.php
+++ b/wordpress/mu-plugins/gg-training-form.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Gravel God — Training Plan Questionnaire JS
+ *
+ * Loads training-plans-form.js on the questionnaire page (/questionnaire/).
+ * This script handles form validation, GA4 tracking (tp_form_start,
+ * tp_form_submit, begin_checkout), and Stripe Checkout redirect via
+ * the Railway API.
+ *
+ * Without this mu-plugin, the "Submit & Pay" button does nothing —
+ * discovered during Sprint Ralph Wiggum CTA audit (Mar 2026).
+ *
+ * Why a mu-plugin instead of wp_enqueue_script in the theme?
+ * SiteGround Optimizer strips/combines scripts unpredictably.
+ * Mu-plugins load before themes and can't be deactivated via admin UI,
+ * making them the most reliable way to guarantee script loading.
+ *
+ * Deployed via SCP to wp-content/mu-plugins/gg-training-form.php
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+add_action( 'wp_enqueue_scripts', 'gg_enqueue_training_form_js' );
+
+function gg_enqueue_training_form_js() {
+    // Only load on the questionnaire page (page ID 5017)
+    if ( ! is_page( 5017 ) ) {
+        return;
+    }
+
+    // wp_enqueue_script is required instead of raw echo because
+    // SiteGround Speed Optimizer strips anonymous <script> tags
+    // from wp_footer output. Enqueued scripts are respected and
+    // combined into the optimizer's bundled JS file.
+    wp_enqueue_script(
+        'gg-training-form',
+        content_url( 'uploads/training-plans-form.js' ),
+        array(),
+        null,
+        true
+    );
+}


### PR DESCRIPTION
## What

The two gravel-side items parked during the handover sprint, resolved:

**1. The 3 remaining `cultural_impact` bor/rating mismatches.** `gravel_god_rating` is authoritative (it feeds overall/tier). 5-mila-marche and korea-epic-ride sync to 0 — both fail the notable-race invariant (prestige 2, tier 3) and their own explanations describe regional scope. cyprus-gran-fondo syncs to 3 — its bor 4 carried an empty explanation, while 3 is the value the published overall (77) is built on.

**2. `gg-training-form.php` was never in git.** The questionnaire's Submit & Pay JS loader (without it, the buy button does nothing — per its own docstring) had sat untracked in a working tree since March, deployed once by manual SCP. Its only copies were a laptop and the server. Now committed, with a `--sync-training-form` flag mirroring the other seven mu-plugins, included in `--deploy-all`, and the deploy-safely skill updated (8 flags; war story recorded).

## Verified

Mu-plugin parity + all four scoring/index integrity suites: 72 passed. `push_wordpress.py --help` shows the new flag; syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)