### PR TITLE
Add Dirt Craft course + YouTube video block + scoped Desert theme

### DIFF
--- a/data/courses/dirt-craft/course.json
+++ b/data/courses/dirt-craft/course.json
@@ -1,0 +1,185 @@
+{
+  "id": "dirt-craft",
+  "title": "Dirt Craft: Technical Gravel Mastery",
+  "subtitle": "Stop fighting the bike. Start riding it.",
+  "description": "The skills, numbers, and instincts that separate riders who race gravel from riders who survive it. 12 lessons built around deliberate practice drills, sensation targets, and the emotional journey from fear to flow.",
+  "price_usd": 29,
+  "stripe_payment_link": "https://buy.stripe.com/xxx",
+  "stripe_price_id": "price_xxx",
+  "instructor": {
+    "name": "Matt Rowe",
+    "title": "Head Coach, Gravel God Cycling",
+    "bio": "A reformed roadie who was genuinely terrible at bike handling — rigid arms, death grip, braking in corners, the whole disaster. Got better through years of deliberate practice: slow, boring, repetitive drills that eventually became invisible instinct. Now helping other riders make the same journey, faster."
+  },
+  "what_youll_learn": [
+    "Break the death-grip cycle and let the bike move beneath you",
+    "Find your personal traction envelope on any surface",
+    "Brake, corner, and climb on loose terrain with specific, repeatable technique",
+    "Read surfaces at speed and pre-adjust before transitions",
+    "Descend gravel as play, not survival — using body position for free speed",
+    "Execute field repairs under pressure in under 5 minutes",
+    "Maintain technique under deep fatigue with the 20-minute reset protocol",
+    "Build a Race Setup Card for any of 757 gravel races worldwide"
+  ],
+  "modules": [
+    {
+      "id": "start-here",
+      "title": "Start Here",
+      "tagline": "How to practice so it actually sticks. Read this first — it's the operating system for every drill that follows.",
+      "lessons": [
+        {
+          "id": "how-to-practice",
+          "title": "How to Practice (So It Actually Sticks)",
+          "file": "lessons/00-how-to-practice.json"
+        }
+      ]
+    },
+    {
+      "id": "trust-the-bike",
+      "title": "Trust the Bike",
+      "tagline": "The bike knows what to do. Your job is to stop preventing it.",
+      "lessons": [
+        {
+          "id": "letting-go",
+          "title": "Letting Go",
+          "file": "lessons/01-letting-go.json"
+        },
+        {
+          "id": "your-body-is-the-suspension",
+          "title": "Your Body Is the Suspension",
+          "file": "lessons/02-your-body-is-the-suspension.json"
+        },
+        {
+          "id": "where-traction-lives",
+          "title": "Where Traction Actually Lives",
+          "file": "lessons/03-where-traction-lives.json"
+        },
+        {
+          "id": "the-quiet-eye",
+          "title": "The Quiet Eye",
+          "file": "lessons/04-the-quiet-eye.json"
+        },
+        {
+          "id": "trust-stack-check",
+          "title": "Module 1: Stack Check",
+          "file": "lessons/m1-stack-check.json"
+        }
+      ]
+    },
+    {
+      "id": "control-the-inputs",
+      "title": "Control the Inputs",
+      "tagline": "Replace fear with specific, repeatable technique.",
+      "lessons": [
+        {
+          "id": "braking-that-builds-confidence",
+          "title": "Braking That Builds Confidence",
+          "file": "lessons/05-braking-that-builds-confidence.json"
+        },
+        {
+          "id": "cornering-without-clenching",
+          "title": "Cornering Without Clenching",
+          "file": "lessons/06-cornering-without-clenching.json"
+        },
+        {
+          "id": "climbing-without-spinning-out",
+          "title": "Climbing Without Spinning Out",
+          "file": "lessons/07-climbing-without-spinning-out.json"
+        },
+        {
+          "id": "reading-surfaces-at-speed",
+          "title": "Reading Surfaces at Speed",
+          "file": "lessons/08-reading-surfaces-at-speed.json"
+        },
+        {
+          "id": "control-stack-check",
+          "title": "Module 2: Stack Check",
+          "file": "lessons/m2-stack-check.json"
+        }
+      ]
+    },
+    {
+      "id": "find-the-speed",
+      "title": "Find the Speed",
+      "tagline": "Speed is the byproduct of skill meeting terrain.",
+      "lessons": [
+        {
+          "id": "descending-as-play",
+          "title": "Descending as Play, Not Survival",
+          "file": "lessons/09-descending-as-play.json"
+        },
+        {
+          "id": "pack-dynamics-and-pacing",
+          "title": "Pack Dynamics & Pacing by Terrain",
+          "file": "lessons/10-pack-dynamics-and-pacing.json"
+        },
+        {
+          "id": "when-things-break",
+          "title": "When Things Break",
+          "file": "lessons/11-when-things-break.json"
+        },
+        {
+          "id": "speed-stack-check",
+          "title": "Module 3: Stack Check",
+          "file": "lessons/m3-stack-check.json"
+        }
+      ]
+    },
+    {
+      "id": "ride-in-flow",
+      "title": "Ride in Flow",
+      "tagline": "If you just ride for watts, you cap your enjoyment. If you get good at riding your bike, your enjoyment is endless.",
+      "lessons": [
+        {
+          "id": "the-final-hour",
+          "title": "The Final Hour and Beyond",
+          "file": "lessons/12-the-final-hour.json"
+        },
+        {
+          "id": "flow-stack-check",
+          "title": "Module 4: Stack Check",
+          "file": "lessons/m4-stack-check.json"
+        }
+      ]
+    },
+    {
+      "id": "skills-lab",
+      "title": "Skills Lab",
+      "tagline": "Deliberate practice for the skills that separate riders — finding your traction limit on purpose, and the hops that turn obstacles into timing problems.",
+      "lessons": [
+        {
+          "id": "finding-your-limits",
+          "title": "Finding Your Limits (On Purpose)",
+          "file": "lessons/14-finding-your-limits.json"
+        },
+        {
+          "id": "hops-and-ruts",
+          "title": "Hops, Ledges, and Getting Out of Ruts",
+          "file": "lessons/15-hops-and-ruts.json"
+        },
+        {
+          "id": "pumping",
+          "title": "Pumping: Speed Without Pedaling",
+          "file": "lessons/16-pumping.json"
+        }
+      ]
+    },
+    {
+      "id": "appendix-the-physics",
+      "title": "Appendix: The Physics",
+      "tagline": "Optional. The why behind the what — including the parts nobody has nailed down.",
+      "optional": true,
+      "lessons": [
+        {
+          "id": "the-physics-honestly",
+          "title": "The Physics, Honestly",
+          "file": "lessons/13-the-physics-honestly.json"
+        }
+      ]
+    }
+  ],
+  "meta_description": "Master gravel bike handling: 12 drill-based lessons from fear to flow. Tire pressure calculators, cornering drills, descent technique, Race Setup Cards for 757 races. $29.",
+  "og_image": "course-dirt-craft-og.png",
+  "status": "development",
+  "theme": "desert"
+}

--- a/data/courses/dirt-craft/lessons/00-how-to-practice.json
+++ b/data/courses/dirt-craft/lessons/00-how-to-practice.json
@@ -1,0 +1,147 @@
+{
+  "id": "how-to-practice",
+  "title": "How to Practice (So It Actually Sticks)",
+  "module": "start-here",
+  "lesson_number": 0,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "20 min",
+      "unit": "of focused drilling beats a 3-hour 'just ride'",
+      "context": "Mileage makes you fitter. It does not make you better at riding your bike. This lesson is the operating system for every drill in this course — read it first, and the rest compounds."
+    },
+    {
+      "type": "callout",
+      "style": "highlight",
+      "content": "**Every other lesson hands you a drill. This one is how to run it.** Skill isn't installed by effort or saddle time — it's installed by a specific, repeatable, fairly boring loop. Worth being straight about who's teaching this: I'm not a naturally gifted bike handler. I was a stiff, nervous roadie who got a lot better by practicing deliberately over a long time. That's the whole method. It's slow, it works, and it's available to anyone willing to be bored on purpose."
+    },
+    {
+      "type": "prose",
+      "content": "### Why 'just ride more' quietly fails you\n\nHere's the thing nobody tells the strong self-taught rider: riding more doesn't fix your handling. It cements it. Lee McCormack, who has taught this longer than almost anyone, puts it flatly: *\"If you just go and ride, you will get better at going and riding. Whatever patterns you have are just going to get burned-in.\"* Every hour you spend death-gripping the bars at 60% of grip is an hour spent making the death grip more automatic.\n\nHe's blunt about where that leaves you: *\"If you don't have a natural talent, you might get stronger and you might get less afraid because you have confidence in your bike, but you're not going to get better. You should practice.\"* Strength and confidence are not skill. You can have a huge engine and still corner like a nervous beginner — because the engine was trained and the hands never were."
+    },
+    {
+      "type": "black_box",
+      "title": "The four rungs (a map, not a law)",
+      "content": "Skill acquisition climbs four rungs, and knowing which one you're on tells you what to do next:\n\n**1. Unconscious incompetence** — you don't know you're doing it wrong. (You think you can corner. You can corner on pavement.)\n\n**2. Conscious incompetence** — you now feel the fault. This course's job is to get you here fast; it's uncomfortable and it's progress.\n\n**3. Conscious competence** — you can do it right, but only when you're thinking hard about it.\n\n**4. Unconscious competence** — it's automatic; you do it right without a thought, even scared and tired.\n\nHonest note: this four-rung model is a teaching heuristic, not hard motor-learning science. It's useful because it names the gap between 'I did the drill once' (rung 3) and 'I do it without thinking mid-race' (rung 4). Reps are what carry you across that gap, and almost everyone quits at rung 3."
+    },
+    {
+      "type": "prose",
+      "content": "### How a skill actually engrains\n\nBetterRide's Gene Hamilton breaks improvement into three parts, and they're the right three: *\"1. Knowledge of how to do the skill correctly. 2. Practicing the skill with a focus on quality. 3. Body awareness.\"* Knowledge you get from a lesson. Quality and awareness you only get from reps that you're actually paying attention to.\n\nAnd not just any reps. The motor-learning research is clear on one dissociation: cramming a skill in one blocked session makes you look good *that day*, but **spacing and varying** your practice is what makes it stick weeks later. (Fair caveat: the size of that retention benefit is debated for real-world sport, so don't treat variety as magic — just know that ten minutes daily beats seventy minutes once, and practicing a skill in slightly different spots beats grooving it in exactly one.)"
+    },
+    {
+      "type": "process",
+      "title": "The Practice Loop",
+      "description": "The repeatable engine under every drill in this course. Run any skill through these five steps and it moves from 'I read about it' to 'my body owns it.' This is the tool the whole course is built on.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Isolate one component.",
+          "detail": "Not 'cornering' — the ONE piece: outside-foot weighting, or eyes-to-exit, or the first-slip point. A skill you can't name a single piece of is a skill you can't practice yet."
+        },
+        {
+          "step": 2,
+          "action": "Drill it slow, until it's boring.",
+          "detail": "Slow speed, low stakes, exaggerated. Boring is the goal — boring means the conscious effort is draining out and the movement is becoming automatic. Excitement means you're still on rung 3."
+        },
+        {
+          "step": 3,
+          "action": "Prove it with a gate.",
+          "detail": "Every drill has a proof gate — a specific, pass-or-fail check. You don't get to say you 'have' a skill because you did it once. You have it when you can do it on demand, both sides, without thinking."
+        },
+        {
+          "step": 4,
+          "action": "Space it, don't cram it.",
+          "detail": "Ten focused minutes several times a week beats one long grind. The rests between sessions are when the pattern consolidates. Put a drill in your warm-up and touch it every ride."
+        },
+        {
+          "step": 5,
+          "action": "Vary it, then chain it.",
+          "detail": "Once a piece is automatic, practice it in different corners, surfaces, and speeds — then combine it with the next piece. Real riding is components chained; you can only chain what each part has become invisible."
+        }
+      ]
+    },
+    {
+      "type": "sensation_target",
+      "label": "What 'automatic' feels like",
+      "content": "You'll know a skill has crossed to rung 4 when it goes quiet. Early on, doing it right feels loud — a checklist you run, effortful and fragile, gone the moment you get scared. Automatic feels like nothing at all: you arrive at the corner and your outside foot is already down, your eyes are already at the exit, and you never decided to do either. That silence — the absence of conscious effort under pressure — is the target. Chase boring. Boring is the sound of a skill becoming yours."
+    },
+    {
+      "type": "drill",
+      "title": "The 20-Minute Block",
+      "time_minutes": 20,
+      "description": "Not a skill drill — a template for how to run every OTHER drill in this course. Use it to turn any lesson's drill into a session that actually sticks.",
+      "proof_gate": {
+        "target": "You can take any drill in this course, name its single component, run it slow until it's boring, and pass its proof gate on demand, both sides — then repeat it across at least three separate days that week."
+      },
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "One skill, one empty space, one focus",
+          "steps": [
+            "Pick ONE drill from one lesson. Just one. Write down the single component it trains.",
+            "Set a 20-minute timer. Do nothing else — no Strava, no 'and then I'll ride home the long way.' This is practice, not a ride.",
+            "Run the drill slow and exaggerated. When your mind wanders, that's the rep talking — bring the focus back to the one component.",
+            "Stop at 20 minutes even if it's going well. Leaving a little in the tank makes you want to come back."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Space it across the week",
+          "steps": [
+            "Take the same drill and do a 10–15 minute block on three different days this week instead of one long session.",
+            "Each session, start by testing the proof gate cold — can you still do it without a warm-up? That cold test is the real measure of retention.",
+            "Notice it getting quieter and more automatic across the days. That's consolidation doing its work between sessions."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Vary and chain",
+          "steps": [
+            "Once the component is automatic, run it in three different settings — a tighter corner, a looser surface, a faster entry.",
+            "Then chain it to the next component (e.g. outside-foot weighting + eyes-to-exit together).",
+            "Goal: the piece survives being combined and varied. That's rung 4 — skill you own, not skill you perform."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "video",
+      "id": "kFlEz0GYD3w",
+      "title": "I Practiced Cornering 50 Times A Day For A Week",
+      "channel": "Paul The Punter",
+      "caption": "A rider runs the exact loop this lesson describes — one skill, endless reps. Watch how much a week of deliberate practice changes."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You've got 90 minutes to spend this week getting better at loose cornering. Which plan actually builds the skill?",
+      "options": [
+        {
+          "text": "One 90-minute ride on your favorite loose trail, cornering as much as possible",
+          "correct": false
+        },
+        {
+          "text": "Three 20-minute focused blocks on separate days drilling ONE cornering component slow, testing the proof gate cold each time, then varying it",
+          "correct": true
+        },
+        {
+          "text": "Watch cornering videos for 90 minutes to build the knowledge first",
+          "correct": false
+        },
+        {
+          "text": "One 90-minute parking-lot session grinding the same corner until it's perfect",
+          "correct": false
+        }
+      ],
+      "explanation": "Skill engrains through spaced, focused, quality reps on an isolated component — three short blocks across the week, each starting with a cold proof-gate test, beats one long session (which grooves whatever you already do, good or bad). Riding the trail is where you USE the skill, not where you build it. Videos give you knowledge (step 1) but not reps. And one long grind is blocked practice — it looks good that day and fades faster than spaced practice."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before you touch any other lesson: pick one drill, run The 20-Minute Block on it, and put it on your calendar for two more days this week. You're not learning a skill yet — you're proving to yourself you can run the loop. Everything else in this course rides on it."
+    },
+    {
+      "type": "callout",
+      "style": "next",
+      "content": "You now have the operating system. Every lesson from here hands you a component and a proof gate — your job is to run them through The Practice Loop until they go quiet. Start with Module 1: Trust the Bike."
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/01-letting-go.json
+++ b/data/courses/dirt-craft/lessons/01-letting-go.json
@@ -1,0 +1,212 @@
+{
+  "id": "letting-go",
+  "title": "Letting Go",
+  "module": "trust-the-bike",
+  "lesson_number": 1,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "20 lbs",
+      "unit": "is what your pedals should feel like",
+      "context": "that's the weight shift between a death grip and a rider who trusts the bike"
+    },
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Rider descends a gravel road at 15 mph. Surface is washboard — shallow, rhythmic corrugations spaced 3-4 inches apart. Rider grips bars with full force, elbows locked, shoulders braced. Body forms a single rigid unit from hands to feet.\n\nThe washboard frequency exceeds the fork's ability to absorb while the rider's weight is loaded through the handlebars. Front wheel begins to bounce. Each bounce lifts the contact patch off the surface for 30-40 milliseconds. The rider, feeling the wheel skip, grips harder.\n\nAt the third bounce, the front wheel lands at a 4-degree angle to the direction of travel. Traction is already reduced by the bouncing. The wheel deflects left. The rigid rider's mass follows. No absorption, no correction. The bike goes down at 15 mph.\n\nPalms bruised from the death grip. Right hip road rash. The crash wasn't caused by the washboard. It was caused by the rider's response to the washboard."
+    },
+    {
+      "type": "callout",
+      "style": "highlight",
+      "content": "**You are not the only one who white-knuckled it.** Two riders, same wall, in their own words:\n\n\"I kept my hands on the hoods on all my descents and would legitimately be terrified at anything over 35mph… putting my hands in the drops made all that instability go away.\" — batwood14, TrainerRoad forum\n\n\"I started yelling at myself to relax because tension/stiffening in the body makes a sketchy descent waaay worse… I refrained from fear braking… I leveled up that ride.\" — funkinslick, TrainerRoad forum"
+    },
+    {
+      "type": "prose",
+      "content": "That crash report could be any of us. I've lived some version of it a dozen times — the white-knuckle descent, the bouncing front wheel, the moment where instinct says HOLD ON and physics says that's the wrong answer. I was a road rider for fifteen years before I touched gravel, and every one of those years trained me to do exactly the wrong thing on loose surfaces. The skill you're about to learn took me two minutes to understand and two seasons to unlearn the opposite. It's the single highest-leverage change I've ever made on a bike.\n\nI know — someone telling you to loosen your grip sounds about as useful as 'just relax' at the dentist. Bear with me. The physics are on my side here."
+    },
+    {
+      "type": "sensation_target",
+      "label": "Heavy feet, quiet hands",
+      "content": "Stand on the pedals for a moment. Now sit back down — but keep 70% of your weight pressing through your feet into the pedals. Your hands rest on the bars like they're resting on a shelf. Fingers wrapped loosely. Palms barely touching.\n\nThis is the target sensation. Pedals feel like they weigh 20 lbs. Hands feel like they're holding a bag of chips you don't want to crush.\n\nI remember the first time I found this position — genuinely shocked that the bike felt more stable with less grip, not more. Everything I'd learned on the road was wrong.\n\nHere's the test: ride 5 minutes of rough gravel, then check your palms. If they're red, sore, or tingling, your weight was in the wrong place. If they feel the same as when you started, you found it."
+    },
+    {
+      "type": "prose",
+      "content": "The death grip is the most common bike handling error in gravel cycling. It's also the most dangerous, because it creates the exact problem the rider is trying to prevent.\n\nThe cycle works like this:\n\n1. **Fear** — the surface looks rough, loose, or unfamiliar.\n2. **Grip** — the rider clamps the bars, locks their elbows, braces their shoulders.\n3. **Rigidity** — the upper body becomes a single rigid unit, transmitting every surface vibration directly through the skeleton.\n4. **Bounce** — the front wheel lifts off the surface with each bump. Contact patch time drops. Steering authority disappears.\n5. **More fear** — the rider feels the wheel skipping and interprets it as loss of control.\n6. **More grip** — back to step 2, but worse.\n\nI ran this exact cycle for two full seasons before I understood what was happening. Every sketchy descent, same sequence — white knuckles, bouncing front wheel, wondering why gravel felt so much harder than it should.\n\nThis isn't a character flaw. It's a deeply wired survival response. When your brain perceives instability, it tells your muscles to clamp down and brace for impact. On pavement, this works fine — the surface is predictable and the bike stays planted regardless of what you do with your upper body. On gravel, it's the mechanism that causes the crash."
+    },
+    {
+      "type": "prose",
+      "content": "The fix is counterintuitive: you have to move your weight DOWN to make the bike more stable.\n\nThis is what experienced gravel riders mean when they say \"let the bike do the work.\" They're not being vague. They're describing a specific weight distribution: heavy feet, light hands, hips as the hinge point between a stable lower body and a floating upper body."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Why This Works (The Physics)",
+          "content": "**Center of mass through the bottom bracket, not the handlebars.** When your weight pushes through the pedals, the lowest and most central point of the bike-rider system carries the load. The bike becomes bottom-heavy, like a weighted Weeble. It self-corrects.\n\n**When your weight is in your hands, the center of mass rises and moves forward.** The bike becomes top-heavy. Every perturbation amplifies instead of damping out.\n\n**Light hands = free steering.** With minimal weight on the bars, the front wheel is free to track over small obstacles — rocks, ruts, washboard ridges — without deflecting the entire bike. The wheel finds its own line. Your job is to let it."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "content": "Road cycling trains you to be a single rigid unit — stiff core, locked hips, power from glutes through pedals. This is correct for pavement. On gravel, you need to be two separate systems: a stable lower body driving the pedals, and a loose upper body that absorbs terrain independently. Lesson 2 goes deep on this separation. For now, focus on one thing: get the weight out of your hands.",
+      "style": "tip"
+    },
+    {
+      "type": "process",
+      "title": "The Weighted Drop",
+      "description": "Deploy on any surface change or rough section. This is the foundational skill of the entire course — every lesson builds on it.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Drop your heels",
+          "detail": "10-15 degrees below horizontal. This engages your calves as shock absorbers and lowers your center of mass by 1-2 cm. Small change, large effect."
+        },
+        {
+          "step": 2,
+          "action": "Bend your elbows",
+          "detail": "Locked elbows transmit vibration. Bent elbows absorb it. Think of your arms as the front suspension you don't have. A 20-degree bend gives you roughly 3 inches of vertical travel."
+        },
+        {
+          "step": 3,
+          "action": "Press through the pedals",
+          "detail": "Actively push your weight down through your feet, even when seated. Imagine the pedals are bathroom scales — you want them reading 70% of your body weight at all times."
+        },
+        {
+          "step": 4,
+          "action": "Release the hands",
+          "detail": "Reduce grip pressure to the minimum needed to keep your hands on the bars. If you're gripping at a 9 out of 10, bring it to a 3."
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "The result: when you hit a bump, the front wheel rises, your arms compress, the energy dissipates through your bent elbows, and the wheel settles back onto the surface still tracking straight. Your palms don't feel it. Your feet do — and feet can handle it.\n\nI spent two years riding gravel with a death grip before someone told me this. Two minutes of deliberate practice changed my riding more than two years of just logging miles."
+    },
+    {
+      "type": "prose",
+      "content": "Watch two riders on the same washboard section. The rigid rider bounces — head bobbing, shoulders ratcheting up toward the ears with every corrugation, bike chattering underneath like it's trying to shake them off. Their line wanders because the front wheel is spending half its time in the air. The loose rider flows. Their head stays level, almost eerily still, while the bike moves independently underneath them. Arms flex, elbows pump gently, hands rest. Same road, same speed, same tires. The difference is entirely in where their weight lives. You can spot a death-gripper from 50 meters away. You can also spot the moment someone figures out The Weighted Drop, because they suddenly look like they belong on the surface instead of fighting it."
+    },
+    {
+      "type": "drill",
+      "title": "Pedal Pressure Intervals",
+      "time_minutes": 15,
+      "description": "Three-minute segments alternating your attention between feet, hands, and both. The goal isn't fitness — it's rewiring your default weight distribution.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Smooth gravel road, easy pace",
+          "steps": [
+            "Find a flat or gently rolling gravel road with a consistent surface.",
+            "Minutes 0-3: Focus entirely on your feet. Press hard into the pedals. Imagine you're trying to push the cranks through the bottom bracket. Don't worry about your hands.",
+            "Minutes 3-6: Focus entirely on your hands. Systematically lighten them. Lift one finger at a time until you find the minimum grip. Can you ride with just thumb and index finger?",
+            "Minutes 6-9: Focus on both simultaneously. Heavy feet AND quiet hands. This is harder than either alone.",
+            "Minutes 9-12: Repeat the cycle. Note whether the sensation is easier to find the second time.",
+            "Minutes 12-15: Free ride. Stop thinking about it. Check your palms at the end — any redness or soreness means you drifted back to the death grip."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Chunky or variable-surface gravel",
+          "steps": [
+            "Same structure as beginner, but on rougher terrain — loose rock, mixed surfaces, or mild washboard.",
+            "The challenge: maintaining light hands when the surface is actively trying to rip the bars from your grip.",
+            "Minutes 0-3: Feet focus. Press through every bump. Let the rough surface push back against your feet, not your hands.",
+            "Minutes 3-6: Hands focus. On rough terrain, lightening your hands will feel wrong. Do it anyway. The bike will track better, not worse.",
+            "Minutes 6-9: Combined focus. This is where the real rewiring happens — rough surface, heavy feet, quiet hands simultaneously.",
+            "Minutes 9-15: Extended combined focus through the roughest section you can find. Palm check at the end."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Tempo power with standing surges on gravel",
+          "steps": [
+            "Warm up 5 minutes on gravel at endurance pace, practicing heavy feet/quiet hands.",
+            "3 x 3-minute intervals at sweet spot (88-93% FTP) on gravel. During each interval, include two 10-second standing surges.",
+            "The standing surges are the test: when you stand, your weight naturally shifts to your hands. Can you stand and surge while keeping your hands light?",
+            "Technique for standing surges: push the bike forward under you as you rise, keep hips over the bottom bracket, hands guide but don't pull.",
+            "Recovery between intervals: 2 minutes easy spinning, maintain the weight distribution even during recovery.",
+            "Palm check after each interval. If your hands hurt after the surges, you loaded the bars when you stood."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "10 minutes of continuous riding on rough gravel with zero palm soreness afterward.",
+        "metric": "binary",
+        "target": "No palm redness, soreness, or tingling after 10 minutes on rough gravel"
+      }
+    },
+    {
+      "type": "drill",
+      "title": "Spirit Fingers",
+      "time_minutes": 10,
+      "description": "A light-grip drill borrowed from moto coaching (via BetterRide): prove to yourself you barely need to hold the bars at all. The fastest way to break a death grip is to ride without one on purpose.",
+      "proof_gate": {
+        "target": "You can ride a slow figure-8 on flat, grippy ground with your fingers floating open off the grips — not wrapped around them — staying balanced and in control, both directions."
+      },
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Flat grass or pavement, walking-to-jogging pace",
+          "steps": [
+            "Ride a slow, wide figure-8 or loop on flat, grippy ground.",
+            "Relax your hands and let your fingers float open in front of the bars instead of wrapping them. Thumbs relaxed under the bars.",
+            "Notice the bike still goes where you point it. The grip you thought you needed was doing nothing but tiring you out.",
+            "If it feels impossible at first, you're gripping from fear, not necessity — slow down until the fingers can open."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Tighten the figure-8",
+          "steps": [
+            "Same drill, tighter radius and a little more speed, fingers still floating.",
+            "Feel how a light grip forces your weight down into your feet and frees the bars to self-steer.",
+            "Goal: a light grip becomes your default, not something you have to remember."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### Why This Matters for Everything Else\n\nThe weighted drop isn't just a handling trick. It's the platform that every other skill in this course sits on.\n\n- **Braking** (Lesson 5): Light hands give you better brake modulation. You can feather the levers instead of grabbing them.\n- **Cornering** (Lesson 6): Weight through the pedals means weight through the tires. More traction when you need it most.\n- **Climbing** (Lesson 7): Pressing through the pedals on loose climbs keeps the rear tire planted. Death grip on climbs shifts weight forward and unloads the drive wheel.\n- **Descending** (Lesson 9): Bent elbows and light hands let the front wheel track through rough descents without deflecting.\n\nIf you nail this one thing — truly internalize heavy feet, quiet hands as your default state — you'll be a fundamentally different rider on gravel. Not because it's magic, but because you've removed the single biggest cause of crashes and replaced it with physics that actually work on loose surfaces.\n\nThis is The Weighted Drop. It's the first tool in your stack, and the one you'll reach for most often. Every lesson that follows assumes you have it dialed — cornering, braking, climbing, descending. They all start here, with your weight in your feet and your hands doing as little as possible."
+    },
+    {
+      "type": "video",
+      "id": "UdFdkebFwRU",
+      "title": "How to Fix Your Body Position on the Gravel Bike",
+      "channel": "Michael van den Ham",
+      "caption": "CX champion demoing gravel body position — watch the neutral, hinged, heavy-feet stance."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're riding a smooth gravel road when the surface transitions abruptly to washboard. You feel the front wheel start to skip. What's the correct immediate response?",
+      "options": [
+        {
+          "text": "Grip the bars tighter to maintain control of the front wheel",
+          "correct": false
+        },
+        {
+          "text": "Brake to reduce speed before the washboard gets worse",
+          "correct": false
+        },
+        {
+          "text": "Press weight down through the pedals, soften your hands, and bend your elbows",
+          "correct": true
+        },
+        {
+          "text": "Stand up to absorb the bumps with your legs",
+          "correct": false
+        }
+      ],
+      "explanation": "The weighted drop is the correct response to any unexpected surface change. Pressing weight through the pedals lowers your center of mass and stabilizes the bike. Softening your hands and bending your elbows lets the front wheel track over the washboard instead of bouncing off it. Gripping tighter amplifies the bounce. Braking on washboard reduces traction further. Standing can work but shifts weight forward — the seated weighted drop is the first move."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before Lesson 2: practice The Weighted Drop for 15 minutes on your next gravel ride. Do the Palm Check afterward — zero redness means you're ready."
+    },
+    {
+      "type": "callout",
+      "content": "Next lesson: Your Body Is the Suspension. You've moved the weight to your feet — now we separate the upper and lower body so you can pedal through rough terrain without your skeleton transmitting every bump to the handlebars. The key joint: the hip hinge.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/02-your-body-is-the-suspension.json
+++ b/data/courses/dirt-craft/lessons/02-your-body-is-the-suspension.json
@@ -1,0 +1,196 @@
+{
+  "id": "your-body-is-the-suspension",
+  "title": "Your Body Is the Suspension",
+  "module": "trust-the-bike",
+  "lesson_number": 2,
+  "blocks": [
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Rider is pedaling through a rough gravel section at 16 mph. Surface is broken hardpack with embedded rocks — not technical, just rough. Rider maintains the rigid skeleton position trained by 6 years of road cycling: stiff core, locked hips, shoulders braced, spine acting as a single column from saddle to helmet.\n\nEach pedal stroke drives the rider's full body weight into the saddle. The saddle transmits every surface irregularity upward through the spine with zero damping. The rider's head bounces 2-3 cm with every bump. Vision blurs. Line selection becomes reactive.\n\nRear wheel catches a 3-inch rut while the right pedal is at the bottom of the stroke. The rigid skeleton has nowhere to send the energy. The force transmits straight up through the locked spine, lifts the rider's hips off the saddle for a fraction of a second. When the hips land, they land off-center. The bike tracks left. The rider overcorrects right. The rear wheel, momentarily unweighted, skips sideways on the loose surface.\n\nDown at 16 mph. Hip bruise, torn shorts, bent derailleur hanger. The terrain was mundane — the kind of section that a skilled gravel rider pedals through without a second thought. The crash was caused by a skeleton that couldn't absorb a 3-inch rut because it had no hinge."
+    },
+    {
+      "type": "hero_stat",
+      "value": "74%",
+      "unit": "of mid-pack gravel crashes",
+      "context": "happen while pedaling through rough terrain — not coasting with active legs"
+    },
+    {
+      "type": "sensation_target",
+      "label": "Accordion between ribcage and pelvis",
+      "content": "Sit on your bike, hands on the hoods, feet on the pedals. Now imagine someone placed a book on your head and told you to keep it there while riding over bumps.\n\nYour head stays level. Your shoulders stay level. But your hips move — dropping into dips, rising over bumps, compressing and extending like an accordion between your ribcage and your pelvis. The distance between your lowest rib and your hip bone changes constantly. Your spine flexes and extends at the lumbar region, not at the neck or upper back.\n\nThis is the target sensation. Your upper body floats. Your lower body works. The dividing line is your hip hinge — roughly at your navel.\n\nHere's the test: ride 30 seconds of rough gravel and watch the horizon. If it bounces, your hinge isn't working — your skeleton is transmitting surface energy straight through to your head. If the horizon stays steady, you've found the separation. Your body just became the suspension fork your gravel bike doesn't have."
+    },
+    {
+      "type": "prose",
+      "content": "Road cycling rewards a rigid body. Stiff core, locked hips, every watt transferring cleanly from glutes to pedals to chain to rear wheel. On smooth pavement, this is correct. There's nothing to absorb, so rigidity equals efficiency.\n\nGravel punishes this same rigidity. The surface is constantly pushing back, and a rigid skeleton has only two options: transmit the force upward (your head bounces, your vision blurs, your line selection degrades) or get lifted off the saddle entirely (momentary loss of rear-wheel traction, exactly when you need it most).\n\nThe fix isn't \"relax.\" Telling a rigid rider to relax is like telling an insomniac to fall asleep. The fix is specific: learn to decouple your upper body from your lower body at the hip hinge.\n\nThink of your body as two separate systems connected by a universal joint:\n\n1. **Lower system** (hips, legs, feet) — drives the pedals, tracks with the terrain, absorbs vertical displacement through hip flexion and extension.\n2. **Upper system** (torso, shoulders, arms, head) — stays level, maintains vision, steers the bike.\n\nThe connection point is your lumbar spine and hip flexors. This is the decoupling joint. When it's working, your hips can move 4-6 inches vertically while your head moves less than half an inch."
+    },
+    {
+      "type": "callout",
+      "content": "This builds directly on Lesson 1's weighted drop. You've already moved your weight to your feet and lightened your hands. Now you're adding the second layer: separating what happens below the hinge from what happens above it. Heavy feet + quiet hands + active hinge = a rider who can pedal through anything.",
+      "style": "tip"
+    },
+    {
+      "type": "prose",
+      "content": "The hip hinge isn't a new movement — it's a movement you already do every time you walk down stairs. Your hips flex and extend to absorb each step while your head stays level. You just haven't done it on a bike."
+    },
+    {
+      "type": "callout",
+      "style": "highlight",
+      "content": "**One cue, whole-ride payoff.** A rider whose diagnosed fault was sitting too high on the bike got a single correction from his coach — get lower, drop the hips, bend the knees:\n\n\"One of the most valuable things I learned… did the most to improve my riding all around.\" — rider review, Ninja MTB clinic (theloamwolf.com)"
+    },
+    {
+      "type": "process",
+      "title": "The Hip Hinge",
+      "description": "Deploy whenever pedaling through rough terrain. This is the upper/lower body separation that turns your skeleton into a suspension system.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Find your neutral",
+          "detail": "Sit on the bike with a slight forward lean, hands on the hoods. Core engaged but not braced — think 30% tension, not 100%. Engaged means your trunk can flex and extend around a stable center. Rigid means it can't flex at all."
+        },
+        {
+          "step": 2,
+          "action": "Initiate from the hips, not the spine",
+          "detail": "When you hit a bump, your hips absorb it by flexing — pelvis tilts, femurs drive slightly upward, distance between ribcage and pelvis decreases. Lumbar spine flexes 10-15 degrees. Thoracic spine barely moves. Head doesn't move."
+        },
+        {
+          "step": 3,
+          "action": "Let the saddle move beneath you",
+          "detail": "The saddle bounces on rough terrain. Instead of bouncing with it (rigid) or hovering above it (exhausting), let your hips track the saddle's movement with a slight delay. Ride the saddle like a shock absorber, not a chair."
+        },
+        {
+          "step": 4,
+          "action": "Keep pedaling",
+          "detail": "The real skill is the hinge while pedaling. Your pedal stroke on rough terrain won't be as smooth as on pavement. That's fine. A slightly rough pedal stroke with rear-wheel traction beats a perfect pedal stroke that bounces you off the bike."
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "I rode gravel for three years as a single rigid unit. My neck hurt after every ride. My lower back screamed on washboard sections. I thought gravel was just uncomfortable. It wasn't — I was fighting my own skeleton."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Why This Works (Core Engagement vs. Core Rigidity)",
+          "content": "**Core rigidity** is what road cycling teaches: brace your trunk like you're about to take a punch. Every muscle fires at maximum, creating a stiff column from hips to shoulders. Great for a 20-second sprint on smooth tarmac. Terrible for 4 hours on gravel.\n\n**Core engagement** is what gravel demands: enough tension to maintain posture and protect your spine, but not so much that your trunk can't flex and extend. Think of a willow tree versus a telephone pole. Both are upright. One survives the wind.\n\nThe practical difference:\n\n- **Rigid core**: bump hits → force transmits through spine → head bounces → you can't see → you pick a bad line → you hit the next bump harder. Cascade.\n- **Engaged core**: bump hits → hips absorb → spine flexes 10-15 degrees → force dissipates in the hip flexors and obliques → head stays level → you see the next bump → you adjust. Absorption.\n\nHow to calibrate: on a scale of 1-10 core tension, road sprinting is a 9. Gravel cruising should be a 3-4. Rough gravel descending might be a 5-6. If you're above 7, you've crossed from engagement into rigidity."
+        }
+      ]
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Row and anti-row: how great riders 'lock into' the bike",
+          "content": "Lee McCormack has a name for the active version of what this lesson is teaching. When your bike rolls through a dip, the bars rock back toward you and you should **pull** — he calls that a **row**. When the bike rolls over a crest, the bars rock away and you should **push** — an **anti-row**. In his words: *\"When you're constantly executing a Row/Anti-Row cycle — even if it's tiny or sideways in a turn — you're not just balanced on your bike: YOU'RE LOCKED INSIDE YOUR BIKE.\"*\n\nThis is what separates a rider who sits on top of the bike, getting bounced around, from one who is welded to it through the terrain. The hip hinge is the position. Row and anti-row is what you *do* from that position — a continuous, tiny give-and-take through the arms and legs that keeps both wheels pressed into the ground. You're not holding still. You're actively rowing the bike into the trail. (Source: leelikesbikes.com/row-anti-row.)"
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### Why Vision Is the Proof\n\nYour head is the ultimate sensor for whether the hinge is working. The vestibular system in your inner ear detects head movement with extreme sensitivity. When your head bounces, three things happen:\n\n1. **Vision degrades.** Your eyes can't stabilize on a target that's moving relative to the terrain. Line selection becomes reactive instead of predictive.\n2. **Balance degrades.** The vestibular system interprets head bounce as instability. Your grip tightens reflexively — and now you've lost the quiet hands from Lesson 1.\n3. **Fatigue accelerates.** Your neck muscles fire constantly trying to stabilize your head. Over a 5-hour ride, this is a significant energy drain that shows up as neck pain, headaches, and upper back tension.\n\nThis is why the proof gate for this lesson is reading a road sign on washboard. If your head is level enough to read text, the hinge is working. If the letters blur, you're still a rigid column."
+    },
+    {
+      "type": "drill",
+      "title": "Stable Head, Moving Hips",
+      "time_minutes": 20,
+      "description": "Six passes through a 200-meter washboard section, building from vision focus to full pedaling with active hip hinge. The goal is to decouple your upper body from the terrain.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "200m washboard, easy pace, coasting allowed",
+          "steps": [
+            "Find a 200-meter section of washboard or consistently rough gravel. Flat or very slight grade.",
+            "Pass 1: Coast through the section. Focus entirely on keeping your eyes locked on a fixed point ahead — a sign, a tree, a fence post. Notice how much your vision bounces. Rate it 1-10.",
+            "Pass 2: Same thing, but now consciously soften your hips. Let the saddle move beneath you. Imagine your pelvis is floating on water. Eyes still locked on the fixed point. Rate vision bounce again.",
+            "Pass 3: Add Lesson 1's weighted drop — heavy feet, quiet hands. Now add the hip hinge. Three systems running simultaneously. Vision bounce should be noticeably less than Pass 1.",
+            "Pass 4: Start pedaling at an easy cadence. Expect the hinge to feel harder now. Your legs are doing two jobs: driving the cranks and absorbing terrain. Keep eyes on the fixed point.",
+            "Pass 5: Increase cadence to your normal comfortable spin. Maintain the hinge while pedaling. This is the hard part — the temptation is to lock up and just power through.",
+            "Pass 6: Free ride at whatever pace feels natural. Don't think about the hinge. Check: can you read a road sign or license plate while riding through? If yes, the hinge is becoming automatic."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "200m rough section, moderate pace, continuous pedaling",
+          "steps": [
+            "Same 200m section, but rougher surface — broken hardpack, loose rock, or mixed terrain with embedded obstacles.",
+            "Pass 1-2: Pedal through at endurance pace. Focus on keeping the horizon line steady in your vision. If you have a head-mounted camera, review the footage — the difference between rigid and hinged is dramatic.",
+            "Pass 3-4: Increase to tempo pace. The hinge gets harder to maintain as effort increases because your core naturally braces when you push harder. Consciously keep core tension at 4-5, not 7-8.",
+            "Pass 5-6: Add out-of-saddle sections. Stand for 10 seconds, then sit back down and immediately re-engage the hinge. The stand-to-sit transition is where most riders lock up. Practice making it smooth.",
+            "Between passes, check three things: (1) Can I read text at distance while riding? (2) Are my hands still light? (3) Does my lower back feel loose, not rigid?"
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "200m rough section, sweet spot power, with surges",
+          "steps": [
+            "Warm up 10 minutes, practicing the hinge at endurance pace on rough gravel.",
+            "4 x 200m passes at sweet spot (88-93% FTP) on the rough section. Each pass includes one 15-second seated surge to threshold.",
+            "The surge is the real test: when power increases, your body wants to lock up. Can you surge to 105% FTP on rough gravel while maintaining the accordion? If your vision bounces during the surge, you lost the hinge.",
+            "Recovery between passes: 90 seconds easy spinning on smooth ground. Use recovery to reset — heavy feet, quiet hands, soft hips. The reset between efforts is as important as the efforts.",
+            "After 4 passes: 5-minute free ride on the roughest terrain you can find. Moderate power, full hinge. If you can hold a conversation and read signs, the decoupling is sticking under fatigue.",
+            "Post-drill check: neck tension, lower back tension, palm soreness. All three should be minimal. If your neck hurts, your head was bouncing. If your lower back hurts, you were hinging at the wrong vertebrae — it should be lumbar/hip, not thoracic."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "Can read a road sign while riding washboard at moderate pace.",
+        "metric": "binary",
+        "target": "Read a road sign or license plate clearly while pedaling through 200m of washboard at 12+ mph"
+      }
+    },
+    {
+      "type": "prose",
+      "content": "### Common Mistakes\n\n**Hinging at the waist instead of the hips.** If you fold forward when you hit bumps, you're flexing at the thoracolumbar junction (around T12-L1) instead of at the hip joint. This loads your lower back and doesn't absorb much. The correct hinge is at the hip — your femur rotates in the hip socket, your pelvis tilts, and your lumbar spine flexes as a secondary movement.\n\n**Hovering above the saddle.** Some riders interpret \"let the saddle move beneath you\" as \"hover above the saddle.\" This works for 30 seconds, then your legs are toast. The goal is to maintain saddle contact with a compliant connection, not to stand on the pedals permanently. Your weight should still be partially on the saddle — just not rigidly.\n\n**Abandoning the weighted drop.** The hinge is Layer 2. The weighted drop from Lesson 1 is Layer 1. Both must run simultaneously. If you focus so hard on the hinge that you shift weight back to your hands, you've traded one problem for another. Heavy feet, quiet hands, active hinge — in that order of priority."
+    },
+    {
+      "type": "video",
+      "id": "c2DUQeeAgNQ",
+      "mtb_demo": true,
+      "title": "The Hinge: The Most Essential Mountain Bike Skill",
+      "channel": "The Pro's Closet",
+      "caption": "The hip hinge in side profile — the exact movement this lesson builds."
+    },
+    {
+      "type": "video",
+      "id": "Y3jdHYO3_zs",
+      "title": "Scalloping corners - rowing and anti-rowing sideways",
+      "channel": "Lee Likes Bikes / Lee McCormack",
+      "mtb_demo": true,
+      "caption": "McCormack demonstrates scalloping and the row/anti-row cycle — the active version of what this lesson teaches."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "When riding rough gravel, what is the primary joint responsible for decoupling the upper body from terrain vibration?",
+      "options": [
+        {
+          "text": "The knee — bent legs absorb bumps before they reach the torso",
+          "correct": false
+        },
+        {
+          "text": "The elbow — bent arms are the front suspension",
+          "correct": false
+        },
+        {
+          "text": "The hip — hip flexion and extension absorb vertical displacement while the upper body stays level",
+          "correct": true
+        },
+        {
+          "text": "The ankle — dropped heels create a spring-like absorption system",
+          "correct": false
+        }
+      ],
+      "explanation": "The hip joint is the primary decoupling point. While bent elbows (Lesson 1) handle front-end absorption and dropped heels lower the center of mass, the hip hinge is what separates the upper and lower body into two independent systems. Hip flexion and extension allow 4-6 inches of vertical displacement at the saddle while keeping the head movement under half an inch. Knees and ankles contribute, but they're part of the lower system — the hip is the dividing line."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before Lesson 3: ride 200 meters of washboard and read a sign while riding it. If your vision bounces, you haven't found The Hip Hinge yet."
+    },
+    {
+      "type": "callout",
+      "content": "Next lesson: Where Traction Actually Lives. You've built the weighted drop and the hip hinge. Now we tackle the other half of the equation — the tires. Specifically: why the pressure you're running is almost certainly too high, and how to find your personal traction window through systematic experimentation instead of guesswork.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/03-where-traction-lives.json
+++ b/data/courses/dirt-craft/lessons/03-where-traction-lives.json
@@ -1,0 +1,205 @@
+{
+  "id": "where-traction-lives",
+  "title": "Where Traction Actually Lives",
+  "module": "trust-the-bike",
+  "lesson_number": 3,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "12-18 PSI",
+      "unit": "typical pressure gap",
+      "context": "between what road converts run on gravel and what actually grips — that gap is costing you speed, comfort, and flats"
+    },
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Rider lines up for a 100-mile gravel race on 42mm tires at 45 PSI. This is 10 PSI below their road pressure. They consider this \"low\" and feel they've adjusted for the surface.\n\nMile 8. Hardpack gravel with embedded rocks. Every rock transmits a sharp jolt through the bars. The tires bounce off the surface rather than conforming to it. The rider's contact patch — the area of tire actually touching the ground — is roughly the size of a thumbprint. On road at this pressure, that's fine. On gravel, it means the tire is riding on top of the surface instead of gripping it.\n\nMile 23. A sweeping left-hand turn on loose-over-hard. The tire skips across the loose marbles instead of pressing through them to the hard base beneath. The rider grabs the brakes — the front wheel washes. They save it, barely. Heart rate spikes to 175. Confidence drops.\n\nMile 41. A rocky descent with walnut-sized stones. At 45 PSI, the tire has zero compliance. Each stone is a binary event: the tire either rolls over it cleanly or deflects off it. One stone catches the rim. Pinch flat. They tube it — 12 minutes lost plus the CO2.\n\nMile 67. Second flat. Same mechanism. They're out of tubes and CO2.\n\nMile 67 to mile 78. Walking. Eleven miles.\n\nThe math is brutal. At 28-32 PSI on those same 42mm tires, the contact patch roughly doubles. The tire conforms around rocks instead of bouncing off them. Rolling resistance on rough surfaces actually DECREASES at lower pressure because the tire absorbs bumps instead of bouncing over them. The rim sits further from the ground, making pinch flats nearly impossible with tubeless setup.\n\nThe rider's pressure choice — made in a parking lot based on road instincts — cost them 90 minutes and a finish."
+    },
+    {
+      "type": "sensation_target",
+      "label": "Quiet tires",
+      "content": "Ride a section of rough gravel at your current pressure. Listen to the tires. You'll hear a high-pitched buzzing or chattering — the sound of rubber bouncing off the surface hundreds of times per second. The tires are fighting the terrain.\n\nNow drop 5 PSI and ride the same section. The pitch drops. The chattering softens. The bike feels like it sank into the surface by a few millimeters.\n\nDrop another 5 PSI. The buzzing may stop entirely. What replaces it is a low hum — the sound of rubber conforming to the surface, deforming around irregularities instead of bouncing off them. The bike feels planted. Traction appears where there was none. You feel the ground THROUGH the tire instead of the tire bouncing OFF the ground.\n\nThis is the target sensation: quiet tires. When the buzzing stops and the hum starts, you've found the pressure where your tires are working with the surface instead of against it.\n\nThere's a floor below this — go too low and the tire squirms in corners, the sidewall flexes uncomfortably, and rim strikes become possible (even tubeless). But the floor is much lower than most riders think. The drill in this lesson will help you find it precisely."
+    },
+    {
+      "type": "prose",
+      "content": "Most gravel riders run too much pressure. Not by a little — by a lot. The reason is simple: road cycling trained you that lower pressure means pinch flats, sluggish handling, and increased rolling resistance. On smooth pavement, all of that is true.\n\nI ran 45 PSI on 40mm tires for an embarrassing number of months after switching to gravel. Bounced over everything, pinch-flatted twice in one ride, white-knuckled every descent — and genuinely believed gravel was just supposed to feel that violent. Then a guy at a group ride watched me air up and said, \"Dude, drop ten PSI and try the next section.\" I thought he was insane. Within 200 meters the bike felt like a completely different machine. That was the moment I realized I'd been solving the wrong problem — fighting the surface instead of letting the tire work with it.\n\nOn gravel, the physics invert."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Why This Works (The Rolling Resistance Inversion)",
+          "content": "On a perfectly smooth surface, a harder tire rolls faster because less rubber deforms at the contact patch. This is why road tires run 80-100 PSI — minimal deformation, minimal energy loss.\n\nBut gravel isn't smooth. When a hard tire hits a bump, it doesn't deform around the bump — it bounces over it. That bounce is wasted energy. The tire lifts off the surface, travels through the air, lands, and has to re-establish grip. Multiply this by thousands of bumps per mile and the energy loss from bouncing FAR exceeds the energy saved by reduced tire deformation.\n\nA softer tire hits the same bump and deforms around it. The rubber flexes, absorbs the impact, and the tire maintains contact with the surface. No bounce, no air time, no re-establishment of grip. The energy goes into hysteresis (rubber flexing) instead of kinetic energy (tire bouncing). Hysteresis losses are small. Bouncing losses are large."
+        },
+        {
+          "title": "Research: Rene Herse Tire Testing",
+          "content": "Rene Herse's testing found that on rough surfaces, lower pressure is measurably faster — not just more comfortable, but actually faster. The crossover point depends on surface roughness, but for typical gravel it's well below what most riders run."
+        }
+      ]
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Why Wider Tires Are Faster on Gravel",
+          "content": "This follows the same physics. A wider tire at the same pressure has a shorter, wider contact patch. A narrower tire has a longer, thinner contact patch. On smooth surfaces, the narrower patch creates slightly less rolling resistance. On rough surfaces, the wider patch provides:\n\n- **More float.** The tire rides on top of loose gravel instead of cutting through it.\n- **More compliance.** More air volume means more suspension effect at the same pressure.\n- **Lower required pressure.** A 42mm tire at 30 PSI has roughly the same casing tension as a 28mm tire at 55 PSI. The wider tire can run lower pressure without risking rim strikes.\n\nLachlan Morton ran 2.1-inch tires on the front at Unbound 200. Not because he needed mountain bike tires on a gravel road — because wider means lower pressure means more grip means faster on rough surfaces. The limiting factor isn't tire width. It's frame clearance and your willingness to look at a bike that doesn't match the magazine photos."
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### The Pressure Window\n\nEvery tire-rider-surface combination has a window:\n\n- **Ceiling**: the pressure above which you're bouncing more than gripping. Comfort degrades, traction drops, flat risk from rim impacts actually increases because the tire can't absorb the hit.\n- **Floor**: the pressure below which the tire squirms in corners, the sidewall folds under hard cornering loads, and rim strikes become possible even with tubeless setup.\n- **Sweet spot**: typically in the lower third of the window. This is where the tire is compliant enough to conform to the surface but stiff enough to corner predictably.\n\nThe window width varies:\n\n- **Hardpack gravel**: Window is 8-12 PSI wide. You have room to err.\n- **Loose-over-hard**: Window narrows to 5-8 PSI. Too high and you bounce on the marbles. Too low and the tire squirms.\n- **Sand or mud**: Window is narrow and low. You want maximum float — the floor is defined by rim protection, not cornering stability.\n- **Rocky/chunky**: Window shifts lower. The tire needs to absorb rock impacts, and the rim needs clearance from strikes.\n\nThe calculator below gives you a starting point. The drill teaches you to find your exact window by feel."
+    },
+    {
+      "type": "process",
+      "title": "The Pressure Window",
+      "description": "Deploy before any race or new tire setup. This is the field method for finding your personal pressure range — not a formula, but a systematic protocol you run on actual terrain.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Start at your current pressure",
+          "detail": "Write down the number. Ride a consistent gravel section — one corner, one rough straight. Rate grip confidence 1-10."
+        },
+        {
+          "step": 2,
+          "action": "Drop 2 PSI from both tires",
+          "detail": "Maintain your front/rear split. Ride the same section at the same pace. Rate grip again. Repeat until you've dropped 10-12 PSI total."
+        },
+        {
+          "step": 3,
+          "action": "Find the ceiling",
+          "detail": "Note the pressure where grip confidence jumped — where the buzzing stopped and the tires went quiet. This is the top of your window."
+        },
+        {
+          "step": 4,
+          "action": "Find the floor",
+          "detail": "Note the pressure where the tire started to squirm in corners or feel vague. This is the bottom of your window."
+        },
+        {
+          "step": 5,
+          "action": "Set your sweet spot",
+          "detail": "Your race pressure lives in the lower third of the window. Record tire model, width, surface type, rider weight, and the window. This is your personal pressure chart."
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### Tire Pressure Window Calculator\n\nStarting-point pressure recommendations based on your setup and terrain. These are STARTING POINTS — the drill below will help you refine to your personal sweet spot.\n\n**How it works:** Base pressure = (rider_weight * 0.18) adjusted by tire volume (width * rim_width), surface modifier (hardpack +3, loose -2, chunky -3, sand -5, mixed 0), and front/rear split (front = base - 2, rear = base + 1). Wider rims allow 1-2 PSI lower. These are tubeless assumptions — add 3-5 PSI for tubed setups.\n\n**Race Setup Card:** When connected to a race profile, pre-populates surface breakdown and adjusts for altitude and climate risk factors.\n\n_Interactive calculator coming soon — the numbers above are the method._"
+    },
+    {
+      "type": "callout",
+      "content": "These numbers assume tubeless tires with fresh sealant. If you're running tubes, add 3-5 PSI to all values — tubes have a hard pinch-flat floor that tubeless eliminates. If you haven't gone tubeless yet, Lesson 11 covers the setup. For now, use the tubed numbers and know that your pressure window will get wider and lower when you make the switch.",
+      "style": "tip"
+    },
+    {
+      "type": "callout",
+      "style": "highlight",
+      "content": "**Setup confidence is real confidence.** One gravel racer, one month apart — before, he got shelled on every descent; after, he'd changed two things: he relaxed, and he went wider:\n\nBefore: \"I lack skill and 'the nerve' to descend fast… riders blasting past me on the fast line.\"\n\nAfter: \"It did help to think about staying loose and let the bike roll. I also upgrade tires… 35mm… They were great!\" — Hypno Toad, bikeforums.net (28mm → 35mm)"
+    },
+    {
+      "type": "prose",
+      "content": "### Front/Rear Split\n\nYour weight distribution on a gravel bike is roughly 40/60 front/rear. This means the rear tire carries more load and needs slightly more pressure to avoid bottoming out.\n\nThe standard split: **front runs 2-3 PSI lower than rear.**\n\nWhy not equal? Because the front tire's job is traction and steering feel. Lower pressure gives you a larger contact patch and more grip for cornering and braking — exactly where you need it. The rear tire's job is supporting your weight and transferring power. It needs slightly more structure to avoid squirm under pedaling loads.\n\nSome riders run an even larger split — 4-5 PSI lower in front — on particularly loose surfaces where front-end grip is the limiting factor. This is a valid approach but makes the rear more prone to bouncing. Start with 2-3 PSI split and experiment."
+    },
+    {
+      "type": "prose",
+      "content": "### The Sealant Factor\n\nTubeless sealant is what makes low gravel pressures possible. Without it, every thorn, sharp rock, and wire fence fragment means a flat. With it, small punctures seal automatically — often without the rider even noticing.\n\nBut sealant degrades. Most latex-based sealants lose effectiveness after 2-4 months as the liquid latex dries out. If you set your tires up in March and race in June, your sealant may be a dried-up ring of rubber inside the tire.\n\nChecklist before dialing in pressure:\n\n- **Fresh sealant**: Added or topped off within the last 6-8 weeks.\n- **Correct amount**: 2-3 oz (60-90ml) per tire for 40-50mm gravel tires. More isn't better — excess sealant adds rotating weight and sloshes.\n- **Bead seated**: Shake the wheel and listen. If you hear a large volume of liquid sloshing, the sealant hasn't coated the inside of the casing. Spin the wheel on its axis and lay it flat for 10 minutes each side.\n- **Valve core clear**: Dried sealant in the valve core prevents accurate pressure readings and makes field inflation difficult. Remove and clean cores every sealant change."
+    },
+    {
+      "type": "drill",
+      "title": "Traction Exploration",
+      "time_minutes": 25,
+      "description": "Ten passes through the same gravel corner or section at progressively lower pressure. You'll map your personal traction envelope — where grip improves, where it peaks, and where it degrades.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Flat gravel loop with one consistent corner, slow pace",
+          "steps": [
+            "You need: a floor pump with an accurate gauge (digital preferred), a short gravel loop with at least one consistent corner, and 25 minutes.",
+            "Start at your current pressure. Write it down. Ride the loop once at a comfortable pace. Focus on the corner: how does the front tire feel? Does it skip, slide, or grip? Rate grip confidence 1-10.",
+            "Stop. Release 2 PSI from both tires (maintain front/rear split — drop both equally). Ride the loop again. Same pace, same corner. Rate grip confidence.",
+            "Repeat: drop 2 PSI, ride, rate. Do this for 10 total passes. You'll cover a range of roughly 20 PSI.",
+            "At some point, grip confidence will improve dramatically — this is the traction window opening up. Note the pressure where this happens.",
+            "At some lower point, the tire may start to feel squirmy or vague in the corner — the sidewall is flexing too much. Note this pressure too.",
+            "Your window is between these two points. Your sweet spot is in the lower third.",
+            "After the drill: pump back to the recommended pressure and ride for 10 minutes to confirm it feels right. Adjust by 1-2 PSI if needed.",
+            "Record your findings: tire model, width, surface type, rider weight, pressure window. This is the beginning of your personal pressure chart."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Mixed-surface loop with corners and rough sections",
+          "steps": [
+            "Same protocol as beginner, but on a loop that includes at least two surface types — hardpack and loose, or hardpack and chunky.",
+            "10 passes, 2 PSI drops per pass. But now you're rating TWO things: corner grip (1-10) and rough-section comfort (1-10).",
+            "You'll likely find that the optimal pressure for cornering and the optimal pressure for straight-line comfort are slightly different. Corner grip improves as you go lower. Straight-line comfort has a sweet spot — go too low and the tire starts feeling sluggish and vague.",
+            "Your race pressure is the compromise between these two: low enough for confident cornering, high enough for efficient straight-line riding.",
+            "Advanced note: if your race has long gravel road sections AND technical corners, consider adjusting pressure at aid stations. 2-3 PSI takes 30 seconds to release or add. Some races are worth the stop."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Race-simulation loop at tempo effort",
+          "steps": [
+            "Same protocol, but ride each pass at tempo effort (76-87% FTP). Higher effort changes how you load the tires — more force through the pedals, more weight shift under power.",
+            "This is closer to race reality. At endurance pace, almost any pressure feels \"fine.\" At tempo on loose gravel, the wrong pressure makes itself known quickly — the rear tire breaks traction on power surges, or the front pushes in corners when you're breathing hard and riding less precisely.",
+            "5 passes at current pressure, then 5 passes at calculator-recommended pressure. Record average lap time for each set of 5.",
+            "Most riders find the lower pressure set is 2-4% faster at the same power. That's 5-10 minutes over a 100-mile race. Free time from air pressure.",
+            "Pair this with the weighted drop from Lesson 1 and the hip hinge from Lesson 2. Low pressure gives the tire more grip. The weighted drop and hinge give you the body position to use that grip. The combination is where real gravel speed lives."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "Can state your personal pressure window for 3 surface types without looking it up.",
+        "metric": "recall",
+        "target": "From memory, state your front and rear pressure for hardpack, loose-over-hard, and chunky gravel — within 2 PSI of your tested values"
+      }
+    },
+    {
+      "type": "prose",
+      "content": "### Building Your Pressure Chart\n\nAfter running the Traction Exploration drill on different surfaces, you'll have the data to build a personal pressure chart. This isn't theoretical — it's YOUR weight, YOUR tires, YOUR tested windows.\n\nA simple version:\n\n| Surface | Front PSI | Rear PSI |\n|---------|-----------|----------|\n| Hardpack | ___ | ___ |\n| Loose/marble | ___ | ___ |\n| Chunky/rocky | ___ | ___ |\n| Sand/mud | ___ | ___ |\n| Mixed (race default) | ___ | ___ |\n\nTape this to your top tube or photograph it on your phone. Before a race, check the course profile for dominant surface types and set pressure accordingly. In Lesson 8, we'll connect this to the race database — the tire pressure calculator will pull surface breakdown data from any of 757 race profiles and give you a race-specific starting pressure.\n\nFor now, build the chart from field testing. The numbers you discover through deliberate experimentation are worth more than any formula, including the calculator above. The calculator gets you in the ballpark. The drill gets you to the seat."
+    },
+    {
+      "type": "prose",
+      "content": "### Weather Adjustments\n\nRain changes everything about tire pressure.\n\n**Wet surfaces**: Drop 3-5 PSI below your dry numbers. Lower pressure increases the contact patch, which increases grip on slick surfaces. The risk of rim strikes is actually lower in wet conditions because the ground is softer.\n\n**Cold**: Tire pressure drops roughly 1 PSI per 10-degree Fahrenheit drop in temperature. If you inflate in a warm garage and ride in 40-degree morning air, you've already lost 3-4 PSI. Set your pressure in the conditions you'll ride in, not in the parking lot.\n\n**Altitude**: Above 5,000 feet, the lower atmospheric pressure means your tire's effective pressure relative to the outside air is slightly higher. Drop 1-2 PSI at altitude. This matters more than most riders realize at races like Leadville or SBT GRVL.\n\n**Mud**: Go as low as your tire and rim will allow. Mud riding is about float — keeping the tire on top of the surface instead of cutting through it. The wider the tire and the lower the pressure, the more float. On genuinely muddy courses, some riders drop to 20-22 PSI on 45mm tires. This would be suicidal on rocky terrain but is optimal in mud."
+    },
+    {
+      "type": "video",
+      "id": "Pki1tNbQfQ4",
+      "title": "The perfect gravel psi? My Unbound testing with Silca",
+      "channel": "The Ride with Ben Delaney",
+      "caption": "Real-world gravel pressure testing — how the numbers actually shake out."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're lining up for a 120-mile gravel race. Course is 60% loose-over-hardpack, 30% chunky rock, 10% pavement. Rain started overnight and the course is wet. You're 170 lbs with gear, riding 42mm tubeless tires. Your dry loose-over-hard pressure is 30F/33R. What pressure do you set?",
+      "options": [
+        {
+          "text": "30F/33R — your tested dry numbers are your numbers, rain or not",
+          "correct": false
+        },
+        {
+          "text": "27F/30R — drop 3 PSI for wet conditions across both tires",
+          "correct": true
+        },
+        {
+          "text": "35F/38R — increase pressure to prevent the tire from squirming on wet, slippery surfaces",
+          "correct": false
+        },
+        {
+          "text": "25F/25R — go as low as possible for maximum grip in the rain",
+          "correct": false
+        }
+      ],
+      "explanation": "Wet conditions call for a 3-5 PSI drop from your tested dry numbers. This increases the contact patch, improving grip on slick surfaces. Increasing pressure does the opposite of what you want — smaller contact patch, less grip, more bouncing. Going extremely low (25/25) ignores the front/rear split and risks sidewall fold on the 30% chunky sections. The correct answer maintains your tested front/rear relationship and applies the wet-condition adjustment. This is also a case where knowing your numbers from the Traction Exploration drill pays off — you're adjusting from a known baseline, not guessing."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before Lesson 4: find your Pressure Window for one surface type. Drop 2 PSI at a time until you feel the tires go quiet, then note where grip degrades. Write down your range."
+    },
+    {
+      "type": "callout",
+      "content": "Next lesson: The Quiet Eye. You've built the weighted drop, the hip hinge, and dialed your tire pressure. Now we address where you're looking — because target fixation (staring at the rock) is how you hit the rock. Lesson 4 teaches the scanning hierarchy that lets obstacles steer around themselves while you focus 3-5 seconds ahead.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/04-the-quiet-eye.json
+++ b/data/courses/dirt-craft/lessons/04-the-quiet-eye.json
@@ -1,0 +1,169 @@
+{
+  "id": "the-quiet-eye",
+  "title": "The Quiet Eye",
+  "module": "trust-the-bike",
+  "lesson_number": 4,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "0.8s",
+      "unit": "minimum fixation time",
+      "context": "for accurate line selection at 18 mph — most panicking riders fixate for 0.2-0.3 seconds, then jerk to the next obstacle"
+    },
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Rider descends a gravel doubletrack at 18 mph. Surface is mixed — packed dirt with embedded fist-sized rocks and a few shallow ruts. Rider's eyes are locked on the rocks 5 feet ahead of the front wheel. Each rock triggers a correction: a jerk left, a jerk right, another left.\n\nThe rider is playing whack-a-mole with the terrain. Every obstacle demands a conscious steering input. Arms are tense from constant correction. The weighted drop from Lesson 1 is gone — hands are loaded because the arms are doing steering work every half-second.\n\nAt the bottom of the descent, the packed dirt transitions to a 15-foot sand patch — visible from 50 meters away to anyone looking for it. The rider doesn't see it. Their eyes are busy cataloging the next rock, 5 feet ahead.\n\nFront wheel hits the sand at 17 mph with no weight adjustment, no speed reduction, no line correction. The wheel digs in and stops. The rider doesn't.\n\nShoulder contusion. Torn bar tape. The rock field was never the problem. The sand patch was the problem, and it was in plain sight the entire time — just not in the rider's sight."
+    },
+    {
+      "type": "callout",
+      "style": "highlight",
+      "content": "**Riders who fixed their eyes say the same thing.** The moment they stopped staring at the front wheel, the speed stopped feeling like an emergency:\n\n\"We tend to focus on the wheels right in front of us. That makes us reactive vs proactive… As soon as I looked ahead… I could actually carve even deeper if I needed to and it felt easy.\" — Power13, TrainerRoad forum\n\n\"Look as far down the trail as possible and dont look at what is directly in front of you.\" — top-voted cue, MTBR descending thread"
+    },
+    {
+      "type": "sensation_target",
+      "label": "Soft eyes — wide gaze, far focus",
+      "content": "Here's what you're looking for: let your eyes go slightly unfocused, like you're staring at a landscape painting instead of reading a text message. Your focal point sits 3-5 seconds ahead of the bike — at 15 mph, that's roughly 65-110 feet. The near field — rocks, roots, ruts within 10 feet — is handled by peripheral vision.\n\nWhen it's right, obstacles seem to steer around themselves. You don't consciously decide to go left of that rock. Your hands make the correction automatically because your peripheral vision registered the rock a full second before you reached it and your motor system handled the adjustment without involving the panic department.\n\nWhen it's wrong, you feel like you're playing a video game — every obstacle is a discrete event requiring a conscious decision. Your arms are busy. Your hands are loaded. You're exhausted after 5 minutes of rough terrain because your brain processed every single rock individually.\n\nThe test: ride 2 minutes of rough gravel, then ask yourself — did I make individual decisions about obstacles, or did the bike just flow through them? If you can't remember the specific rocks you avoided, your quiet eye is working. If you can describe each one, you were target-fixating."
+    },
+    {
+      "type": "prose",
+      "content": "### Why Your Eyes Are Lying to You\n\nYour visual system has two modes, and gravel requires the one you almost never use on the road.\n\n**Central vision** is the sharp, high-resolution cone in the center of your visual field — roughly 2-3 degrees wide. This is what you use to read, to identify, to focus. On the road, central vision does almost all the work: read the sign, spot the pothole, track the wheel ahead.\n\n**Peripheral vision** covers the remaining 170+ degrees. It's low-resolution but extremely fast at detecting motion, contrast changes, and spatial relationships. It operates largely below conscious awareness.\n\nOn pavement, central vision dominates because the surface is predictable. You only need to spot the occasional hazard. On gravel, the surface IS the hazard — every square foot contains visual information. If you try to process gravel with central vision, you overload immediately. Your eyes dart from obstacle to obstacle. Each fixation lasts 0.2-0.3 seconds — too short for your motor system to plan a smooth response. The result is reactive, jerky handling.\n\nThe fix: push central vision far ahead and let peripheral vision handle the near field. This is exactly backward from what your instincts demand. Your brain wants to stare at the thing that might hurt you. Staring at it is what makes you hit it."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Why This Works (Target Fixation Neuroscience)",
+          "content": "Target fixation isn't a metaphor. It's a documented neuromuscular phenomenon: you steer toward whatever you focus your central vision on. Motorcyclists learn this on day one of training. Cyclists rarely learn it at all.\n\nThe mechanism: your hands follow your eyes. When you fixate on a rock, your vestibular system and motor cortex subtly orient the bike toward that rock. The harder you stare — the more urgently you think \"don't hit that\" — the more precisely you steer toward it. The survival instinct to watch the threat IS the mechanism that causes the collision.\n\nThis is why Lesson 1's weighted drop matters here. When your hands are light (Lesson 1) and your hips are the hinge (Lesson 2), the front wheel has the freedom to track around small obstacles on its own. Your peripheral vision spots the rock, your hands make a micro-correction below conscious awareness, and the bike flows through. But this only works if your central vision is somewhere else — far ahead, scanning the big picture.\n\nIf you're staring at the rock AND your hands are loaded, two systems are fighting: target fixation is steering you toward the rock while your conscious mind is trying to steer you away from it. Conscious corrections at 18 mph are too slow. Target fixation wins."
+        }
+      ]
+    },
+    {
+      "type": "process",
+      "title": "The Quiet Eye",
+      "description": "Deploy on every rough section, descent, and unfamiliar terrain. This is the scanning hierarchy that replaces reactive obstacle-dodging with predictive terrain reading.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Surface type (far vision, 4-6 seconds ahead)",
+          "detail": "Identify what you're riding into — hardpack, loose, sand, wet. This is the strategic scan. It determines whether you need to adjust speed, pressure distribution, or body position before you arrive."
+        },
+        {
+          "step": 2,
+          "action": "Line (mid vision, 2-4 seconds ahead)",
+          "detail": "Find the smoothest, most predictable path for the surface ahead. On gravel, the best line is almost never the geometric shortest path. It's the one with the most consistent surface."
+        },
+        {
+          "step": 3,
+          "action": "Obstacle (peripheral vision, 0-2 seconds ahead)",
+          "detail": "Specific objects that need micro-corrections. Handled by peripheral vision and automatic motor responses — NOT by central vision and conscious steering."
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "Most struggling riders invert this hierarchy completely. They scan obstacles first (central vision locked 5 feet ahead), occasionally glance at line (mid-range), and almost never scan surface type (far ahead). They're answering the least important question with their most powerful visual tool while ignoring the most important question entirely.\n\nThe Quiet Eye is really just restoring the correct hierarchy: surface → line → obstacle, far → mid → peripheral."
+    },
+    {
+      "type": "callout",
+      "content": "The Lesson 3 traction work connects directly here. When you know your tire pressure window and you've felt where grip lives on different surfaces, the surface-type scan becomes actionable — you're not just seeing that the surface changes, you're predicting exactly how the bike will respond. Quiet eyes plus traction knowledge means you're reading the terrain like a book instead of reacting to it like a pinball machine.",
+      "style": "tip"
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Research: The 0.8-Second Quiet Eye Threshold",
+          "content": "Sports vision research on athletes in targeting and interception tasks found a critical threshold: expert performers fixate on their target for at least 0.8 seconds before initiating movement. This \"quiet eye\" period — a single, stable fixation — gives the motor system enough time to plan and execute a smooth, accurate response.\n\nBelow 0.8 seconds, accuracy degrades sharply. The movements become reactive instead of planned — exactly the jerky, obstacle-by-obstacle riding pattern from central-vision overload.\n\nOn gravel at 18 mph, you cover about 26 feet per second. A 0.8-second fixation means your eyes should hold steady on a point roughly 20 feet ahead while your peripheral vision handles everything closer. At higher speeds, the fixation point moves farther out — at 25 mph, 30+ feet ahead. At lower speeds, it comes in — at 10 mph, 12 feet is sufficient. The constant isn't distance, it's TIME: hold the fixation for 0.8 seconds minimum before moving to the next scan point."
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "I rode gravel for years with my eyes glued to the ground 5-8 feet ahead. Constant corrections, tired arms, near-misses. The first time I deliberately pushed my focal point out to 3 seconds ahead, the bike felt like it was on rails. Same trail. Same tires. Same rider — just looking in the right place."
+    },
+    {
+      "type": "drill",
+      "title": "Target Stare",
+      "time_minutes": 20,
+      "description": "100-meter repetitions at progressive speeds. The goal is to retrain your default focal distance — pushing central vision far ahead while peripheral vision handles the near field. You'll feel exposed at first. That's the point.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Smooth to moderate gravel, 10 mph",
+          "steps": [
+            "Find a straight gravel road or path with at least 100 meters of clear sightline. Mild surface texture — small gravel, light washboard, minor ruts. Nothing that requires major line changes.",
+            "Pick a visible target point at the far end of the 100m — a fence post, tree, sign, road marker. Something fixed and obvious.",
+            "Rep 1-3: Ride the 100m at 10 mph with your central vision locked on the far target. Do NOT look down at the ground in front of you. Let your peripheral vision handle the near field. Your hands will want to tighten — keep the Lesson 1 weighted drop: heavy feet, quiet hands.",
+            "Rep 4-6: Same speed, same target lock, but now consciously notice what your peripheral vision is picking up. Can you sense the surface changes and small obstacles without looking at them directly? You should feel adjustments happening in your hands that you didn't consciously decide.",
+            "Rep 7-10: Same speed, but pick a NEW target point for each rep — a different far-field object. Practice shifting your gaze from one far target to another without letting it drop to the near field between shifts.",
+            "After 10 reps, ride 2 minutes freely. Check: did your focal distance drift back to 5 feet? If so, your default hasn't shifted yet — repeat the drill next ride."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Chunky gravel with obstacles, 15 mph",
+          "steps": [
+            "Same 100m format, but on rougher terrain — embedded rocks, variable surface, ruts. Terrain that actively tempts you to look down.",
+            "Rep 1-3: 15 mph, central vision locked on far target. At this speed, you cover 100m in about 15 seconds. The near field will feel chaotic in your peripheral vision. Trust it. The Lesson 2 hip hinge matters here — if your upper body is decoupled, the bike can handle small deflections without your conscious input.",
+            "Rep 4-6: Add the scanning hierarchy. Start each rep by identifying the surface type far ahead (hardpack? loose? transition?), then let your mid-range vision read the general line, then let peripheral vision manage obstacles. One flow: far → mid → peripheral. No jumping back to near field.",
+            "Rep 7-10: Deliberately place obstacles in your path — water bottles, small rocks, sticks. Ride toward them with central vision on the far target. Your peripheral vision should detect them and your hands should steer around them automatically. If you fixate on the obstacle, you'll hit it. This is target fixation training — the obstacle is the test, not the target.",
+            "Debrief: how many obstacles did you avoid without consciously steering? How many did you fixate on? The ratio improves with practice."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Technical gravel with rocks and ruts, 20+ mph",
+          "steps": [
+            "Find a gravel descent or fast section where you naturally reach 20+ mph. This is where the quiet eye pays its biggest dividends — and where the instinct to target-fixate is strongest.",
+            "Rep 1-2: Ride the section at race pace with your standard vision pattern. Note where your eyes go — honestly. Most riders will catch themselves staring 5-10 feet ahead at obstacles, especially on rough sections.",
+            "Rep 3-5: Same section, same speed, but force the quiet eye: central vision 3-5 seconds ahead (at 20 mph, that's 90-150 feet). Peripheral vision handles everything closer. Hold each fixation for a full 0.8 seconds before shifting to the next scan point. Count \"one-Mississippi\" if you need an anchor.",
+            "Rep 6-8: Add the full technique stack from Lessons 1-3: weighted drop (heavy feet, quiet hands) + hip hinge (upper body floating) + traction awareness (you know where grip lives). The quiet eye is the final layer — you've built the physical platform that lets far-field vision work, because your hands are light enough to make peripheral corrections automatically.",
+            "Rep 9-10: Full race simulation. Ride the section as fast as you'd ride it in a race. The goal: zero conscious obstacle-avoidance decisions. Every correction should happen below awareness. If you catch yourself thinking about a specific rock, your eyes dropped."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "1 full minute of continuous riding on rough gravel without looking at the front wheel.",
+        "metric": "binary",
+        "target": "60 seconds on rough, variable-surface gravel with central vision held at 3+ seconds ahead. Zero conscious obstacle-avoidance inputs — all corrections handled by peripheral vision and automatic motor responses."
+      }
+    },
+    {
+      "type": "prose",
+      "content": "### Integrating the Quiet Eye With Everything Else\n\nThis is the fourth and final lesson in Module 1, and it's not an accident that it comes last. The quiet eye doesn't work in isolation — it requires the physical platform you built in Lessons 1-3.\n\n- **Lesson 1 (Weighted Drop)**: Light hands allow peripheral-vision corrections. If your hands are loaded with body weight, small steering inputs are impossible — you need big, conscious movements. Light hands = automatic micro-corrections.\n- **Lesson 2 (Hip Hinge)**: A decoupled upper body means the bike can deflect over obstacles without disturbing your visual field. If your skeleton is rigid, every bump bounces your head and resets your focal point. The hinge keeps your eyes stable.\n- **Lesson 3 (Traction)**: Knowing your pressure window and grip limits means the surface-type scan is actionable. \"I see loose gravel ahead\" becomes \"I see loose gravel ahead and I know my 32 PSI on 42mm tires will hold at this speed\" — that's the difference between seeing and understanding.\n\nWith all four lessons stacked: your weight is low (stable), your body is decoupled (smooth), your tires are set correctly (traction), and your eyes are far ahead (strategy). That's the complete trust platform. You're no longer fighting the bike. You're riding it."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're approaching a hazard section — a 30-meter stretch of embedded rocks and shallow ruts at 16 mph. Where should your central vision be focused?",
+      "options": [
+        {
+          "text": "On the biggest rocks directly ahead, so you can steer around each one",
+          "correct": false
+        },
+        {
+          "text": "Alternating rapidly between the near field and far field to track everything",
+          "correct": false
+        },
+        {
+          "text": "3-5 seconds ahead of the bike, scanning surface type and line, with peripheral vision handling individual obstacles",
+          "correct": true
+        },
+        {
+          "text": "On the exit point of the hazard section, ignoring everything in between",
+          "correct": false
+        }
+      ],
+      "explanation": "Central vision should be 3-5 seconds ahead (at 16 mph, roughly 70-115 feet), scanning the surface type and selecting the general line. Individual obstacles within the hazard section are handled by peripheral vision and automatic motor responses — not by central fixation. Staring at specific rocks triggers target fixation (you steer toward what you stare at) and limits your fixation time below the 0.8-second minimum needed for accurate motor planning. Rapidly alternating between near and far fragments both systems without giving either enough processing time. Looking only at the exit ignores the scanning hierarchy — you need surface type and line information, not just a destination."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before Module 2: ride 1 full minute of rough gravel using The Quiet Eye — focal point 3-5 seconds ahead, all corrections via peripheral vision, zero looks at your front wheel. If you can do this, your Trust stack is solid."
+    },
+    {
+      "type": "callout",
+      "content": "That's Module 1 complete: Trust the Bike. You've built the physical platform — weight low, body decoupled, tires dialed, eyes far ahead — that lets the bike do what it's designed to do on loose surfaces. Up next: Module 2, Control the Inputs. You'll take this foundation and layer specific technique on top of it — braking, cornering, climbing, surface reading. The shift is from \"stop fighting the bike\" to \"start directing it with precision.\" First up: Lesson 5, Braking That Builds Confidence. Turns out everything you learned about braking on the road is actively wrong on gravel.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/05-braking-that-builds-confidence.json
+++ b/data/courses/dirt-craft/lessons/05-braking-that-builds-confidence.json
@@ -1,0 +1,284 @@
+{
+  "id": "braking-that-builds-confidence",
+  "title": "Braking That Builds Confidence",
+  "module": "control-the-inputs",
+  "lesson_number": 5,
+  "blocks": [
+    {
+      "type": "sensation_target",
+      "label": "Quiet discs — soft hiss, not howl",
+      "content": "Pull both brake levers gently until you hear the pads contact the rotors. That first whisper of friction — a soft, steady hiss — is the sound of controlled deceleration. Now squeeze harder. The hiss becomes a howl, a pulsing scream of metal and heat. That's panic braking.\n\nThe target sensation is all hiss, no howl. Light, steady pressure across both levers, left hand doing slightly more work than right. The bike slows progressively — no lurch, no skid, no weight transfer violent enough to unload either tire.\n\nHere's the test: descend a gravel hill and listen. If you can hear your rotors from 20 feet away, you're spending braking budget you don't have. If the only sound is tire crunch and wind, you've found it.\n\nOne more thing — your hands should feel almost bored. Two fingers on each lever, the rest wrapped around the bar for stability. If all four fingers are on the levers and your forearms are burning, you're white-knuckling the brakes the same way Lesson 1's death grip white-knuckled the bars."
+    },
+    {
+      "type": "hero_stat",
+      "value": "70-80%",
+      "unit": "of your stopping power",
+      "context": "comes from the front brake — the one most gravel riders are afraid to use"
+    },
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Rider descends wet loose gravel at 19 mph. Road instinct: rear brake dominant. Right hand squeezes harder than left. Rear tire locks. Skids sideways, cutting a 4-foot arc across the loose surface.\n\nPanic response: rider grabs the front brake to compensate and arrest the slide. On wet loose gravel, the front tire has roughly 40% of its dry traction budget. The front washes out instantly — no warning, no progressive slide, just gone.\n\nDown at 19 mph. Left hip, left shoulder, left palm. Bike slides into the ditch.\n\nThe rear brake felt safer. It was the most dangerous input the rider made. The locked rear caused the slide. The panic grab of the front turned a recoverable skid into an unrecoverable crash.\n\nThe rider behind — who scrubbed speed with both brakes before the wet section and coasted through it — rolled past without touching a lever."
+    },
+    {
+      "type": "prose",
+      "content": "### Why Road Braking Instincts Will Crash You\n\nOn pavement, rear-brake-dominant technique is suboptimal but survivable. The rear tire has enough traction on asphalt that a lockup just means a skid mark and some lost speed. The front tire is nearly impossible to wash out on dry road. So road riders develop a habit: right hand does the work, left hand assists.\n\nOn gravel, this habit is actively dangerous. Here's why:\n\n1. **The rear tire has less traction than you think.** On loose gravel, the rear contact patch is already near its friction limit just from your body weight and pedaling forces. Add braking force, and you exceed the limit almost immediately. The rear locks, and a locked rear wheel has zero directional stability — it slides wherever gravity and momentum want it to go.\n\n2. **The front tire has more traction than you think.** Under braking, weight transfers forward. This loads the front tire and unloads the rear. The front contact patch grows, gains traction, and can handle significantly more braking force. On dry hardpack gravel, the front brake can deliver 3-4x the deceleration of the rear before losing grip.\n\n3. **The rear brake is a steering input, not just a speed input.** When the rear wheel locks and slides, the bike rotates around the front contact patch. You're no longer braking — you're turning. And you're turning in a direction you didn't choose."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Traction Circle Physics",
+          "content": "Every tire has a finite budget of grip. Think of it as a circle — a fixed-radius circle whose size depends on surface type, tire pressure, tire width, and load.\n\nInside the circle, you're fine. Outside the circle, you're sliding.\n\nThe critical insight: **braking and turning share the same budget.** If you're using 80% of the traction circle for braking, you only have 20% left for cornering. If you're using 80% for cornering, you only have 20% for braking.\n\nThis is why braking mid-corner crashes people. It's not that the surface suddenly got slippery. It's that you asked the tire to do two expensive things at once, and the total exceeded the budget.\n\nThe solution is spatial separation: brake in the straight sections, coast through the corners. This sounds obvious when you read it, but watch any group of gravel riders descend a twisty gravel road and count how many are braking through the turns. It's most of them. I was one of them for years."
+        }
+      ]
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Stopping Distance Derivation and Braking Mechanics",
+          "content": "**70/30 front-rear split.** On dry gravel, aim for 70-80% of your braking force from the front, 20-30% from the rear. The front does the real stopping; the rear provides stability and a small contribution. On wet gravel, shift toward 60/40 — the front still leads, but you give the rear a bit more because weight transfer is more destabilizing on slick surfaces.\n\n**Pulse braking on loose surfaces.** Instead of steady pressure, apply the brakes in quick pulses — squeeze for half a second, release for half a second. Each pulse decelerates the bike. Each release lets the tires re-establish grip. This is slower than sustained braking but vastly more controlled. On loose-over-hardpack, pulse braking can cut stopping distance by 20-30% compared to a locked wheel that's plowing through loose material.\n\n**Speed-scrub zones.** Before every corner, identify the straight section where you'll do your braking. All of it. Enter the corner at the speed you want to carry through it. Coast through the turn. Accelerate out. This is the single most effective thing you can do for your descending. It's not about bravery — it's about moving your braking to where the tires have full traction budget available.\n\n**2-finger discipline.** Use your index and middle fingers on the brake levers. Ring finger and pinky stay wrapped around the bar. This does three things: (1) limits maximum braking force so you physically can't panic-grab, (2) maintains your grip on the handlebar for steering authority, and (3) reduces forearm fatigue on long descents. Modern hydraulic discs generate more than enough power with two fingers. If you need all four fingers to stop, your brakes need service.\n\nIf you nailed the weighted drop from Lesson 1, your hands are already light on the bars. Two-finger braking is the natural extension — light hands, light braking inputs, heavy feet keeping the bike planted."
+        }
+      ]
+    },
+    {
+      "type": "data_table",
+      "caption": "Maximum Deceleration and Stopping Distance by Surface Type (from 20 mph, 170 lb rider, hydraulic disc brakes, 42mm tires at 30 PSI)",
+      "headers": [
+        "Surface",
+        "Max Deceleration (g)",
+        "Stopping Distance (ft)",
+        "Front/Rear Split",
+        "Notes"
+      ],
+      "rows": [
+        [
+          "Dry Hardpack",
+          "0.65-0.75",
+          "28-32",
+          "80/20",
+          "Best grip. Full front-brake authority. Closest to road braking."
+        ],
+        [
+          "Wet Hardpack",
+          "0.40-0.55",
+          "38-52",
+          "70/30",
+          "Grip drops 30-40%. Pulse braking preferred. Watch for clay."
+        ],
+        [
+          "Loose Gravel",
+          "0.30-0.45",
+          "46-70",
+          "65/35",
+          "Loose material rolls under tires. Pulse braking essential. Rear locks easily."
+        ],
+        [
+          "Wet Loose Gravel",
+          "0.20-0.30",
+          "70-104",
+          "60/40",
+          "Worst common surface. Stopping distance 2-3x dry hardpack. Scrub speed early."
+        ],
+        [
+          "Sand",
+          "0.15-0.25",
+          "84-140",
+          "55/45",
+          "Front digs in. Very light front input. Speed management > braking."
+        ],
+        [
+          "Mud",
+          "0.10-0.20",
+          "104-208",
+          "50/50",
+          "Near-zero grip. Rim contamination reduces pad bite. Pump brakes to clear mud."
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "content": "Look at those stopping distances. On dry hardpack, you stop in 30 feet from 20 mph. On wet loose gravel, it's 70-104 feet — more than triple. If you're carrying road-calibrated braking expectations into a wet gravel descent, you're going to overshoot every corner. The numbers don't lie, even when the surface looks rideable.",
+      "style": "tip"
+    },
+    {
+      "type": "process",
+      "title": "The Braking Budget",
+      "description": "The traction circle concept applied as a pre-descent planning tool. Deploy before every gravel descent.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Identify speed-scrub zones",
+          "detail": "Before the descent begins, pick the straight sections where you will do ALL your braking."
+        },
+        {
+          "step": 2,
+          "action": "Set entry speed with 2-finger front-brake drag",
+          "detail": "Use index and middle fingers on the front lever to scrub speed progressively before each corner or surface change."
+        },
+        {
+          "step": 3,
+          "action": "Coast through corners — zero brake input mid-turn",
+          "detail": "The traction circle is fully committed to turning. Any braking input mid-corner steals from the turning budget."
+        },
+        {
+          "step": 4,
+          "action": "Pulse-brake on loose",
+          "detail": "Squeeze-release, never lock. Each pulse decelerates; each release lets the tires re-establish grip."
+        }
+      ]
+    },
+    {
+      "type": "drill",
+      "title": "Speed-Set-Coast",
+      "time_minutes": 20,
+      "description": "Ride the same descent 5 times, progressively reducing the number of braking zones. Discover how much unnecessary braking you've been doing — most riders are shocked.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Gentle gravel descent, 5-8% grade, clear sightlines",
+          "steps": [
+            "Find a gravel descent you know well — 1-2 minutes long, moderate grade, corners you can see through. Ride it top to bottom at your normal pace.",
+            "Run 1 — Unlimited braking: Ride the descent naturally. Count every time you touch the brakes. Most riders hit 8-15 braking events on a 2-minute descent. Write the number down.",
+            "Run 2 — Five braking zones: Pick the 5 most important places to brake (usually before corners and at surface changes). Brake ONLY in those zones. Coast everywhere else.",
+            "Run 3 — Three braking zones: Cut to 3. You have to choose. Which corners actually need braking? Which ones did you brake for out of habit?",
+            "Run 4 — One braking zone: One single scrub point. Pick the spot where you need the most speed reduction. Everything else is body position, line choice, and the weighted drop from Lesson 1.",
+            "Run 5 — Zero braking: Enter the descent at a speed that lets you coast the entire way without touching the brakes. This will be slower than your normal entry speed. That's the point — this run teaches you what speed the descent actually requires."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Steeper gravel descent, mixed surfaces, 8-12% grade",
+          "steps": [
+            "Same structure as beginner, but on a descent with surface changes — hardpack to loose, or dry to wet patches.",
+            "Key difference: your braking zones should align with surface transitions. Scrub speed BEFORE you reach the loose or wet section, not during.",
+            "Run 1: Count total braking events. Also note WHERE you're braking — straights or corners?",
+            "Runs 2-3: Prioritize your braking zones. Brake on straights before corners, not in the corners themselves. Apply the traction circle — separate braking from turning.",
+            "Run 4: One braking zone. Use body position and the quiet eye (Lesson 4) to manage speed everywhere else. Let your focus drift 3-5 seconds ahead of the bike.",
+            "Run 5: Zero braking. Find the entry speed where the descent rides itself. Your hip hinge from Lesson 2 and weighted drop from Lesson 1 do the speed management."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Race-intensity descent with time pressure",
+          "steps": [
+            "Warm up with one easy run to identify the 2-3 critical braking points.",
+            "Run 1: Descend at race pace — the speed you'd actually carry in a race. Count braking events. For most riders at race pace, this is 3-6 events.",
+            "Runs 2-3: Reduce to 2 braking zones, then 1. Find speed through line selection and body position, not brakes. Use drops position for aerodynamic speed management (preview of Lesson 9).",
+            "Run 4: Zero braking at a moderate entry speed. Focus: can you maintain quiet hands and the weighted drop at the speed where your instincts scream 'brake'?",
+            "Run 5: Full send with 1-2 strategic braking points. Time this run. Compare to Run 1. Most riders find they're within 2-3 seconds despite dramatically less braking — because smoother = faster."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "Halve your braking events on a familiar descent while maintaining the same speed.",
+        "metric": "count",
+        "target": "50% reduction in braking events compared to your first unlimited run, at the same or faster speed"
+      }
+    },
+    {
+      "type": "recovery_protocol",
+      "title": "When Prevention Fails",
+      "scenarios": [
+        {
+          "label": "Rear Lockup Release",
+          "situation": "Your rear wheel locks and begins to skid sideways.",
+          "steps": [
+            "Immediately release the rear brake completely. Not feather — RELEASE. A locked rear wheel has zero directional stability. An unlocked rear wheel, even one that's still decelerating, tracks straight.",
+            "Keep the front brake steady. Do not grab it harder. Do not release it. Whatever pressure you had, maintain it. The front is your only functional brake right now.",
+            "Let the bike track straight for 1-2 seconds. Do not try to steer. The rear wheel needs to re-establish traction and the bike needs to realign. Your hip hinge from Lesson 2 is your friend here — keep the upper body loose.",
+            "Reapply the rear brake gently — 50% of whatever pressure caused the lockup. If it locks again, your speed is still too high for the surface. Front brake only until speed drops.",
+            "Debrief: the lockup happened because you asked the rear for more than it could give. Next time, shift more braking to the front earlier. The data table above tells you the split."
+          ]
+        },
+        {
+          "label": "Front Washout",
+          "situation": "Your front tire pushes, slides, or begins to lose traction during braking.",
+          "steps": [
+            "This is the honest part: if the front tire fully washes out during braking, your recovery options are extremely limited. Prevention is the strategy, not recovery.",
+            "If you feel the front beginning to push — a vague, greasy sensation through the bars — immediately reduce front brake pressure by 50%. Not release, reduce. You need to bring the tire back inside the traction circle.",
+            "Shift your weight rearward by pressing harder through the pedals. This unloads the front contact patch slightly and can restore grip.",
+            "Do not turn the handlebars. On a pushing front tire, steering input makes the slide worse. Straight-line the bike and let the tire find its own grip.",
+            "If you're in a corner when the front pushes, straighten the bike as much as the road allows. A wider line with less lean angle gives the front tire more grip budget. Accept a wider exit rather than forcing the original line.",
+            "The real fix is upstream: scrub speed before corners (speed-scrub zones), use pulse braking on loose surfaces, and never combine heavy braking with turning. If you're recovering from a front push, you overspent the budget 5 seconds earlier."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "drill",
+      "title": "Front Brake Only",
+      "time_minutes": 20,
+      "description": "BetterRide's single-brake isolation drill: ride a descent pretending your rear brake doesn't exist. It forces you to finish braking in a straight line before the corner and to trust the front — the lever that does most of the work and the one most gravel riders underuse.",
+      "proof_gate": {
+        "target": "You can descend a familiar gravel trail using only the front brake, finishing all braking before each corner and staying centered (not creeping back over the rear), in full control."
+      },
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Gentle known descent, front brake only",
+          "steps": [
+            "Pick a descent you know well with clear runouts.",
+            "Ride it pretending you have no rear brake — front only. Do all your slowing in a straight line before each corner.",
+            "Never brake and turn at the same time: cut speed straight, then release and turn.",
+            "Feel how much stopping power the front actually has. It's more than fear lets you believe."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Add speed, keep it front-only",
+          "steps": [
+            "Same descent, carry more entry speed, still front-only.",
+            "Stay centered and hinged — don't creep back over the rear to feel 'safe'; that unweights the tire you're braking with.",
+            "Goal: brake-before-the-corner and front-brake trust become automatic. Then add the rear back as a fine-tuner, not the main event."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### Building the Race Setup Card: Braking Distance Reference\n\nThis lesson feeds directly into your Race Setup Card. The stopping distance data above, combined with the surface breakdown from any race profile in the 757-race database, gives you a braking reference for specific descents.\n\nIf a race profile shows a descent with wet loose gravel at mile 47, you now know: stopping distance from 20 mph is 70-104 feet. Triple what you're used to on dry hardpack. You plan your speed-scrub zones before you roll out of bed on race morning.\n\nLesson 8 (Reading Surfaces at Speed) will build on this — teaching you to identify surface types in real time so you can adjust braking strategy on the fly. For now, the key lesson is simpler: **know the numbers, plan the zones, separate braking from turning.**"
+    },
+    {
+      "type": "video",
+      "id": "5Z7-cV6XoXc",
+      "mtb_demo": true,
+      "title": "How To Brake In Any Situation | MTB Skills",
+      "channel": "Global Mountain Bike Network",
+      "caption": "Front and rear braking demonstrated — see the weight shift and modulation."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're descending a gravel road at 22 mph. Ahead, a sweeping left-hand corner with a transition from dry hardpack to wet loose gravel at the apex. What is the correct braking sequence?",
+      "options": [
+        {
+          "text": "Brake lightly through the corner, reducing speed gradually as you enter the wet section",
+          "correct": false
+        },
+        {
+          "text": "Scrub speed to 12-15 mph on the dry hardpack before the corner, coast through the wet section with zero braking",
+          "correct": true
+        },
+        {
+          "text": "Use rear brake only through the wet section to avoid front wheel washout",
+          "correct": false
+        },
+        {
+          "text": "Maintain speed and use body position to carry momentum through the corner",
+          "correct": false
+        }
+      ],
+      "explanation": "The traction circle is the key here. Braking through the corner — especially into a wet loose section — means you're asking the tires to brake AND turn simultaneously. On wet loose gravel, the traction budget is already small (stopping distance 2-3x dry hardpack). You need all of it for turning. The correct sequence: do ALL braking on the dry hardpack before the corner (where stopping distance is 28-32 feet, not 70-104 feet), set your entry speed, and coast through the wet section with zero brake input. Using rear-only braking in the wet is exactly the Incident Report scenario — rear locks, front grab, down. Maintaining speed through a wet surface transition is how you test the data table the hard way."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before Lesson 6: ride a familiar descent and count your braking events. Then ride it again using The Braking Budget — scrub before, coast through. Target: halve the count."
+    },
+    {
+      "type": "callout",
+      "content": "Next lesson: Cornering Without Clenching. You've learned to separate braking from turning. Now we'll teach you what to do IN the turn — asymmetric loading, line selection, and the 85% rule that keeps the front tire planted when the surface tries to push it.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/06-cornering-without-clenching.json
+++ b/data/courses/dirt-craft/lessons/06-cornering-without-clenching.json
@@ -1,0 +1,241 @@
+{
+  "id": "cornering-without-clenching",
+  "title": "Cornering Without Clenching",
+  "module": "control-the-inputs",
+  "lesson_number": 6,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "85%",
+      "unit": "of calculated max speed",
+      "context": "is the entry speed that keeps you upright when the surface lies to you"
+    },
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Rider enters a sweeping gravel corner at 17 mph. It's a nice bend — wide, good sightlines, dry packed surface at the entry. Midway through the turn, the surface transitions from packed gravel to loose over hardpack. The change was visible 30 feet earlier. The rider wasn't looking — eyes were on the front wheel, not scanning ahead (Lesson 4).\n\nThe front tire pushes. Not a dramatic washout — just a subtle drift toward the outside of the turn. The contact patch is sliding across marble-sized aggregate instead of biting into packed earth.\n\nThe rider's response is pure road instinct: tighten grip on the bars, tense the shoulders, and squeeze the left brake lever to slow down. Every input is exactly wrong.\n\nTighter grip transfers weight to the handlebars, increasing the load on a front tire that's already past its traction limit. Tensed shoulders prevent the bike from leaning independently of the body. Braking mid-corner demands traction that's already fully committed to turning — the traction circle from Lesson 5, exceeded in both dimensions simultaneously.\n\nThe front tire gives up. The bike low-sides into the drainage ditch at 14 mph. Hip, elbow, handlebar tape.\n\nThe surface change was the trigger. The rider's inputs were the cause. Three corrections — any one of them — would have saved the turn: looking ahead and spotting the transition, taking a wider line through the loose section, or simply not braking mid-corner."
+    },
+    {
+      "type": "sensation_target",
+      "label": "Asymmetric loading — outside foot heavy, inside hand almost empty",
+      "content": "Stand next to a wall and press your outside hand against it, like you're holding yourself upright while leaning. Your weight drives through your outside foot into the ground. That's the target sensation in a gravel corner.\n\nIn the turn: your outside foot is weighted and dropped — a heavy platform pushing straight down through the pedal into the tire. Your inside hand is barely touching the bar. If someone pulled the inside grip out of your hand mid-corner, almost nothing would change.\n\nThe bike leans beneath you while your body stays more upright than the bike. You're not leaning WITH the bike like a motorcycle racer — you're hovering above it while it falls into the turn.\n\nHere's the test: after a set of corners, check which palm is more fatigued. If both palms feel equal, you're cornering like pavement — symmetric, rigid, leaning your body with the bike. If the inside palm feels fresh and the outside foot feels heavy, you've found gravel cornering.\n\nThis is the weighted drop from Lesson 1, adapted for turns. Same principle — weight through the feet, quiet hands — but now it's asymmetric. Outside foot does 60-70% of the work. Inside hand does almost nothing."
+    },
+    {
+      "type": "prose",
+      "content": "### Line Selection: Surface First, Geometry Second\n\nOn pavement, the fastest line through a corner is the geometric apex — the racing line. Late entry, clip the inside, wide exit. Every road cyclist has internalized this. On a clean surface with predictable grip, it's correct.\n\nOn gravel, the fastest line is the one with the best surface. And the best surface is often nowhere near the geometric apex.\n\nThe scanning hierarchy for corner entry:\n\n1. **Surface quality** — Find the smoothest, most consistent surface. Packed tire tracks, the outside line where cars have compressed the gravel, the inside line where water drainage has swept away loose material. Read the surface first.\n2. **Surface transitions** — Identify where the surface changes: packed to loose, dry to wet. A transition mid-corner is where crashes happen (see the Incident Report). If there's a transition in the corner, your line must avoid it — or cross it while the bike is upright and traveling straight.\n3. **Debris and hazards** — Rocks, ruts, sand patches, puddles hiding potholes. These are secondary to overall surface quality but can ruin a good line.\n4. **Geometric apex** — Only after the surface questions are answered do you think about the traditional racing line. Often the best surface line IS close to the geometric line. Sometimes it's 3 feet wider. Take the 3 feet.\n\nI spent my first two years of gravel racing running the geometric line through every corner. Fast on paper, disastrous on dirt. The day I started choosing lines by surface quality instead of geometry, I stopped crashing in corners. Not gradually — I just stopped."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "The outside-foot question, settled",
+          "content": "\"Outside foot down\" vs \"keep your pedals level\" is the loudest argument in bike handling, and it's a fake fight. Once you read what each camp actually says, they agree — they only differ on which one is the *default*.\n\nLee McCormack (who's known for level pedals) is explicit: *\"When you aggressively pump a corner (e.g., in a perfect and supportive berm) keep your feet level. When you're trying to survive a sketchy turn (e.g., on off-camber gravel), put all of your weight on your outside pedal.\"* BetterRide's Gene Hamilton argues outside-foot-down for traction; MBR's Paul Burwell teaches level as the neutral reset and drops the outside foot when the corner tightens and he needs maximum lean. Same answer, different defaults.\n\n**The gravel translation:** most gravel corners are flat, loose, and off-camber — exactly the \"survive it, set an edge\" case. So on gravel, **outside foot down and weighted is your working default**, and level feet are the exception you reach for when you're pumping a supportive berm or a bermed-out ditch line. This is the reverse of the modern flow-trail MTB default, and it's correct because your surface is the low-traction one."
+        },
+        {
+          "title": "Angulation vs inclination — lean the bike, or lean with it?",
+          "content": "Two ways to lean, and you need both. **Angulation** is leaning the *bike* more than your body — your weight stays stacked over the tires for grip. **Inclination** is leaning bike and body together as one unit, motorcycle-style. The folk rule says \"flat corner = angulation, berm = inclination,\" but ZEP Coaching debunks that as a false binary: *\"Pretty much all corners can have both... the point isn't when to do one and not the other but which one should be applied or focused on more.\"*\n\nOn loose flat gravel you lean toward **angulation** — bike leaned underneath you, body up, weight driving down through the outside foot into the contact patch (which is the same reason outside-foot-down wins here). In a supportive berm you can afford more **inclination**. McCormack's cue for the angulation feel: *\"Lean your bike more than your body. Stay loose. Let your bars turn on their own.\"*"
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "style": "tip",
+      "content": "**Get in the drops for anything fast or loose.** On a steep or sketchy gravel descent, riding the drops (not the hoods) puts your hands closer to the levers with more braking leverage, lowers your center of gravity, and locks your hands in so a hit can't bounce them off the bars. Hoods are fine at moderate speed and for climbing and visibility — but when it gets fast and loose, the drops are a control position, not just an aero one. One rider in the research put it bluntly: putting his hands in the drops \"made all that instability go away.\""
+    },
+    {
+      "type": "prose",
+      "content": "### High-Traction vs. Low-Traction Technique\n\nNot all gravel corners are the same. Your technique should change based on available grip.\n\n**High-traction corners (dry hardpack, packed fire road, firm dirt):**\n\n- Outside pedal weighted and dropped to 6 o'clock\n- Lean the bike into the turn — the bike leans more than your body\n- Inside hand light, providing gentle counterpressure to initiate and hold the lean\n- Outside hand firm but not clenched — this is your anchor point\n- Look through the exit of the corner, not at the apex (Lesson 4's quiet eye, applied to turns)\n- You can lean significantly — 20-30 degrees on good hardpack. The tire's knobs engage with the packed surface\n\n**Low-traction corners (loose gravel, wet, sand over hardpack):**\n\n- Keep the bike more upright. Less lean = less side-load on the tires = more traction budget\n- Steer through the turn rather than leaning through it. Turn the bars slightly in the direction of the turn\n- Wider line — the larger radius reduces the centripetal force at any given speed\n- Weight still through the outside foot, but your body stays more centered over the bike\n- Slower entry speed — the 85% rule (below) is non-negotiable on low-grip surfaces\n- Do not pedal through the corner if your inside pedal might clip. Level cranks, outside foot heavy\n\nThe transition between these techniques should happen based on what you FEEL through the tires and bars, not what the surface looks like. Lesson 3's traction exploration taught you to feel grip through your tires. In a corner, that same sensation tells you which technique applies. The quiet tire feel from correct pressure is your real-time feedback."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Wet Corner Physics and Coefficient Adjustments",
+          "content": "Wet gravel is a different sport. Everything you know about cornering gets a coefficient applied to it, and that coefficient is less than 1.\n\n**Wider lines.** The wider your radius, the less centripetal force the tires must generate. A line 2-3 feet wider than your dry-weather line can be the difference between grip and slide. Yes, you travel a slightly longer distance. You also stay upright.\n\n**Earlier apex.** On dry gravel, a late apex lets you see through the corner before committing. On wet gravel, an earlier apex gives you more room on the exit — which is where things go wrong when traction degrades. If the rear slides on exit, a wider exit line gives you space to recover.\n\n**Brake BEFORE, not during.** This is Lesson 5's core principle, amplified. On wet gravel, the traction circle is roughly 40% smaller than dry. Any braking input mid-corner is stealing from an already tiny turning budget. All speed management happens in the straight section before the turn. Set your entry speed on dry ground if possible.\n\n**Avoid painted lines, manhole covers, and metal grates.** These aren't gravel features, but they show up on gravel roads that share infrastructure with paved roads. Wet metal and paint have friction coefficients close to ice. Cross them while upright and straight, or don't cross them.\n\n**Accept the cost.** Wet corners are slower. Period. The rider who accepts a 20% speed reduction in wet corners and stays upright finishes ahead of the rider who tries to maintain dry-weather pace and crashes once. I've done the math on this with race files — a single crash costs 2-5 minutes. Riding 20% slower through 30 wet corners costs about 90 seconds total."
+        }
+      ]
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Corner Speed Physics — Friction Coefficients and Lean Angle Math",
+          "content": "Every corner has a theoretical maximum speed. It's determined by physics: radius, surface friction coefficient, tire width, lean angle, and rider mass. The calculator below will give you the number.\n\nNever enter at that number. Enter at 85%.\n\nI'll be honest — I still get nervous in loose corners. The difference isn't that the fear went away. It's that I have a checklist now instead of a prayer.\n\nThe 85% rule exists because the calculator assumes a uniform surface, a consistent radius, zero wind, and a rider who holds a perfect line. Gravel gives you none of these. The surface changes mid-corner. The radius tightens where you can't see. A gust pushes you. You tense up and add 2 degrees of lean you didn't plan.\n\nThe 15% margin absorbs all of it. At 85% of max, you have budget to handle one surprise — a loose patch, a tightening radius, a front-tire push — without exceeding the traction limit. At 100% of max, any surprise puts you on the ground.\n\nThis isn't about being timid. It's about being honest about how much you don't know about the next 50 feet of surface. The best gravel riders I've watched don't carry more corner speed than everyone else. They carry better-calibrated corner speed — fast enough to be competitive, slow enough to handle surprises.\n\nAfter enough reps through a familiar set of corners, your 85% starts creeping up naturally. Not because you're being braver, but because you're reading the surface better (Lesson 8), your traction sense is sharper (Lesson 3), and your body defaults to the right technique without conscious thought. That's the progression from Lesson 12's flow state — earned speed, not hoped-for speed."
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### Corner Speed Calculator\n\nEstimate the maximum and recommended entry speed for a gravel corner. The recommended speed applies the 85% safety margin — the speed you should actually carry.\n\n_Interactive calculator coming soon — the numbers above are the method._"
+    },
+    {
+      "type": "callout",
+      "content": "The calculator gives you a starting point, not gospel. Real corners have variable radius, camber, and surface changes that no formula captures. Use the numbers to calibrate your instincts — if the calculator says 14 mph max on loose gravel and you've been entering at 18, that's a conversation worth having with yourself. The figure-8 drill below will teach your body what the numbers mean.",
+      "style": "tip"
+    },
+    {
+      "type": "process",
+      "title": "The 85% Rule",
+      "description": "The corner entry speed protocol. Deploy on every gravel corner where you cannot see the full exit.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Read the surface 50m out",
+          "detail": "Identify surface type, transitions, and debris before you commit to the corner."
+        },
+        {
+          "step": 2,
+          "action": "Choose the smoothest line",
+          "detail": "Pick the line with the best surface quality — not the geometric apex. Packed tire tracks, compressed outside line, swept inside line."
+        },
+        {
+          "step": 3,
+          "action": "Scrub to 85% of estimated max before turn-in",
+          "detail": "All braking happens on the straight before the corner. Use The Braking Budget from Lesson 5."
+        },
+        {
+          "step": 4,
+          "action": "Weight outside foot, lighten inside hand",
+          "detail": "Outside pedal dropped to 6 o'clock, heavy. Inside hand barely touching the bar. Bike leans beneath you."
+        },
+        {
+          "step": 5,
+          "action": "Coast through — no braking, no steering correction",
+          "detail": "The 15% margin absorbs surprises. Trust the setup. Exit wide if needed — wide is faster than crashed."
+        }
+      ]
+    },
+    {
+      "type": "drill",
+      "title": "Figure-8 Progression",
+      "time_minutes": 20,
+      "description": "Two markers on flat gravel, 20 meters apart. Ride figure-8s around them, tightening the radius over 4 sessions. This is where you build corner feel — the connection between lean angle, speed, and surface grip that no calculator can replace.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Flat gravel parking area, wide turns, low speed",
+          "steps": [
+            "Set two markers (water bottles, cones, rocks) 20 meters apart on a flat gravel surface.",
+            "Ride figure-8s around the markers at a comfortable speed — 8-10 mph. Focus on smooth, round turns, not speed.",
+            "Outside foot down at 6 o'clock in every turn. Inside hand light. Feel the asymmetric loading from the sensation target.",
+            "Ride 10 laps. On each lap, notice: Where does the front tire push? Where does it bite? Where do you tense up?",
+            "Move the markers 1 meter closer (19m apart). Ride 10 more laps. The tighter radius forces slightly more lean or slightly lower speed — your choice.",
+            "Continue tightening by 1 meter every 10 laps until you feel the front tire begin to push or your confidence drops. That's your current limit. Mark it.",
+            "Session goal: find your limit radius at 8-10 mph. No crashes, no heroics. Just data collection."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Mixed-surface gravel, moderate speed, technique focus",
+          "steps": [
+            "Same setup, but choose a surface with some variety — packed in some areas, looser in others. This forces you to adjust technique mid-figure-8.",
+            "Start at 20m spacing, 10-12 mph. Higher speed means the turns demand more lean or a wider radius.",
+            "Practice switching between high-traction technique (lean the bike, stay upright) on packed sections and low-traction technique (bike upright, steer through) on loose sections.",
+            "Every 5 laps, tighten the markers by 1 meter. Feel how the required technique changes as the radius shrinks.",
+            "At each radius, do 2 laps with exaggerated outside-foot weighting, then 2 laps with intentionally equal hand pressure. Notice the difference in front-tire feedback.",
+            "Target: reach 12m spacing at 10-12 mph with zero front-tire push on either surface.",
+            "If the front pushes: slow down 1 mph and try again. Speed is the cheapest fix for a pushing front tire."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Progressive speed at fixed radius, simulating race corner entry",
+          "steps": [
+            "Set markers at 15m apart — a moderately tight radius that simulates a real gravel corner.",
+            "Run 1: 5 laps at 10 mph. Establish your technique baseline. Outside foot heavy, inside hand empty, quiet eye through the exit.",
+            "Run 2: 5 laps at 12 mph. Same radius, 20% more speed. Feel where the traction limit shifts. More lean needed, or wider turns?",
+            "Run 3: 5 laps at 14 mph. This is approaching real descent corner speeds on tight turns. The front tire will tell you things. Listen.",
+            "Run 4: 5 laps at 15-16 mph if surface allows. You're now at 85-90% of what the calculator predicts for this radius on loose gravel.",
+            "Run 5: Back to 10 mph, but tighten markers to 10m. The smallest radius tests low-speed bike control — steering precision, body position, pedal clearance.",
+            "Debrief: Which speed + radius combination felt like 85% effort? That's your calibrated corner speed for this surface."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "Complete a 5-meter radius figure-8 at 10 mph on loose gravel with zero front-tire push.",
+        "metric": "binary",
+        "target": "5m radius, 10 mph, loose gravel surface, no front-tire push through 5 consecutive laps"
+      }
+    },
+    {
+      "type": "recovery_protocol",
+      "title": "When Prevention Fails",
+      "scenarios": [
+        {
+          "label": "Mid-Corner Front Tire Push",
+          "situation": "You're mid-corner and feel the front tire drift — a vague, greasy sensation through the bars. The tire is sliding toward the outside of the turn.",
+          "steps": [
+            "Widen the line immediately. Push the bike toward the outside of the corner. A wider radius reduces centripetal force on the tire — this is the single most effective input you have.",
+            "Reduce lean angle. Straighten the bike as much as the road allows. Less lean = less side-load = more traction budget for the front tire to recover.",
+            "Press harder through the outside foot. Drive your weight down through the pedal, not through the bars. This stabilizes the bike from below and shifts load away from the pushing front tire.",
+            "Do NOT brake. Any braking input adds force to a tire already past its traction limit. The traction circle is full — braking will overflow it and the front will wash out completely.",
+            "Do NOT steer tighter. Turning the bars into the corner increases the demand on a front tire that's already sliding. Fight the instinct to correct the line by steering — you correct it by widening.",
+            "Accept the wide exit. You'll drift 2-4 feet outside your intended line. That costs 1-2 seconds. A front washout costs 2-5 minutes and skin."
+          ]
+        },
+        {
+          "label": "Mid-Corner Rear Slide",
+          "situation": "The rear tire breaks loose mid-corner — you feel the back end step out, sliding toward the outside of the turn.",
+          "steps": [
+            "Stay off the brakes. Both brakes. A sliding rear tire has zero directional stability, and grabbing the front brake while the rear is loose will low-side you instantly.",
+            "Look where you want to go. Your body follows your eyes. Look at the exit of the corner, not at the sliding rear wheel. This keeps your upper body oriented in the right direction and prevents overcorrection.",
+            "Let the rear find its own grip. On most gravel surfaces, a rear slide is self-correcting if you don't make it worse. The tire will scrub speed through friction and re-engage. Keep your weight on the outside foot and wait.",
+            "If the rear catches suddenly, do NOT overcorrect. A snapping rear tire can kick the bike in the opposite direction. Keep your hands light on the bars and your core engaged. Let the bike settle beneath you.",
+            "Once grip returns, hold your line for 2-3 seconds before making any input. The tire needs time to re-establish full traction. Steering or braking immediately after recovery puts you right back at the limit."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### Why This Matters for the Race Setup Card\n\nThe corner speed calculator feeds into your Race Setup Card. For any of the 757 races in the database, you can look at the descent profiles, estimate corner radii from satellite imagery or race reports, and calculate your target entry speeds by surface type.\n\nThis turns \"I hope I can make that corner\" into \"I know I need to enter that corner at 14 mph on wet hardpack.\" That number goes on the card. You see it before the race. When you crest the climb and start the descent, you already know the plan.\n\nLesson 9 (Descending as Play) will build on this — adding body position, aero tuck timing, and gradient-based weight shift to your corner speed fundamentals. For now, the foundation is this: **choose lines by surface, separate braking from turning (Lesson 5), load the outside foot, lighten the inside hand, and never enter faster than 85%.**"
+    },
+    {
+      "type": "video",
+      "id": "WVXgAqpjOAs",
+      "title": "How to Corner & Descend On Your Gravel Bike",
+      "channel": "The Pro's Closet",
+      "caption": "Gravel-specific cornering with multi-angle framing — line, lean, and outside-foot loading."
+    },
+    {
+      "type": "video",
+      "id": "GFKPtEzE4xw",
+      "title": "OVER 40 MOUNTAIN BIKE TIPS: CORNERING WITH CONFIDENCE | Loose over Hardpack!",
+      "channel": "Joy of Bike",
+      "mtb_demo": true,
+      "caption": "Cornering specifically on loose-over-hardpack — Dirt Craft's exact surface."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're mid-corner on gravel at 15 mph when you feel the front tire push — a vague, drifting sensation through the bars. The surface has transitioned from packed to loose. What is the correct immediate response?",
+      "options": [
+        {
+          "text": "Apply the front brake to slow down and regain control",
+          "correct": false
+        },
+        {
+          "text": "Lean the bike harder into the turn to increase tire contact patch",
+          "correct": false
+        },
+        {
+          "text": "Widen the line, reduce lean angle, and press harder through the outside foot — do not brake",
+          "correct": true
+        },
+        {
+          "text": "Straighten up, brake to a stop, and walk through the loose section",
+          "correct": false
+        }
+      ],
+      "explanation": "A front-tire push means the tire has exceeded its traction budget for the current combination of speed, lean angle, and surface friction. Braking mid-corner adds braking force to an already-overloaded traction circle — this is the Incident Report crash. Leaning harder increases the side-load and makes the push worse. The correct response: widen the line (increasing effective radius, reducing centripetal force), reduce lean angle (decreasing side-load on the tire), and press harder through the outside foot (the weighted drop, driving traction through the rear tire and stabilizing the bike). No brake input. You're managing the traction circle — reducing the demands on it until the tire recovers grip. This is ugly and costs you 1-2 seconds. Crashing costs 2-5 minutes."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before Lesson 7: find a gravel corner and ride it 10 times. Use The 85% Rule every time. Note where the front tire pushes. Tighten the radius by 1 meter each set of 5."
+    },
+    {
+      "type": "callout",
+      "content": "Next lesson: Climbing Without Spinning Out. You've mastered the traction circle for braking and turning. Now we apply it to the other direction — driving force through the rear tire on loose climbs without breaking traction. The torque ceiling, cadence strategy, and why standing on gravel climbs is often the wrong move.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/07-climbing-without-spinning-out.json
+++ b/data/courses/dirt-craft/lessons/07-climbing-without-spinning-out.json
@@ -1,0 +1,267 @@
+{
+  "id": "climbing-without-spinning-out",
+  "title": "Climbing Without Spinning Out",
+  "module": "control-the-inputs",
+  "lesson_number": 7,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "3rd",
+      "unit": "pedal stroke",
+      "context": "is where most gravel climb wheel-spin events happen — the torque spike from standing catches a tire already near its friction limit"
+    },
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Rider approaches a 10% gravel pitch at 9 mph. Road instinct kicks in — they stand out of the saddle and surge, exactly the way they would attack on pavement. First pedal stroke holds. Second stroke, the rear tire chirps. Third stroke, the rear wheel spins freely for a full revolution.\n\nThe standing surge unloaded the rear wheel by shifting the rider's center of mass forward and up. Peak pedal force in a standing surge reaches 1.4x the rider's body weight. On pavement, the tire's coefficient of friction handles this easily. On loose-over-hard gravel, the maximum transmittable torque is roughly 40% lower than pavement.\n\nThe rider sits back down, but they're now in a 53x19 — a gear that requires 350W to turn at 60 RPM on this gradient. Their fatigued power is 220W. Cadence drops to 42 RPM. The bike wobbles. Momentum dies. They unclip and walk.\n\nThe rider next to them never stood. They were seated, hips hinged forward, spinning 78 RPM in a 36x34. Same gradient, same power, half the peak torque per pedal stroke. Zero wheel slip. They crested the climb still pedaling."
+    },
+    {
+      "type": "sensation_target",
+      "label": "Butter, not peanut butter",
+      "content": "Each pedal stroke presses into something that gives smoothly and consistently. No skip. No grab. No surge. The resistance feels like pushing a knife through room-temperature butter — constant, yielding, predictable.\n\nThe moment you feel catch-and-release — a tiny hesitation followed by a jolt of acceleration — you're above the torque ceiling. That catch-and-release is the tire alternating between static and dynamic friction. It's the gravel equivalent of a check engine light: something is about to break.\n\nHere's the calibration: on a loose gravel climb, pedal at a cadence where you could close your eyes and not know the surface had changed. That's the target. If you can feel each pedal stroke individually through the rear tire, your torque is too high."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Torque vs. Traction Physics and Gear Ratio Math",
+          "content": "Every combination of surface, tire, pressure, and gradient has a maximum torque the rear wheel can transmit before it breaks traction. This is the torque ceiling. On pavement, the ceiling is so high you'll never hit it — your legs give out first. On gravel, the ceiling drops dramatically, and it moves around depending on what's under your tire.\n\nThe math is simple. Torque at the rear wheel = pedal force x crank length x gear ratio. For a given power output, torque is inversely proportional to cadence:\n\n- **200W at 60 RPM** = 31.8 Nm at the crank\n- **200W at 80 RPM** = 23.9 Nm at the crank\n- **200W at 100 RPM** = 19.1 Nm at the crank\n\nSame power, same speed, same climb. But the 60 RPM rider is putting 67% more torque through the rear tire per pedal stroke than the 100 RPM rider. On hardpack, this doesn't matter. On loose gravel, that extra torque is the difference between grip and spin.\n\nThis is why cadence strategy on gravel is the opposite of road climbing orthodoxy. On pavement, lower cadence at higher torque is often more efficient for sub-threshold efforts. On gravel, higher cadence at lower torque keeps you under the ceiling."
+        }
+      ]
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Why Standing Kills You — Weight Transfer and Torque Spike Physics",
+          "content": "When you stand on a road climb, three things happen:\n\n1. **Weight shifts forward.** Your center of mass moves from above the bottom bracket to above the handlebars. On pavement, this is fine — both wheels have abundant traction. On gravel, you've just unloaded the drive wheel by 15-25% of your body weight.\n2. **Torque spikes.** Standing climbing produces peak pedal forces 1.3-1.5x higher than seated climbing at the same average power. Each downstroke is a hammer blow. On pavement, the tire absorbs it. On gravel, the tire spins.\n3. **Cadence drops.** Most riders stand at 55-65 RPM, vs 75-90 seated. Lower cadence = higher torque per stroke = closer to the ceiling.\n\nThe combined effect is devastating: you've simultaneously reduced rear-wheel traction AND increased the force trying to break that traction. It's a double penalty.\n\nThis doesn't mean you can never stand on gravel. On hardpack, standing works fine. On moderate gradients (under 6-7%), the traction penalty is manageable. But on loose surfaces above 8%, standing is a coin flip — and the coin is weighted against you."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "content": "Remember the weighted drop from Lesson 1? This is the climbing version. Heavy feet, quiet hands applies here too — but with a twist. On climbs, 'heavy feet' means pressing your weight DOWN through the pedals with smooth, circular strokes, not hammering on the downstroke. And 'quiet hands' means resisting the road instinct to pull on the bars during each pedal stroke. Pulling the bars lifts the rear wheel. Every time.",
+      "style": "tip"
+    },
+    {
+      "type": "prose",
+      "content": "### The Seated Climbing Ready Position\n\nThis is your default position for any gravel climb above 6% gradient on a loose surface.\n\n1. **Hinge at the hips.** Tilt your pelvis forward, bringing your chest closer to the stem. This shifts your center of mass forward without unloading the rear wheel — because you're still seated. Think of dropping your belly button toward the top tube.\n2. **Chin toward stem.** Not dramatically — just enough that your weight distribution favors the front wheel slightly. On steep gravel, the front wheel wants to wander. A slight forward lean anchors it.\n3. **Slide forward on the saddle.** Move 1-2 cm forward from your normal position. This keeps your weight centered over the bottom bracket rather than behind it, where steep gradients naturally push you.\n4. **Hands on the tops or hoods — never the drops.** Drops on a steep climb pull your upper body too far forward and can unweight the rear. Tops give you a relaxed position. Hoods give you brake access for gradient changes.\n5. **Relax your grip.** Death grip on climbs doesn't just waste energy — it makes you pull on the bars with each pedal stroke, which rocks the bike side to side and destabilizes the rear tire. Light hands, smooth circles.\n\nThe result: you're driving power straight down through the rear tire with maximum weight on the contact patch, while your upper body stays quiet and centered. The bike doesn't rock. The tire doesn't skip."
+    },
+    {
+      "type": "prose",
+      "content": "### Cadence Strategy for Loose Surfaces\n\nThe goal is simple: same power output, lower peak torque per pedal stroke. That means spinning faster in an easier gear.\n\n**Target cadence by surface:**\n- Hardpack: Normal climbing cadence (70-85 RPM). No special adjustment needed.\n- Loose-over-hard: Add 5-10 RPM to your normal climbing cadence. The loose top layer is thin but will punish torque spikes.\n- Full loose (deep gravel, sand, mud): Add 10-20 RPM. Spin as fast as you can without bouncing on the saddle. Smooth circles, not pistons.\n\n**The cadence-gradient matrix:**\nAs gradient increases, your speed drops and your available gearing becomes the limiting factor. This is where most riders get caught — they run out of gear before the climb runs out of gradient.\n\n- **Under 6%**: Stand or sit, your choice. Torque ceiling is high enough on most surfaces.\n- **6-8%**: Seated preferred on anything looser than hardpack. Cadence target: 75-85 RPM.\n- **8-11%**: Seated mandatory on loose surfaces. Cadence target: 70-80 RPM. This is the danger zone where gear selection makes or breaks you.\n- **11%+**: You need your absolute easiest gear, and you need to be okay with 60-70 RPM if that's all the gear allows. At this gradient, even perfect technique can't save you if your gearing tops out.\n\nIf your cadence drops below 55 RPM on a loose climb, you're almost certainly above the torque ceiling. The rear tire might not be spinning visibly, but it's micro-slipping on every downstroke — each slip costs you 2-3% of your forward momentum. Over a 20-minute climb, that's minutes lost to invisible traction failures."
+    },
+    {
+      "type": "data_table",
+      "caption": "Peak Pedal Torque by Cadence at Common Climbing Power Outputs",
+      "headers": [
+        "Power (W)",
+        "60 RPM",
+        "70 RPM",
+        "80 RPM",
+        "90 RPM",
+        "100 RPM"
+      ],
+      "rows": [
+        [
+          "150W",
+          "23.9 Nm",
+          "20.5 Nm",
+          "17.9 Nm",
+          "15.9 Nm",
+          "14.3 Nm"
+        ],
+        [
+          "200W",
+          "31.8 Nm",
+          "27.3 Nm",
+          "23.9 Nm",
+          "21.2 Nm",
+          "19.1 Nm"
+        ],
+        [
+          "250W",
+          "39.8 Nm",
+          "34.1 Nm",
+          "29.8 Nm",
+          "26.5 Nm",
+          "23.9 Nm"
+        ],
+        [
+          "300W",
+          "47.7 Nm",
+          "40.9 Nm",
+          "35.8 Nm",
+          "31.8 Nm",
+          "28.6 Nm"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "content": "The table above shows crank torque, not rear-wheel torque. Rear-wheel torque depends on your gear ratio. A 36x34 (1.06:1) transmits nearly the same torque to the wheel as the crank produces. A 40x11 (3.64:1) multiplies it by 3.6x. This is why being in the wrong gear on a gravel climb isn't just uncomfortable — it's mechanically impossible to maintain traction.",
+      "style": "tip"
+    },
+    {
+      "type": "process",
+      "title": "The Torque Ceiling",
+      "description": "The gravel climbing protocol. Deploy on any loose-surface climb above 6% gradient.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Shift to target gear before the gradient steepens",
+          "detail": "Shifting under load on loose gravel causes chain tension spikes that break rear-wheel traction. Get into your climbing gear early."
+        },
+        {
+          "step": 2,
+          "action": "Slide forward on saddle, chin toward stem",
+          "detail": "Hinge at the hips to shift your center of mass forward without unloading the rear wheel. Anchors the front wheel on steep pitches."
+        },
+        {
+          "step": 3,
+          "action": "Increase cadence 10-15 RPM above your road instinct",
+          "detail": "Same power, lower torque per pedal stroke. The physics are simple: higher cadence keeps you under the traction ceiling."
+        },
+        {
+          "step": 4,
+          "action": "Feel for 'butter not peanut butter'",
+          "detail": "If you feel catch-and-release — a tiny hesitation followed by a jolt — cadence is too low. Shift easier and spin faster until resistance is smooth and constant."
+        },
+        {
+          "step": 5,
+          "action": "Stay seated above 8% on loose surfaces",
+          "detail": "Standing unloads the rear wheel by 15-25% and spikes peak pedal force by 1.3-1.5x. Both push you over the torque ceiling."
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### Gearing Check Calculator\n\nWill your gearing survive the steepest pitch on your target race? Enter your details below. If you select a race from the database, max gradient and surface type will auto-populate from 757 race profiles.\n\n**How it works:** Fatigued power = 65% FTP (simulating hour 4+ of a long race). Speed calculated from power = (mass x 9.81 x gradient x speed) + rolling resistance. Cadence derived from speed, gear ratio, and wheel circumference. Pass threshold: cadence >= 55 RPM. Warning zone: 55-65 RPM. Comfortable: 65+ RPM.\n\n_Interactive calculator coming soon — the numbers above are the method._"
+    },
+    {
+      "type": "prose",
+      "content": "### Reading the Calculator Results\n\n**If you got ADEQUATE:** Good. Your gearing can handle the worst this course throws at you — at least on paper. But remember, the calculator assumes fatigued power at 65% FTP. If you've been riding for 8 hours and you're at 50% FTP, the math gets worse. Build in a margin.\n\n**If you got UNDERGEARED:** You have three options, ranked by effectiveness:\n\n1. **Change your cassette.** A 10-51T cassette (SRAM Eagle-style) or 11-46T gives you a bailout gear that will save you on the steepest pitches. This is the correct answer for most riders.\n2. **Change your chainring.** Dropping from a 42T to a 38T or 36T chainring shifts your entire gear range toward easier gears. You lose top-end speed on descents, but on a gravel course with 15%+ pitches, you weren't going to use that top end anyway.\n3. **Get stronger.** This works but takes 6-12 months. The cassette swap takes 15 minutes.\n\nI rode my first gravel race with a 42x11-36 cassette because that's what came on the bike. I walked three climbs. The guy who passed me on every single one was running a 38x11-46. We had similar FTPs. He just did the math beforehand and I didn't."
+    },
+    {
+      "type": "drill",
+      "title": "Cadence Ceiling Finder",
+      "time_minutes": 20,
+      "description": "Climb the same gravel hill four times at increasing cadence to find the exact RPM where rear-tire slip disappears. This maps your personal torque ceiling for this surface and gradient.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Moderate gravel climb (5-8%), endurance pace",
+          "steps": [
+            "Find a gravel climb that takes 2-4 minutes at easy effort. Consistent surface — not a mix of hardpack and loose. You want to isolate the cadence variable.",
+            "Rep 1: Climb at your natural road-climbing cadence. Note your gear, RPM, and any rear-tire slip events. Count them. Even a chirp counts.",
+            "Rep 2: Shift one gear easier, target +10 RPM over your Rep 1 cadence. Same power — just spinning faster. Count slip events.",
+            "Rep 3: Shift one more gear easier, target +20 RPM over Rep 1. At this cadence, the torque per stroke should be noticeably lower. Count slip events.",
+            "Rep 4: Find the cadence where you register zero rear-tire slip for the entire climb. This is your cadence floor for this gradient and surface.",
+            "Cool down with an easy spin back to the start. Record: gradient, surface type, cadence floor, gear used."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Steep gravel climb (8-12%), sweet spot power",
+          "steps": [
+            "Same structure, but on a steeper pitch with looser surface. The torque ceiling drops with both gradient and surface quality.",
+            "Rep 1: Natural cadence at sweet spot power (88-93% FTP). Count slips. On steep loose gravel, you may get 5+ events in a single climb.",
+            "Rep 2: +10 RPM. You'll need to shift 1-2 gears easier. If you run out of gears, that's data — record it.",
+            "Rep 3: +20 RPM. Focus on smooth, circular pedal strokes. Eliminate any mashing. If your butt bounces on the saddle, you've gone too far.",
+            "Rep 4: Zero-slip cadence. On steep loose gravel, this might require a cadence that feels absurdly high — 90+ RPM on a 10% climb. That's the physics talking.",
+            "Record results alongside your beginner-variant data. You're building a personal torque ceiling map: gradient x surface = minimum cadence."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Race-simulation climbing, mixed surfaces and gradients",
+          "steps": [
+            "Find a climb with surface transitions — starts hardpack, goes loose, or vice versa. Real race conditions.",
+            "Rep 1: Constant power, constant cadence through the entire climb. Count slips, and note WHERE they happen. The surface transitions are where the torque ceiling shifts under you.",
+            "Rep 2: Same power, but adjust cadence at each surface transition. Shift to an easier gear the moment the surface loosens. Shift back when it firms up. Count slips.",
+            "Rep 3: Add the seated climbing ready position — hinge forward, slide forward on saddle, light hands. Combined with cadence adjustment. Count slips.",
+            "Rep 4: Full race execution. Seated ready position, cadence adjusted by surface, power modulated by gradient (back off 5-10% on the steepest loose pitch, push 5-10% harder on the hardpack sections). Target: zero slips, same average power as Rep 1.",
+            "Compare Rep 1 and Rep 4 times. The technique-optimized run is almost always faster at equal or lower average power."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "Zero rear-wheel spin events on a familiar gravel climb at race-relevant power.",
+        "metric": "binary",
+        "target": "Complete a 3+ minute gravel climb at sweet spot power with zero rear-tire slip events — no chirps, no skips, no full spins"
+      }
+    },
+    {
+      "type": "recovery_protocol",
+      "title": "When Prevention Fails",
+      "scenarios": [
+        {
+          "label": "Rear Wheel Spin-Out",
+          "situation": "Your rear wheel breaks traction mid-climb — you feel the cadence spike and hear the tire buzz against loose surface.",
+          "steps": [
+            "Immediately ease pedal pressure. Reduce force on the downstroke by 50% — but do NOT stop pedaling. A complete pause followed by a restart creates a torque spike that spins the wheel again.",
+            "Shift up 1-2 gears while soft-pedaling. A harder gear at lower cadence sounds counterintuitive, but it reduces the torque spike per stroke that caused the spin. You're trading cadence for smoother force delivery.",
+            "Once the tire re-engages, gradually increase cadence back to your target. Feel for the butter sensation — smooth, constant resistance. If you feel catch-and-release, you're still too close to the ceiling.",
+            "Do NOT stand up. Standing shifts your weight forward, unloads the rear wheel further, and increases peak pedal force by 1.3-1.5x. All three make the spin worse. Stay seated, hips hinged forward, weight driving straight down through the pedals.",
+            "If the wheel spins a second time at the reduced effort, shift one more gear harder and drop power to 80% of what you were holding. Traction takes priority — you can't climb at all if the wheel won't grip."
+          ]
+        },
+        {
+          "label": "Total Traction Loss on Steep Loose Climb",
+          "situation": "The rear wheel is spinning freely, momentum is gone, and you're about to stop on a steep loose pitch.",
+          "steps": [
+            "Shift to your easiest gear BEFORE you come to a full stop. Once you're stationary, shifting under zero chain tension can drop the chain or jam the derailleur. Get the gear right while the wheel is still turning, even slowly.",
+            "If you still have any forward momentum, attempt a trackstand. Level the cranks, apply light pressure to the front brake, and balance. Even 3-5 seconds of stillness lets you restart without unclipping on a steep grade.",
+            "If you must unclip, unclip on the UPHILL side. Unclipping downhill on a steep pitch puts your foot on the low side — the bike tips away from you, and you're chasing it across loose gravel. Uphill foot plants on stable ground above the bike.",
+            "To restart: point the bike at a slight diagonal across the slope (not straight up). This reduces the effective gradient by 20-30%. One firm pedal stroke to get moving, then straighten your line once you have momentum.",
+            "If the surface is too loose to restart at any angle, walk the bike to the next firm section — hardpack, exposed rock, compacted tire tracks. Remount there. Walking 30 meters beats spinning the rear wheel for 2 minutes and going nowhere."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### When Standing Actually Works on Gravel\n\nI've spent this entire lesson telling you not to stand. Here's when to break that rule:\n\n- **Hardpack climbs under 8%.** The surface has enough friction to handle the torque spike. Stand if you need to stretch or change muscle recruitment.\n- **Short punchy kickers (under 30 seconds).** Sometimes the gradient spikes to 15%+ for a very short distance. If you can clear it in 20 pedal strokes, a brief standing burst may be faster than trying to shift and spin — as long as you commit fully and don't half-stand.\n- **When you need to accelerate, not sustain.** Standing to gap a competitor on a brief hard section is a legitimate tactic. But do it on the firmest surface available, and sit back down the moment you've made your move.\n\nThe rule of thumb: stand on surface you trust, sit on surface you don't. And if you're not sure about the surface, sit. You can always stand later. You can't un-spin a rear wheel."
+    },
+    {
+      "type": "video",
+      "id": "dWBBh0zIWlI",
+      "mtb_demo": true,
+      "title": "How To Climb Anything On Your Mountain Bike",
+      "channel": "Global Mountain Bike Network",
+      "caption": "Weight balance on loose, steep climbs — keeping the front down and the rear hooked up."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're approaching a 2-mile gravel climb that starts at 5% on packed dirt, steepens to 10% on loose rock for half a mile, then eases to 7% on hardpack for the final stretch. You're 4 hours into a race and sitting at roughly 65% FTP. What's your climbing strategy?",
+      "options": [
+        {
+          "text": "Stand and surge the entire climb to maintain momentum and get it over with quickly",
+          "correct": false
+        },
+        {
+          "text": "Stay seated the entire climb in your easiest gear to minimize torque throughout",
+          "correct": false
+        },
+        {
+          "text": "Seated at normal cadence on the packed 5%, shift easier and add 10-15 RPM for the loose 10% section with hips hinged forward, then stand and push the hardpack 7% finish",
+          "correct": true
+        },
+        {
+          "text": "Walk the loose 10% section to save energy for the hardpack finish",
+          "correct": false
+        }
+      ],
+      "explanation": "The correct approach adjusts technique to each surface and gradient. The packed 5% is low enough gradient that normal climbing works. The loose 10% is the danger zone — seated ready position, higher cadence, lower torque per stroke to stay under the ceiling. The hardpack 7% finish is firm enough to stand if you want to push the pace. Walking the loose section costs far more time than spinning through it with proper technique. Staying in the easiest gear the whole time wastes energy on the sections where you have more traction available."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before Lesson 8: ride your regular gravel climb using The Torque Ceiling. Zero rear-wheel spin events. If the rear breaks loose, cadence was too low."
+    },
+    {
+      "type": "callout",
+      "content": "Next lesson: Reading Surfaces at Speed. You've learned to manage traction on climbs — now we train your eyes to predict what's coming BEFORE you reach it. The 50-meter scan, sound as a reading tool, and the four gravel surface signatures. This is the last lesson in Module 2, and it bridges directly to Module 3: Find the Speed.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/08-reading-surfaces-at-speed.json
+++ b/data/courses/dirt-craft/lessons/08-reading-surfaces-at-speed.json
@@ -1,0 +1,178 @@
+{
+  "id": "reading-surfaces-at-speed",
+  "title": "Reading Surfaces at Speed",
+  "module": "control-the-inputs",
+  "lesson_number": 8,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "3 sec",
+      "unit": "of advance notice",
+      "context": "is the difference between a smooth adjustment and a panic reaction — surface reading buys you that time"
+    },
+    {
+      "type": "sensation_target",
+      "label": "Prediction without surprise",
+      "content": "When surface reading is working, transitions feel like walking from carpet onto tile — you noticed before your foot landed, so the change in feel is expected. Your body pre-adjusts. The bike says nothing because you already answered.\n\nWhen surface reading isn't working, every transition jolts you. The bike shouts at you through the bars and pedals: 'I didn't know that was coming.' Neither did you. You spend the next 3 seconds recovering instead of riding.\n\nHere's the test: ride 20 minutes on varied gravel surfaces. If you feel surprised by a surface change more than twice, your eyes aren't scanning far enough ahead. If you feel surprised zero times, you've found the reading distance."
+    },
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Two riders descend a gravel road at 22 mph. The surface is hardpack — fast, predictable, high traction. Both riders are in the drops, weight balanced, elbows bent. Correct position for the current surface.\n\nFifty meters ahead, the road transitions. Color shifts from dark brown to pale beige. Texture changes from smooth to granular. The pale section is loose-over-hard — a 2-inch layer of marble-sized aggregate sitting on top of a firm base.\n\nRider B notices the color change. Five seconds before contact, they move to the hoods, lighten their grip, press weight through the pedals, and drop tire pressure 2 PSI via their electronic dropper valve. They cross the transition without incident.\n\nRider A is looking at the road 10 feet ahead. They enter the loose section at full speed with hardpack body position — weight forward, firm grip, high confidence. The front tire hits the loose aggregate and deflects 3 inches left. The rigid upper body follows the deflection. Rider A grabs both brakes. On loose gravel. At 22 mph.\n\nRider A barely saves it — a full-body wobble, both feet unclipped, heart rate at 190. The loose section was 200 meters long. The surface change was visible from 50 meters away. They had 5 seconds of warning and used none of it."
+    },
+    {
+      "type": "prose",
+      "content": "### The Four Gravel Surfaces\n\nEvery gravel road you'll ever ride is one of four surfaces, or a transition between them. Each has a visual signature, a sound signature, and a specific set of physics that dictate how your bike behaves.\n\n**1. Hardpack**\n- **Visual**: Dark, uniform color. Often has tire tracks compressed into the surface. May show a slight sheen when wet. Vegetation grows close to the edges — the surface is stable enough that plants aren't getting buried.\n- **Sound**: Quiet hum, similar to rough pavement. Consistent pitch. No crunch.\n- **Physics**: High traction, low rolling resistance. Behaves like rough pavement. This is where you can push speed, corner aggressively, and brake confidently. Treat it like road with slightly wider margins.\n- **Body position**: Normal riding. All techniques from road cycling transfer here.\n\n**2. Loose-Over-Hard**\n- **Visual**: Lighter color than hardpack — the fresh, uncompacted aggregate sits on top. Often pale beige, white, or light gray. Tire tracks may be visible but filled with loose material. The surface looks 'dusty' or 'sugary.'\n- **Sound**: Crunch. Distinct, rhythmic crackling under both tires. Pitch rises with speed. If it sounds like walking on fresh snow, you're on loose-over-hard.\n- **Physics**: The loose layer moves under your tires while the hard base provides a floor. Front wheel can deflect in the loose layer. Traction is available but delayed — the tire has to push through the loose stuff to grip the base. Braking distances increase 30-50%.\n- **Body position**: Weighted drop (Lesson 1). Light hands, heavy feet. Let the front wheel wander — it will find the hard layer. Do not fight it.\n\n**3. Sand and Mud**\n- **Visual**: Sand is obvious — pale, fine-grained, often in patches where water has deposited it. Mud is dark, wet, reflective. Both tend to accumulate in low spots, inside corners, and at the base of climbs where water pools.\n- **Sound**: Sand hisses — a high-pitched, continuous friction sound. Mud is silent until it grabs, then it makes a sucking sound as the tire pulls free.\n- **Physics**: Both dramatically increase rolling resistance and reduce traction. Sand deflects the front wheel laterally. Mud grabs and releases unpredictably. Both reduce braking effectiveness to near zero. Speed management happens BEFORE you enter these sections, not during.\n- **Body position**: Weight back slightly, very light hands. In sand, momentum is survival — if you slow below a critical speed, the tire sinks and you stop. In mud, accept the speed the surface gives you.\n\n**4. Washboard**\n- **Visual**: Rhythmic corrugations running perpendicular to the road. Spacing is typically 2-4 inches. Often most pronounced on the inside line of curves and on descents where vehicles brake. The surface looks rippled.\n- **Sound**: Brrrrrrr. A low-frequency vibration that you feel before you hear. Frequency increases with speed. At high speed, it becomes a continuous drone.\n- **Physics**: Washboard bounces the wheels off the surface at a frequency determined by your speed and the corrugation spacing. At certain speeds, the bounce frequency matches the suspension frequency (your arms and legs) and amplifies. This is the resonance trap — the bike feels like it's shaking apart.\n- **Body position**: This is Lesson 1 and 2 territory. Weighted drop, hip hinge, arms as suspension. The key is to NOT speed up or slow down to escape the vibration — changing speed just shifts you into a different resonance. Maintain speed, absorb with your body, and let the wheels skip."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Sound Frequencies as Surface Sensors",
+          "content": "Your ears are a surface sensor that works when your eyes are busy. Each surface has a distinct audio signature, and with practice, you can identify transitions by sound before you consciously register the visual change.\n\n- **Hardpack to loose**: The hum breaks into a crunch. You'll hear it in the rear tire first (it contacts the new surface before your eyes adjust).\n- **Loose to sand**: The crunch flattens into a hiss. Rolling resistance increases and you feel the bike decelerate.\n- **Any surface to washboard**: A low-frequency rumble that starts in the handlebars before it reaches your ears.\n- **Dry to wet**: Sound gets muffled. The crisp crunch of dry loose gravel becomes a dull thud when wet. The surface absorbed the high-frequency sounds.\n\nThis isn't metaphorical. Experienced gravel riders describe 'hearing' the surface change before they see it. What they're actually doing is processing the rear tire's audio feedback 0.5-1 second before the front tire reaches the new surface. That extra second is free adjustment time.\n\nThe drill in this lesson trains this explicitly. But for now, just start paying attention to what your tires sound like. Most riders have never consciously listened."
+        }
+      ]
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Surface Science — Color Cues, Texture Rules, and Vegetation Signals",
+          "content": "Visual surface reading follows a hierarchy: color first, texture second, vegetation third.\n\n**Color rules:**\n- Darker = more compact, more moisture, higher traction. Water compression packs the surface.\n- Lighter = fresher material, less compacted, more loose. Freshly graded roads are the lightest and loosest.\n- Wet sheen = caution. Wet hardpack is grippy. Wet loose-over-hard is treacherous — the water lubricates the layer between loose and hard.\n- Green tinge at edges = stable surface. Vegetation only grows where the road isn't being churned up regularly.\n\n**Texture rules:**\n- Smooth, uniform = hardpack. Safe to push.\n- Granular, visible individual stones = loose. Respect the torque ceiling.\n- Ridged or rippled = washboard. Absorb, don't fight.\n- Shiny when wet = clay content. Clay is the grease of gravel — nearly zero traction when wet, excellent when dry.\n\n**Vegetation rules:**\n- Grass growing IN the road = rarely trafficked, surface may be unpredictable.\n- Grass growing TO the road edge = stable, packed surface.\n- No vegetation at edges = recently graded. Expect the loosest, freshest material. Treat like a different road than the one you researched.\n- Moss or algae = persistent moisture. These sections will be slippery even on dry days because they never fully dry."
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### The 50-Meter Scan\n\nIn Lesson 4, you learned the quiet eye — focal point 3-5 seconds ahead, soft peripheral vision near-field. Surface reading extends that framework with a specific scanning pattern.\n\n1. **Primary gaze: 50 meters ahead.** At 20 mph, 50 meters is 5.5 seconds away. This is your color-scan distance. You're looking for changes in surface color, which signal transitions. A shift from dark to light = hardpack to loose. A shift from uniform to patchy = mixed surface ahead.\n2. **Secondary gaze: 20 meters ahead.** This is your texture-confirmation distance. At 20 mph, you have 2.2 seconds. By now, you should know what surface is coming and be initiating your adjustment — body position, grip, cadence, line choice.\n3. **Peripheral: immediate.** Your near-field peripheral vision handles the current surface. You don't need to look down — your feet and hands are telling you what's under the tires right now.\n\nThe most common mistake: looking at 10 meters instead of 50. At 10 meters, you have 1.1 seconds to identify, decide, and execute. That's not enough time for a body position change, a gear shift, and a line selection. By the time you react, you're already on the new surface with the wrong setup.\n\nI crashed three times in my first gravel season. Every single one was a surface transition I entered without adjusting. I was looking 10 meters ahead. The surface changes were visible from 50. Three crashes, three lessons in why reading distance matters more than reading accuracy."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Rain Chemistry — How Water Transforms Every Surface Type",
+          "content": "Every surface changes character when it rains. If you can predict those changes before you encounter them, you're riding a different race than the riders who can't.\n\n**Hardpack + rain = variable.** Clay-heavy hardpack becomes slick within 10 minutes of rain. Gravel-heavy hardpack actually improves slightly — the moisture adds weight that compacts the surface. The key indicator is color: if the wet hardpack turns reddish or orange, it has high clay content. Expect ice-rink conditions in corners.\n\n**Loose-over-hard + rain = adhesion.** Light rain is actually beneficial — the moisture helps the loose layer stick to the hard base, creating a firmer surface. Heavy rain reverses this: the water lubricates the interface between layers, and the loose material slides on the hard base like a hydroplaning tire.\n\n**Sand + rain = cement or quicksand.** Lightly wet sand packs hard and becomes fast — think of walking on the wet part of a beach. Saturated sand becomes a trap that stops wheels dead. The difference is 15 minutes of rain.\n\n**Washboard + rain = amplified.** Water collects in the corrugation troughs, creating micro-puddles that splash on each bounce. The visual reading is harder because the water obscures the corrugation depth. The physics are worse because each trough now has water that further reduces traction during the bounce. Slow down 10-15% on wet washboard — the resonance trap is more severe when your tires are hydroplaning in the troughs.\n\n**The universal rain rule:** Drop tire pressure 2-4 PSI when rain starts. The added contact patch compensates for the reduced coefficient of friction on every surface type. This alone prevents more rain-day crashes than any technique adjustment. Lesson 3's pressure window already accounts for this — add the 'wet adjustment' column to your Race Setup Card."
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### Tire Pressure Window Calculator\n\nGet a race-specific tire pressure recommendation that accounts for surface mix, altitude, and weather. Select a race from 757 profiles to auto-populate course data, or enter manually.\n\n**How it works:** Base pressure from rider weight and tire width using Silca's formula (adjusted for gravel). Front/rear split: front runs 2-3 PSI lower than rear for gravel (more contact patch where steering happens). Wet adjustment: -2 to -4 PSI depending on surface. Altitude adjustment: -1 PSI per 3,000 ft above sea level (atmospheric pressure reduction inflates tires). Tubeless insert: floor drops 3-5 PSI below standard tubeless. Tubed: floor 5+ PSI higher than tubeless due to pinch flat risk.\n\n_Interactive calculator coming soon — the numbers above are the method._"
+    },
+    {
+      "type": "callout",
+      "content": "This calculator builds on Lesson 3's tire pressure fundamentals. If you haven't done the Traction Exploration drill from Lesson 3, do that first. The calculator gives you a starting window; the drill gives you the confidence to actually run those pressures. Numbers without feel are just numbers.",
+      "style": "tip"
+    },
+    {
+      "type": "process",
+      "title": "The 50-Meter Scan",
+      "description": "The surface reading protocol. Deploy continuously on any gravel ride — this becomes your default visual pattern.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Eyes 50 meters ahead — identify surface type",
+          "detail": "Hardpack (dark, uniform), loose-over-hard (light, granular), sand/mud (pale patches or wet/reflective), washboard (rippled corrugations). Color is your first signal."
+        },
+        {
+          "step": 2,
+          "action": "Listen — tire noise pitch changes before visual cues",
+          "detail": "Hum-to-crunch = hardpack to loose. Crunch-to-hiss = loose to sand. Low rumble = washboard incoming. Your rear tire hits the new surface before your eyes adjust."
+        },
+        {
+          "step": 3,
+          "action": "Pre-adjust: Weighted Drop for rough, pressure shift for surface change, line choice for transitions",
+          "detail": "Execute the full pre-adjustment sequence: line (50m), body position (30m), speed (20m), cadence/gear (10m)."
+        },
+        {
+          "step": 4,
+          "action": "Confirm on contact — did the surface match your read?",
+          "detail": "If yes, your scan is calibrated. If no, note the miss — was it a color misread, a hidden transition, or a depth misjudgment? Each miss sharpens the next read."
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### Putting It All Together: The Pre-Adjustment Sequence\n\nYou've seen the surface 50 meters ahead. You've identified it. Now what? Here's the adjustment sequence, in order of priority:\n\n1. **Line choice** (50m out). Move to the best surface available. On a wide gravel road, the center crown is often more packed than the edges. The tire tracks from vehicles are harder than the shoulders. Pick your line before you arrive.\n2. **Body position** (30m out). Shift to the position that matches the incoming surface. Hardpack: ride normally. Loose: weighted drop, light hands. Sand: weight back, momentum is king. Washboard: arms as suspension, hips as hinge.\n3. **Speed management** (20m out). If you need to slow down for the transition, do it NOW, on the current surface where you have traction. Do not brake on the new surface until you know how it responds.\n4. **Cadence/gear** (10m out). If the surface is loose, shift to an easier gear before you arrive. Shifting under load on a loose surface causes chain tension spikes that can break rear-wheel traction.\n\nThis sequence takes 5 seconds. It happens in the space between 50 meters and contact. After two weeks of deliberate practice, it becomes unconscious. Your eyes scan, your body adjusts, and you don't even register the transition as an event. That's the goal: prediction without surprise."
+    },
+    {
+      "type": "drill",
+      "title": "Narrate the Surface",
+      "time_minutes": 20,
+      "description": "Ride varied gravel terrain and call out each surface type OUT LOUD 3 seconds before you reach it. This forces conscious surface identification until it becomes automatic. The narration is the training — after 20 minutes, your eyes will be scanning without being told to.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Easy pace on a road with 2-3 surface types",
+          "steps": [
+            "Find a gravel route with at least 2-3 surface transitions in a 3-mile stretch. An out-and-back on a road that changes character works well.",
+            "Ride at easy endurance pace. Your attention should be on reading, not on effort.",
+            "For every surface change, call out the type 3 seconds before you reach it: 'Hardpack.' 'Loose-over-hard.' 'Sand patch.' 'Washboard.'",
+            "After calling the surface, call your adjustment: 'Light hands.' 'Weight back.' 'Easy gear.' Say it out loud — the verbalization forces the decision to be explicit.",
+            "Ride 20 minutes total. Count your successful calls (correct identification, 3+ seconds ahead) and your surprises (surface hit you before you called it).",
+            "Target: 7 out of 10 correct calls on your first session. By session 3, you should be at 9 out of 10."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Tempo pace on varied multi-surface gravel",
+          "steps": [
+            "Same narration protocol, but at tempo pace (76-88% FTP). The added speed compresses your reaction time and forces you to scan further ahead.",
+            "Add COLOR calls to your narration: 'Light section ahead — loose.' 'Dark line — packed.' 'Wet sheen on right — avoid.'",
+            "When you identify a transition, execute the full pre-adjustment sequence: line, position, speed, gear. Call each step out loud.",
+            "Ride 20 minutes. Now count not just identifications but adjustments. Did you actually change your body position before the transition? Did you shift before the loose section?",
+            "Target: 8 out of 10 identifications AND completed adjustments. Calling the surface means nothing if your body doesn't move."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "High-speed surface reading with group or simulated pressure",
+          "steps": [
+            "Ride at race pace (sweet spot to threshold) on a route with frequent surface transitions. If possible, ride with a partner who pushes your pace.",
+            "Stop narrating out loud — by now, the habit should be internalized. Instead, focus on the sensation: does every transition feel predicted? Are you surprised by anything?",
+            "Add weather reading: ride in the first 30 minutes after rain, or on a morning with dew. The surfaces you know in dry conditions will behave differently. Can you predict the wet behavior from the dry signatures you've learned?",
+            "Bonus challenge: ride a gravel route you've never ridden before. Zero prior knowledge. Read it cold. If you can call 8 out of 10 surfaces correctly on an unfamiliar road, you've internalized the skill.",
+            "Record your results. Compare surprise count at race pace to your first beginner session. The gap tells you how much your reading has improved under stress."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "Correctly identify surface type before contact, 9 out of 10 transitions, on a varied gravel route.",
+        "metric": "ratio",
+        "target": "9 out of 10 surface transitions correctly identified 3+ seconds before contact on a route with at least 10 transitions"
+      }
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're riding at 18 mph on hardpack when you see three things simultaneously: the road color lightens 40 meters ahead, the right side of the road has fresh tire tracks (darker), and there's a puddle on the left edge. What's your adjustment priority?",
+      "options": [
+        {
+          "text": "Brake hard to slow down before the surface change, then pick a line",
+          "correct": false
+        },
+        {
+          "text": "Move to the right side (darker, packed tire tracks), shift to a lighter grip and easier gear, scrub speed gently on the current hardpack",
+          "correct": true
+        },
+        {
+          "text": "Stay on your current line and ride through — surface changes at 18 mph aren't dangerous",
+          "correct": false
+        },
+        {
+          "text": "Avoid the puddle by moving to the center of the road where the loose material is deepest",
+          "correct": false
+        }
+      ],
+      "explanation": "Line choice comes first — the darker tire tracks on the right indicate packed surface, the best available traction. Speed management comes second — scrub speed on the current hardpack where braking is safe, not on the loose surface ahead. Grip and gear adjustment come third — lighter hands for the loose section, easier gear in case you need to climb. Hard braking wastes your traction budget and may not leave enough grip for the transition. Ignoring the change is how Rider A in the black box nearly crashed. Avoiding the puddle by moving to the center puts you in the loosest material."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before Module 3: ride 20 minutes of varied gravel using The 50-Meter Scan. Call every surface transition 3 seconds before contact. 9 out of 10 correct means your Control stack is complete."
+    },
+    {
+      "type": "callout",
+      "content": "This is the last lesson in Module 2: Control the Inputs. You started Module 2 learning to brake without crashing. You finish it reading surfaces before you reach them. The progression — braking, cornering, climbing, reading — has given you specific, repeatable techniques for every input your bike receives.\n\nModule 3 is where it gets fun. You're no longer fighting the terrain or white-knuckling through transitions. Now we find the speed that's been hiding in the skills you've built. Lesson 9: Descending as Play, Not Survival.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/09-descending-as-play.json
+++ b/data/courses/dirt-craft/lessons/09-descending-as-play.json
@@ -1,0 +1,316 @@
+{
+  "id": "descending-as-play",
+  "title": "Descending as Play, Not Survival",
+  "module": "find-the-speed",
+  "lesson_number": 9,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "45 sec",
+      "unit": "free time on a single descent",
+      "context": "between a rider who brakes constantly and one who manages speed through body position"
+    },
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Two riders crest the same climb together. Same legs, same bikes, same tires.\n\nRider A sits on the hoods, upright, hands hovering over the brake levers. The descent begins — 6% grade, packed gravel with scattered loose patches. Rider A brakes entering every loose section, releases, brakes again when speed rebuilds. Eleven brake events in 2.1 km. Each event scrubs 3-5 mph, each recovery costs 4-6 seconds. Rider A arrives at the bottom with forearms pumped, disc rotors hot, and 45 seconds of lost time.\n\nRider B drops into the drops at the crest. Lower center of mass, better brake leverage, 22% less frontal area. Weight shifts rearward as the gradient steepens. On smooth sections, Rider B tucks — forearms on the bar tops, chin low, pedals level. On loose sections, Rider B rises slightly off the saddle, absorbs through bent elbows and weighted feet. Two brake events total: once before a switchback, once before a cattle guard.\n\nRider B arrives at the bottom 45 seconds ahead, grinning, with cold rotors.\n\nThe gap wasn't fitness. It was hand position and technique."
+    },
+    {
+      "type": "sensation_target",
+      "label": "Controlled falling",
+      "content": "Gravity pulls the bike downhill. Your job is to guide it, not resist it.\n\nHere's the target sensation: you feel the bike accelerating under you like a sled on snow. Your hands rest in the drops — not gripping, just guiding. The brakes are there, but they're a precision tool, not a panic button. You use them the way a sculptor uses a chisel: deliberate, specific, brief.\n\nWhen it's right, descending feels like surfing. The terrain is the wave. You read it, you adjust, you flow with it. The speed feels earned, not scary, because you chose it through position instead of fighting it with brake pads.\n\nWhen it's wrong, you feel like you're being chased. Every bump is a threat. Your forearms burn. Your rotors howl. You arrive at the bottom exhausted from a section that should have been recovery.\n\nThe difference isn't courage. It's technique."
+    },
+    {
+      "type": "prose",
+      "content": "I spent years descending gravel like Rider A. Hands on the hoods, body upright, braking at every surface change. I told myself I was being \"safe.\" What I was actually being was slow AND less stable — upright position means higher center of mass, worse brake modulation, and more wind resistance that I then had to brake against.\n\nThe cruel irony of fearful descending: the things you do to feel safe make you less safe. Sitting upright catches more wind, which builds more speed between brake events, which requires harder braking, which reduces traction on loose surfaces. The death spiral is real, and it starts with hand position."
+    },
+    {
+      "type": "prose",
+      "content": "### The Drops Are Your Default Descent Position\n\nDrops give you four things at once: 8-12 cm lower center of mass, better brake leverage at the mechanical advantage point, 22% less frontal area, and bent elbows that act as suspension (Lesson 1). The CdA table in the accordion below shows exactly what that's worth in seconds per kilometer.\n\nIf drops are uncomfortable for more than 30 seconds, fix your bike fit first."
+    },
+    {
+      "type": "data_table",
+      "caption": "Weight Shift by Gradient — Hips Move Back as the Road Tips Down",
+      "headers": [
+        "Gradient",
+        "Weight F/R",
+        "Hip Position",
+        "Key Cue"
+      ],
+      "rows": [
+        [
+          "0-4%",
+          "45/55",
+          "Normal on saddle, pedals level",
+          "Standard drops"
+        ],
+        [
+          "4-8%",
+          "40/60",
+          "Hips back 2-3 cm on saddle",
+          "Rear tire stays loaded"
+        ],
+        [
+          "8-12%",
+          "35/65",
+          "Behind saddle, belly over BB",
+          "Arms extended, elbows bent"
+        ],
+        [
+          "12%+",
+          "30/70",
+          "Butt behind and above saddle",
+          "If rear wheel lifts, move back"
+        ]
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### The Aero Tuck\n\n30%+ drag reduction over standard drops. Forearms flat on the bar tops, chin low, knees against the top tube, pedals level and weighted. That's it.\n\nThe rule: tuck when you can see 5+ seconds of smooth, straight road ahead. The moment you're uncertain — drops, hands on levers. I tuck maybe 30% of a typical descent. The rest is drops. The tuck is a tool, not a permanent state."
+    },
+    {
+      "type": "prose",
+      "content": "### Your Body Is a Speed Dial\n\nFaster: get lower, tuck tighter. Slower: sit up, open your chest to the wind, spread your knees. On a moderate descent, that range is 5-8 mph without touching the brakes.\n\nWhy this matters: braking on gravel costs traction (the traction circle from Lesson 5). Every mph you manage through body position is grip you keep in reserve for the moments that actually need brakes."
+    },
+    {
+      "type": "prose",
+      "content": "### Line Choice: Surface First, Geometry Second\n\nOn pavement, the geometric racing line wins. On gravel, it might run through the loosest section. Gravel hierarchy:\n\n1. **Best surface.** Packed tire tracks, darker soil, smooth lines between ruts. The grippiest line is the fastest line, even if it's geometrically longer.\n2. **Fewest transitions.** Every surface change (packed to loose, dry to wet) costs traction. Minimize crossings.\n3. **Geometric efficiency.** Only after #1 and #2. On loose corners, the wide line through packed surface beats the tight apex through marbles.\n\nThis stacks directly on Lesson 4 (The Quiet Eye) and Lesson 8 (Reading Surfaces at Speed). Eyes 3-5 seconds ahead, reading surface, choosing grip."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Aero Physics: CdA, Drag Reduction, and Wind Tunnel Data",
+          "blocks": [
+            {
+              "type": "data_table",
+              "caption": "Terminal Velocity and Time Savings by Body Position (6% Gravel Descent, 1 km, 75 kg Rider + 9 kg Bike)",
+              "headers": [
+                "Position",
+                "Approx CdA (m²)",
+                "Terminal Velocity",
+                "1 km Time",
+                "Time vs Hoods Upright"
+              ],
+              "rows": [
+                [
+                  "Hoods, upright",
+                  "0.45",
+                  "28 mph / 45 km/h",
+                  "80 sec",
+                  "—"
+                ],
+                [
+                  "Hoods, bent elbows",
+                  "0.40",
+                  "30 mph / 48 km/h",
+                  "75 sec",
+                  "5 sec faster"
+                ],
+                [
+                  "Drops, standard",
+                  "0.35",
+                  "32 mph / 52 km/h",
+                  "69 sec",
+                  "11 sec faster"
+                ],
+                [
+                  "Drops, tucked",
+                  "0.28",
+                  "36 mph / 58 km/h",
+                  "62 sec",
+                  "18 sec faster"
+                ]
+              ]
+            },
+            {
+              "type": "callout",
+              "content": "These numbers assume zero braking and a smooth surface — real descents involve braking zones, surface changes, and corners. But the pattern holds: Rider A on the hoods with constant braking loses 40-50 seconds per km of descent versus Rider B in the drops with selective braking. Over a race with 10+ km of total descending, that's 5-8 minutes of free time from position alone.",
+              "style": "tip"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "content": "Add The Position Ladder to your Race Setup Card (started in Lesson 3, expanded in Lesson 8). Write it on a stem note until it's automatic.",
+      "style": "tip"
+    },
+    {
+      "type": "prose",
+      "content": "Every gravel article tells you to 'relax and let the bike flow.' That's like telling someone afraid of heights to 'just don't look down.' Here's what actually works — a position sequence you can run mechanically, even when your brain is screaming."
+    },
+    {
+      "type": "process",
+      "title": "The Position Ladder",
+      "description": "Your descent body position protocol. Deploy at every crest before the road tips down.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Drops as default",
+          "detail": "Hands in the drops, fingers on levers."
+        },
+        {
+          "step": 2,
+          "action": "Elbows bent 20°, chin low",
+          "detail": "Arms are suspension, not scaffolding."
+        },
+        {
+          "step": 3,
+          "action": "Weight shift by gradient",
+          "detail": "<4% stay neutral. 4-8% hips back slightly. 8-12% butt behind saddle. >12% full attack position."
+        },
+        {
+          "step": 4,
+          "action": "Tuck on smooth straights",
+          "detail": "Forearms horizontal, back flat. Only when you can see 5+ seconds ahead."
+        },
+        {
+          "step": 5,
+          "action": "Open up before corners",
+          "detail": "Exit tuck, hands ready on levers. Transition back to drops before the turn, not during."
+        }
+      ]
+    },
+    {
+      "type": "drill",
+      "title": "The Aero Progression",
+      "time_minutes": 30,
+      "description": "Same descent, five times, with progressive body positions. Time each run. Discover exactly how much free speed your position is worth — no extra watts required.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Moderate gravel descent, 3-5% grade, 1-2 km",
+          "steps": [
+            "Find a gravel descent you know well — consistent surface, good visibility, no traffic. 3-5% grade, at least 1 km long.",
+            "Run 1: Hoods, upright. Normal posture, hands on top of hoods. Ride it the way you'd naturally descend. Time it.",
+            "Run 2: Hoods, bent elbows. Same position, but consciously bend your elbows 20 degrees and lower your torso. Time it.",
+            "Run 3: Drops. Hands in the drops, natural arm bend, lower torso. Time it. Note how brake access changes — you should feel MORE control, not less.",
+            "Run 4: Drops with tuck on straights. When the road is straight and surface is smooth, lower your torso further — forearms toward bar tops, chin down. Return to standard drops for any curve or surface change. Time it.",
+            "Run 5: Full race execution. Choose the right position for each section — tuck the straights, drops through turns, weight shift by gradient. Time it.",
+            "Compare times. The gap between Run 1 and Run 5 is your free speed — watts you never had to produce."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Mixed-surface descent with turns, 4-8% grade",
+          "steps": [
+            "Same five-run structure, but on a descent with surface transitions and at least 2-3 turns.",
+            "Run 1: Hoods upright. Count your brake events. Write the number down.",
+            "Run 2: Hoods, bent elbows. Count brake events again. Should already be fewer — lower position means less wind speed buildup between braking zones.",
+            "Run 3: Drops. Focus on brake modulation — how much LESS force you need to achieve the same deceleration with better lever position.",
+            "Run 4: Drops with selective tuck. Tuck ONLY on smooth straights where you can see 5+ seconds ahead. Count brake events.",
+            "Run 5: Race execution. Add line choice from the teaching section — surface first, geometry second. Time it. Count brake events.",
+            "You should see both faster times AND fewer brake events as positions progress. That's the whole point."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Race-intensity descent, 6-10% with technical features",
+          "steps": [
+            "Warm up thoroughly. This variant pushes into higher speeds.",
+            "Run 1: Race-pace, hoods. Ride the descent as you would in a race from the hoods. Record time and max speed.",
+            "Run 2: Race-pace, drops. Focus on the weight shift protocol by gradient. Record time and max speed.",
+            "Run 3: Race-pace with tuck and line optimization. Full technique stack: drops, tuck on straights, weight shift by gradient, surface-first line choice. Record time and max speed.",
+            "Run 4: Recovery run — easy pace, drops position, focus on smoothness and reading the surface 5 seconds ahead.",
+            "Run 5: Final race-pace run. Integrate everything. This run should feel the smoothest AND be the fastest.",
+            "Review: compare Run 1 vs Run 5. The time gap represents technique-only speed gains. If Run 5 is your fastest and felt the most controlled, you're descending correctly."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "Follow a faster descender through a gravel descent without falling back — not through bravery, but through less braking and better position.",
+        "metric": "comparative",
+        "target": "Maintain contact with a known faster descender through an entire gravel descent using technique (position, line choice, selective braking), not risk tolerance"
+      }
+    },
+    {
+      "type": "data_table",
+      "caption": "Brake or Carry — The Selective Braking Decision (Lesson 5's Speed-Set-Coast Applied to Descents)",
+      "headers": [
+        "Situation",
+        "Action",
+        "Why"
+      ],
+      "rows": [
+        [
+          "Before turns",
+          "Brake on packed surface, release before the corner",
+          "Straight-line braking preserves traction for the turn (Lesson 5/6)"
+        ],
+        [
+          "Before surface transitions",
+          "Scrub speed while still on good surface",
+          "Braking on loose gravel costs traction you need for stability"
+        ],
+        [
+          "Blind crests / corners",
+          "Slow to sight-distance speed",
+          "Stop within what you can see, always"
+        ],
+        [
+          "Packed surface, clear visibility",
+          "Let it run — tuck if straight",
+          "This is where position earns free speed"
+        ],
+        [
+          "Post-braking zone",
+          "Carry exit speed to next feature",
+          "Don't re-scrub what you already managed"
+        ],
+        [
+          "Committed line",
+          "No mid-line braking",
+          "Pick your line, trust it, ride it — mid-line braking breaks traction"
+        ]
+      ]
+    },
+    {
+      "type": "video",
+      "id": "nON4UHAAgUk",
+      "title": "How to Descend on a Gravel Bike",
+      "channel": "Gravel Cyclist",
+      "caption": "Gravel descending technique — body position and line choice at speed."
+    },
+    {
+      "type": "video",
+      "id": "pdP1khKfDVA",
+      "title": "Gravel Gods // Ep. 5 // Let The Pros Handle It",
+      "channel": "SAFA Brian",
+      "caption": "Long-form: watch pros ride technical gravel at speed. Notice how relaxed and low they stay, how early they brake, and how they let the bike move. This is descending as play, done well."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're descending a gravel road at 25 mph. Ahead, you see the road kicks from 4% to 10% gradient, the surface transitions from packed to loose, and there's a right-hand sweeper 200 meters ahead. What's your sequence?",
+      "options": [
+        {
+          "text": "Tuck to build speed before the steep section, then brake hard into the corner",
+          "correct": false
+        },
+        {
+          "text": "Brake now on the packed surface, shift weight rearward for the 10% section, move to drops if not already there, pick the packed line through the sweeper",
+          "correct": true
+        },
+        {
+          "text": "Maintain speed and ride the geometric racing line through the corner for maximum efficiency",
+          "correct": false
+        },
+        {
+          "text": "Sit up to use wind resistance as the primary braking force through the entire section",
+          "correct": false
+        }
+      ],
+      "explanation": "Brake while you still have traction — on the packed surface at 4% grade, before the loose section begins. Shift weight rearward as the gradient steepens to 10% (hips behind saddle, 35/65 weight distribution). Being in the drops gives you the best brake leverage and lowest center of mass for the steep loose section. Through the sweeper, pick the line with the best surface (packed tire tracks, darker soil), not the geometric apex — the fastest line on loose gravel is the grippiest line, even if it's longer. Tucking before a steep loose section with a corner builds speed you'll need to brake away on reduced-traction surface. Sitting upright works for gentle speed management but isn't precise enough for this sequence."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before Lesson 10: ride a familiar descent 5 times using The Position Ladder. Time each run. Discover how much free speed lives in body position alone."
+    },
+    {
+      "type": "callout",
+      "content": "Next lesson: Pack Dynamics & Pacing by Terrain. You've found speed through position — now we find speed through strategy. How to draft on gravel (it's different from road), when to leave a group, and why the rider who paces by surface type finishes 20 minutes faster at the same average power.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/10-pack-dynamics-and-pacing.json
+++ b/data/courses/dirt-craft/lessons/10-pack-dynamics-and-pacing.json
@@ -1,0 +1,184 @@
+{
+  "id": "pack-dynamics-and-pacing",
+  "title": "Pack Dynamics & Pacing by Terrain",
+  "module": "find-the-speed",
+  "lesson_number": 10,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "20 min",
+      "unit": "faster at the same average power",
+      "context": "when pacing is adjusted by surface type instead of holding constant wattage"
+    },
+    {
+      "type": "sensation_target",
+      "label": "Elastic connection / Surfing, not grinding",
+      "content": "Two sensation targets for this lesson, because it covers two skills.\n\n**Drafting on gravel — the bungee cord.** When you're following a wheel on smooth gravel, you feel an elastic connection to the rider ahead. Not rigid, not slack — elastic. The gap stretches on rough patches as you both navigate independently, then contracts as the surface smooths out and you slide back into the draft. You're connected but not chained. The bungee cord stretches to 3-4 bike lengths on rough stuff, contracts to 1.5-2 on smooth. If you feel rushed — lunging to close gaps, braking to avoid overlapping — the bungee is too tight. If you lose the wheel every time the surface changes, it's too loose.\n\n**Pacing by surface — surfing the wave.** Good surfaces are the wave. You catch them, push them, ride the efficiency. Bad surfaces are the trough between waves. You don't fight the trough — you survive it patiently and wait for the next wave. When the pacing is right, hard efforts feel productive (high speed per watt) and easy efforts feel strategic (preserving yourself for the next productive section). When the pacing is wrong, hard efforts feel futile (grinding 250W for 14 mph on sand) and easy efforts feel guilty (coasting on hardpack where you should be banking time)."
+    },
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Two riders start a 150-mile gravel race with identical 250-watt FTP.\n\nRider A holds 250W everywhere. Steady. Disciplined. On loose gravel where drivetrain efficiency drops to 78%, those 250W produce 14 mph. On packed hardpack where efficiency is 95%, those 250W produce 19 mph. Rider A is grinding heroically on the bad surfaces and coasting on the good ones. By mile 100, glycogen is depleted from the sustained high-torque effort on loose sections. By mile 130, Rider A bonks. The last 20 miles take 2 hours.\n\nRider B rides by surface, not by power meter. On loose gravel: 85% FTP (213W) — patient, spinning, preserving glycogen during low-efficiency sections where extra watts produce minimal speed gains. On packed hardpack: 105% FTP (263W) — pushing where the return on investment is highest. Sand and mud: 75% FTP, purely survival. Smooth pavement: 110% FTP, banking time.\n\nRider B's average power for the day: 248W. Nearly identical to Rider A. But Rider B finishes 20 minutes faster and has enough left for a kick in the final 10 miles.\n\nSame engine. Same fuel. Different allocation. The power meter doesn't know what surface you're on. You have to."
+    },
+    {
+      "type": "prose",
+      "content": "I raced my first three gravel events staring at my power meter like it was a metronome. 250 watts. Hold 250 watts. The surface was irrelevant. The group around me was irrelevant. I was a 250-watt robot.\n\nI bonked in two of those three races. Not from underfueling — from misallocating effort. I was spending my most expensive watts on surfaces where those watts barely moved me forward, and then coasting through the sections where those watts would have been most efficient.\n\nGravel pacing isn't steady-state. It's investment allocation. You have a fixed budget of kilojoules for the day. Spend them where the return is highest."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Draft Savings Math and Pull Rotation Calculations",
+          "blocks": [
+            {
+              "type": "prose",
+              "content": "### Draft Savings on Gravel vs. Road\n\nDrafting on gravel works. It doesn't work as well as road drafting — roughly half the benefit you get on pavement — but 15-25% power savings is still significant, depending on gap and surface.\n\nWhy the savings are lower than road (25-35%):\n- Wider tires and lower speeds reduce the aerodynamic benefit\n- Rough surfaces create gaps that break the draft pocket\n- Line choice divergence means you're frequently offset from the ideal draft position\n- Riders spread laterally to pick their own lines through rough sections\n\nBut even 15% is enormous over a long day. At 250W solo, a 20% draft savings at the same speed costs roughly 200W. Over a 6-hour race, that's the difference between 5,400 kJ and 4,320 kJ of total work. That's meaningful glycogen you're keeping in reserve."
+            },
+            {
+              "type": "prose",
+              "content": "### Pull Rotation Math for Gravel\n\nOn the road, pull rotation is simple: take a pull, swing off, drift back. Equal time, equal effort. On gravel, it's more nuanced because the surface changes the calculus.\n\n**The energy cost of leading on gravel:**\n- On smooth gravel at 18-20 mph, leading costs roughly 25-30% more energy than drafting (similar to road)\n- On rough gravel at 14-16 mph, the aero penalty for leading drops to 10-15% — rolling resistance is now the dominant force, and that doesn't change based on position\n- On loose gravel at 10-14 mph, leading costs maybe 5-8% more than drafting — nearly irrelevant\n\nThis means pull rotation should adjust by surface:\n\n- **Packed sections (18+ mph)**: Short pulls (30-60 sec). The aero penalty is high, so rotate frequently to spread the cost.\n- **Mixed sections (14-18 mph)**: Longer pulls (1-2 min). The penalty is moderate, and constant rotation disrupts the group on variable surfaces.\n- **Rough sections (under 14 mph)**: Don't bother rotating. Everyone rides their own line at their own pace. The draft barely matters at these speeds. Regroup on the next smooth section.\n\nA practical rule: rotate on hardpack, single-file on mixed, every-rider-for-themselves on rough. Regroup after every rough section."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "**The variable-gap protocol:**\n\n- **Smooth, packed surface**: 1.5-2 bike lengths. Close enough for real aero benefit. You can hold a tight line because the surface is predictable.\n- **Mixed or transitional surface**: 2-3 bike lengths. You need room to pick your own line through loose patches without overlapping the rider ahead when they slow unexpectedly.\n- **Rough, loose, or technical surface**: 3-4 bike lengths. Each rider needs full independence to navigate. The draft benefit at these speeds (12-16 mph) is minimal anyway — rolling resistance dominates aerodynamic drag at low speeds.\n\nThe mistake I see constantly in gravel races: riders hold road-race gaps (half a wheel to one wheel) on loose gravel. When the rider ahead hits a rock and swerves, the follower has no reaction time. On gravel, the half-wheel game will put you on the ground."
+    },
+    {
+      "type": "prose",
+      "content": "### When to Leave a Group: Three Signals\n\nGroups in gravel racing are alliances of convenience, not permanent commitments. The wrong group costs more energy than solo riding. Here are the three signals that it's time to go:\n\n**Signal 1: The group pace doesn't match your race plan.** If the group is pushing 105% FTP on loose gravel (where your plan says 85%), you're burning matches you need later. This is the hardest signal to act on because the group FEELS efficient. It is efficient — for the group's pace. But if that pace depletes you by mile 100, the drafting savings were a bad trade.\n\n**Signal 2: The group is mechanically chaotic.** Erratic pace changes, poor line choice, riders overlapping wheels on rough terrain. If you're spending more mental energy avoiding crashes than you're saving in watts, leave. A smooth solo ride at 20W higher is less fatiguing than a chaotic group ride at 20W lower.\n\n**Signal 3: The group is slower than your sustainable solo pace on the current surface.** Do the math: if you can hold 18 mph solo on packed gravel, and the group is doing 19.5 mph, the draft savings make staying worthwhile. But if the group is doing 17 mph, you're going slower AND burning the mental energy of group riding. Ride off the front.\n\nThe flip side: if a faster group comes by and their pace matches your plan, don't let ego keep you from latching on. Free watts are free watts."
+    },
+    {
+      "type": "prose",
+      "content": "### Surface-Adjusted Pacing\n\nThis is the core concept of the lesson. Your power meter is surface-blind. You are not.\n\n**The efficiency spectrum:**\n- **Smooth pavement**: ~95% drivetrain efficiency. 250W = 250W of forward motion. Push here. 105-110% FTP.\n- **Packed hardpack gravel**: ~92% efficiency. Nearly as good as pavement. Push here. 100-105% FTP.\n- **Loose-over-hard gravel**: ~85% efficiency. Moderate losses from tire deflection and micro-slip. Hold steady. 90-95% FTP.\n- **Loose gravel / chunky rock**: ~78% efficiency. Significant losses. Ease off. 80-90% FTP.\n- **Sand, mud, deep gravel**: ~65% efficiency. A third of your power vanishes into the surface. Survival mode. 70-80% FTP.\n\nThe math is simple: on a surface where 250W produces 14 mph, going to 280W might produce 14.5 mph. That extra 30W bought you 0.5 mph — terrible return on investment. But on packed gravel where 250W produces 19 mph, those same extra 30W might produce 20.5 mph. Same watts, 3x the speed gain.\n\nThis is why constant-wattage pacing fails on gravel. The surfaces are too variable. The rider who allocates power by efficiency — pushing where watts convert to speed, easing off where they don't — finishes faster at the same or lower average power."
+    },
+    {
+      "type": "callout",
+      "content": "Surface-adjusted pacing connects directly to your fueling strategy. Pushing hard on efficient surfaces means higher carbohydrate burn during those windows — which is fine if you're fueling for it. The Gravel God Academy Hydration Mastery course covers carbohydrate periodization by effort level. The short version: eat on the easy surfaces so you have fuel for the hard pushes. Don't try to eat at 105% FTP on packed gravel — eat at 80% FTP on the rough stuff when intensity is low enough to digest.",
+      "style": "tip"
+    },
+    {
+      "type": "prose",
+      "content": "### Power Meter Pacing vs. Terrain Pacing\n\nPower meters are extraordinary tools. They're also dangerously seductive on gravel because they give you a precise number that ignores context.\n\n**Power meter pacing (road model):** Hold target watts. Adjust for grade. Ignore surface.\n\n**Terrain pacing (gravel model):** Hold target EFFORT relative to surface efficiency. Adjust for grade AND surface AND group dynamics.\n\nIn practice:\n- Glance at power on smooth sections to calibrate your effort (\"this feels like 260W and it IS 260W — good\").\n- Ignore power on rough sections. Ride by feel and surface. If your power drops to 200W on loose gravel because you're being patient, that's correct strategy, not weakness.\n- Use normalized power (NP) as your post-ride check, not average power. Terrain pacing produces a higher variability index (NP/avg) than road pacing — typically 1.05-1.15 vs road's 1.00-1.05. That's expected and correct.\n\nIf your NP equals your average power on a gravel race, you were pacing like it was a road time trial. You left time on the table."
+    },
+    {
+      "type": "process",
+      "title": "The Elastic Gap",
+      "description": "Your drafting and pacing protocol. Deploy any time you're riding with others or managing effort across mixed surfaces.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "On smooth surfaces: close to 1.5-2 bike lengths",
+          "detail": "Maximum draft benefit where the surface is predictable."
+        },
+        {
+          "step": 2,
+          "action": "On rough surfaces: open to 3-4 lengths",
+          "detail": "Each rider needs independence to pick their own line."
+        },
+        {
+          "step": 3,
+          "action": "Feel the bungee cord",
+          "detail": "Constant elastic tension — never snapped tight or fully slack."
+        },
+        {
+          "step": 4,
+          "action": "Push efficient surfaces, ease off inefficient ones",
+          "detail": "Hardpack = 100-105% FTP. Loose/sand = 80-85% FTP."
+        },
+        {
+          "step": 5,
+          "action": "Three signals to leave a group",
+          "detail": "Pace too hot, too much braking, or group is slower than your solo pace on this surface."
+        }
+      ]
+    },
+    {
+      "type": "drill",
+      "title": "Accordion Intervals",
+      "time_minutes": 30,
+      "description": "Practice surface-adjusted pacing and variable-gap drafting on a familiar loop. The goal: faster average speed with equal or lower normalized power compared to steady-state riding.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Solo, 30-minute loop with mixed surfaces",
+          "steps": [
+            "Find a 30-minute gravel loop you know well — one with at least 2-3 distinct surface types (pavement, packed gravel, loose gravel).",
+            "Ride 1: Steady-state baseline. Hold the most even effort you can for the entire loop. Record time and average/normalized power.",
+            "Ride 2 (next ride): Surface-adjusted. Push packed sections to 100-105% FTP. Ease loose sections to 80-90% FTP. Pavement at 105-110% FTP. Survival pace on any sand or mud.",
+            "Compare times and normalized power. If Ride 2 is faster with equal or lower NP, the pacing strategy works.",
+            "The key sensation: Ride 2 should feel EASIER overall despite being faster. Hard efforts feel productive. Easy efforts feel strategic, not lazy.",
+            "Repeat weekly. Track the gap between steady-state and surface-adjusted times. It should widen as you get better at reading when to push and when to wait."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "With a partner, practicing variable-gap drafting",
+          "steps": [
+            "Ride with a partner of similar ability on a mixed-surface loop.",
+            "Practice the accordion: smooth sections at 1.5-2 bike lengths, rough sections at 3-4 bike lengths. The gap opens and closes like a bungee cord.",
+            "Pull rotation by surface: rotate on packed sections (30-60 sec pulls), single-file on mixed, solo lines on rough. Regroup after each rough section.",
+            "Target: zero 'rushed' moments. If either rider feels lunging to close a gap or braking to avoid a collision, the gap management needs work.",
+            "After 20 minutes, switch — the follower leads. Both riders should feel the difference between leading on smooth (hard) vs leading on rough (barely different from following).",
+            "Post-ride comparison: both riders should show lower NP than their solo steady-state baseline at equal or faster average speed. That's the draft working."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Group simulation with surge management",
+          "steps": [
+            "With 2-4 riders, simulate race-group dynamics on a mixed-surface loop.",
+            "Designate one rider to set pace. That rider deliberately surges on smooth sections (simulating race attacks) and eases on rough sections.",
+            "Followers practice: close the gap on smooth (where draft matters most), let it stretch on rough (where it doesn't). Do NOT chase surges on loose gravel — the cost is too high and the draft benefit is too low.",
+            "Practice the three 'leave' signals: if the group pace exceeds your plan by more than 10% on rough surfaces for 5+ minutes, soft-pedal and let them go.",
+            "After 30 minutes, regroup and discuss: which surges were worth following? Which should have been ignored? Map the answers to surface type.",
+            "Key metric: the riders who managed their effort by surface should have lower NP and feel fresher than riders who matched every surge regardless of terrain."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "Average speed on a familiar loop increases 2-4% with equal or lower normalized power, demonstrating that surface-adjusted pacing extracts more speed from the same energy budget.",
+        "metric": "percentage",
+        "target": "2-4% faster average speed on familiar loop with equal or lower normalized power compared to steady-state baseline"
+      }
+    },
+    {
+      "type": "prose",
+      "content": "### Putting It Together: Race Day Execution\n\nHere's how all of this integrates on race day:\n\n**First 30 minutes:** Find a group that matches your target effort on the first smooth section. Don't evaluate based on the start line chaos — wait for the first real surface to see who's pacing wisely and who's redlining. Sit in the draft. Conserve.\n\n**Miles 10-80 (or your race's middle 60%):** Surface-adjusted pacing with group dynamics. Push on efficient surfaces, ease on inefficient ones. Rotate on smooth, ride solo lines on rough. Eat and drink on the rough sections when intensity is low.\n\n**The decision points:** Every time the group surges on rough terrain, evaluate: is this group still net-positive for me? If someone attacks on loose gravel, let them go. You'll likely catch them when they bonk at mile 100.\n\n**Final 20%:** This is where surface pacing pays its dividend. If you've been banking energy on the rough sections all day, you have glycogen left. The riders who ground out constant watts are fading. Push the packed sections harder. Sit up on the rough stuff. The separation happens now.\n\nThis connects to everything you've built: weighted drop and body suspension (Lessons 1-2) let you ride rough terrain without fatigue. Braking technique (Lesson 5) preserves traction. Surface reading (Lesson 8) tells you when to push. Descending position (Lesson 9) gives you free time. Now pacing ties it all together into a race strategy."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're 80 miles into a 150-mile gravel race. You're sitting in a group of 6 riders on packed hardpack doing 19 mph. Your normalized power with the group is 225W (90% FTP). The course turns onto 8 miles of loose, chunky gravel. Two riders in the group immediately push to the front and increase effort to maintain speed. What do you do?",
+      "options": [
+        {
+          "text": "Match their effort to hold your position in the group — losing the draft would cost more energy than the surge",
+          "correct": false
+        },
+        {
+          "text": "Let the gap open to 3-4 bike lengths, ride your own line at 80-85% FTP, and plan to regroup when the surface improves",
+          "correct": true
+        },
+        {
+          "text": "Attack off the front to separate from the group before the loose section disrupts the paceline",
+          "correct": false
+        },
+        {
+          "text": "Drop to the back of the group and soft-pedal to recover for the next paved section",
+          "correct": false
+        }
+      ],
+      "explanation": "On loose, chunky gravel at 12-16 mph, draft savings drop to 5-8% — nearly irrelevant. The riders pushing hard on this surface are spending their most expensive watts on the lowest-return terrain. Let the gap stretch to 3-4 lengths so you can pick your own line through the rough stuff (Lesson 8). Ride at 80-85% FTP — patient, spinning, preserving glycogen. When the surface transitions back to packed gravel, close the gap using the draft savings where they actually matter. If those two riders burned themselves on the loose section, you'll catch them easily. If they didn't, you rejoin the group at the same cost as before but with more fuel in the tank. Attacking on loose gravel is the worst possible investment. Soft-pedaling completely wastes the section — 80-85% FTP still moves you forward at reasonable speed."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before Lesson 11: ride a 30-minute loop twice — once at steady power, once using The Elastic Gap (push hardpack, ease off loose). Compare average speed at equal or lower normalized power."
+    },
+    {
+      "type": "callout",
+      "content": "Next lesson: When Things Break. You've found the speed — now we make sure a flat tire at mile 68 doesn't turn into a DNF. Three critical field repairs, timed, with dirty hands. The sequence IS the calm.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/11-when-things-break.json
+++ b/data/courses/dirt-craft/lessons/11-when-things-break.json
@@ -1,0 +1,342 @@
+{
+  "id": "when-things-break",
+  "title": "When Things Break",
+  "module": "find-the-speed",
+  "lesson_number": 11,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "6 minutes",
+      "unit": "of actual repair work",
+      "context": "became an 11-mile walk and a DNF — because the rider hadn't practiced since the garage tutorial 6 months ago"
+    },
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Mile 68 of a 130-mile gravel race. Rear tire loses pressure over 30 seconds — classic tubeless puncture, small thorn still embedded. Rider has a plug kit in their saddle bag. They bought it 6 months ago and practiced once in the garage on a clean tire in good light.\n\nThey stop. Hands are shaking from 4 hours of riding. They fumble the plug tool, drop the insertion needle in the grass, find it, try to locate the puncture by sound. Can't hear the hiss over wind and their own breathing. Spin the wheel — sealant spray marks the hole. They push the plug in at the wrong angle, it doesn't seat. Pull it out, try again. This time it holds, but the tire is flat.\n\nThey reach for a CO2 cartridge. First cartridge: they don't seat the inflator head properly. Half the CO2 vents into the air. Tire reaches 15 PSI — not enough to seat the bead. Second cartridge: bead seats, but they're now at 38 PSI with no way to adjust and zero backup inflation.\n\nThey ride 3 miles. The plug fails — it was inserted crooked. Tire goes flat again. No more CO2. No frame pump. They walk 11 miles to the next aid station.\n\nThe repair itself required 6 minutes of calm, sequenced work. The rider spent 22 minutes in escalating panic and burned both cartridges. The mechanical didn't end their race. The lack of practiced, automatic repair sequence did."
+    },
+    {
+      "type": "sensation_target",
+      "label": "Calm hands, clear sequence",
+      "content": "You pull over. You don't think about what to do — your hands are already unzipping the saddle bag. Plug tool, insertion needle, CO2. Laid out on the ground in order. Spin the wheel, find the hole, push the plug straight in. One smooth motion. Inflate, check, ride.\n\nThe feeling isn't bravery or grit. It's boredom. You've done this 30 times. Your hands know the sequence the way your legs know how to pedal. The adrenaline is still there — shaking hands, elevated heart rate, the clock ticking — but it flows around the sequence instead of disrupting it.\n\nThat's the target: a 3-minute tire plug that feels routine. Not because the situation isn't stressful, but because the motor pattern is deeper than the stress."
+    },
+    {
+      "type": "prose",
+      "content": "This is a motor skills problem, not a knowledge problem. You already know what a tire plug is. You need your hands to know it too. Three repairs, timed, under fatigue. That's the lesson.\n\nI learned this the hard way at a race in 2022 — fumbled a plug at mile 90, burned both CO2 cartridges, walked 8 miles in cycling shoes. I'd practiced exactly once, in my garage, with clean hands and good lighting. Now I practice monthly, outside, after a ride. The difference between a 3-minute fix and a DNF is reps, not knowledge."
+    },
+    {
+      "type": "prose",
+      "content": "### Repair 1: Tubeless Tire Plug — Target Time: Under 3 Minutes\n\nMost common gravel mechanical. The sequence:\n\n1. **Lean the bike drive-side up.** Don't flip it.\n2. **Spin the wheel slowly.** Listen for hiss, look for sealant spray. If the object is still embedded, leave it — it's marking the hole.\n3. **Remove the object.** Pull straight out. Note the angle — your plug goes in at the same angle.\n4. **Insert the plug.** Firm, steady, no wiggle. Push until ~1 cm of plug material remains visible. Pull the needle straight out.\n5. **Inflate.** One CO2 cartridge, properly seated. Target 30-35 PSI.\n6. **Spin and check.** 10 seconds with the plug at the bottom. Hissing = pull it, try again with a fresh strip.\n7. **Ride.** Check pressure at 5 min and 15 min."
+    },
+    {
+      "type": "data_table",
+      "headers": [
+        "Failure",
+        "Cause",
+        "Fix"
+      ],
+      "rows": [
+        [
+          "Plug won't seal",
+          "Inserted at wrong angle",
+          "Match the puncture angle, not perpendicular to tire surface"
+        ],
+        [
+          "Plug pushed through",
+          "Inserted too far",
+          "Stop when ~1 cm remains outside the tire"
+        ],
+        [
+          "CO2 vented into air",
+          "Bad inflator seal",
+          "Practice inflator head attachment until automatic"
+        ]
+      ],
+      "caption": "Tire Plug Failure Modes"
+    },
+    {
+      "type": "prose",
+      "content": "### Repair 2: Tube in a Tubeless Tire — Target Time: Under 8 Minutes\n\nBackup when the plug fails or the cut is too large (sidewall slice, double puncture, bead won't seal).\n\n1. **Unseat one bead.** Start opposite the valve. Push bead into center channel for slack. Use tire levers if needed.\n2. **Remove the valve core.** Sealant will drain — let it. You don't need it with a tube inside.\n3. **Wipe the tire interior.** Glove, rag, whatever. \"Mostly clean\" is good enough for race-day survival.\n4. **Slightly inflate the tube.** 5-10 PSI — just enough for shape. Prevents pinching.\n5. **Insert the tube.** Valve through rim hole first, tuck all the way around. Run your fingers around both sides to check for pinching. This is the critical step.\n6. **Re-seat the bead.** Work from the valve outward in both directions. Push already-seated bead into center channel for slack on the last section.\n7. **Inflate.** 35-40 PSI. Higher than normal tubeless — the tube needs more support.\n8. **Check for bulges.** Bulge = pinched tube. Deflate, fix, re-inflate.\n\nMost common failure: pinching the tube under the bead (immediate flat). Prevention: step 5."
+    },
+    {
+      "type": "prose",
+      "content": "### Repair 3: Chain Quick Link — Target Time: Under 5 Minutes\n\n1. **Shift to smallest cog (and smallest ring if 2x) before the chain jams.** If wrapped around cassette or derailleur, untangle first.\n2. **Identify the broken link.** Remove the damaged link AND the adjacent one — quick links connect outer plate to outer plate. Usually 2 links removed.\n3. **Push the pin out with your chain tool.** Slightly shorter chain is fine for finishing.\n4. **Thread the chain.** Chainring, through rear derailleur cage, over cassette cog. Check wear marks on cage plates if unsure of routing.\n5. **Connect the quick link.** One half on each end, plates outward. Pull taut by pressing backward on pedals — it clicks. No click = not enough tension. Stand and press.\n6. **Test all gears gently.** Shorter chain may not reach largest cog + largest chainring. Avoid that combo."
+    },
+    {
+      "type": "callout",
+      "content": "Carry the RIGHT quick link for your chain. 11-speed and 12-speed links are not interchangeable. Check your chain speed, buy the matching link, put it in the saddle bag. Verify once a season.",
+      "style": "tip"
+    },
+    {
+      "type": "data_table",
+      "headers": [
+        "Item",
+        "Spec",
+        "Check Before Race"
+      ],
+      "rows": [
+        [
+          "Tire plug kit",
+          "3+ plug strips + insertion needle",
+          "Strips dry out — squeeze test for flexibility"
+        ],
+        [
+          "Spare tube",
+          "Must fit your tire size (e.g., 45mm)",
+          "A 25-28mm road tube will NOT survive in a 45mm casing"
+        ],
+        [
+          "CO2 cartridges x2",
+          "16g min, 20g preferred for 40mm+",
+          "Two is non-negotiable — one inflates, one insures"
+        ],
+        [
+          "CO2 inflator head",
+          "Practice with YOUR specific model",
+          "They're all slightly different"
+        ],
+        [
+          "Tire levers x2",
+          "Lightweight plastic",
+          "Don't skip these for tubeless"
+        ],
+        [
+          "Chain quick link",
+          "Must match drivetrain speed (11s/12s)",
+          "11-speed and 12-speed are NOT interchangeable"
+        ],
+        [
+          "Chain tool",
+          "Micro size or multi-tool integrated",
+          "Test on a spare chain before race day"
+        ],
+        [
+          "Multi-tool",
+          "4/5/6mm hex + T25 Torx",
+          "Verify all bits present"
+        ],
+        [
+          "Spare derailleur hanger",
+          "Frame-specific — order the right one",
+          "No spare = singlespeed conversion if it snaps"
+        ]
+      ],
+      "caption": "Repair Kit Audit — Minimum for 40+ Mile Events"
+    },
+    {
+      "type": "callout",
+      "content": "Audit your kit the week before every race, not the morning of. Replace anything you used last race.",
+      "style": "tip"
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Sealant Chemistry and Chain Mechanics",
+          "blocks": [
+            {
+              "type": "prose",
+              "content": "### Sealant Chemistry\n\nSealant maintenance is repair prevention. Fresh sealant (replaced every 2-3 months, or when it's visibly clumping) plugs small punctures before you even know they happened. Dried-out sealant plugs nothing. Check it by removing the valve core and poking a thin stick through the valve hole. If the sealant is liquid, you're good. If it's a ball of latex, you're riding unprotected. Race week: add 1 oz of fresh sealant regardless of what's in there.\n\nLatex-based sealants (Stan's, Orange Seal) work by suspending microparticles in ammonia-stabilized latex. When air escapes through a puncture, the pressure differential forces particles into the hole where they interlock and the latex cures around them. The ammonia evaporates over time — that's why sealant dries out. Higher temperatures accelerate evaporation. Desert races: check sealant the day before, not the week before."
+            },
+            {
+              "type": "prose",
+              "content": "### Chain Mechanics\n\nA bicycle chain is a series of inner and outer plate pairs connected by pins, with rollers between each pair that engage the cassette and chainring teeth. A quick link (also called a master link) replaces one pin connection with two interlocking plates that snap together under tension.\n\nWhy chains break on gravel: cross-chaining under load (big-big or small-small combos), impact from rocks hitting the lower chain run, or accumulated wear past 0.5% stretch where the rollers no longer seat properly in cassette valleys. A worn chain skips under hard pedaling — the rollers ride up the tooth faces instead of seating in the valleys. This is why chain replacement at 0.5% elongation prevents the cascading failure of chain + cassette + chainring."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "data_table",
+      "headers": [
+        "Don't",
+        "Why",
+        "Lead Time"
+      ],
+      "rows": [
+        [
+          "Install new tires night before",
+          "Bead not seated, sealant not distributed, pressure window unknown",
+          "1 week minimum — ride them first"
+        ],
+        [
+          "Swap chain morning of",
+          "New chains need 50-100 mi to stretch into cassette; skips under load on worn cassette",
+          "1 week + 50 miles"
+        ],
+        [
+          "Carry a tool you've never used",
+          "The middle of a race is not the time to read instructions",
+          "Practice once before it goes in the saddle bag"
+        ]
+      ],
+      "caption": "Nothing New on Race Day — Mechanical Edition"
+    },
+    {
+      "type": "prose",
+      "content": "### The Nuclear Option: Singlespeed Conversion\n\nDerailleur hanger snapped, rear derailleur destroyed, no spare. Last resort before walking.\n\n1. **Remove the rear derailleur entirely.**\n2. **Shorten the chain.** Remove links until it wraps taut (not binding) around one chainring and one cog — no derailleur to take up tension.\n3. **Pick your gear.** Middle cog = compromise. On a 1x 40T / 11-42, the 19T or 21T cog.\n4. **Route chain** directly from chainring to cog, skipping derailleur cage.\n5. **Ride gently.** No tensioner = slightly loose chain. Smooth cadence, no hard surges.\n\nI've done it once — 40 miles on a single gear after a cattle guard destroyed my derailleur. Miserable and I finished. Those are compatible outcomes."
+    },
+    {
+      "type": "callout",
+      "content": "This lesson covers mechanical breakdowns only. Bonking, dehydration, and fueling failures are a completely different system — that's Hydration Mastery Lesson 1 in Gravel God Academy. Don't conflate the two: a mechanical is a skills problem you solve with practiced hands. A bonk is a planning problem you solve 3 hours before it happens.",
+      "style": "tip"
+    },
+    {
+      "type": "process",
+      "title": "The Calm Hands Sequence",
+      "description": "Your field repair protocol. Deploy the moment something breaks. The sequence IS the calm.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Stop. Breathe. 6-2-7 once.",
+          "detail": "Your hands will shake — that's fine."
+        },
+        {
+          "step": 2,
+          "action": "Diagnose",
+          "detail": "Puncture (hissing/flat) or chain (dangling/jammed)."
+        },
+        {
+          "step": 3,
+          "action": "For puncture: locate hole, insert plug, inflate",
+          "detail": "Target: 3 minutes."
+        },
+        {
+          "step": 4,
+          "action": "For chain: find break, thread quick link, close",
+          "detail": "Target: 5 minutes."
+        },
+        {
+          "step": 5,
+          "action": "Test ride 50 meters before committing",
+          "detail": "If the fix fails, go to the backup (tube for puncture, singlespeed for chain)."
+        }
+      ]
+    },
+    {
+      "type": "drill",
+      "title": "Timed Repair Drills",
+      "time_minutes": 20,
+      "description": "Practice each of the 3 critical repairs under progressively realistic conditions. Time every attempt. The goal is automatic motor sequence under stress — not just knowing the steps, but having hands that execute them without conscious thought.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Garage, clean hands, no time pressure",
+          "steps": [
+            "Set up in your garage or workshop with good lighting and a clean floor.",
+            "Repair 1 — Tubeless plug: Deflate your rear tire partially. Use a pick or awl to create a small hole in the tread (or use an old tire). Practice the full plug sequence. Time it. Target: under 5 minutes on first attempts, under 3 minutes within 3 sessions.",
+            "Repair 2 — Tube in tubeless: Fully unseat one bead, remove valve core, insert a tube, re-seat the bead, inflate. Time it. Target: under 12 minutes on first attempts, under 8 minutes within 3 sessions.",
+            "Repair 3 — Chain quick link: Use your chain tool to break the chain at a link. Remove 2 links. Reconnect with the quick link. Time it. Target: under 8 minutes on first attempts, under 5 minutes within 3 sessions.",
+            "Run all 3 in sequence. Total time is your baseline. Write it down.",
+            "Repeat monthly. If any repair exceeds the target time, add an extra session that month."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Outdoors, on a trail, realistic conditions",
+          "steps": [
+            "Ride to a gravel trailhead or remote gravel road. Stop at an uneven, non-ideal spot — not your garage, not a picnic table.",
+            "Repair 1 — Tubeless plug: With dirty hands and the bike leaning against a fence or tree (no bike stand), execute the full plug sequence. Time it. Target: under 3 minutes.",
+            "Repair 2 — Tube in tubeless: Same conditions. Gravel under your knees, wind blowing, no clean surface. This is where you discover that sealant makes everything slippery. Time it. Target: under 8 minutes.",
+            "Repair 3 — Chain quick link: Greasy hands, no rag, chain dragging in the dirt. Time it. Target: under 5 minutes.",
+            "Note which repairs got slower in field conditions vs garage. That delta is your vulnerability — it's where panic will cost you the most time on race day."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "After a 2-hour ride, fatigued hands, timed",
+          "steps": [
+            "Ride 2 hours at sweet spot effort (88-93% FTP) with gravel sections and surges. Your forearms should be fatigued, grip strength diminished, fine motor control compromised.",
+            "Pull over immediately — no cool-down, no stretching, no shaking out your hands.",
+            "Start the clock. Execute all 3 repairs in sequence: plug, tube, chain. Total time target: 16 minutes (3 + 8 + 5).",
+            "Your hands will be shaking. Your fingers will feel thick and clumsy. This is exactly what mile 68 feels like. This is the point of the drill.",
+            "If total time exceeds 20 minutes, the sequence isn't automatic yet. Add a mid-ride repair practice to your next 3 long rides.",
+            "Track times across sessions. When fatigued time is within 20% of fresh time, the motor pattern is race-ready."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "All 3 repairs completed under target time, outdoors, after a ride — the full race-pace simulation.",
+        "metric": "timed",
+        "target": "Tubeless plug under 3 min, tube install under 8 min, chain link under 5 min — all outdoors, all after a 2+ hour ride"
+      }
+    },
+    {
+      "type": "recovery_protocol",
+      "title": "When the Repair Fails",
+      "scenarios": [
+        {
+          "label": "Plug Won't Hold",
+          "situation": "You've inserted a tire plug but it's still leaking — the plug is crooked, the hole is too large, or the plug material didn't expand enough to seal.",
+          "steps": [
+            "Do NOT burn your second CO2 cartridge trying to re-inflate over a failed plug. You'll need that cartridge for the tube.",
+            "Pull the failed plug out. Leave the hole open.",
+            "Go straight to Repair 2: install a tube. Unseat one bead, remove the valve core, wipe the worst of the sealant out, insert the tube, re-seat, inflate with your remaining CO2.",
+            "This is why you carry both a plug kit AND a tube. The plug is the 3-minute fix. The tube is the backup when the 3-minute fix doesn't work. Carrying only one means a single failure mode ends your race."
+          ]
+        },
+        {
+          "label": "Tube Won't Seat in Tubeless Tire",
+          "situation": "You've installed a tube but the tire bead won't seat on the rim — the tire sits crooked, bulges in one spot, or won't hold pressure because the bead isn't locked into the rim hook.",
+          "steps": [
+            "Deflate completely. Remove the valve core from the tube to dump air fast.",
+            "Work the tire bead into the center channel of the rim all the way around both sides. The center channel has the smallest circumference — this creates the slack you need.",
+            "Re-seat the bead one side at a time. Start at the valve and work outward in both directions with your thumbs. Push the bead UP and OVER the rim hook, not just inward.",
+            "Replace the valve core. Inflate hard and fast — a full CO2 blast. The rapid pressure increase is what snaps the bead into the hook. A slow pump often can't generate enough force.",
+            "If the bead pops into place, you'll hear a distinct double-snap (one per side). If you don't hear it, deflate and start over from step 2. Check for tube pinched under the bead — run your fingers around both sides before inflating again."
+          ]
+        },
+        {
+          "label": "Chain Tool Breaks the Pin",
+          "situation": "You pushed the chain pin out to remove a damaged link, but the pin deformed or broke — now you can't reconnect using the chain tool.",
+          "steps": [
+            "If you have a quick link, you don't need the chain tool pin at all. A quick link connects outer plate to outer plate. Remove the damaged link section so both chain ends terminate in outer plates, then snap the quick link on.",
+            "If you have no quick link and the pin is broken or deformed, shorten the chain further to skip the damaged link entirely. Push out the NEXT pin (one link away from the damage) using what's left of your chain tool.",
+            "Route the shortened chain from chainring to a middle cog, skipping the rear derailleur. You're now riding singlespeed — no shifting, no derailleur tension needed.",
+            "Pick a gear you can both climb and cruise in. On a typical 1x gravel setup, the 19T-21T cog is the compromise. It won't be comfortable anywhere, but it'll be rideable everywhere.",
+            "Pedal smoothly. A shortened chain with no derailleur tensioner has slack — hard surges or standing sprints can bounce it off. Seated, steady effort gets you to the finish."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "video",
+      "id": "xZ8HqKPrRXY",
+      "title": "How To Fix A Punctured Tubeless Tyre | GCN Tech",
+      "channel": "GCN Tech",
+      "caption": "Tubeless plug repair, step by step — the field fix this lesson covers."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're at mile 85 of a 120-mile gravel race. Your rear tire goes flat over 30 seconds. You stop and find a 4mm sidewall cut — sealant is spraying from the gash. You have a plug kit, a spare tube, 2 CO2 cartridges, and tire levers. What's the correct sequence?",
+      "options": [
+        {
+          "text": "Plug the sidewall cut, inflate with CO2, ride carefully",
+          "correct": false
+        },
+        {
+          "text": "Skip the plug — unseat the bead, remove the valve core, install the tube, re-seat, inflate with CO2",
+          "correct": true
+        },
+        {
+          "text": "Plug the cut from the inside by unseating the bead, then re-seat and inflate",
+          "correct": false
+        },
+        {
+          "text": "Apply extra sealant through the valve, spin the wheel to distribute, and hope it seals",
+          "correct": false
+        }
+      ],
+      "explanation": "A 4mm sidewall cut is too large for a standard plug — plugs work on tread punctures where the surrounding rubber compresses around the plug material. Sidewall cuts don't compress the same way because the casing is thinner and more flexible. The correct move is to go straight to Repair 2: tube in the tubeless tire. Don't waste time attempting a plug that won't hold — every failed attempt costs time and composure. Remove the valve core (sealant will drain, but you don't need it with a tube), install the tube, re-seat the bead, and inflate. The tube bridges the sidewall gap from the inside. Use your first CO2 cartridge carefully — seat the inflator head properly and inflate to 35-40 PSI. Keep the second cartridge as insurance for the remaining 35 miles."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment before Lesson 12: run The Calm Hands Sequence for all 3 repairs this week. Timed. Outdoors. After a ride. If any repair exceeds the target time, repeat it until your hands know the sequence without your brain."
+    },
+    {
+      "type": "callout",
+      "content": "Next lesson: The Final Hour and Beyond. You've learned to ride the bike (Lessons 1-10) and fix the bike (this lesson). Now comes the hardest part — maintaining everything you've learned when your body and brain are falling apart at hour 5. The fatigue cascade is coming for all of us. The question is whether you notice it before it notices you.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/12-the-final-hour.json
+++ b/data/courses/dirt-craft/lessons/12-the-final-hour.json
@@ -1,0 +1,406 @@
+{
+  "id": "the-final-hour",
+  "title": "The Final Hour and Beyond",
+  "module": "ride-in-flow",
+  "lesson_number": 12,
+  "blocks": [
+    {
+      "type": "sensation_target",
+      "label": "The reset click",
+      "content": "Every 20 minutes after hour 2, you run a 10-second body scan. It becomes as automatic as looking at your power meter.\n\nHeavy feet? Check. Quiet hands? ... No. Grip is at a 6. You consciously drop it to a 3. Elbows bent? They'd drifted straight — you bend them. Hinge moving? Hips had locked — you rock your pelvis once. Breathing anchored? You'd been shallow-chesting for who knows how long — you take three belly breaths. Eyes on far target? Your scan had contracted — you push your focal point back to 50 meters.\n\nThere's a moment — maybe a half-second — where the corrections land and the whole system re-engages. Your body settles into the pattern you drilled fresh. The front wheel starts floating over bumps again instead of smashing through them. Your line choice opens up. Your braking becomes proactive instead of reactive.\n\nThat's the click. It's the sensation of the right pattern re-engaging after fatigue has silently disengaged it. It doesn't last forever — fatigue will erode it again in 15-20 minutes. That's why you scan again. The click is not permanent. It's renewable."
+    },
+    {
+      "type": "black_box",
+      "title": "Incident Report",
+      "content": "Mile 130 of 150. The rider has been on the bike for 6 hours and 40 minutes. They are riding at 16 mph on a gravel descent with moderate loose-over-hardpack surface.\n\nThey don't notice that their forearms are pumped — grip pressure has been creeping up since hour 3. They're holding the bars at a 7 out of 10 instead of the 3 they practiced in Lesson 1. Their elbows have gradually straightened. The front wheel has been transmitting every bump for the last 30 minutes.\n\nThey don't notice that they're riding the geometric line through corners instead of the surface-optimal line they drilled in Lesson 6. The geometric apex is shorter but crosses a loose patch. Fresh, they'd read that surface in 0.8 seconds and adjust. At hour 6, their scan distance has contracted from 50 meters to 15.\n\nThey almost miss a braking point. The curve comes up faster than expected — not because the speed changed, but because their visual processing has slowed and their braking zones have been shrinking all afternoon. They grab both brakes hard. The rear locks for half a second. They save it.\n\nThey don't know their technique has degraded. They don't know that they don't know. They think they're \"just tired\" — legs heavy, motivation fading. The actual problem is that 11 lessons worth of skill are dissolving in a specific, predictable order, and nobody told them to check.\n\nThis is the fatigue cascade. It happens to every rider on every long ride. The difference between finishing strong and finishing scared is whether you have a system to catch it."
+    },
+    {
+      "type": "hero_stat",
+      "value": "~⅓",
+      "unit": "of technical precision lost by hour 4",
+      "context": "for most riders in a long gravel race — and they don't notice it happening"
+    },
+    {
+      "type": "prose",
+      "content": "Everything from Lessons 1-11 was built for this moment — when your body wants to quit being skilled and your brain has to intervene.\n\nTechnique doesn't just fade with fatigue. It degrades in a specific, predictable sequence that's invisible from the inside. You feel \"tired.\" What's actually happening is systematic loss of motor patterns. The good news: predictable means catchable."
+    },
+    {
+      "type": "prose",
+      "content": "### The Fatigue Cascade\n\nSkill degradation follows a consistent order. Fitness, nutrition, heat, and course difficulty shift the timeline — but the sequence is remarkably stable."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "Fatigue Cascade Neuroscience: Stages and Mechanisms",
+          "blocks": [
+            {
+              "type": "data_table",
+              "headers": [
+                "Stage",
+                "Typical Onset",
+                "What Degrades",
+                "Skills Lost",
+                "Warning Sign"
+              ],
+              "rows": [
+                [
+                  "1: Grip escalation",
+                  "Hour 2-3",
+                  "Hands clamp from 3/10 to 6-7/10 — brain defaults to primitive motor pattern",
+                  "L1: weighted drop inverts, forearm fatigue accelerates",
+                  "Pinky check fails"
+                ],
+                [
+                  "2: Pedaling breakdown",
+                  "Hour 3-4",
+                  "Dead spots grow, mashing replaces smooth stroke, cadence drifts lower",
+                  "L1: pedal weighting, L7: rear-wheel spin on loose surfaces",
+                  "Standing surges on moderate grades"
+                ],
+                [
+                  "3: Line choice collapse",
+                  "Hour 4-5",
+                  "Scan contracts 50m to 15m, geometric lines replace surface-optimal",
+                  "L4 + L6 + L8 + L9: cornering, surface reading, descending",
+                  "Terrain changes surprise you"
+                ],
+                [
+                  "4: Reactive braking",
+                  "Hour 5+",
+                  "Braking in corners, grabbing rear, panic-stopping",
+                  "L1+L4+L5+L6+L8+L9 compound loss — surviving, not riding",
+                  "Braking mid-corner"
+                ]
+              ],
+              "caption": "Fatigue Cascade Stages"
+            },
+            {
+              "type": "prose",
+              "content": "The cascade follows the neurological hierarchy of motor control. Grip escalation (Stage 1) happens first because it's a reversion to the brainstem's startle-grip reflex — the oldest motor pattern, and the one the brain defaults to under stress and resource depletion. Stages 2-3 involve prefrontal and cerebellar coordination that degrades as blood glucose drops and core temperature rises. Stage 4 is the compound failure: when scan distance contracts AND grip escalates AND the hinge freezes, the rider has lost the feedforward planning loop entirely and is operating in pure reactive mode — stimulus → response, no anticipation. The body scan interrupts this cascade by forcing conscious re-engagement of the prefrontal planning loop, even briefly."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### The Pinky Check\n\nEvery 15-20 minutes, lift both pinkies off the bars.\n\nEasy and natural = grip is fine. Feels risky, like you might lose control = Stage 1 of the cascade. Binary, instant, no estimation needed.\n\nPinky check fails: run the full body scan. Pinky check passes: keep riding, check again in 15-20 minutes."
+    },
+    {
+      "type": "prose",
+      "content": "### The Full Body Scan — 10 Seconds\n\nThis is the reset protocol. Run it every 20 minutes after hour 2, or immediately when the pinky check fails.\n\n1. **Feet** (2 seconds): Check that your pedals feel heavy — 70% of your weight pressing through your feet. If your feet feel light and your hands feel heavy, push weight down. Drop your heels 10 degrees. This is Lesson 1.\n\n2. **Hands** (2 seconds): Confirm grip at 3 out of 10, fingers wrapped loosely. If you're clamping, consciously release until the bars feel like a shelf your hands are resting on. This is Lesson 1.\n\n3. **Elbows and shoulders** (2 seconds): Elbows should be bent 20 degrees, shoulders dropped away from ears. If your arms are straight and your shoulders are up, you've lost the suspension system from Lesson 2. Bend and drop.\n\n4. **Hips** (2 seconds): Check that the hinge is moving. Rock your pelvis forward and back once. If your lower back feels locked and your vision is bouncing, the hinge has frozen. One conscious hip-rock resets it. This is Lesson 2.\n\n5. **Eyes and breath** (2 seconds): Notice whether you're looking 50 meters ahead or just 15. Push the focal point out to 3-5 seconds ahead. Take one deep belly breath. Exhale completely. This is Lesson 4.\n\nTen seconds. Five checkpoints. Each one maps to a skill you've already drilled. The scan doesn't teach you anything new — it re-engages what fatigue has silently disengaged."
+    },
+    {
+      "type": "prose",
+      "content": "### Two-Rule Mode\n\nAt hour 5+, you can't hold 11 lessons in working memory. Cognitive load shedding: reduce everything to two rules for the current terrain.\n\n- **Rolling gravel descent**: (1) Eyes 50 meters ahead. (2) Brakes before corners, not in them.\n- **Loose gravel climb**: (1) Stay seated. (2) Spin, don't mash.\n- **Technical singletrack**: (1) Light hands. (2) Look where you want to go.\n\nTwo rules you can actually hold are worth more than ten you can't. Rotate as terrain changes — you're choosing from a list you've already internalized."
+    },
+    {
+      "type": "prose",
+      "content": "### The 11-Lesson Stack vs. Fatigue"
+    },
+    {
+      "type": "data_table",
+      "headers": [
+        "Lesson",
+        "Core Skill",
+        "Fatigue Reversion"
+      ],
+      "rows": [
+        [
+          "L1: Letting Go",
+          "Weighted drop, quiet hands",
+          "First to erode — grip escalates, weight shifts to hands"
+        ],
+        [
+          "L2: Body Is the Suspension",
+          "Hip hinge, upper/lower separation",
+          "Core stiffens, hinge freezes"
+        ],
+        [
+          "L3: Traction",
+          "Tire pressure, traction sense",
+          "Fatigue-proof — pressure window set pre-race"
+        ],
+        [
+          "L4: Quiet Eye",
+          "Scan distance, peripheral processing",
+          "50m scan contracts to 15m stare"
+        ],
+        [
+          "L5: Braking",
+          "Braking budget, pulse braking",
+          "Regresses to panic-grabbing rear brake"
+        ],
+        [
+          "L6: Cornering",
+          "Surface-optimal lines, asymmetric loading",
+          "Defaults to geometric lines, symmetric grip"
+        ],
+        [
+          "L7: Climbing",
+          "Torque ceiling, cadence strategy",
+          "Reverts to standing surges and mashing"
+        ],
+        [
+          "L8: Surface Reading",
+          "50m scan, surface pre-adjustment",
+          "Stops pre-reading as scan contracts"
+        ],
+        [
+          "L9: Descending",
+          "Drops position, body-position speed",
+          "Retreats to hoods and constant braking"
+        ],
+        [
+          "L10: Pack Dynamics",
+          "Surface-adjusted pacing, variable-gap drafting",
+          "Reverts to constant-watt grinding"
+        ],
+        [
+          "L11: Repairs",
+          "3 timed repairs under pressure",
+          "Motor sequences survive better than decisions"
+        ]
+      ],
+      "caption": "What You Built, What Fatigue Takes"
+    },
+    {
+      "type": "callout",
+      "content": "Foundational skills (grip, hinge) degrade first — overridden by survival instincts. Complex skills (line choice, pacing) degrade because they require cognitive processing that fatigue erodes. The body scan catches the early ones. Two-rule mode protects the later ones.",
+      "style": "tip"
+    },
+    {
+      "type": "process",
+      "title": "The Dirt Craft Stack",
+      "description": "Your complete tool inventory. Every tool you've built across 12 lessons, in the order fatigue takes them away — and the order you restore them.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "The Weighted Drop (L1)",
+          "detail": "Heavy feet, quiet hands. The foundation everything else sits on."
+        },
+        {
+          "step": 2,
+          "action": "The Hip Hinge (L2)",
+          "detail": "Upper and lower body separation. Head stays level, hips absorb."
+        },
+        {
+          "step": 3,
+          "action": "The Pressure Window (L3)",
+          "detail": "Your personal tire pressure range for each surface type."
+        },
+        {
+          "step": 4,
+          "action": "The Quiet Eye (L4)",
+          "detail": "Eyes 3-5 seconds ahead. Obstacles steer around themselves."
+        },
+        {
+          "step": 5,
+          "action": "The Braking Budget (L5)",
+          "detail": "Scrub before corners, coast through. Two fingers, never grab."
+        },
+        {
+          "step": 6,
+          "action": "The 85% Rule (L6)",
+          "detail": "Enter every corner at 85% of estimated max. Smooth surface first, geometry second."
+        },
+        {
+          "step": 7,
+          "action": "The Torque Ceiling (L7)",
+          "detail": "Higher cadence, lower gear, zero wheel spin. Butter, not peanut butter."
+        },
+        {
+          "step": 8,
+          "action": "The 50-Meter Scan (L8)",
+          "detail": "Read the surface before you reach it. Adjust before the transition, not during."
+        },
+        {
+          "step": 9,
+          "action": "The Position Ladder (L9)",
+          "detail": "Drops default. Weight shift by gradient. Tuck on straights."
+        },
+        {
+          "step": 10,
+          "action": "The Elastic Gap (L10)",
+          "detail": "Close on smooth, open on rough. Push efficient surfaces, ease off inefficient."
+        },
+        {
+          "step": 11,
+          "action": "The Calm Hands Sequence (L11)",
+          "detail": "Stop, breathe, diagnose, repair, test. The sequence IS the calm."
+        },
+        {
+          "step": 12,
+          "action": "The 20-Minute Reset (L12)",
+          "detail": "Body scan every 20 minutes. Correct what's drifted. The Pinky Check is your early warning."
+        }
+      ]
+    },
+    {
+      "type": "process",
+      "title": "The 20-Minute Reset",
+      "description": "Your fatigue management protocol. Deploy from hour 2 onward, every 20 minutes, for the rest of the ride.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Set a 20-minute repeating mental timer",
+          "detail": "Some riders use a watch beep. Some count climbs. Whatever anchors the cadence."
+        },
+        {
+          "step": 2,
+          "action": "At each mark, run the 10-second body scan",
+          "detail": "Feet heavy? Hands quiet? Hinge moving? Eyes on far target? Breathing anchored?"
+        },
+        {
+          "step": 3,
+          "action": "If any check fails, correct it",
+          "detail": "Feel the \"click\" as the right pattern re-engages."
+        },
+        {
+          "step": 4,
+          "action": "The Pinky Check",
+          "detail": "Lift pinkies off the bars. If it feels dangerous, you're deep in the fatigue cascade — deploy Two-Rule Mode."
+        },
+        {
+          "step": 5,
+          "action": "Two-Rule Mode",
+          "detail": "Pick only 2 rules to follow (e.g., \"heavy feet\" + \"eyes far\"). Shed everything else. Simplify to survive."
+        }
+      ]
+    },
+    {
+      "type": "drill",
+      "title": "Fatigue Simulation Protocol",
+      "time_minutes": 60,
+      "description": "A 3+ hour structured ride that simulates race-day fatigue and tests your ability to maintain technical skill under degradation. This is the capstone drill of the course — it integrates everything.",
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "3-hour ride, self-assessment checkpoints",
+          "steps": [
+            "Plan a 3-hour gravel ride that includes at least 3 technical sections (corners, descents, loose climbs, rough terrain).",
+            "Hours 0-2: Ride at moderate endurance pace (65-75% FTP). Focus on executing all skills cleanly. This is your baseline.",
+            "At the 2-hour mark, begin the protocol: every 20 minutes, run the full body scan (feet, hands, elbows, hips, eyes).",
+            "After each body scan, ride a 2-minute 'skills proof' segment on the most technical terrain available. Rate your execution 1-10 on: grip pressure, line choice, braking control, body position.",
+            "Write down your scores (or speak them into a voice memo). Don't adjust the score to be kind to yourself — if your line choice was a 6, write 6.",
+            "After the ride, compare your hour-3 scores to your hour-1 baseline. The gap is your current degradation rate.",
+            "Repeat weekly for 4 weeks. Track whether the gap shrinks."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "3.5-hour ride with sweet spot blocks and skills tests",
+          "steps": [
+            "Plan a 3.5-hour gravel ride with technical sections every 20-30 minutes.",
+            "Hours 0-1: Endurance pace warm-up with conscious skill execution. Set your baseline scores on the first technical section.",
+            "Hours 1-2: Sweet spot effort (88-93% FTP) on gravel with 30-second surges every 10 minutes. This accelerates fatigue deliberately.",
+            "Hour 2 onward: Begin the protocol. Body scan every 20 minutes. Skills proof segment after each scan.",
+            "At each skills proof segment, add a specific test: (1) Pinky check — pass/fail. (2) Braking test — can you coast through a corner without braking? (3) Line test — did you ride the surface-optimal or geometric line?",
+            "Rate each segment 1-10. Note which skills degraded first — this tells you YOUR personal cascade order.",
+            "Compare scores at hour 3.5 to hour 1. Target: within 35% of baseline."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "4+ hour ride simulating race-day conditions",
+          "steps": [
+            "Plan a 4+ hour gravel ride at race intensity — sweet spot blocks, tempo sustained efforts, gravel climbs at threshold.",
+            "Hours 0-2: Race-simulation effort. Include group riding if possible. Push hard enough that hour 3 feels genuinely difficult.",
+            "Hour 2 onward: Full protocol. Body scan every 20 minutes. Skills proof segment every 20 minutes. Rate execution 1-10.",
+            "Hour 3 onward: Enter two-rule mode. For each terrain section, choose only 2 rules. After the section, assess: did you hold both rules?",
+            "Hour 4: Run the full skills proof one final time. Score grip, line choice, braking, body position, scan distance each 1-10.",
+            "This is your race readiness test. Compare hour-4 scores to fresh scores from a separate easy ride.",
+            "Target: hour-4 composite score within 25% of fresh composite score. Most untrained riders lose roughly a third of their technical precision. If you're under 25%, your fatigue resilience system is working."
+          ]
+        }
+      ],
+      "proof_gate": {
+        "description": "Technical execution score at hour 4 stays within 25% of fresh score — measured across grip pressure, line choice, braking control, body position, and scan distance.",
+        "metric": "percentage",
+        "target": "Less than 25% degradation from fresh baseline at hour 4 — your hour-4 composite score improves by at least 2 points over 4 weeks of practice"
+      }
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're at hour 4 of a 6-hour gravel race. You run the pinky check and it feels dangerous — like lifting your pinkies might cost you control. You also notice you've been braking in corners for the last 20 minutes. What fatigue cascade stage are you in, and what's the correction sequence?",
+      "options": [
+        {
+          "text": "Stage 1 only — just grip pressure. Loosen your hands and keep riding.",
+          "correct": false
+        },
+        {
+          "text": "Stage 4 — reactive braking. Focus on braking earlier before corners.",
+          "correct": false
+        },
+        {
+          "text": "Stages 1 and 4 simultaneously — run the full body scan, reset grip first, then push scan distance out to restore proactive braking zones.",
+          "correct": true
+        },
+        {
+          "text": "You're beyond correction — slow down and survive to the finish.",
+          "correct": false
+        }
+      ],
+      "explanation": "The failed pinky check confirms Stage 1 (grip pressure). Braking in corners confirms Stage 4 (reactive braking). But Stage 4 doesn't happen in isolation — if you're braking reactively, it's because your scan distance contracted (Stage 3) and your grip escalation (Stage 1) has been compounding for at least an hour. The correction starts at Stage 1 because grip is the foundation: run the full body scan, reset grip to a 3, bend your elbows, drop your shoulders. Then push your eyes back to 50 meters ahead — this restores the visual lead time you need to set speed BEFORE corners instead of braking IN them. You're not beyond correction. You're exactly where the scan was designed to catch you. The click is available. You just have to run the sequence."
+    },
+    {
+      "type": "prose",
+      "content": "### The Deliberate Practice Framework\n\nThe progression from here isn't more lessons — it's repetition under increasingly demanding conditions until the skills become how you ride."
+    },
+    {
+      "type": "data_table",
+      "headers": [
+        "Cadence",
+        "Practice",
+        "Details"
+      ],
+      "rows": [
+        [
+          "Monthly",
+          "Pick one skill to sharpen",
+          "Rotate through L1-L11. Run that lesson's drill at all 3 levels. Re-test the proof gate."
+        ],
+        [
+          "Weekly",
+          "One ride with conscious skill focus",
+          "Pick a 20-min block. Announce the skill. Rate execution 1-10."
+        ],
+        [
+          "Every long ride",
+          "Run the fatigue protocol",
+          "Body scan every 20 min after hour 2. Rate skills proof segments. Track scores."
+        ],
+        [
+          "Every race",
+          "Two-rule mode from the start",
+          "Don't wait for fatigue — start with 2 rules for opening terrain. Rotate as terrain changes."
+        ],
+        [
+          "Quarterly",
+          "Timed repair drills",
+          "L11 skills decay fastest. After a ride. Outdoors. Timed."
+        ]
+      ],
+      "caption": "Ongoing Practice Schedule"
+    },
+    {
+      "type": "callout",
+      "content": "Your Race Setup Card — the one you've been building through the calculators in Lessons 3, 5, 6, 7, 8, and 9 — is the tangible artifact of this course. Tire pressure windows, gearing checks, corner speed targets, braking distances, descent position triggers, all tied to a specific race from the 757 in the database. Print it. Tape it to your stem. It's not a cheat sheet — it's proof that you've done the work and pre-decided things that your fatigued brain shouldn't be deciding at mile 130.",
+      "style": "tip"
+    },
+    {
+      "type": "prose",
+      "content": "### Training Wheels You're Meant to Grow Out Of\n\nAll of this — 12 lessons, drills, proof gates, calculators — was scaffolding. The destination is the ride where you haven't thought about technique in 2 hours because it's just how you ride now.\n\nI was the rigid roadie white-knuckling washboard at 12 mph. Now I descend gravel with my pinkies floating. It took 18 months of deliberate work. On the other side of that work is a completely different relationship with the bike.\n\nIf you just ride for watts, you cap your enjoyment. If you get good at riding your bike, your enjoyment is endless.\n\nLook — you just read 12 lessons from a guy on the internet. That's worth exactly as much as what you do with it on the bike this weekend. The course is done. The riding isn't.\n\nGo ride."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment after this course: ride 3+ hours and run The 20-Minute Reset from hour 2 onward. Rate your technical execution 1-10 at each checkpoint. Track it over 4 weeks. Watch the scores converge with your fresh-legs baseline. That convergence is proof that these tools work — and proof that you don't need this course anymore."
+    },
+    {
+      "type": "callout",
+      "content": "This course is training wheels you're meant to grow out of. The drills had structure so you could learn without structure. The proof gates had numbers so you could eventually ride without numbers. The body scan had a checklist so that one day, you won't need the checklist — your body will just click back into the right pattern on its own. That's the goal. Not 12 lessons memorized. Twelve lessons forgotten because they became automatic. See you on the gravel.",
+      "style": "next"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/13-the-physics-honestly.json
+++ b/data/courses/dirt-craft/lessons/13-the-physics-honestly.json
@@ -1,0 +1,221 @@
+{
+  "id": "the-physics-honestly",
+  "title": "The Physics, Honestly",
+  "module": "appendix",
+  "lesson_number": 13,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "22°",
+      "unit": "of lean is the ceiling on dry loose gravel",
+      "context": "On the road you corner at 40°+. On gravel the bike is barely tipped when it lets go. Nothing about the lean angle warns you. That's the whole problem."
+    },
+    {
+      "type": "callout",
+      "style": "highlight",
+      "content": "**This lesson is optional.** Everything before it told you what to do. This one tells you why — and, more usefully, where the honest answer is \"nobody actually knows.\" You do not need the math to ride well. You need it when the folklore in the group ride contradicts what your body already learned in the drills, and you want to know who's right."
+    },
+    {
+      "type": "prose",
+      "content": "I built this lesson backwards. I had a research pass comb through the physics, the moto and rally literature, and every forum thread I could find. Then I had a second, more skeptical pass try to tear the first one apart. It worked. Two of my favorite theories died on the table — including one that felt so right I'd have taught it with a straight face. What follows is only what survived being attacked. Where something is still genuinely unsettled, I say so instead of selling you a clean answer that isn't there."
+    },
+    {
+      "type": "prose",
+      "content": "### One number runs everything: μ\n\nEvery surface has a grip coefficient — μ, \"mew.\" It's the single number that sets both how hard you can brake and how far you can lean. Tarmac is roughly μ = 0.85. Dry loose-over-hardpack gravel is roughly μ = 0.4. That's less than half.\n\nEverything that feels strange about gravel falls out of that one number. You are not a worse rider than you were on the road. You are riding a surface with half the grip, using instincts calibrated for the surface with all of it."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "The Mu Number — the two formulas worth knowing",
+          "content": "**Lean ceiling.** The most you can lean before the tire slides is `lean = arctan(μ)`. On tarmac (μ≈0.85) that's about 40° — the lean roadies live at. On gravel (μ≈0.4) it's about **22°**. The bike feels almost upright at the limit. This is why gravel corners lie to you: on the road, deep lean is the warning signal that you're near the edge, and on gravel that signal never arrives — you're at the edge while the bike still feels casual.\n\n**Corner speed.** The fastest you can hold a corner of radius R is `v = √(μ · g · R)`. At μ = 0.4: a tight 10-meter switchback caps at ~14 mph, a 20-meter bend at ~20 mph, an open 40-meter sweeper at ~28 mph. Halving μ from road to gravel drops every one of those numbers by ~30%.\n\nThese are clean-physics ceilings for a steady, flat, single-μ corner. Real gravel is bumpy, cambered, and its μ changes patch to patch — so treat them as the wall you never touch, which is exactly what The 85% Rule from Lesson 6 is for."
+        }
+      ]
+    },
+    {
+      "type": "data_table",
+      "caption": "Lean ceiling and corner-speed ceiling by surface. Note how little lean gravel gives you — and that you are never lean-angle-limited on gravel, you are grip-limited at a lean angle that feels safe.",
+      "headers": [
+        "Surface",
+        "μ (approx)",
+        "Max lean",
+        "40m sweeper cap",
+        "20m bend cap"
+      ],
+      "rows": [
+        [
+          "Dry tarmac",
+          "0.85",
+          "40°",
+          "~41 mph",
+          "~29 mph"
+        ],
+        [
+          "Dry hardpack",
+          "0.65",
+          "33°",
+          "~36 mph",
+          "~25 mph"
+        ],
+        [
+          "Dry loose-over-hard",
+          "0.40",
+          "22°",
+          "~28 mph",
+          "~20 mph"
+        ],
+        [
+          "Wet loose gravel",
+          "0.25",
+          "14°",
+          "~22 mph",
+          "~16 mph"
+        ]
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### You can't brake yourself over the bars on the loose stuff. Until you can.\n\nThe fear that keeps riders off the front brake is going over the bars. On loose gravel that fear is misfiled. Pitching forward over the front wheel takes about 0.56–0.63 g of deceleration for normal bike-and-rider geometry. Loose gravel can only deliver about 0.3–0.5 g before the tire slides. The tire runs out of grip and washes **before** you can generate enough braking force to loop it. On the loose layer, the front brake's failure mode is a wash, not an endo — and a straight-line wash is far more survivable than the crash you're bracing for.\n\nThat is a real result, and it is why you can trust the front brake more than road instinct lets you. But it has a hard edge, and the edge is the whole reason this isn't a slogan."
+    },
+    {
+      "type": "callout",
+      "style": "warn",
+      "content": "**Where the endo comes back.** The \"can't go over the bars\" result is about the loose layer only. The instant your front tire finds high grip mid-brake — a swept-clean hardpack apex, a slab of rock, a pavement transition, a stone that stops the wheel dead — μ jumps back toward 0.6–0.8 and the pitchover threshold is right there again. The dangerous move is internalizing \"I can't endo on gravel\" and then hauling the front brake as you cross onto firm ground. Brake hard on the loose. Ease as the surface firms."
+    },
+    {
+      "type": "prose",
+      "content": "### The front brake does 76–86% of the work — even here\n\nLesson 5 told you 70–80% of your braking comes from the front. The physics backs it, and it's worth knowing why, because the reasoning is the opposite of the road version.\n\nOn tarmac the front does almost everything because you brake hard enough to lift the rear nearly off the ground — at that point the rear tire has no weight on it and its brake is nearly useless. On gravel you never brake that hard, so the rear keeps some load. But run the weight transfer at gravel's actual deceleration and the front still ends up supplying roughly 76–86% of the stopping force. The rear contributes real but modest braking — on the order of a fifth of the total. Use both. Trust the front. Just don't expect the rear to be your main speed control; its bigger job on gravel is steadying the bike and steering, not scrubbing speed."
+    },
+    {
+      "type": "black_box",
+      "title": "Two myths this course refuses to sell you",
+      "content": "**Myth 1: \"Commit harder and the front tire digs through the loose stuff to the grippy layer underneath.\"** This one is everywhere — rally schools teach a version of it — and it's the theory I almost taught you, because it makes committing feel like physics instead of nerve. It's wrong. A bike tire at a fixed pressure doesn't push harder into the ground when you load it; it just grows its contact patch. It does not spike the pressure needed to knife through to hardpack. When I had this checked, the claim failed verification outright and the mechanism didn't survive contact with how tires actually work. Committing is still right — but because tentative inputs make you stiff, late, and reactive, not because braking manufactures grip.\n\n**Myth 2: \"Hips way back, always.\"** Hips back is correct for one specific reason: on a steep grade, gravity is trying to pitch you forward, and getting back keeps the rear loaded and buys your arms room to absorb hits. That's real — keep doing it on the steeps. What's false is treating hips-back as a braking trick. Sliding your weight back to \"get grip\" actually unweights the front tire, which is the one you most need to brake and steer. Move back for grade and impacts. Don't move back to out-think the brake."
+    },
+    {
+      "type": "accordion",
+      "items": [
+        {
+          "title": "The genuinely unresolved part: front-vs-rear bias on the loose",
+          "content": "Here's where honest ends and folklore begins, and where you should distrust anyone who sounds too certain — including a coach.\n\nTwo defensible answers pull in opposite directions:\n\n**Pure stopping-power says front-biased.** You stop shortest by using the front hard, as above.\n\n**Crash-survival says bias slightly toward the rear.** If a tire has to let go, you desperately want it to be the rear, because a rear that steps out is recoverable and a front that washes usually isn't — the front wheel is what keeps you balanced. So there's a rational case for deliberately biasing a little more rear than \"shortest stop\" would suggest, trading a few feet of stopping distance for the safer tire being the one that breaks first.\n\nNobody has tested this cleanly on loose-over-hardpack at 30 mph. Moto and rally lore says one thing, road-bike lore says another, and neither was measured on your surface. The practical resolution isn't a number — it's the drills. Ride the one-brake and skid drills from Module 2 until you can feel which tire is about to go and modulate before it does. Feel beats the formula here, because the formula genuinely runs out."
+        }
+      ]
+    },
+    {
+      "type": "process",
+      "title": "The Mu Number",
+      "description": "A field method for turning a surface you can see into the two ceilings you actually ride to. You're not computing anything mid-corner — you're building the instinct off the bike so the numbers are already in your body when it counts.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Read the surface and name its μ out loud: tarmac ~0.85, dry hardpack ~0.65, dry loose-over-hard ~0.4, wet loose ~0.25.",
+          "detail": "Say the number. Naming it fights the road instinct that every dirt surface grips the same."
+        },
+        {
+          "step": 2,
+          "action": "Convert μ to a lean ceiling: roughly, 0.4 → ~22°, 0.65 → ~33°.",
+          "detail": "On loose, expect the bike to feel almost upright at the limit. If it feels tipped-over like a road corner, you are already past the edge."
+        },
+        {
+          "step": 3,
+          "action": "Convert μ to a corner-speed feel: on loose, an open sweeper you'd take at 40 on tarmac is a high-20s corner.",
+          "detail": "Halve the grip, cut ~30% off the speed."
+        },
+        {
+          "step": 4,
+          "action": "Debit the budget: braking and cornering draw from the same μ.",
+          "detail": "If you're still braking at turn-in, you have less grip left for the corner — so finish the hard braking earlier on the loose than you would on the road."
+        },
+        {
+          "step": 5,
+          "action": "Ride to 85% of that ceiling (Lesson 6), because your μ estimate is rough and the surface changes patch to patch.",
+          "detail": "The 15% is your margin for being wrong about the number."
+        }
+      ]
+    },
+    {
+      "type": "sensation_target",
+      "label": "What the grip ceiling feels like",
+      "content": "On loose gravel, the front tire warns you before it lets go — but the warning is faint and it comes through the bars, not through lean angle. It's a vague, greasy, drifting vagueness in the steering, like the front wheel briefly stopped telling you the truth. On the road you'd feel that as heavy lean. On gravel you feel almost no lean at all and then that soft drift. Learn that drift as the signal. It arrives earlier and quieter than you expect, and it is the only honest edge-of-grip cue the surface gives you."
+    },
+    {
+      "type": "drill",
+      "title": "The Skidpad Audit",
+      "time_minutes": 20,
+      "description": "A constant-radius circle whose only purpose is to let you feel the 22° ceiling so you stop being surprised by it. You are proving to your body that gravel lets go at a lean that feels absurdly safe — and that the warning comes through the bars, not the bike's angle.",
+      "proof_gate": {
+        "target": "You can ride your circle at a speed where the front tire audibly and feelably drifts, hold it there for a full lap without tightening your grip, and back off by feel before it washes — in both directions."
+      },
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Flat loose-gravel lot, big circle, low speed, full runout",
+          "steps": [
+            "Scuff a circle about 12–15 meters across in a flat, empty gravel lot with nothing to hit.",
+            "Ride it at an easy pace. Outside foot down and weighted, inside hand light, eyes across the circle to the far side — never at the front wheel.",
+            "Each lap, add a hair of speed. Notice how little the bike is leaning even as it gets quick. Say the lean out loud: \"that's maybe fifteen degrees.\" It will feel like nothing.",
+            "Keep adding until the front tire starts to whisper and drift — that vague greasy feel through the bars. That's the edge. That's 22° and μ = 0.4, live.",
+            "Back off by two mph. Sit right under the drift for a full lap. This is the point of the whole drill: the edge is calm, quiet, and at a lean you'd never have believed.",
+            "Switch directions. Your weak side will find the edge earlier. Spend more laps there.",
+            "Session goal: locate the drift in both directions without a crash and without a death grip. No heroics. You're collecting one feeling."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Mixed loose-over-hardpack, tighter circle, add a brake",
+          "steps": [
+            "Same circle on loose-over-hardpack. Find the drift, then start easing the front brake gently while cornering.",
+            "Feel the budget move: as you add brake, the cornering grip shrinks and the drift arrives at a lower speed. That's the μ budget being split between braking and turning, in real time.",
+            "Now do the opposite — release the brake mid-corner and feel grip return to the corner. You are feeling the friction budget breathe.",
+            "Session goal: connect \"more brake = less lean available\" as a sensation, not a sentence."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Known corner, build to the 85% line",
+          "steps": [
+            "Take a real gravel corner you've already run in the Figure-8 and Lesson 6 drills.",
+            "Estimate its μ and radius, get a rough ceiling speed, and set your entry at 85% of it.",
+            "Run it repeatedly, nudging entry speed up by half-mph steps, holding eyes to the exit, finishing braking before turn-in.",
+            "Session goal: arrive at an entry speed that feels fast and calm at once — the number and the body finally agreeing."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're on dry loose-over-hardpack (μ ≈ 0.4) entering a sweeper. The bike feels barely leaned — nothing like a committed road corner — yet you feel a faint drift through the bars. What's actually happening?",
+      "options": [
+        {
+          "text": "You have tons of margin left — the bike isn't even leaned over, so lean in harder",
+          "correct": false
+        },
+        {
+          "text": "You're at the grip ceiling. On gravel the limit arrives at ~22° of lean, so 'barely leaned' plus a front drift means you're already at the edge",
+          "correct": true
+        },
+        {
+          "text": "The front tire is underinflated; add pressure to firm up the steering",
+          "correct": false
+        },
+        {
+          "text": "You need to shift your weight back to drive the front tire down into the surface for more grip",
+          "correct": false
+        }
+      ],
+      "explanation": "On gravel you are grip-limited, not lean-limited. arctan(0.4) ≈ 22°, so the tire lets go at a lean that feels trivially safe compared to the road — the surface gives you no lean-angle warning. The faint drift through the bars is the real edge signal; heed it. Adding lean pushes you past the limit. And weighting the rear to 'drive the front down for grip' is the myth this lesson debunked — loading a fixed-pressure tire grows its contact patch, it doesn't knife it through to the hardpack."
+    },
+    {
+      "type": "prose",
+      "content": "### What this changes about how you ride\n\nNothing, if the drills are already in your body. Everything, if you've been waiting for permission to trust them. The physics doesn't give you a new technique — it tells you the techniques you drilled are the correct ones and the folklore fighting them is wrong. You corner at a lean that feels too safe because 22° really is the ceiling. You trust the front brake because you genuinely can't loop it on the loose. You finish braking early because the grip budget is smaller and shared. You commit because tentative is slow and reactive — not because committing conjures traction.\n\nAnd when someone on the group ride tells you to lean back and feather the rear into every loose corner, you'll know exactly which half of that is real and which half is a road habit wearing a gravel jersey."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment: run The Skidpad Audit once this week and find the front-tire drift in both directions. Write down the speed where it showed up. That number — your real edge, felt not calculated — is worth more than every formula in this lesson."
+    },
+    {
+      "type": "callout",
+      "style": "next",
+      "content": "That's the physics, honestly — including the parts nobody has nailed down. Go back to the drills. The formulas were only ever here to tell you the drills weren't lying to you."
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/14-finding-your-limits.json
+++ b/data/courses/dirt-craft/lessons/14-finding-your-limits.json
@@ -1,0 +1,195 @@
+{
+  "id": "finding-your-limits",
+  "title": "Finding Your Limits (On Purpose)",
+  "module": "skills-lab",
+  "lesson_number": 14,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "60-70%",
+      "unit": "of available grip is where scared riders live",
+      "context": "You leave a third of your traction unused because you've never met the limit in a place where meeting it was free. This lesson is where you go find it."
+    },
+    {
+      "type": "callout",
+      "style": "highlight",
+      "content": "**Most skills courses skip this, and it's a real gap.** You can't confidently ride to an edge you've never felt. So we go feel it — deliberately, at walking pace, in an empty lot where a mistake costs a foot down and nothing else. You're not learning to crash. You're learning where the crash starts, so you can ride just under it instead of guessing."
+    },
+    {
+      "type": "prose",
+      "content": "### Why you have to feel it, not read it\n\nEvery number in this course — the μ estimates, the 22° lean ceiling, the 85% rule — is a map. Maps don't ride bikes. What lets you commit to a loose corner at speed is a body that has already felt the tire let go, and knows the feeling a half-second before it happens. That's not readable. It gets installed one controlled slip at a time.\n\nMost riders who look brave on the descent aren't. They found the limit slowly, in a field at low speed, enough times that the edge became information instead of fear. That's the whole difference, and it's practice, not nerve."
+    },
+    {
+      "type": "black_box",
+      "title": "The safe-skid principle",
+      "content": "Not all slides are equal, and this is the whole reason this lesson is safe to teach.\n\nA REAR-wheel skid is recoverable. The bike yaws, the rear steps out, and the geometry of the bike wants to straighten itself back out — you have a half-second to a full second to react, and the correction (ease off, steer with it) is learnable at low speed. You can skid the rear all day.\n\nA FRONT-wheel wash is not recoverable in the same way. The front wheel is what keeps you balanced; when it goes, there's often no time to catch it. So we treat the two tires completely differently. The rear, you deliberately break loose and play with. The front, you walk up to the edge of and never deliberately cross. Every drill below respects that line."
+    },
+    {
+      "type": "sensation_target",
+      "label": "The first whisper of slip",
+      "content": "On the rear brake, ease the lever until the tire stops rolling cleanly and starts to smear — a low grinding drag, the back of the bike going slightly light and loose under your hips. That's the first slip. It is not violent and it is not an emergency. It's a quiet handoff from grip to slide. Learn that exact moment — the sound, the loosening at your seat — because it is the same signal, scaled up, that you'll feel at 25 mph. The whole game is meeting it here so you recognize it there."
+    },
+    {
+      "type": "process",
+      "title": "The Slip Ladder",
+      "description": "Your repeatable method for meeting any traction limit safely: climb toward the edge in small steps, touch it, and step back. Never jump to the top rung. The ladder is the tool; every drill in this lesson is a way to climb it.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Pick a consequence-free arena.",
+          "detail": "Flat, open gravel or grass-over-dirt, long runout, nothing to hit, no traffic. Grass-over-dirt is ideal early — it slides at low speed and the landing is soft."
+        },
+        {
+          "step": 2,
+          "action": "Isolate one input.",
+          "detail": "One tire, one brake, or one corner — never all of it at once. You are collecting a single clean signal, not riding a trail."
+        },
+        {
+          "step": 3,
+          "action": "Climb in small steps.",
+          "detail": "Add a little speed, brake pressure, or lean each rep. The moment you feel the first slip, that rung is found. Do not force the next rung — earn it."
+        },
+        {
+          "step": 4,
+          "action": "Touch the edge, then release.",
+          "detail": "Feel the slip, then immediately ease the input and feel grip return. The release is the motor program you're installing — regaining control is the skill, not losing it."
+        },
+        {
+          "step": 5,
+          "action": "Log the rung and repeat.",
+          "detail": "Note the speed or lever pressure where slip began. Repeat until that rung is boring, then climb one more. Boring means it's becoming automatic. Automatic is the goal."
+        }
+      ]
+    },
+    {
+      "type": "drill",
+      "title": "Rear-Brake Skid & Steer",
+      "time_minutes": 20,
+      "description": "The safest, highest-value feel drill there is: deliberately lock and release the rear, then learn to steer the bike with a sliding rear. This is where a locked rear stops being an emergency and becomes an input you own.",
+      "proof_gate": {
+        "target": "You can lock the rear, hold a straight skid, and release into clean grip on demand — and initiate a small rear-wheel drift to the left and to the right and ride it out, without a front-brake grab and without a death grip."
+      },
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Flat gravel or grass-over-dirt, straight line, 8-12 mph",
+          "steps": [
+            "Roll at a slow, steady speed in the attack position — hinged, level feet, light hands.",
+            "Squeeze ONLY the rear brake hard enough to lock the wheel. Feel the rear slide straight behind you. Keep your eyes up and forward, not down at the wheel.",
+            "Release. Feel the tire grip and roll again. That lock-and-release is one rep.",
+            "Do 15-20 reps until locking and releasing the rear feels casual and controlled, not startling.",
+            "Goal: delete the flinch. A locked rear should feel like a tool you picked up, not a mistake that happened to you."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Same surface, add steering — the pendulum",
+          "steps": [
+            "At 10-15 mph, lock the rear and, as it slides, steer/lean gently to the LEFT. The rear will step out to the right and the bike will pivot. Ride it out, release, grip returns.",
+            "Repeat to the RIGHT. Alternate: lock-drift-left, release, lock-drift-right, release — a slow pendulum.",
+            "Feel how the slide is steerable — a sliding rear is a direction-change tool, which is exactly 'backing it into' a loose corner, learned where it's free.",
+            "Goal: both directions feel equally available. Your weak side will lag; spend more reps there."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Approach into a loose flat corner",
+          "steps": [
+            "On a known loose flat corner, carry a touch of rear brake into the entry and let the rear drift slightly as you turn, then release to grip for the exit.",
+            "Keep it small and deliberate. You're blending the pendulum into a real corner, not sliding for show.",
+            "Goal: use a controlled rear drift to rotate the bike into the corner, then hook up and drive out."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "style": "tip",
+      "content": "This drill sequence is lifted straight from how DH pro Ben Cathro teaches braking (Pinkbike, *How To Bike* EP5): descend a repeatable slope using only one brake at a time, shifting your weight over the wheel you're braking with, and treat the lockup as the lesson — squeeze until it slips, ease until it grips. The feedback loop *is* the skill."
+    },
+    {
+      "type": "drill",
+      "title": "Single-Brake Isolation Descent (Cathro Method)",
+      "time_minutes": 25,
+      "description": "Isolate each brake on a slope you can comfortably ride, so you learn what each one actually does before you ever combine them. Rear first (safe to skid), front second (walk to the edge, never cross it).",
+      "proof_gate": {
+        "target": "You can descend the slope on the rear brake alone and on the front brake alone, modulating each right up to — but the front never past — its slip point, in full control."
+      },
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Rear brake only — gentle repeatable slope",
+          "steps": [
+            "Find a gravel slope you can ride comfortably, with a clear runout at the bottom.",
+            "Descend using ONLY the rear brake. Shift your weight back over the rear tire to load it.",
+            "Modulate: squeeze until the rear starts to slip, ease until it grips. Ride the whole slope playing that edge.",
+            "Goal: learn exactly how much rear brake the surface will take before it breaks loose."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Front brake only — approach the edge, do NOT cross it",
+          "steps": [
+            "Same slope. Descend using ONLY the front brake, weight centered and low, hinged back — never stiff-armed over the bars.",
+            "Squeeze progressively and feel the front load up and bite. The front will give you far more stopping power than you expect — that's the point.",
+            "The moment you feel the faintest front chatter or drift, EASE. Do not chase a front skid. On the loose you're proving the front is trustworthy and strong, not trying to wash it. Find the edge; live just under it.",
+            "Goal: overwrite the road-brain fear of the front lever with a felt sense of how much grip it actually has."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Blend — both brakes, front-led",
+          "steps": [
+            "Now combine: lead with the front, support with the rear, on the same slope at a faster roll-in.",
+            "Do most of your slowing early and upright; feel the front carry ~70-80% of the work while the rear steadies and fine-tunes.",
+            "Goal: a smooth, front-led, one-zone stop that finishes before any corner would begin."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "prose",
+      "content": "### The one rule that keeps this safe\n\n**Skid the rear all you want. Never chase a front skid.** The rear is your playground — lock it, drift it, pendulum it, back it into corners. The front is a cliff edge you learn the location of by walking up to it slowly, never by jumping off. When the front finally does let go on the trail someday — and it will — your body will recognize the feeling *because you spent time near it here*, and your trained response (ease, don't grab, weight the outside) will fire before your panic does.\n\nThat's the entire purpose of deliberately finding your limits: not to live at the edge, but to make the edge familiar enough that it stops running your decisions."
+    },
+    {
+      "type": "video",
+      "id": "kR4B7XvedkM",
+      "title": "Where To Skid On Your Mountain Bike | MTB Skills",
+      "channel": "Global Mountain Bike Network",
+      "mtb_demo": true,
+      "caption": "Where and how to skid, and how to control the rear once it breaks loose."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're building a limit-finding practice session in an empty gravel lot. Which approach actually develops usable feel — and stays safe?",
+      "options": [
+        {
+          "text": "Ride a fast trail and push into every corner until something slides, learning from whatever happens",
+          "correct": false
+        },
+        {
+          "text": "Deliberately lock and release the REAR to learn the slide and its recovery, while only ever approaching the FRONT's slip point without crossing it",
+          "correct": true
+        },
+        {
+          "text": "Practice washing the front wheel at speed so you learn to catch it when it happens for real",
+          "correct": false
+        },
+        {
+          "text": "Avoid skidding entirely — it wears tires and teaches bad habits",
+          "correct": false
+        }
+      ],
+      "explanation": "A rear skid is recoverable, so you deliberately break it loose and rehearse the release — that's The Slip Ladder in action. A front wash usually isn't recoverable, so you walk up to its edge to learn its location and trust its power, but never chase it. Pushing a fast trail until something random slides isn't practice — it's gambling with real consequences. And skidding, done deliberately in a safe arena, is exactly how you install the feel you can't get any other way."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment: one 20-minute session in an empty lot this week doing nothing but Rear-Brake Skid & Steer. Find the first-slip point, ride the pendulum both directions, and write down the speed where the rear breaks loose. You now own a number your body found, not a number you read."
+    },
+    {
+      "type": "callout",
+      "style": "next",
+      "content": "You've met the edge on purpose and lived just under it. Every corner and descent in this course gets easier once the limit stops being a mystery — because now you're riding to a line you've actually felt, not one you're guessing at in the dark."
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/15-hops-and-ruts.json
+++ b/data/courses/dirt-craft/lessons/15-hops-and-ruts.json
@@ -1,0 +1,174 @@
+{
+  "id": "hops-and-ruts",
+  "title": "Hops, Ledges, and Getting Out of Ruts",
+  "module": "skills-lab",
+  "lesson_number": 15,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "2",
+      "unit": "wheels, lifted in sequence — not together",
+      "context": "The hop that clears logs, ledges, and rut edges is a J-shaped move: front wheel up first, then scoop the rear up to meet it. Works on flat pedals, no clip-in required. It's one of the more useful obstacle skills for gravel — and one of the harder ones to learn, so we'll break it down."
+    },
+    {
+      "type": "callout",
+      "style": "highlight",
+      "content": "**Two related skills.** A repeatable hop clears the ledge, log, or lip that would otherwise stop you or pitch you. And getting out of a rut — usually by riding it, occasionally by hopping — keeps a rut from becoming a crash. We'll break the hop down properly and be upfront about which parts of rut technique are well-established and which are advanced or thinly documented."
+    },
+    {
+      "type": "prose",
+      "content": "### The hop worth learning: front first, then scoop\n\nForget pulling both wheels up at once by yanking on clipped-in pedals — that's a party trick that abandons you the moment you're on flat pedals or tired. The hop that transfers to real terrain is the **manual-first** hop, sometimes called the American or J-hop, because the bike traces a J: the front rises, then the rear is scooped up to join it.\n\nLee McCormack is unambiguous about the sequence: *\"Yes, you should begin your bunny hop with a manual.\"* His load-and-fire cue for the front: *\"Rock back onto your rear wheel. Wait for the wheel to become loaded, then explode upward by pushing down on your pedals.\"* Then the rear comes up not by kicking, but by scooping the pedals up with your feet while bending your legs to suck the bike up into you (BikeRadar). Ben Cathro's cue for that second half: *\"as the rear wheel rises, push your bum back, claw your bars up, and then push them forward.\"*\n\nOne honesty note: the names are a mess online — some people call the simultaneous lift a 'J-hop' too. Ignore the naming fight. The mechanic that works and transfers is *front up first, then scoop the rear.*"
+    },
+    {
+      "type": "process",
+      "title": "The J-Hop",
+      "description": "The sequence, broken into the two halves you'll drill separately before you ever combine them. Half one is a manual. Half two is a scoop. The hop is just the two joined at the right moment.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Load the rear.",
+          "detail": "From the attack position, rock your weight back onto the rear wheel and let it compress. You're loading a spring — don't rush it."
+        },
+        {
+          "step": 2,
+          "action": "Explode up for the front lift.",
+          "detail": "Push down through the pedals and drive your weight up and back. The front wheel comes up in a manual motion — this is half one, and it's why you drill manuals first."
+        },
+        {
+          "step": 3,
+          "action": "Scoop the rear.",
+          "detail": "As the front peaks, scoop the pedals upward with your feet and bend your legs to pull the bike up into your body. On flats this scoop is the whole rear lift; clipped in, the leg-bend does most of it. Do NOT just kick backward — it's a scoop plus a tuck."
+        },
+        {
+          "step": 4,
+          "action": "Push the bars forward and level out.",
+          "detail": "Claw the bars up, then push them forward to bring the bike level in the air so both wheels land together. Land in the attack position, ready to ride away."
+        }
+      ]
+    },
+    {
+      "type": "drill",
+      "title": "Split the Hop: Manual, then Scoop",
+      "time_minutes": 25,
+      "description": "You do not learn the hop by attempting hops. You learn it by drilling each half until it's automatic, then joining them. This is The Practice Loop applied to the most component-heavy skill in the course.",
+      "proof_gate": {
+        "target": "You can lift the front wheel on demand with a load-and-explode manual motion, and separately scoop the rear wheel off the ground while rolling — before you ever try to do both in one move."
+      },
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Front half only — the load-and-lift",
+          "steps": [
+            "On flat ground, from the attack position, practice ONLY the front lift: rock back, load the rear wheel, explode up, front wheel rises.",
+            "Small lifts. You're learning the load-and-fire timing, not going big. Reset to attack position every rep.",
+            "Do 20+ reps until the front comes up from the load, not from you hauling on the bars."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Rear half only — the scoop",
+          "steps": [
+            "Now practice ONLY the rear lift while rolling slowly: scoop the pedals up with your feet and bend your legs to lift the rear wheel off the ground.",
+            "Feel that it's a scoop-and-tuck, not a backward kick. On flats, point the toes slightly and lift; the leg-bend absorbs the bike upward.",
+            "Do 20+ reps until you can pop the rear up an inch or two on command."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Join the halves over a small target",
+          "steps": [
+            "Lay a stick or paint line on the ground. Roll at it slowly and join the two halves: front up, then scoop the rear to follow.",
+            "Push the bars forward to level the bike and land both wheels together in the attack position.",
+            "Raise the obstacle only when the timing is clean over the line. Height is a byproduct of timing, never the goal."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "black_box",
+      "title": "Getting out of a rut: ride it first, hop it last",
+      "content": "Ruts scare riders into doing the one thing that guarantees a crash: staring down into the rut and stiffening. The established answer, and it's well-backed by named coaches, is almost always to **ride the rut, not hop out of it**. Four verified cues:\n\n**Stay centered — not back.** PMBIA coach Russ Risdon: *\"If you get over the back, that will mean minimal front traction and control… You want to be as centered as possible.\"* The instinct to sit back in a rut is exactly wrong; it strips the front wheel of grip and your options.\n\n**Treat it like a skinny and look through it.** Risdon again: *\"if you are looking outside of the rut, you can catch the side and crash.\"* Don't drop your head and stare into the groove, and don't look out over the edge — look ahead along the rut to where it releases you.\n\n**Stay low and loose, minimal steering.** Coach Clive Forth: relax the knees, push the elbows out, *\"use minimal steering input,\"* and don't lean hard into the rut edges — leaning in just presses your tire into the wall.\n\n**Steer with the rear.** Forth's technique for guiding the bike through: rather than steering from the front, *\"thrust the bike through the legs below us,\"* driving it into the trail and kicking the feet through so the bike moves under a stable body.\n\n**Hopping out (advanced, and honestly under-documented):** you *can* reposition the bike sideways with a lateral J-hop — punch the bars up and away, kick across with the trailing foot. But be straight about the evidence: no credentialed coach teaches a clean 'hop out of the rut' method or drill; the solid coaching is all about riding the rut well. Treat the sideways hop as a bonus skill, not your first answer. Your first answer is centered weight, eyes through, and commitment."
+    },
+    {
+      "type": "prose",
+      "content": "### A safe way to build the lateral hop\n\nIf you want the sideways hop as a general skill — repositioning the bike laterally over a line, an edge, or an obstacle — build it where a miss is free. A sensible self-directed progression is to **hop sideways up onto a low curb**: it gives you a defined edge, a clear target, and a soft-ish consequence. Start with a curb an inch or two high, hop onto it from alongside, and only raise the height once you can place the bike both directions on command.\n\nTwo honest caveats. First, the sideways-hop *execution* is coach-verified (Clive Forth), but this specific curb-height progression is a community practice drill, not something a name-brand coach teaches — so treat it as a reasonable way to build the skill, not gospel. Second, and more important: I'm not selling this as a rut-escape drill. When I looked, no credentialed coach connects curb-hopping to getting out of ruts — that link is folklore. The curb ladder builds a lateral hop, which is a genuinely useful bike-handling skill. Getting out of ruts is mostly the riding technique above."
+    },
+    {
+      "type": "drill",
+      "title": "The Curb Ladder",
+      "time_minutes": 20,
+      "description": "Build the lateral hop against a defined edge with a soft consequence. A curb is the perfect teacher: it tells you instantly whether you cleared it, and it doesn't hurt much when you don't.",
+      "proof_gate": {
+        "target": "You can hop sideways onto a low curb from alongside it, placing both wheels cleanly on top, in both directions and on command."
+      },
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "Straight hop onto a low curb, head-on",
+          "steps": [
+            "Find a low curb (1–2 inches). Roll at it head-on at walking pace and J-hop both wheels up onto it.",
+            "Land in attack position. This proves your basic hop clears a real edge before you add the sideways component."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Sideways hop onto the curb",
+          "steps": [
+            "Ride ALONGSIDE the curb, a foot away. Initiate the J-hop and, as the front lifts, punch the bars up and away toward the curb while kicking the legs across.",
+            "Place both wheels on top. Reset. Repeat until you can land it consistently on your strong side.",
+            "Switch sides. Your weak side will be ugly — that's the point of practicing it here and not in a rut."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Raise the edge, both directions",
+          "steps": [
+            "Only once both directions are reliable, find a slightly higher edge and repeat.",
+            "Keep it low enough that a miss is a foot-down, not a crash. Height comes from timing, not courage.",
+            "Goal: place the bike laterally onto a defined edge, either direction, on demand — a genuine repositioning tool for lines, edges, and obstacles."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "video",
+      "id": "SyJm_w3dOuA",
+      "title": "How To Ride Ruts | Mountain Bike Cornering Skills",
+      "channel": "Global Mountain Bike Network",
+      "mtb_demo": true,
+      "caption": "Riding ruts as a feature, not a hazard — vision, commitment, and letting the rut hold your line."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You drop into a deep, firm rut at speed and want out of it. What's the sound first move?",
+      "options": [
+        {
+          "text": "Immediately try to bunny-hop sideways out of the rut",
+          "correct": false
+        },
+        {
+          "text": "Stare down into the rut to track exactly where your front wheel is going",
+          "correct": false
+        },
+        {
+          "text": "Look OUT of the rut to your exit, stay light and centered, and ride it out — reserving a lateral hop for when riding out truly isn't possible",
+          "correct": true
+        },
+        {
+          "text": "Grab both brakes hard to slow down until the rut ends",
+          "correct": false
+        }
+      ],
+      "explanation": "Ride out of the rut first: eyes out to the exit (not down at the dirt), light hands, centered weight, and let the rut guide the wheels while you steer with vision and hips. Most ruts release you if you stop fighting them. Hopping sideways out is a genuinely advanced, situational move — a bonus built on a solid J-hop, not your first answer. And staring down or grabbing brakes are the two classic ways to turn a rut into a crash."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment: spend one session drilling ONLY the two halves of the J-hop — front lift, then rear scoop — separately, using The Practice Loop. Don't try to clear anything. Own each half first. The hop assembles itself once the halves are automatic."
+    },
+    {
+      "type": "callout",
+      "style": "next",
+      "content": "That's the hop that transfers to real terrain, plus an honest map of what's solid and what's shaky in rut technique. With your limit-finding work, most obstacles shift from a fear problem to a timing problem you can practice."
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/16-pumping.json
+++ b/data/courses/dirt-craft/lessons/16-pumping.json
@@ -1,0 +1,144 @@
+{
+  "id": "pumping",
+  "title": "Pumping: Speed Without Pedaling",
+  "module": "skills-lab",
+  "lesson_number": 16,
+  "blocks": [
+    {
+      "type": "hero_stat",
+      "value": "2-for-1",
+      "unit": "one skill that both absorbs impacts and makes speed",
+      "context": "Pumping is how you carry speed through rolling gravel — dips, whoops, undulating doubletrack — without spending watts. It's the same motion that smooths out chatter. Fair warning up front: it's real physical work, not free speed. But it's watts you'd otherwise never get back."
+    },
+    {
+      "type": "callout",
+      "style": "highlight",
+      "content": "**This is the closest thing to free speed in gravel, and it isn't quite free.** On rolling terrain, a rider who pumps carries momentum through every dip and rise while you pedal-and-coast and bleed speed. The skill is one thing — managing pressure through the bike — and it does two jobs: it makes speed on rolling ground, and it absorbs bumps when you don't want the speed. Learn it once, use it constantly."
+    },
+    {
+      "type": "prose",
+      "content": "### The whole mechanic in one sentence\n\nLee McCormack, who is the canonical source on this, puts it as plainly as it gets: *\"To pump rollers, you unweight on the front sides and press hard on the back sides. This way the fronts don't slow you down, and the backs give you speed.\"*\n\nThat's it. As you crest a roller or the top of a dip, you get light — you let the bike come up into you instead of shoving it into the upslope. As you come over the top and down the back side, you push hard, driving the bike down and forward into the descending face. His cue: *\"Push your legs down the backsides. Do this hard… The heavier you push into a backside, the lighter the bike will be on the frontside.\"* Light on the fronts so they don't brake you, heavy on the backs so they drive you."
+    },
+    {
+      "type": "prose",
+      "content": "### It's the same motion as row/anti-row\n\nYou already met the timing engine in Module 1. Pumping *is* row and anti-row applied to terrain: in the trough you **row** — pull the bars back, push the feet down, drive into the backside. Over the crest you **anti-row** — hinge and push the bars forward, pull the feet up, get light. When you cycle those with the bumps, your hands and feet trace little ellipses and the bike surges. If row/anti-row clicked for you, pumping is that skill pointed at rollers."
+    },
+    {
+      "type": "black_box",
+      "title": "The physics: push through the trough, not down the slope",
+      "content": "Most people pump at the wrong moment, and the physics says exactly when. From engineer and Pinkbike editor Seb Stott: *\"You don't want to extend your arms and legs when you're on the steepest part of the down slope, but the most tightly curved part of the transition… Push through the trough, compress over the crest.\"*\n\nWhy: at the curved bottom of a dip, your push is briefly in line with where you're going, so the work adds speed. On the straight, steepest part of a slope, the same push is aimed partly sideways to your travel and mostly wasted.\n\nAnd the honest part: *\"pumping is not 'free speed.' The work you do pushing yourself away from the ground… is what provides the energy that accelerates you.\"* Anyone who's done a few pump-track laps knows the burn. You're not cheating physics — you're doing real work at the one instant it converts cleanly into speed."
+    },
+    {
+      "type": "sensation_target",
+      "label": "The surge",
+      "content": "A good pump doesn't feel like effort in your legs the way pedaling does — it feels like a shove that arrives half a beat after you push. You compress over the top, then drive down the back, and a moment later the bike squirts forward underneath you like you squeezed it out of the dip. When the timing is off, there's no surge — you just feel like you're doing squats for nothing. Chase the surge. It's the feedback that tells you the push landed in the trough, not on the slope."
+    },
+    {
+      "type": "process",
+      "title": "The Pump Cycle",
+      "description": "The timing, broken into the four moments of a single roller or dip. Learn it on one bump, then chain it. This is row/anti-row aimed at terrain.",
+      "steps": [
+        {
+          "step": 1,
+          "action": "Approach light and low.",
+          "detail": "Come in off the pedals-and-coast habit, in the attack position — low, loose, weight in the feet. Stop pedaling before the terrain; pedaling through it fights the pump."
+        },
+        {
+          "step": 2,
+          "action": "Get light over the crest.",
+          "detail": "As you reach the top of the roller or the near lip of a dip, unweight — anti-row: hinge, push the bars forward, let the bike rise into you. Don't shove the bike into the upslope; that's braking."
+        },
+        {
+          "step": 3,
+          "action": "Push hard through the trough.",
+          "detail": "At the tightly curved bottom — not the steepest part of the slope — drive down and forward. Row: pull the bars back, push the feet down, into the backside. This is where the speed is made."
+        },
+        {
+          "step": 4,
+          "action": "Recover and reload.",
+          "detail": "Come back to light and low, ready for the next crest. On a series of rollers it becomes a rhythm: light-crest, heavy-trough, light-crest, heavy-trough."
+        }
+      ]
+    },
+    {
+      "type": "drill",
+      "title": "One Roller, Then the Track",
+      "time_minutes": 30,
+      "description": "You can't learn pumping by reading it and you can't learn it on a fitness ride. You learn it on repeatable rollers — ideally a pump track, which exists for exactly this — by trying to gain speed without pedaling.",
+      "proof_gate": {
+        "target": "You can roll into a single dip or roller with no pedaling and come out measurably faster than you entered, feeling the surge — then string several together and hold speed through them without a pedal stroke."
+      },
+      "variants": [
+        {
+          "level": "beginner",
+          "label": "One roller or dip, no pedaling",
+          "steps": [
+            "Find one roller, dip, or the bottom of a small gully you can approach the same way repeatedly.",
+            "Coast in — no pedaling through it. Get light over the top, push hard through the curved bottom.",
+            "The test is simple: did you come out faster than a dead coast would have? Compare a passive roll-through against a pumped one. Feel the difference.",
+            "Reps until the surge is repeatable, not accidental."
+          ]
+        },
+        {
+          "level": "intermediate",
+          "label": "Pump track — the cardinal-sin rule",
+          "steps": [
+            "Get to a pump track. This is the tool built for this skill; there is no faster way to learn it.",
+            "One rule: no pedaling. Pedaling is the cardinal sin here — the whole point is to circulate on pump alone.",
+            "Do laps. Early laps you'll die and go slow; that's the work of pumping being real. Keep the timing on the troughs.",
+            "Session goal: complete a lap, however slowly, without a single pedal stroke."
+          ]
+        },
+        {
+          "level": "race-pace",
+          "label": "Rolling gravel — carry it into the real world",
+          "steps": [
+            "On undulating doubletrack or a rolling gravel road, stop pedaling through the dips and pump them instead.",
+            "Notice how much speed you hold across a series of rises that you used to pedal-and-coast through.",
+            "Goal: pump the rolling stuff by default, spending watts only where pumping can't reach."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "video",
+      "id": "04e_s9_LpVA",
+      "mtb_demo": true,
+      "title": "How To Get More Speed From Trails With Pumping | Ben Cathro EP6",
+      "channel": "Pinkbike",
+      "caption": "The exact mechanic this lesson teaches — push through the troughs, float over the crests."
+    },
+    {
+      "type": "knowledge_check",
+      "question": "You're pumping a roller to gain speed. Where and how do you put the power down?",
+      "options": [
+        {
+          "text": "Extend hard on the steepest part of the downslope — that's where gravity helps most",
+          "correct": false
+        },
+        {
+          "text": "Push hard through the tightly curved bottom of the trough, and get light over the crest",
+          "correct": true
+        },
+        {
+          "text": "Pedal hard over the top of each roller to add speed",
+          "correct": false
+        },
+        {
+          "text": "Stay heavy and planted the whole way through to maximize traction",
+          "correct": false
+        }
+      ],
+      "explanation": "Push through the trough, compress over the crest. At the curved bottom your push lines up with your direction of travel, so the work becomes speed; on the steepest straight part of the slope the same push is aimed partly across your path and wasted. Get light over crests so the upslopes don't brake you. Pedaling fights the pump, and staying heavy the whole way erases the light-fronts half of the skill. And remember — this is real work, which is why it's the trough, not everywhere."
+    },
+    {
+      "type": "commitment",
+      "content": "Your commitment: find one roller or dip and prove to yourself you can exit it faster than a dead coast, no pedaling — just timing. If you can get to a pump track, do one no-pedal lap. That surge is the whole skill; everything else is reps."
+    },
+    {
+      "type": "callout",
+      "style": "next",
+      "content": "Pumping turns rolling terrain from a place you spend watts into a place you make speed. Paired with your cornering and limit work, it's how a ride stops being a series of efforts and starts being one connected, flowing line."
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/m1-stack-check.json
+++ b/data/courses/dirt-craft/lessons/m1-stack-check.json
@@ -1,0 +1,202 @@
+{
+  "id": "trust-stack-check",
+  "title": "Module 1: Trust the Bike — Stack Check",
+  "module": "trust-the-bike",
+  "lesson_number": null,
+  "blocks": [
+    {
+      "type": "callout",
+      "content": "You've built 4 tools so far:\n\n1. **The Weighted Drop** — drop heels, bend elbows, press through pedals, release hands\n2. **The Hip Hinge** — decouple upper and lower body at the hips\n3. **The Pressure Window** — find your tire pressure envelope by surface type\n4. **The Quiet Eye** — central vision 3-5 seconds ahead, peripheral handles the rest\n\nTime to see what stuck.",
+      "style": "tip"
+    },
+    {
+      "type": "quiz",
+      "question": "You hit unexpected washboard at 17 mph. What's the immediate physical response?",
+      "options": [
+        {
+          "text": "Brake to reduce speed before the washboard gets worse",
+          "correct": false
+        },
+        {
+          "text": "Stand up to absorb the bumps with your legs",
+          "correct": false
+        },
+        {
+          "text": "Drop heels, bend elbows, press weight through the pedals, soften your grip",
+          "correct": true
+        },
+        {
+          "text": "Grip the bars tighter and power through it",
+          "correct": false
+        }
+      ],
+      "explanation": "The Weighted Drop is the correct response to any unexpected surface change. Drop heels 10-15 degrees, bend elbows for 3 inches of vertical travel, press 70% of your weight through the pedals, and reduce grip to a 3 out of 10. Braking on washboard reduces traction. Standing shifts weight forward. Gripping tighter starts the death grip cycle."
+    },
+    {
+      "type": "quiz",
+      "question": "What should your palms feel like after 10 minutes of rough gravel?",
+      "options": [
+        {
+          "text": "Red and slightly sore — that means you were holding on properly",
+          "correct": false
+        },
+        {
+          "text": "Tingling from vibration — the bars transmit a lot of energy",
+          "correct": false
+        },
+        {
+          "text": "Exactly the same as when you started — no redness, no soreness, no tingling",
+          "correct": true
+        },
+        {
+          "text": "Numb — reduced blood flow is normal on rough terrain",
+          "correct": false
+        }
+      ],
+      "explanation": "The Palm Check is the proof gate for Lesson 1. If your palms are red, sore, or tingling after rough gravel, your weight was in your hands, not your feet. Correct weight distribution means your palms barely register the ride — the energy goes through your pedals, not your handlebars."
+    },
+    {
+      "type": "quiz",
+      "question": "What's the primary decoupling joint between upper and lower body on gravel?",
+      "options": [
+        {
+          "text": "Knees — they flex to absorb bumps",
+          "correct": false
+        },
+        {
+          "text": "Shoulders — they float above the terrain",
+          "correct": false
+        },
+        {
+          "text": "Hips — the hip hinge separates a stable lower body from a floating upper body",
+          "correct": true
+        },
+        {
+          "text": "Elbows — bent elbows are the primary suspension",
+          "correct": false
+        }
+      ],
+      "explanation": "The Hip Hinge is the decoupling joint. Road cycling trains your body as a single rigid unit — stiff core, locked hips, power from glutes. Gravel demands two separate systems: a stable lower body driving the pedals, and a loose upper body absorbing terrain independently. The hips are where the separation happens."
+    },
+    {
+      "type": "quiz",
+      "question": "Your vision bounces on rough terrain — you can't read a road sign while riding washboard. What's the problem?",
+      "options": [
+        {
+          "text": "You need a suspension fork",
+          "correct": false
+        },
+        {
+          "text": "Your hip hinge isn't engaged — your skeleton is transmitting bumps straight to your head",
+          "correct": true
+        },
+        {
+          "text": "You need to focus harder on the sign",
+          "correct": false
+        },
+        {
+          "text": "Your tire pressure is too low and the bike is wallowing",
+          "correct": false
+        }
+      ],
+      "explanation": "Vision bounce is the telltale sign that the Hip Hinge isn't engaged. When your hips aren't decoupling upper from lower body, every bump travels through your rigid skeleton directly to your head. The proof gate for Lesson 2: you should be able to read a road sign while riding washboard. If you can't, your body is one rigid unit instead of two separate systems."
+    },
+    {
+      "type": "quiz",
+      "question": "Your tires are buzzing on gravel — a high-pitched hum that makes the bike skip across the surface instead of sticking to it. Pressure is too ___?",
+      "options": [
+        {
+          "text": "Low — the tires are folding and creating friction noise",
+          "correct": false
+        },
+        {
+          "text": "High — the tires are bouncing off the surface instead of conforming to it",
+          "correct": true
+        },
+        {
+          "text": "About right — that buzzing sound is normal on gravel",
+          "correct": false
+        },
+        {
+          "text": "Unrelated — tire buzz depends on tread pattern, not pressure",
+          "correct": false
+        }
+      ],
+      "explanation": "Quiet tires are the sensation target for Lesson 3. When pressure is right, the buzzing stops. The bike sticks to the surface instead of skipping across it. You feel the ground through the tire, not the tire bouncing off the ground. High pressure on gravel causes the tire to ride on top of the surface, losing grip and creating that characteristic high-pitched buzz."
+    },
+    {
+      "type": "quiz",
+      "question": "Race day. It rained overnight, and the course is wet. Your dry-condition Pressure Window starts at 32 PSI. How do you adjust?",
+      "options": [
+        {
+          "text": "Add 3-5 PSI for better puncture protection on wet roads",
+          "correct": false
+        },
+        {
+          "text": "Drop 3-5 PSI from your dry baseline to increase the contact patch",
+          "correct": true
+        },
+        {
+          "text": "Keep the same pressure — rain doesn't affect tire grip on gravel",
+          "correct": false
+        },
+        {
+          "text": "Drop 10+ PSI to maximize grip in the mud",
+          "correct": false
+        }
+      ],
+      "explanation": "Wet conditions call for dropping 3-5 PSI from your dry baseline. Lower pressure increases the tire's contact patch, giving you more rubber on the ground when traction is reduced. Dropping too much (10+) risks pinch flats and squirmy handling. Adding pressure makes the problem worse — a harder tire has less grip on wet surfaces."
+    },
+    {
+      "type": "quiz",
+      "question": "Where should your central vision be focused when riding gravel?",
+      "options": [
+        {
+          "text": "On the ground directly in front of your wheel to spot obstacles",
+          "correct": false
+        },
+        {
+          "text": "3-5 seconds ahead of your current position",
+          "correct": true
+        },
+        {
+          "text": "On the rider in front of you",
+          "correct": false
+        },
+        {
+          "text": "Alternating between near and far every few seconds",
+          "correct": false
+        }
+      ],
+      "explanation": "The Quiet Eye technique puts your central vision 3-5 seconds ahead. At 18 mph, that's roughly 50 meters. Your peripheral vision handles near-field obstacles — rocks, ruts, and roots steer around themselves when you're not staring at them. The scanning hierarchy: surface type first, line second, individual obstacles last."
+    },
+    {
+      "type": "quiz",
+      "question": "You see a sharp rock 5 feet ahead on a gravel descent. What do you NOT do?",
+      "options": [
+        {
+          "text": "Trust your peripheral vision and maintain your far focal point",
+          "correct": false
+        },
+        {
+          "text": "Make a subtle weight shift to guide the bike around it",
+          "correct": false
+        },
+        {
+          "text": "Stare directly at the rock and try to steer around it",
+          "correct": true
+        },
+        {
+          "text": "Maintain your current line if the rock isn't in your path",
+          "correct": false
+        }
+      ],
+      "explanation": "Target fixation: looking at the rock makes you hit the rock. At 5 feet, it's too late for a deliberate line change anyway — that decision needed to happen 3-5 seconds earlier. The correct response is to keep your focal point ahead and let peripheral vision guide micro-adjustments. The Quiet Eye means you already identified this obstacle when it was 50 meters out and chose your line accordingly."
+    },
+    {
+      "type": "callout",
+      "content": "If you got 6 or more correct, your Trust stack is solid. You've internalized the foundation: weight through the pedals, hips as the hinge, pressure dialed, eyes ahead. Welcome to Module 2: Control the Inputs.",
+      "style": "tip"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/m2-stack-check.json
+++ b/data/courses/dirt-craft/lessons/m2-stack-check.json
@@ -1,0 +1,248 @@
+{
+  "id": "control-stack-check",
+  "title": "Module 2: Control the Inputs — Stack Check",
+  "module": "control-the-inputs",
+  "lesson_number": null,
+  "blocks": [
+    {
+      "type": "callout",
+      "content": "Your tool stack is now 8 deep:\n\n**Module 1 — Trust the Bike:**\n1. **The Weighted Drop** — heels down, elbows bent, weight through pedals, hands quiet\n2. **The Hip Hinge** — decouple upper and lower body at the hips\n3. **The Pressure Window** — tire pressure envelope by surface and conditions\n4. **The Quiet Eye** — central vision 3-5 seconds ahead, scanning hierarchy\n\n**Module 2 — Control the Inputs:**\n5. **The Braking Budget** — front-dominant, pulse on loose, speed-set-coast\n6. **The 85% Rule** — enter every corner at 85% of estimated max speed\n7. **The Torque Ceiling** — maximum pedal force before the rear tire breaks loose\n8. **The 50-Meter Scan** — read surface transitions before you reach them\n\n2 retrieval questions from Module 1. 8 questions from Module 2. Time to see what stuck.",
+      "style": "tip"
+    },
+    {
+      "type": "quiz",
+      "question": "Spaced retrieval — Module 1: What does \"heavy feet, quiet hands\" mean physically?",
+      "options": [
+        {
+          "text": "Pedal hard and don't touch the brakes",
+          "correct": false
+        },
+        {
+          "text": "70% of your weight pressing through the pedals, hands resting on the bars with minimal grip pressure",
+          "correct": true
+        },
+        {
+          "text": "Stand on the pedals and hover your hands above the bars",
+          "correct": false
+        },
+        {
+          "text": "Push a hard gear and keep your upper body relaxed",
+          "correct": false
+        }
+      ],
+      "explanation": "Heavy feet, quiet hands is the Lesson 1 sensation target. 70% of your weight presses through the pedals into the bottom bracket — the lowest, most stable point of the bike-rider system. Your hands rest on the bars like resting on a shelf, bearing almost no load. Grip at a 3 out of 10. If your palms are red after rough gravel, the weight was in the wrong place."
+    },
+    {
+      "type": "quiz",
+      "question": "Spaced retrieval — Module 1: The Quiet Eye scanning hierarchy on gravel: ___ → ___ → ___.",
+      "options": [
+        {
+          "text": "Obstacle → line → speed",
+          "correct": false
+        },
+        {
+          "text": "Near field → mid field → far field",
+          "correct": false
+        },
+        {
+          "text": "Surface type → line → obstacle",
+          "correct": true
+        },
+        {
+          "text": "Speed → braking point → exit",
+          "correct": false
+        }
+      ],
+      "explanation": "The scanning hierarchy is surface type first, line second, individual obstacles last. Most riders invert this — they stare at rocks (obstacles) while missing the sand patch (surface type) that's the real hazard. Surface type determines your available traction. Line determines your path through that traction. Individual obstacles are handled by peripheral vision once the first two are set."
+    },
+    {
+      "type": "quiz",
+      "question": "What percentage of stopping power comes from the front brake on gravel?",
+      "options": [
+        {
+          "text": "50% — equal braking is the safest approach",
+          "correct": false
+        },
+        {
+          "text": "30-40% — the rear brake does most of the work on loose surfaces",
+          "correct": false
+        },
+        {
+          "text": "70-80% — weight transfers forward under deceleration, loading the front tire",
+          "correct": true
+        },
+        {
+          "text": "90%+ — you should almost never use the rear brake",
+          "correct": false
+        }
+      ],
+      "explanation": "70-80% of stopping power comes from the front brake because weight transfers forward under deceleration, increasing the front tire's contact patch and grip. The road instinct — rear-brake-dominant — is the number one cause of wet gravel crashes. The rear tire is already light under braking. Locking it is easy and leads to skids, overcorrection, and going down."
+    },
+    {
+      "type": "quiz",
+      "question": "Your rear wheel locks on wet gravel and begins to skid sideways. What's the correct recovery sequence?",
+      "options": [
+        {
+          "text": "Apply the front brake to compensate and straighten out",
+          "correct": false
+        },
+        {
+          "text": "Keep the rear brake applied and steer into the skid",
+          "correct": false
+        },
+        {
+          "text": "Full release of the rear brake, let the bike track straight, then gently reapply",
+          "correct": true
+        },
+        {
+          "text": "Release both brakes and coast until the bike stabilizes",
+          "correct": false
+        }
+      ],
+      "explanation": "Full release, track straight, gentle reapply. A locked rear wheel has zero directional control — it's a sled. Releasing the brake lets the tire regain traction and directional authority. Let the bike track straight for a beat, then reapply gently. Grabbing the front brake during a rear skid is the classic two-wheel-lockup crash sequence."
+    },
+    {
+      "type": "quiz",
+      "question": "You're entering a gravel corner. The 85% Rule means:",
+      "options": [
+        {
+          "text": "Use 85% of your available brake power before the corner",
+          "correct": false
+        },
+        {
+          "text": "Enter at 85% of your estimated maximum speed for that corner",
+          "correct": true
+        },
+        {
+          "text": "Lean the bike to 85% of maximum lean angle",
+          "correct": false
+        },
+        {
+          "text": "Maintain 85% of your straightaway speed through the turn",
+          "correct": false
+        }
+      ],
+      "explanation": "The 85% Rule: never enter a gravel corner faster than 85% of your calculated maximum speed. The 15% margin accounts for surface variability, mid-corner surprises (loose patch, wet spot), and the reality that your traction estimate is an estimate. On pavement, you can push to 95%. On gravel, the consequences of miscalculation are immediate."
+    },
+    {
+      "type": "quiz",
+      "question": "Mid-corner on loose gravel, your front tire pushes — it's drifting wider than your intended line. What do you NOT do?",
+      "options": [
+        {
+          "text": "Look where you want to go, not where the bike is heading",
+          "correct": false
+        },
+        {
+          "text": "Brake to slow down and regain front-tire grip",
+          "correct": true
+        },
+        {
+          "text": "Slightly reduce lean angle to unload the front tire",
+          "correct": false
+        },
+        {
+          "text": "Weight the outside pedal harder to increase tire contact",
+          "correct": false
+        }
+      ],
+      "explanation": "Do NOT brake mid-corner. The traction circle means your tires have a fixed grip budget — it's already being spent on cornering forces. Braking mid-corner demands traction the tire doesn't have, and the front washes out completely. The correct responses: look through the turn, reduce lean angle slightly, and weight the outside pedal. Prevention beats recovery — the 85% Rule exists so you never need to brake mid-corner."
+    },
+    {
+      "type": "quiz",
+      "question": "On a loose gravel climb above 8% gradient, should you stand or stay seated?",
+      "options": [
+        {
+          "text": "Stand — you can produce more power out of the saddle",
+          "correct": false
+        },
+        {
+          "text": "Alternate — stand on the steep bits, sit on the flatter sections",
+          "correct": false
+        },
+        {
+          "text": "Seated — standing unloads the rear wheel and causes the tire to spin on loose surfaces",
+          "correct": true
+        },
+        {
+          "text": "Stand with your weight shifted far back over the rear wheel",
+          "correct": false
+        }
+      ],
+      "explanation": "Seated. Standing on loose gravel shifts your weight forward and up, unloading the rear tire at the exact moment you're applying peak torque. The result: rear-wheel spin every 2-3 pedal strokes, wasted energy, lost momentum. Seated climbing keeps your weight centered over the rear tire. Hinge at hips, chin toward stem, slide forward slightly. Higher cadence + lower gear = same power with lower peak torque per stroke."
+    },
+    {
+      "type": "quiz",
+      "question": "\"Butter, not peanut butter\" refers to what sensation?",
+      "options": [
+        {
+          "text": "The smooth feeling of a well-lubricated chain",
+          "correct": false
+        },
+        {
+          "text": "How your tires should feel on properly-pressured hardpack",
+          "correct": false
+        },
+        {
+          "text": "A smooth pedal stroke without catch-and-release — each press gives consistently without skipping or surging",
+          "correct": true
+        },
+        {
+          "text": "The consistency of effort you should target on long gravel climbs",
+          "correct": false
+        }
+      ],
+      "explanation": "The Torque Ceiling sensation target. Each pedal stroke presses into something that gives smoothly and consistently — like a knife through butter. No skip, no grab, no surge. The moment you feel catch-and-release — peanut butter — you've exceeded the torque ceiling and the rear tire is on the edge of breaking loose. Higher cadence, lower gear, stay below the ceiling."
+    },
+    {
+      "type": "quiz",
+      "question": "Name the 4 gravel surface types from Lesson 8.",
+      "options": [
+        {
+          "text": "Smooth, chunky, sandy, muddy",
+          "correct": false
+        },
+        {
+          "text": "Hardpack, loose-over-hard, sand/mud, washboard",
+          "correct": true
+        },
+        {
+          "text": "Packed gravel, loose gravel, dirt, rock",
+          "correct": false
+        },
+        {
+          "text": "Fine gravel, coarse gravel, mixed surface, technical",
+          "correct": false
+        }
+      ],
+      "explanation": "The 4 surface types: hardpack, loose-over-hard, sand/mud, and washboard. Each has a distinct visual signature, sound profile, and riding technique. The 50-Meter Scan means identifying transitions between these surfaces before you reach them — not when your front wheel discovers them. Sound is a reading tool: tire noise pitch and rhythm change with each surface type."
+    },
+    {
+      "type": "quiz",
+      "question": "You're approaching a surface transition from hardpack to loose gravel at 20 mph. What's your adjustment priority?",
+      "options": [
+        {
+          "text": "Brake hard before the transition, then coast through",
+          "correct": false
+        },
+        {
+          "text": "Shift to a lower gear and increase cadence",
+          "correct": false
+        },
+        {
+          "text": "Weighted Drop first, then choose your line through the loose, then maintain pressure awareness",
+          "correct": true
+        },
+        {
+          "text": "Maintain speed — loose gravel requires momentum to stay upright",
+          "correct": false
+        }
+      ],
+      "explanation": "The adjustment priority for any surface transition: Weighted Drop first (heels down, elbows bent, weight through pedals), then line selection (smoothest path through the new surface), then pressure awareness (are your tires at the right pressure for this surface?). The Weighted Drop is always first because it takes a fraction of a second and gives you the stable platform to make every other decision from."
+    },
+    {
+      "type": "callout",
+      "content": "If you got 8 or more correct, your Control stack is locked in. You own 8 tools — 4 that built trust, 4 that gave you specific, repeatable technique. Module 3: Find the Speed.",
+      "style": "tip"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/m3-stack-check.json
+++ b/data/courses/dirt-craft/lessons/m3-stack-check.json
@@ -1,0 +1,248 @@
+{
+  "id": "speed-stack-check",
+  "title": "Module 3: Find the Speed — Stack Check",
+  "module": "find-the-speed",
+  "lesson_number": null,
+  "blocks": [
+    {
+      "type": "callout",
+      "content": "11 tools in the stack:\n\n**Module 1 — Trust the Bike:**\n1. The Weighted Drop\n2. The Hip Hinge\n3. The Pressure Window\n4. The Quiet Eye\n\n**Module 2 — Control the Inputs:**\n5. The Braking Budget\n6. The 85% Rule\n7. The Torque Ceiling\n8. The 50-Meter Scan\n\n**Module 3 — Find the Speed:**\n9. The Position Ladder\n10. The Elastic Gap\n11. The Calm Hands Sequence\n\n2 from Module 1. 2 from Module 2. 6 from Module 3.",
+      "style": "tip"
+    },
+    {
+      "type": "quiz",
+      "question": "Spaced retrieval — Module 1: The Hip Hinge decouples which two body systems?",
+      "options": [
+        {
+          "text": "Left side and right side — for independent pedaling",
+          "correct": false
+        },
+        {
+          "text": "Arms and legs — so your hands stay quiet while your legs drive",
+          "correct": false
+        },
+        {
+          "text": "Upper body and lower body — a stable lower body drives the pedals while a loose upper body absorbs terrain",
+          "correct": true
+        },
+        {
+          "text": "Core and extremities — a rigid core with flexible limbs",
+          "correct": false
+        }
+      ],
+      "explanation": "The Hip Hinge decouples upper and lower body. Your lower body is the stable, weighted platform driving the pedals. Your upper body floats above the terrain, absorbing bumps independently through bent elbows and a hinged torso. Road cycling trains you as one rigid unit. Gravel demands two separate systems, and the hip is where the separation happens."
+    },
+    {
+      "type": "quiz",
+      "question": "Spaced retrieval — Module 2: The Braking Budget says to coast through ___.",
+      "options": [
+        {
+          "text": "Rough sections — braking on bumpy terrain causes bouncing",
+          "correct": false
+        },
+        {
+          "text": "Straightaways — save your braking for corners",
+          "correct": false
+        },
+        {
+          "text": "Corners — scrub speed before the turn, coast through it",
+          "correct": true
+        },
+        {
+          "text": "Descents — let gravity do the work",
+          "correct": false
+        }
+      ],
+      "explanation": "Speed-set-coast: scrub speed before the corner, then coast through it. The traction circle means braking and cornering compete for the same limited grip budget. Braking mid-corner demands traction the tire can't provide. The Braking Budget is about spending your stopping power in the right places — straight-line braking zones before turns, not inside them."
+    },
+    {
+      "type": "quiz",
+      "question": "What's the default hand position for gravel descents?",
+      "options": [
+        {
+          "text": "Hoods — for quick access to shifting",
+          "correct": false
+        },
+        {
+          "text": "Tops — for a relaxed, upright position",
+          "correct": false
+        },
+        {
+          "text": "Drops — 22% aero improvement over hoods with full brake lever access",
+          "correct": true
+        },
+        {
+          "text": "Alternating between hoods and drops every few minutes",
+          "correct": false
+        }
+      ],
+      "explanation": "Drops are the default descent position. You get a 22% aero improvement over hoods, full brake lever access (more leverage from the bottom of the lever), and a lower center of mass. Most riders default to hoods because it feels more comfortable — but comfort isn't the goal on a descent. Control and speed are."
+    },
+    {
+      "type": "quiz",
+      "question": "At greater than 12% grade on a gravel descent, where should your body weight be?",
+      "options": [
+        {
+          "text": "Centered over the bottom bracket as always",
+          "correct": false
+        },
+        {
+          "text": "Forward over the handlebars for front-wheel traction",
+          "correct": false
+        },
+        {
+          "text": "Behind the saddle to prevent going over the bars",
+          "correct": true
+        },
+        {
+          "text": "Standing on the pedals with equal weight distribution",
+          "correct": false
+        }
+      ],
+      "explanation": "On steep descents above 12%, gravity wants to pitch you forward over the handlebars. Moving your weight behind the saddle — hips back, arms extended — keeps the rear wheel loaded and prevents the over-the-bars scenario. The steeper the grade, the further back you go. This is the weight shift by gradient principle from Lesson 9."
+    },
+    {
+      "type": "quiz",
+      "question": "Smooth, straight section on a gravel descent — no obstacles, good visibility. What position?",
+      "options": [
+        {
+          "text": "Stay in the drops, ready for anything",
+          "correct": false
+        },
+        {
+          "text": "Sit up and stretch — take advantage of the easy section",
+          "correct": false
+        },
+        {
+          "text": "Aero tuck — drops with elbows in, pedals level, chin low for 30% drag reduction",
+          "correct": true
+        },
+        {
+          "text": "Stand on the pedals to keep blood flowing",
+          "correct": false
+        }
+      ],
+      "explanation": "The Position Ladder: when the terrain allows it, tuck for free speed. A full aero tuck in the drops delivers roughly 30% drag reduction compared to riding upright on the hoods. On a smooth straight descent, that's free time — same gravity, same slope, significantly less air resistance. The key word is 'smooth' — you only tuck when the surface and visibility allow you to commit to the position."
+    },
+    {
+      "type": "quiz",
+      "question": "Draft savings on gravel vs road: roughly how much less efficient is drafting on gravel?",
+      "options": [
+        {
+          "text": "About the same — 25-35% savings on both surfaces",
+          "correct": false
+        },
+        {
+          "text": "About half — 15-25% on gravel vs 25-35% on road",
+          "correct": true
+        },
+        {
+          "text": "Drafting doesn't work on gravel — the speeds are too low",
+          "correct": false
+        },
+        {
+          "text": "Slightly less — 20-30% on gravel vs 25-35% on road",
+          "correct": false
+        }
+      ],
+      "explanation": "Draft savings on gravel are roughly half of road: 15-25% vs 25-35%. Lower speeds mean less aerodynamic benefit, and variable surfaces force larger gaps. But 15-25% power savings is still enormous over a 150-mile race. The Elastic Gap accounts for this — your following distance stretches and contracts with surface quality."
+    },
+    {
+      "type": "quiz",
+      "question": "Name the three signals that tell you it's time to leave a group.",
+      "options": [
+        {
+          "text": "Riders are rude, the pace is boring, you want to ride alone",
+          "correct": false
+        },
+        {
+          "text": "Pace is too hot, too much braking in the group, the group is slower than your solo pace",
+          "correct": true
+        },
+        {
+          "text": "You're at the back too often, pulls are uneven, the group won't rotate",
+          "correct": false
+        },
+        {
+          "text": "Heart rate too high, legs cramping, nutrition window missed",
+          "correct": false
+        }
+      ],
+      "explanation": "Three signals to leave: (1) the pace is too hot — you're above threshold just to hold the wheel, (2) there's too much braking in the group — the ride is surge-and-brake instead of smooth, meaning the draft savings are being eaten by the inefficiency, (3) the group is slower than your solo pace — the draft benefit doesn't compensate for the pace reduction."
+    },
+    {
+      "type": "quiz",
+      "question": "Surface changes from hardpack to loose gravel while you're drafting at 1.5-2 bike lengths. What happens to your gap?",
+      "options": [
+        {
+          "text": "Close it to 1 length — less aero benefit means you need to be closer",
+          "correct": false
+        },
+        {
+          "text": "Maintain 1.5-2 lengths — consistency is key",
+          "correct": false
+        },
+        {
+          "text": "Opens to 3-4 lengths — loose surface means more reaction time needed and less predictable lines",
+          "correct": true
+        },
+        {
+          "text": "Drop back to 5+ lengths — loose gravel drafting isn't worth the risk",
+          "correct": false
+        }
+      ],
+      "explanation": "The Elastic Gap: 1.5-2 bike lengths on smooth surfaces, opening to 3-4 on rough or loose. Loose gravel means less predictable lines from the rider ahead, more debris spray, and longer stopping distances. The gap stretches like a bungee cord — smooth sections pull it tight, rough sections let it open. Never fight to close the gap on bad surfaces."
+    },
+    {
+      "type": "quiz",
+      "question": "Target time for a tubeless tire plug in the field?",
+      "options": [
+        {
+          "text": "Under 1 minute — speed is everything in a race",
+          "correct": false
+        },
+        {
+          "text": "Under 3 minutes — calm hands, clear sequence",
+          "correct": true
+        },
+        {
+          "text": "Under 5 minutes — there's no rush, do it right",
+          "correct": false
+        },
+        {
+          "text": "Under 10 minutes — most riders take this long on race day",
+          "correct": false
+        }
+      ],
+      "explanation": "Under 3 minutes. The Calm Hands Sequence is a practiced, repeatable sequence — not a panicked fumble. When you've repped the repair, your hands know what to do even when your brain is running on fumes at mile 68. The sequence IS the calm. Monthly practice with dirty, tired hands is what separates a 3-minute plug from an 11-mile walk."
+    },
+    {
+      "type": "quiz",
+      "question": "Your tubeless plug won't hold after the first attempt. Next step?",
+      "options": [
+        {
+          "text": "Try a second plug in the same hole",
+          "correct": false
+        },
+        {
+          "text": "Use your second CO2 cartridge to force more sealant to the puncture",
+          "correct": false
+        },
+        {
+          "text": "Don't waste the second CO2 — install a tube",
+          "correct": true
+        },
+        {
+          "text": "Add more sealant and spin the wheel to coat the area",
+          "correct": false
+        }
+      ],
+      "explanation": "Don't waste a second CO2 on a plug that already failed. Install a tube. CO2 cartridges are finite and irreplaceable in the field. One failed plug attempt tells you the puncture is too large or in the wrong location for a plug. Switching to a tube is the reliable fallback — and you practiced that too (target: under 8 minutes). Stubbornness with a failed repair is how a 6-minute stop becomes a DNF."
+    },
+    {
+      "type": "callout",
+      "content": "11 tools. If you can name them all without looking back, you're ready for Module 4: Ride in Flow. The final lesson isn't about learning a new skill — it's about keeping all 11 skills engaged when your body wants to quit being skilled. That's The Final Hour.",
+      "style": "tip"
+    }
+  ]
+}

--- a/data/courses/dirt-craft/lessons/m4-stack-check.json
+++ b/data/courses/dirt-craft/lessons/m4-stack-check.json
@@ -1,0 +1,294 @@
+{
+  "id": "flow-stack-check",
+  "title": "Module 4: Ride in Flow — Stack Check",
+  "module": "ride-in-flow",
+  "lesson_number": null,
+  "blocks": [
+    {
+      "type": "callout",
+      "content": "\"If you just ride for watts, you cap your enjoyment. If you get good at riding your bike, your enjoyment is endless.\"\n\n12 lessons. 12 tools. This is the final exam — one scenario per tool. No trivia. Just riding.",
+      "style": "tip"
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 15. You're warming up on smooth gravel when the road surface suddenly transitions to chunky, fist-sized rocks. Your front wheel starts bouncing. What tool do you deploy and what does it feel like?",
+      "options": [
+        {
+          "text": "The Braking Budget — slow down before the rocks and coast through",
+          "correct": false
+        },
+        {
+          "text": "The Weighted Drop — heels down, elbows bent, 70% weight through pedals, hands at a 3 out of 10",
+          "correct": true
+        },
+        {
+          "text": "The Quiet Eye — look past the rocks to the smooth section beyond",
+          "correct": false
+        },
+        {
+          "text": "The Pressure Window — your tires are too hard for this surface",
+          "correct": false
+        }
+      ],
+      "explanation": "The Weighted Drop is always the first response to any surface change. It takes a fraction of a second and gives you the stable platform for everything else. Heels drop 10-15 degrees, elbows bend for 3 inches of vertical travel, 70% of weight presses through the pedals, grip drops to a 3. The front wheel stops bouncing because it's free to track the surface instead of transmitting every bump through locked arms."
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 28. You've been on washboard for 3 minutes. Your vision is bouncing — you can't read the terrain ahead clearly. Everything past 20 feet is a blur. Which tool has disengaged, and what's the fix?",
+      "options": [
+        {
+          "text": "The Quiet Eye — refocus your gaze further ahead",
+          "correct": false
+        },
+        {
+          "text": "The Hip Hinge — your upper and lower body have re-coupled into one rigid unit. Rock your pelvis, re-engage the accordion between ribcage and pelvis",
+          "correct": true
+        },
+        {
+          "text": "The Weighted Drop — you've drifted back to the death grip",
+          "correct": false
+        },
+        {
+          "text": "The 50-Meter Scan — you need to read the surface transitions earlier",
+          "correct": false
+        }
+      ],
+      "explanation": "Vision bounce means the Hip Hinge has disengaged. Your skeleton is transmitting bumps from the wheels straight to your head because your hips stopped absorbing vertical displacement. The fix: consciously re-engage the accordion between ribcage and pelvis. Rock your pelvis once to find the hinge. When it's working, your head stays remarkably level while your hips do the absorbing. The proof gate: you should be able to read a road sign while riding washboard."
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 40. You hear a high-pitched buzzing from your tires on a section of loose-over-hardpack. The bike feels skittish and keeps deflecting off small rocks. What tool applies, and what's the target sensation?",
+      "options": [
+        {
+          "text": "The Torque Ceiling — you're applying too much force through the pedals",
+          "correct": false
+        },
+        {
+          "text": "The 50-Meter Scan — you should have read this surface coming",
+          "correct": false
+        },
+        {
+          "text": "The Pressure Window — your tires are too hard. The target is quiet tires that stick to the surface, not skip across it",
+          "correct": true
+        },
+        {
+          "text": "The Weighted Drop — more weight through the pedals will settle the bike",
+          "correct": false
+        }
+      ],
+      "explanation": "Tire buzz and skittish handling on loose-over-hardpack means your pressure is too high for the surface. The Pressure Window target sensation is quiet tires — the bike sticks to the surface instead of bouncing off it. You feel the ground through the tire, not the tire skating on top. If you can stop safely, drop 3-5 PSI. If you can't stop, deploy the Weighted Drop as a short-term compensation — but the real fix is pressure."
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 55. A rock appears 8 feet ahead on a fast gravel descent. You feel the urge to stare at it and jerk the bars. What tool overrides that instinct?",
+      "options": [
+        {
+          "text": "The Braking Budget — scrub speed and steer around it",
+          "correct": false
+        },
+        {
+          "text": "The Weighted Drop — press weight through pedals for stability",
+          "correct": false
+        },
+        {
+          "text": "The Quiet Eye — keep your focal point 3-5 seconds ahead, let peripheral vision handle the rock",
+          "correct": true
+        },
+        {
+          "text": "The 85% Rule — you were going too fast for this terrain",
+          "correct": false
+        }
+      ],
+      "explanation": "The Quiet Eye overrides target fixation. Looking at the rock makes you hit the rock — that's not folk wisdom, it's how motor control works. Your hands steer where your eyes focus. At 8 feet and speed, the line decision already happened when the rock was at 50 meters. Keep your central vision 3-5 seconds ahead. Your peripheral vision registered the rock and your body is already making the micro-adjustment. Trust the system."
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 68. You're descending a wet gravel road toward a sharp left-hand switchback. You need to lose 8 mph before the corner. Where do you brake?",
+      "options": [
+        {
+          "text": "Through the first half of the corner — trail braking is fast",
+          "correct": false
+        },
+        {
+          "text": "In the straight-line braking zone before the corner, front-dominant, then coast through the turn",
+          "correct": true
+        },
+        {
+          "text": "Gradually through the entire approach and corner",
+          "correct": false
+        },
+        {
+          "text": "Hard on the rear brake just before the turn-in point",
+          "correct": false
+        }
+      ],
+      "explanation": "The Braking Budget: speed-set-coast. All braking happens in the straight-line zone before the corner. Front-brake-dominant (70-80% of stopping power). Then you coast through the turn — zero braking input mid-corner. The traction circle means braking and cornering compete for the same grip. On wet gravel, the budget is even tighter. Spend it all before the turn-in, then let the tires do one job at a time."
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 82. You enter a sweeping gravel corner and the surface looks looser than expected. You estimated 18 mph max. The 85% Rule says you should enter at:",
+      "options": [
+        {
+          "text": "18 mph — you estimated correctly, trust your calculation",
+          "correct": false
+        },
+        {
+          "text": "15.3 mph — 85% of 18 mph, the margin accounts for exactly this kind of surface surprise",
+          "correct": true
+        },
+        {
+          "text": "12 mph — when in doubt, go slow",
+          "correct": false
+        },
+        {
+          "text": "16 mph — split the difference between cautious and calculated",
+          "correct": false
+        }
+      ],
+      "explanation": "85% of 18 mph is 15.3 mph. The 15% margin exists precisely for moments like this — when the surface is worse than expected mid-corner. If you entered at your estimated max and the surface degrades, your only options are bad (brake mid-corner, run wide, crash). At 85%, you have traction in reserve. The 85% Rule isn't about being slow — it's about never needing to brake where braking is most dangerous."
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 95. You're grinding up a 10% loose gravel climb. Every 3rd pedal stroke, you feel a skip — the rear tire breaks traction for an instant, then catches. What tool and what's the fix?",
+      "options": [
+        {
+          "text": "The Weighted Drop — shift more weight to your feet",
+          "correct": false
+        },
+        {
+          "text": "The Hip Hinge — decouple your upper body to smooth the power delivery",
+          "correct": false
+        },
+        {
+          "text": "The Torque Ceiling — you're above it. Shift to an easier gear, increase cadence, stay seated with hips hinged forward",
+          "correct": true
+        },
+        {
+          "text": "The Pressure Window — drop tire pressure for more grip",
+          "correct": false
+        }
+      ],
+      "explanation": "The catch-and-release skip is the sensation of exceeding the Torque Ceiling — maximum force before the rear tire breaks loose. The fix: shift to an easier gear and increase cadence. Same power output, lower peak force per pedal stroke. Stay seated — standing on a 10% loose climb unloads the rear wheel and makes it worse. Hinge at hips, chin toward stem. Butter, not peanut butter."
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 108. You're riding at 19 mph when you notice the road surface ahead changes from dark, packed gravel to lighter, looser material. You're 5 seconds away. What tool, and what's the sequence?",
+      "options": [
+        {
+          "text": "The Braking Budget — scrub speed before the transition",
+          "correct": false
+        },
+        {
+          "text": "The 50-Meter Scan — you've identified the transition. Weighted Drop, choose line through the new surface, maintain pressure awareness",
+          "correct": true
+        },
+        {
+          "text": "The Quiet Eye — keep looking past the transition to the surface beyond",
+          "correct": false
+        },
+        {
+          "text": "The Pressure Window — assess whether your pressure is right for the new surface",
+          "correct": false
+        }
+      ],
+      "explanation": "The 50-Meter Scan caught the transition 5 seconds early — exactly as designed. Now execute: Weighted Drop first (heels, elbows, pedal pressure, hands), then choose your line through the new surface (smoothest path, not geometric shortest), then maintain pressure awareness (is the bike responding correctly to this surface?). Pre-adjustment means the transition feels smooth instead of jolting. The rider behind you who didn't scan is about to get a surprise."
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 118. You're on a long, smooth gravel descent — good visibility, no obstacles for 200 meters, gentle grade. The rider ahead is 3 seconds in front of you. How do you maximize free speed?",
+      "options": [
+        {
+          "text": "Close the gap and draft at 1.5 bike lengths for maximum savings",
+          "correct": false
+        },
+        {
+          "text": "The Position Ladder — drops, elbows in, chin low, pedals level. Full tuck on the smooth straight for 30% drag reduction",
+          "correct": true
+        },
+        {
+          "text": "Pedal hard to catch the rider and use the draft",
+          "correct": false
+        },
+        {
+          "text": "Coast and rest — save energy for the next climb",
+          "correct": false
+        }
+      ],
+      "explanation": "The Position Ladder: when terrain allows, climb the ladder to the most aerodynamic position. On a smooth, obstacle-free descent with good visibility, a full aero tuck delivers 30% drag reduction — that's free time, no extra watts. The rider 3 seconds ahead is too far for useful draft anyway. This is the free speed lesson from Lesson 9: same gravity, same slope, same legs, significantly less air resistance."
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 125. You're drafting in a group of 4 on rolling gravel. The surface transitions from hardpack to loose. What happens to your following distance?",
+      "options": [
+        {
+          "text": "Hold tight at 1.5 lengths — don't lose the draft",
+          "correct": false
+        },
+        {
+          "text": "Drop back to 5+ lengths — loose surface drafting isn't safe",
+          "correct": false
+        },
+        {
+          "text": "The Elastic Gap opens from 1.5-2 lengths to 3-4 lengths — the bungee stretches on rough surfaces",
+          "correct": true
+        },
+        {
+          "text": "Move to the side for a better line rather than adjusting gap",
+          "correct": false
+        }
+      ],
+      "explanation": "The Elastic Gap: your following distance behaves like a bungee cord. Smooth hardpack pulls it tight (1.5-2 bike lengths). Loose gravel lets it stretch (3-4 lengths). The rider ahead will take less predictable lines on loose surfaces, debris spray increases, and your stopping distance grows. Never fight to close the gap on bad surfaces — the draft benefit isn't worth the crash risk. The gap will naturally close again when the surface improves."
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 133. You hear a sudden hissing from your rear tire — sealant spraying. You pull over. The puncture is a clean 3mm hole from a thorn. What tool, and what's the sequence?",
+      "options": [
+        {
+          "text": "Remove the tire, install a tube, inflate with CO2",
+          "correct": false
+        },
+        {
+          "text": "Add more sealant and spin the wheel",
+          "correct": false
+        },
+        {
+          "text": "The Calm Hands Sequence — locate the hole, insert the plug, wait for sealant to bond, spin the wheel to verify, ride",
+          "correct": true
+        },
+        {
+          "text": "Ride on it — sealant will handle a 3mm hole eventually",
+          "correct": false
+        }
+      ],
+      "explanation": "The Calm Hands Sequence. A clean 3mm thorn hole is the textbook plug scenario. Locate the hole (sealant spray tells you where), insert the plug tool with a bacon strip, let sealant bond to the plug, spin the wheel to verify the seal, ride. Under 3 minutes if you've practiced monthly. Save the CO2 and the tube for when the plug fails. Calm hands, clear sequence — the sequence IS the calm."
+    },
+    {
+      "type": "quiz",
+      "question": "Mile 140 of 150. Your forearms ache. You're riding the geometric line through corners instead of the surface-optimal line. You almost missed a braking point. You don't feel like anything is wrong — you just feel tired. What tool do you deploy?",
+      "options": [
+        {
+          "text": "The Weighted Drop — re-engage heavy feet, quiet hands",
+          "correct": false
+        },
+        {
+          "text": "The Braking Budget — start braking earlier to compensate for slower reactions",
+          "correct": false
+        },
+        {
+          "text": "The 20-Minute Reset — run the full body scan: heavy feet? quiet hands? hinge moving? breathing anchored? eyes on far target? Find the click",
+          "correct": true
+        },
+        {
+          "text": "Just push through — 10 miles to go, technique can wait",
+          "correct": false
+        }
+      ],
+      "explanation": "The 20-Minute Reset. What you're describing is Stage 3 of the fatigue cascade — line choice collapse and contracted scan distance — with Stage 4 (reactive braking) beginning. You don't feel like anything is wrong because the degradation is invisible from the inside. The 20-Minute Reset is the 10-second body scan: heavy feet? Quiet hands? Hinge moving? Breathing anchored? Eyes on far target? Each correction takes a fraction of a second. Then the click — the moment the right pattern re-engages. It won't last forever. Fatigue will erode it again. That's why you scan every 20 minutes. The click is renewable."
+    },
+    {
+      "type": "callout",
+      "content": "You built 12 tools across 12 lessons:\n\n1. The Weighted Drop\n2. The Hip Hinge\n3. The Pressure Window\n4. The Quiet Eye\n5. The Braking Budget\n6. The 85% Rule\n7. The Torque Ceiling\n8. The 50-Meter Scan\n9. The Position Ladder\n10. The Elastic Gap\n11. The Calm Hands Sequence\n12. The 20-Minute Reset\n\nThis course is training wheels you're meant to grow out of. The drills stop being drills and become how you ride. The checklists stop being checklists and become automatic. The tools stay — they're yours now.\n\nGo ride.",
+      "style": "tip"
+    }
+  ]
+}

--- a/scripts/create_dirt_craft_stripe_product.py
+++ b/scripts/create_dirt_craft_stripe_product.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Create Stripe product, price, and payment link for the Dirt Craft course.
+
+Creates on the Gravel God Stripe account (gravelgodcycling.com):
+  - Product: "Dirt Craft: Technical Gravel Mastery"
+  - Price: $49 one-time
+  - Payment Link: auto-generated, ready to embed
+
+After creation, updates data/courses/dirt-craft/course.json with the
+stripe_price_id and stripe_payment_link.
+
+Usage:
+  export STRIPE_SECRET_KEY=sk_live_...   # Gravel God account key (NOT the Endure Labs SaaS key)
+  python scripts/create_dirt_craft_stripe_product.py --dry-run
+  python scripts/create_dirt_craft_stripe_product.py
+
+The script resolves the key from --key-file, then $STRIPE_SECRET_KEY, then the
+macOS Keychain entry 'stripe-gg', then a no-echo prompt — so the live secret
+never lands in shell history. It confirms the account name before creating, and
+is idempotent (won't duplicate an existing dirt-craft product).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+try:
+    import stripe
+except ImportError:
+    print("ERROR: stripe package not installed. Run: pip install stripe")
+    sys.exit(1)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+COURSE_JSON_PATH = PROJECT_ROOT / "data" / "courses" / "dirt-craft" / "course.json"
+
+DIRT_CRAFT_PRODUCT = {
+    "name": "Dirt Craft: Technical Gravel Mastery",
+    "description": (
+        "A 7-module technical gravel skills course. 21 lessons of deliberate-practice "
+        "drills, sensation targets, and honest physics — from fear to flow. Covers body "
+        "position, braking, cornering, climbing, descending, pumping, hops, limit-finding, "
+        "and the mental game, with embedded technique videos."
+    ),
+    "metadata": {
+        "category": "course",
+        "course_id": "dirt-craft",
+    },
+}
+
+DIRT_CRAFT_PRICE = {
+    "unit_amount": 49 * 100,  # $49.00 in cents
+    "currency": "usd",
+    "nickname": "Dirt Craft — $49 one-time",
+    "metadata": {
+        "type": "course",
+        "course_id": "dirt-craft",
+    },
+}
+
+PAYMENT_LINK_SETTINGS = {
+    "after_completion": {
+        "type": "redirect",
+        "redirect": {
+            # Worker enrolls the buyer via webhook before this redirect fires.
+            "url": "https://gravelgodcycling.com/course/dirt-craft/?enrolled=1",
+        },
+    },
+    "metadata": {
+        "course_id": "dirt-craft",
+    },
+}
+
+
+def dry_run():
+    print("=" * 60)
+    print("DRY RUN — Dirt Craft course Stripe product")
+    print("=" * 60)
+    print(f"\nProduct: {DIRT_CRAFT_PRODUCT['name']}")
+    print(f"  {DIRT_CRAFT_PRODUCT['description'][:100]}...")
+    print(f"  metadata: {DIRT_CRAFT_PRODUCT['metadata']}")
+    print(f"\nPrice: ${DIRT_CRAFT_PRICE['unit_amount'] / 100:.0f} (one-time)")
+    print(f"  nickname: {DIRT_CRAFT_PRICE['nickname']}")
+    print(f"\nPayment Link:")
+    print(f"  after_completion: redirect to {PAYMENT_LINK_SETTINGS['after_completion']['redirect']['url']}")
+    print(f"\nWill update: {COURSE_JSON_PATH}")
+    print(f"  stripe_price_id → <price_id>")
+    print(f"  stripe_payment_link → <payment_link_url>")
+    print(f"\nRe-run without --dry-run (with the Gravel God STRIPE_SECRET_KEY) to create.")
+
+
+def _get_stripe_key(key_file: str | None = None) -> str:
+    """Get Stripe key from file, env, keychain, or prompt (no shell history)."""
+    import subprocess
+    if key_file:
+        path = Path(key_file).expanduser()
+        if not path.exists():
+            print(f"ERROR: Key file not found: {path}")
+            sys.exit(1)
+        key = path.read_text().strip()
+        if key:
+            return key
+    key = os.environ.get("STRIPE_SECRET_KEY", "")
+    if key:
+        return key
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", "stripe-gg", "-w"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:
+        pass
+    import getpass
+    try:
+        key = getpass.getpass("Stripe secret key (Gravel God account): ")
+    except EOFError:
+        print("ERROR: No TTY available and no key provided.")
+        print("  Use --key-file /path/to/key.txt or save to Keychain:")
+        print("  security add-generic-password -s stripe-gg -a gravel-god -w sk_live_...")
+        sys.exit(1)
+    if not key.strip():
+        print("ERROR: No key provided.")
+        sys.exit(1)
+    save = input("Save to macOS Keychain as 'stripe-gg'? [y/N] ")
+    if save.lower() == "y":
+        subprocess.run([
+            "security", "add-generic-password",
+            "-s", "stripe-gg", "-a", "gravel-god", "-w", key.strip(),
+        ])
+        print("  Saved to Keychain.")
+    return key.strip()
+
+
+def create_product(*, yes: bool = False, key_file: str | None = None):
+    key = _get_stripe_key(key_file=key_file)
+    stripe.api_key = key
+
+    if not key.startswith("sk_live_"):
+        print(f"WARNING: key is {key[:8]}… — this is NOT a live key. A product created")
+        print("  here will be in TEST mode and cannot take real payments.")
+        if not yes:
+            if input("Continue in test mode? [y/N] ").lower() != "y":
+                print("Aborting. Export the live Gravel God STRIPE_SECRET_KEY (sk_live_...).")
+                sys.exit(1)
+
+    account = stripe.Account.retrieve()
+    acct_name = account.get("business_profile", {}).get("name", account.id)
+    print(f"Stripe account: {acct_name}")
+    print(f"Account ID: {account.id}")
+    if not yes:
+        confirm = input("\nIs this the Gravel God Stripe account (gravelgodcycling.com)? [y/N] ")
+        if confirm.lower() != "y":
+            print("Aborting. Set STRIPE_SECRET_KEY to the Gravel God account key.")
+            sys.exit(1)
+    else:
+        print("  (--yes flag: skipping confirmation)")
+
+    existing = stripe.Product.search(query="metadata['course_id']:'dirt-craft'")
+    if existing.data:
+        print("\nWARNING: A product with course_id=dirt-craft already exists:")
+        for p in existing.data:
+            print(f"  {p.id}: {p.name}")
+        existing_price = stripe.Price.list(product=existing.data[0].id, limit=1)
+        if existing_price.data:
+            print(f"  Using existing price: {existing_price.data[0].id}")
+            _write_course_json(existing_price.data[0].id, None)
+            return {"product_id": existing.data[0].id,
+                    "price_id": existing_price.data[0].id, "skipped": True}
+        if not yes and input("Create a price on it? [y/N] ").lower() != "y":
+            print("Aborting.")
+            sys.exit(0)
+        product_id = existing.data[0].id
+    else:
+        print(f"\nCreating product: {DIRT_CRAFT_PRODUCT['name']}...")
+        product = stripe.Product.create(**DIRT_CRAFT_PRODUCT)
+        print(f"  Product created: {product.id}")
+        product_id = product.id
+
+    print(f"Creating price: ${DIRT_CRAFT_PRICE['unit_amount'] / 100:.0f}...")
+    price = stripe.Price.create(product=product_id, **DIRT_CRAFT_PRICE)
+    print(f"  Price created: {price.id}")
+
+    stripe.Product.modify(product_id, default_price=price.id)
+    print("  Set as default price")
+
+    print("Creating payment link...")
+    payment_link = stripe.PaymentLink.create(
+        line_items=[{"price": price.id, "quantity": 1}],
+        **PAYMENT_LINK_SETTINGS,
+    )
+    print(f"  Payment link: {payment_link.url}")
+
+    _write_course_json(price.id, payment_link.url)
+    print("\nDone. Next: flip course.json status to \"active\", regenerate, and deploy:")
+    print("  python3 wordpress/generate_courses.py --course dirt-craft")
+    print("  python3 scripts/push_wordpress.py --sync-courses")
+    return {"product_id": product_id, "price_id": price.id,
+            "payment_link": payment_link.url}
+
+
+def _write_course_json(price_id: str, payment_link: str | None):
+    if not COURSE_JSON_PATH.exists():
+        print(f"\nWARNING: {COURSE_JSON_PATH} not found — update manually:")
+        print(f"  stripe_price_id: {price_id}")
+        if payment_link:
+            print(f"  stripe_payment_link: {payment_link}")
+        return
+    course = json.loads(COURSE_JSON_PATH.read_text(encoding="utf-8"))
+    course["stripe_price_id"] = price_id
+    if payment_link:
+        course["stripe_payment_link"] = payment_link
+    COURSE_JSON_PATH.write_text(
+        json.dumps(course, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"\nUpdated {COURSE_JSON_PATH}")
+    print(f"  stripe_price_id: {price_id}")
+    if payment_link:
+        print(f"  stripe_payment_link: {payment_link}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--yes", action="store_true", help="skip confirmation prompts")
+    ap.add_argument("--key-file", help="path to a file containing the Stripe secret key")
+    args = ap.parse_args()
+    if args.dry_run:
+        dry_run()
+    else:
+        create_product(yes=args.yes, key_file=args.key_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/wordpress/generate_courses.py
+++ b/wordpress/generate_courses.py
@@ -199,11 +199,41 @@ def get_flat_lessons(course: dict) -> list:
 # ── CSS ──────────────────────────────────────────────────────
 
 
+def course_page_class(course: dict) -> str:
+    """Wrapper class for the course page. Adds a scoped theme class when the
+    course opts into one via course.json "theme" (e.g. "desert"). Themes only
+    add scoped overrides — untouched courses keep the default look."""
+    theme = (course or {}).get("theme")
+    if theme == "desert":
+        return "gg-course-page gg-course-theme-desert"
+    return "gg-course-page"
+
+
+# Desert Editorial theme: warm-paper block surfaces + gold hairlines, scoped so it
+# ONLY affects courses with theme:"desert" (Dirt Craft). Hydration/Deliver are
+# untouched. Warms up the block backgrounds that otherwise use dark #3a2e25.
+DESERT_THEME_CSS = """
+/* ── Desert Editorial theme (scoped: theme:"desert" only) ── */
+.gg-course-theme-desert .gg-course-hero{background:var(--gg-color-warm-paper,#f5efe6);color:var(--gg-color-dark-brown,#3a2e25);border-bottom:2px solid var(--gg-color-gold,#9a7e0a)}
+.gg-course-theme-desert .gg-course-hero h1{color:var(--gg-color-dark-brown,#3a2e25)}
+.gg-course-theme-desert .gg-course-hero-subtitle{color:var(--gg-color-secondary-brown,#7d695d)}
+.gg-course-theme-desert .gg-guide-img-caption{background:var(--gg-color-warm-paper,#f5efe6);color:var(--gg-color-secondary-brown,#7d695d);border:1px solid var(--gg-color-tan,#d4c5b9);border-top:1px solid var(--gg-color-gold,#9a7e0a)}
+.gg-course-theme-desert .gg-guide-video-meta{background:var(--gg-color-warm-paper,#f5efe6);border:1px solid var(--gg-color-tan,#d4c5b9);border-top:0}
+.gg-course-theme-desert .gg-guide-video-title{color:var(--gg-color-dark-brown,#3a2e25)}
+.gg-course-theme-desert .gg-guide-video-frame{border:1px solid var(--gg-color-tan,#d4c5b9)}
+.gg-course-theme-desert .gg-guide-process-num{background:var(--gg-color-gold,#9a7e0a);color:var(--gg-color-warm-paper,#f5efe6)}
+.gg-course-theme-desert .gg-guide-tab-bar{background:var(--gg-color-warm-paper,#f5efe6)}
+.gg-course-theme-desert .gg-guide-gate-kicker{background:var(--gg-color-warm-paper,#f5efe6);color:var(--gg-color-gold,#9a7e0a)}
+.gg-course-theme-desert .gg-guide-rider-selector,
+.gg-course-theme-desert .gg-guide-rider-badge{background:var(--gg-color-warm-paper,#f5efe6)}
+"""
+
+
 def build_course_css() -> str:
     """Return all course-specific CSS, including guide block CSS and gamification."""
     guide_css = build_guide_css()
     return f"""{guide_css}
-
+{DESERT_THEME_CSS}
 /* ── Course Layout ── */
 /* overflow-x:clip (not hidden) — hidden creates a scroll container that
    breaks position:sticky on the lesson sidebar */
@@ -2101,7 +2131,7 @@ def build_landing_page(course: dict, all_courses: list = None) -> str:
   {get_ga4_head_snippet()}
 </head>
 <body>
-<div class="gg-course-page">
+<div class="{course_page_class(course)}">
 {header}
 
 <div class="gg-course-hero">
@@ -2274,7 +2304,7 @@ def build_lesson_page(course: dict, module: dict, lesson: dict,
   {get_ga4_head_snippet()}
 </head>
 <body>
-<div class="gg-course-page">
+<div class="{course_page_class(course)}">
 {header}
 
 <!-- Purchase Gate -->

--- a/wordpress/generate_guide.py
+++ b/wordpress/generate_guide.py
@@ -789,13 +789,43 @@ def render_image(block: dict) -> str:
 
 
 def render_video(block: dict) -> str:
-    """Render a video block with optional poster and caption."""
+    """Render a video block. Two shapes:
+    - YouTube embed: {"id", "title"?, "channel"?, "caption"?, "start"?, "mtb_demo"?}
+    - Self-hosted asset: {"asset_id", "poster"?, "alt"?, "caption"?}
+    """
+    caption = block.get("caption", "")
+    cap = f'<figcaption class="gg-guide-img-caption">{_md_inline(esc(caption))}</figcaption>' if caption else ''
+
+    # YouTube embed (Dirt Craft-style). Detected by "id" (a YouTube video id).
+    if block.get("id"):
+        vid = esc(block["id"])
+        src = f'https://www.youtube.com/embed/{vid}'
+        start = block.get("start")
+        if start:
+            src += f'?start={int(start)}'
+        title = esc(block.get("title", ""))
+        channel = esc(block.get("channel", ""))
+        meta_bits = ['<span class="gg-guide-video-kicker">Watch</span>']
+        if title:
+            meta_bits.append(f'<span class="gg-guide-video-title">{title}</span>')
+        if channel:
+            meta_bits.append(f'<span class="gg-guide-video-channel">{channel}</span>')
+        if block.get("mtb_demo"):
+            meta_bits.append('<span class="gg-guide-video-mtb">MTB demo &middot; transfers to gravel</span>')
+        meta = f'<div class="gg-guide-video-meta">{"".join(meta_bits)}</div>'
+        return (
+            '<figure class="gg-guide-video gg-guide-video--embed">'
+            f'<div class="gg-guide-video-frame"><iframe src="{src}" title="{title}" '
+            'loading="lazy" allowfullscreen referrerpolicy="strict-origin-when-cross-origin" '
+            'allow="accelerometer; encrypted-media; picture-in-picture"></iframe></div>'
+            f'{meta}{cap}</figure>'
+        )
+
+    # Self-hosted asset (existing behavior).
     asset_id = esc(block["asset_id"])
     poster_id = block.get("poster", "")
     alt = esc(block.get("alt", ""))
-    caption = block.get("caption", "")
     poster = f' poster="/guide/media/{esc(poster_id)}-1x.webp"' if poster_id else ''
-    cap = f'<figcaption class="gg-guide-img-caption">{_md_inline(esc(caption))}</figcaption>' if caption else ''
     return f'<figure class="gg-guide-img gg-guide-video"><video src="/guide/media/{asset_id}.mp4"{poster} controls preload="none" class="gg-guide-img-el">{alt}</video>{cap}</figure>'
 
 
@@ -1895,6 +1925,14 @@ def build_guide_css() -> str:
 .gg-guide-img--half-width{float:right;width:50%;margin:0 0 16px 20px}
 .gg-guide-img-placeholder{display:none;padding:32px 24px;background:#3a2e25;color:#d4c5b9;font-family:'Sometype Mono',monospace;font-size:12px;letter-spacing:1px;text-align:center;border:3px solid #3a2e25;min-height:120px;align-items:center;justify-content:center}
 .gg-guide-img--missing .gg-guide-img-placeholder{display:flex}
+.gg-guide-video--embed{margin:0 0 20px}
+.gg-guide-video-frame{position:relative;width:100%;aspect-ratio:16/9;border:3px solid #3a2e25;background:#1a1613;line-height:0}
+.gg-guide-video-frame iframe{position:absolute;inset:0;width:100%;height:100%;border:0}
+.gg-guide-video-meta{display:flex;gap:10px;align-items:baseline;flex-wrap:wrap;background:#3a2e25;border:3px solid #3a2e25;border-top:0;padding:8px 12px}
+.gg-guide-video-kicker{font-family:'Sometype Mono',monospace;font-size:10px;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:#c9a92c}
+.gg-guide-video-title{font-family:'Source Serif 4',Georgia,serif;font-weight:700;font-size:14px;color:#f5efe6}
+.gg-guide-video-channel{font-family:'Sometype Mono',monospace;font-size:11px;color:#d4c5b9}
+.gg-guide-video-mtb{font-family:'Sometype Mono',monospace;font-size:9px;letter-spacing:1px;text-transform:uppercase;color:#4ECDC4;border:2px solid #178079;padding:1px 6px}
 
 /* ── Tooltips ── */
 .gg-tooltip-trigger{position:relative;cursor:help;border-bottom:2px dotted #9a7e0a;text-decoration:none}


### PR DESCRIPTION
Ports the **Dirt Craft** technical-gravel-skills course (21 lessons / 7 modules, authored in `wattgod/dirt-craft-course`) into the production course platform, with the minimal renderer support needed to serve it. Built and verified against clean `main` in an isolated worktree — **does not touch the in-flight `feat/media-radar` work.**

## Renderer changes (additive, no regressions)
- **`render_video`** now handles **YouTube embed** blocks (`{id, title, channel, mtb_demo, start}`) in addition to the existing self-hosted `{asset_id}` path — responsive 16:9 iframe, meta line, optional "MTB demo · transfers to gravel" badge. Dirt Craft has 12 embedded videos.
- **Per-course `theme` field.** `theme:"desert"` adds a **scoped** `gg-course-theme-desert` class + CSS (warm-paper surfaces, gold hairlines). Applies **only** to courses that opt in — **hydration and Deliver render identically to before** (verified: their wrapper divs get no theme class).

## Verification
- 21 lesson pages + landing build with **0 tracebacks, 0 empty/leaked blocks**.
- **All 81 `test_guide_templates.py` tests pass.** Hydration course still builds.
- GA4 present on lessons; ENROLL CTAs on landing (CLAUDE.md hard rules).

## How the port works (dual-repo + sync)
Dirt Craft is authored in its own repo against `preview.py`. A new `scripts/sync_to_production.py` adapter (in that repo) copies lessons here and normalizes block-schema drift: accordion `panels`→`items`, data_table `columns`→`headers`, and degrades the 4 not-yet-interactive calculators to static "method" blocks. The production renderer stays generic.

## Status & follow-ups (not blocking this PR)
- `status: development` — **not live.** Stripe payment link + price get wired before `active` + deploy.
- The 4 interactive calculators reference JS widgets that don't exist on production yet; they render as static reference for now. Building them is a scoped follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)