### PR TITLE
intel-fix: stop linking to tire guides that were never generated

### DIFF
--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -234,6 +234,7 @@ def build_index_entry_from_profile(slug: str, data: dict) -> dict:
         "has_profile": True,
         "profile_url": f"/race/{slug}/",
         "discipline": rating.get("discipline", "gravel"),
+        "has_tire_guide": bool(race.get("tire_recommendations", {}).get("primary")),
     }
 
     # Include coordinates if available
@@ -333,6 +334,7 @@ def build_index_entry_from_flat(race: dict) -> dict:
         "profile_url": None,
         "has_rwgps": False,
         "discipline": "gravel",
+        "has_tire_guide": False,
     }
 
 

--- a/web/race-index.json
+++ b/web/race-index.json
@@ -30,6 +30,7 @@
     "has_profile": true,
     "profile_url": "/race/transcontinental-race/",
     "discipline": "bikepacking",
+    "has_tire_guide": true,
     "lat": 48.2082,
     "lng": 16.3738
   },
@@ -63,6 +64,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-divide/",
     "discipline": "bikepacking",
+    "has_tire_guide": true,
     "lat": 51.18,
     "lng": -115.57,
     "rwgps_id": "53936176",
@@ -100,6 +102,7 @@
     "has_profile": true,
     "profile_url": "/race/unbound-200/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.404,
     "lng": -96.1816,
     "rwgps_id": "46551378",
@@ -139,6 +142,7 @@
     "has_profile": true,
     "profile_url": "/race/the-traka/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.9793,
     "lng": 2.8199,
     "st": "Rider footage and reviews referenced here describe the retired Traka 360 ultra, which shared Girona's Traka week with today's Traka 200. Riders described a dark, technical start with curbs and roundabouts before hitting dirt, an early technical descent around mile 10-12 with loose cutbacks that caused crashes and field separation, and continuous, often muddy gravel. Nutrition was treated as critical — described by more than one rider as an eating competition, not a cycling competition — with recommendations to eat whole foods like Pringles and take advantage of feed-zone variety. Tire setups favoring an aggressive front tread with a faster-rolling rear tire were reported for descent control. The Traka 200, run today as a standalone Friday one-day event, covers the Empordà plains and finishes through the Gavarres massif singletrack back into Girona.",
@@ -175,6 +179,7 @@
     "has_profile": true,
     "profile_url": "/race/cheaha-challenge-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 33.8139,
     "lng": -85.7633,
     "st": "The Cheaha Challenge in Jacksonville, Alabama is the state's biggest bicycle race, featuring multiple distance options including the 126-mile ultra ride for expert cyclists. The race starts and finishes at JSU's Pete Matthews Coliseum. More than 700 cyclists register annually, with participants coming from around the world and bringing their families. The event includes a beginner-friendly time trial starting at Piedmont and going down Tiger Trail. Race director Brook Nelson notes the event has significant economic impact on Calhoun County, with over 40 percent of participants returning to ride in the area throughout the year due to the southern hospitality and quality riding terrain they experience during the race."
@@ -209,6 +214,7 @@
     "has_profile": true,
     "profile_url": "/race/colorado-trail-race/",
     "discipline": "bikepacking",
+    "has_tire_guide": true,
     "lat": 38.7252,
     "lng": -105.6077,
     "rwgps_id": "53731235",
@@ -246,6 +252,7 @@
     "has_profile": true,
     "profile_url": "/race/le-loop/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 50.6292,
     "lng": 3.0573,
     "st": "Le Loop features a Vegas edition with a closed course through Red Rocks Canyon. The main climb averages 4% grade but is highly wind dependent, with strong headwinds forcing riders to maintain 500+ watts even on flat and downhill recovery sections. The scenic red rock terrain provides beautiful views but challenging conditions. One rider noted needing 429 watts for 13 minutes to set competitive times on the main climbing segment. The course offers a more accessible alternative to the epic Mount Charleston climb further from town. Wind conditions appear to be the primary factor affecting performance and race times."
@@ -280,6 +287,7 @@
     "has_profile": true,
     "profile_url": "/race/trans-am-bike-race/",
     "discipline": "bikepacking",
+    "has_tire_guide": true,
     "lat": 37.1232,
     "lng": -78.4928,
     "rwgps_id": "46785461",
@@ -317,6 +325,7 @@
     "has_profile": true,
     "profile_url": "/race/uci-gravel-worlds/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.2083,
     "lng": 5.7148,
     "rwgps_id": "53011652"
@@ -352,6 +361,7 @@
     "has_profile": true,
     "profile_url": "/race/unbound-xl/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.404,
     "lng": -96.1816,
     "rwgps_id": "53768538",
@@ -388,6 +398,7 @@
     "has_profile": true,
     "profile_url": "/race/badlands/",
     "discipline": "bikepacking",
+    "has_tire_guide": true,
     "lat": 37.1735,
     "lng": -3.5995,
     "rwgps_id": "53936171",
@@ -425,6 +436,7 @@
     "has_profile": true,
     "profile_url": "/race/crusher-in-the-tushar/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.3336,
     "lng": -113.2755,
     "rwgps_id": "32869577",
@@ -461,7 +473,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-nove-colli/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Leadville Trail 100 MTB",
@@ -493,6 +506,7 @@
     "has_profile": true,
     "profile_url": "/race/leadville-100/",
     "discipline": "mtb",
+    "has_tire_guide": true,
     "lat": 39.2508,
     "lng": -106.2925,
     "rwgps_id": "3227417",
@@ -532,6 +546,7 @@
     "has_profile": true,
     "profile_url": "/race/bwr-california/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 32.9595,
     "lng": -117.2653,
     "rwgps_id": "54026340",
@@ -571,6 +586,7 @@
     "has_profile": true,
     "profile_url": "/race/la-marmotte/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.052,
     "lng": 6.033,
     "st": "La Marmotte is described as one of the hardest grand fondos in the world, featuring four huge climbs totaling 65 kilometers of climbing and 5,000 meters of vertical gain. The course is significantly longer than a typical Tour de France mountain stage, with most riders taking 8-12 hours to finish and many abandoning. Key challenges include dramatic elevation changes, with sections like the balcony road from Alpe d'Huez offering scenic but scary descents of 800 meters. Riders emphasize two critical success factors: proper pacing on the climbs and consistent fueling throughout the long day. The race starts early from Bourg d'Oisans, and riders report concerns about hot weather conditions affecting performance. Preparation involves careful tapering with 50% volume reduction in final days and strategic carb loading on Thursday-Friday before the event."
@@ -606,6 +622,7 @@
     "has_profile": true,
     "profile_url": "/race/mallorca-312/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 39.7967,
     "lng": 3.1203,
     "st": "The Mallorca 312 is described as a grueling 9-hour endurance test that begins with a neutralized start before becoming extremely challenging. The race features a brutal mountain section in the first four hours that causes dramatic field reduction, with groups dropping from 50 riders to just 7 survivors. The first climb is particularly selective, quickly eliminating riders. After the mountains, riders face 150 kilometers of wind-exposed flats that require constant effort even in small groups. The combination of sustained climbing followed by wind-battered flats creates a true test of endurance, with only the strongest riders surviving to contest the finish."
@@ -640,6 +657,7 @@
     "has_profile": true,
     "profile_url": "/race/torino-nice-rally/",
     "discipline": "bikepacking",
+    "has_tire_guide": true,
     "lat": 46.6034,
     "lng": 1.8883,
     "rwgps_id": "53387121",
@@ -677,6 +695,7 @@
     "has_profile": true,
     "profile_url": "/race/big-sugar/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 36.3729,
     "lng": -94.2088,
     "rwgps_id": "52306059",
@@ -716,6 +735,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-lourdes-tourmalet/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 43.1,
     "lng": -0.05,
     "st": "The provided transcript for GFNY Lourdes Tourmalet appears to contain primarily music lyrics and audio fragments rather than rider commentary about the race experience. No specific information about course features, terrain conditions, challenges, or race-day insights could be extracted from the available content. The transcript mentions mud and dirt, which could suggest off-road conditions, but lacks the detailed rider perspective needed to provide actionable intelligence about this 97.6-mile race through the Hautes-Pyrénées region of France with 13,333 feet of elevation gain."
@@ -751,6 +771,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-maryland/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 39.4143,
     "lng": -77.4103,
     "st": "Gran Fondo Maryland is a 96-97 mile ride with four timed climbing sections (T1, T2, T3, T4) and multiple aid stations. Riders describe T1 as the worst climb with extremely steep gradients that challenge even properly geared bikes. The course features very steep climbs throughout, with riders struggling even when using low gearing combinations like 30 front chainring and 30 cassette. National Champion riders start at 8am while others start at 8:30am with a neutral rollout. Participants must stay right during timed sections for chip timing to register properly. The event provides quality swag including jerseys and elevation profile stickers similar to professional tours. Pacing is crucial due to the challenging 10,000 feet of elevation gain over the distance."
@@ -786,6 +807,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-earth/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.9794,
     "lng": 2.8214,
     "series_id": "gravel-earth-series",
@@ -824,6 +846,7 @@
     "has_profile": true,
     "profile_url": "/race/haute-route-alps/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 43.7102,
     "lng": 7.262
   },
@@ -858,6 +881,7 @@
     "has_profile": true,
     "profile_url": "/race/mount-baker-hill-climb/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 48.8667,
     "lng": -121.6833,
     "st": "The Mount Baker Hill Climb begins with rolling hills for the first 10 miles before transitioning to serious mountain climbing at mile 14. Riders describe perfect fall weather conditions starting around 50 degrees and warming up significantly during the climb. The course passes notable landmarks including snow plow sheds, Mount Baker ski area, White Salmon Lodge, and Hundred Meadows before multiple hairpin turns near the finish. Key challenges include the dramatic difficulty increase at mile 14 and remaining hairpins after Hundred Meadows that can give false hope of nearing the finish. The race features three divisions with staggered starts, beginning at 8:15 AM. Critical logistics include the road reopening to vehicle traffic at noon, requiring riders to complete their descent before cars are allowed back on the mountain road."
@@ -893,6 +917,7 @@
     "has_profile": true,
     "profile_url": "/race/paris-brest-paris/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 48.6433,
     "lng": 1.8308,
     "st": "Paris-Brest-Paris is a 1200 kilometer randonneur event from Paris to Brest and back every four years. Riders face strong headwinds for the first 600 kilometers that can be mentally challenging and cause some to consider quitting. The event requires cycling through the night with proper lighting and involves reaching control points within strict time limits. Weather conditions vary from cold evenings requiring leg warmers to potential rain and snow. Riders burn approximately 40,000 calories total and can sleep outdoors or book beds at control points. Any reliable bicycle works from vintage steel to carbon fiber, but riders must be able to perform all mechanical repairs themselves. The French provide generous support with food and drinks. Successful completion grants lifelong randonneur status and qualifies riders for future ultra-distance events."
@@ -928,6 +953,7 @@
     "has_profile": true,
     "profile_url": "/race/quebrantahuesos/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 42.519,
     "lng": -0.366
   },
@@ -962,6 +988,7 @@
     "has_profile": true,
     "profile_url": "/race/steamboat-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.4848,
     "lng": -106.8317,
     "rwgps_id": "53876176",
@@ -999,6 +1026,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-of-flanders-sportive/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 50.844,
     "lng": 3.604,
     "st": "Riders describe the Ronde van Vlaanderen route as featuring 59 total bergs (climbs) across Flanders, with the most infamous being the Muur de Geraardsbergen that hits without warm-up, followed quickly by the Bosberg. The fearsome Koppenberg around Oudenaarde is a major challenge, while the Cinberg stands out as the steepest berg of all. The route concludes with a double finale of UDA Quant and Patberg before an easy run-in. Cobbled sections feel very wobbly and induce significant vibration, requiring riders to keep their seat contact and avoid excessive speed, especially in wet conditions. Weather is a major factor as all cobbles and climbs will be wet whether actively raining or not. The full challenge covers 290km with over 4000m of climbing, though the sportive version is 160km with 2000m. Pacing is critical as racing every climb prevents completion of the full distance."
@@ -1034,6 +1062,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-worlds/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.8089,
     "lng": -96.7078,
     "rwgps_id": "51659517",
@@ -1071,6 +1100,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-du-tour/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.052,
     "lng": 6.033
   },
@@ -1105,6 +1135,7 @@
     "has_profile": true,
     "profile_url": "/race/dirty-reiver/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 55.2265,
     "lng": -2.5725,
     "rwgps_id": "53326466",
@@ -1142,6 +1173,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-locos/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 31.9814,
     "lng": -98.0309,
     "rwgps_id": "48976863",
@@ -1179,6 +1211,7 @@
     "has_profile": true,
     "profile_url": "/race/haute-route-dolomites/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.5369,
     "lng": 12.1354,
     "st": "The Haute Route Dolomites features iconic climbs including the formidable Passo Pordoi as the opening challenge - 30 kilometers long with 6% average gradient, 28 switchbacks, and over 2000 meters elevation with no warm-up. The route covers 120 kilometers with four iconic Dolomiti climbs totaling over 3000 meters of elevation, including the Giau, Falzarego, and Fedaya passes. Riders describe the tarmac as dreams are made of with breathtaking scenery and exhilarating descents. The event creates a unique atmosphere where competitors encourage each other while racing together. Conditions can be extremely hot, and riders describe it as the hardest day of their lives requiring mental strength to push through when tired with 15k still remaining."
@@ -1214,6 +1247,7 @@
     "has_profile": true,
     "profile_url": "/race/lardechoise/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.0862,
     "lng": 4.6292
   },
@@ -1248,6 +1282,7 @@
     "has_profile": true,
     "profile_url": "/race/mid-south/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 36.1156,
     "lng": -97.0586,
     "rwgps_id": "48969927",
@@ -1285,6 +1320,7 @@
     "has_profile": true,
     "profile_url": "/race/midnight-sun-randonnee/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 63.8284,
     "lng": 20.2598
   },
@@ -1319,6 +1355,7 @@
     "has_profile": true,
     "profile_url": "/race/taiwan-kom-challenge/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 24.0295,
     "lng": 121.6043
   },
@@ -1353,6 +1390,7 @@
     "has_profile": true,
     "profile_url": "/race/white-rose-classic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 53.9214,
     "lng": -1.8255,
     "st": "The available transcripts do not contain specific information about the White Rose Classic race course, terrain, or conditions. One video discusses general training advice for consecutive weekend events, recommending no more than two or three events in a row to avoid staleness, emphasizing serious recovery between events, and suggesting short, intense midweek rides to maintain form rather than long endurance sessions. The other video appears unrelated to gravel racing. No specific details about the White Rose Classic's course features, elevation challenges, surface conditions, or race-day logistics are mentioned in these transcripts."
@@ -1388,6 +1426,7 @@
     "has_profile": true,
     "profile_url": "/race/bwr-cedar-city/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 37.6774,
     "lng": -113.0618,
     "rwgps_id": "39282960",
@@ -1427,6 +1466,7 @@
     "has_profile": true,
     "profile_url": "/race/grafton-to-inverell-classic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -29.69,
     "lng": 152.93,
     "st": "The Grafton to Inverell is one of Australia's oldest one-day races, running for over 60 years. The 142-mile course features 11,096 feet of climbing starting with a deceptively lumpy 70k section from the coast. The main challenge is the Gibraltar Range climb - a 16k, 1,000m ascent taking about 40 minutes with consistent gradient. After the climb, riders face open windswept plains between feed zones, then final lumps into Inverell that many forget about. The course is described as super bumpy throughout, with rolling highway roads that zap legs on climbs. Early sections include the Cuddle Creek climb at 20k where sprint point competitions create race dynamics. Riders emphasize being reactive early, following moves on Gibraltar without overextending, and remembering that nobody wins on the big climb alone."
@@ -1462,6 +1502,7 @@
     "has_profile": true,
     "profile_url": "/race/haute-route-pyrenees/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 43.232,
     "lng": -0.078
   },
@@ -1495,6 +1536,7 @@
     "has_profile": true,
     "profile_url": "/race/jeroboam/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.5985,
     "lng": 9.9722,
     "rwgps_id": "44742357",
@@ -1532,6 +1574,7 @@
     "has_profile": true,
     "profile_url": "/race/leroica/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 43.4685,
     "lng": 11.4349,
     "st": "L'Eroica features 15 gravel sections total, with the first section being 2.5k long as one of the shortest. The unpaved sections vary significantly - some are quite compacted where riders can follow worn tire tracks without much issue, while others like Section 12 from Asciano present very steep climbs with fairly loose gravel. The loose gravel causes back wheel slippage when riders get out of the saddle on steep sections, requiring weight management techniques. The route covers the Tuscan countryside with technical descents and challenging climbs. Riders describe experiencing every sensation possible on a bike under the Tuscan sun, with hills, technical descents, and scenic views across postcard-perfect Tuscany. The course recreates historic cycling battles over the unpaved roads of the Chianti region."
@@ -1567,6 +1610,7 @@
     "has_profile": true,
     "profile_url": "/race/paris-roubaix-challenge/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 50.694,
     "lng": 3.174
   },
@@ -1601,6 +1645,7 @@
     "has_profile": true,
     "profile_url": "/race/strade-bianche-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": true,
     "lat": 43.1672,
     "lng": 11.4676,
     "rwgps_id": "53843273",
@@ -1638,6 +1683,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-of-nilgiris/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "No gravel cycling race content found in the provided transcripts. The transcripts appear to cover topics unrelated to the Tour of Nilgiris cycling race, including botanical content about flowering plants, content in Tamil language, and brief mentions of heat. No actionable intelligence about course conditions, terrain, challenges, gear recommendations, or race-specific information could be extracted from these video sources."
   },
   {
@@ -1671,6 +1717,7 @@
     "has_profile": true,
     "profile_url": "/race/best-buddies-challenge-hyannis-port/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 42.3554,
     "lng": -71.0602
   },
@@ -1705,6 +1752,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-la-fausto-coppi/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.384,
     "lng": 7.549,
     "st": "Riders describe La Fausto Coppi as featuring beautiful but very tough climbing sections. International participants from Holland, Australia, Kenya, Colorado, and Washington State emphasize the challenging nature of the climbs while praising the scenic beauty. Multiple riders mention it being their first time attempting this ride, with one noting they cried during portions of the event. The heat appears to be a significant factor during the race. Despite the difficulty, riders consistently describe the experience as beautiful and enjoyable, with one calling it the best cycling experience they've ever had. The event attracts a diverse international field of participants who appreciate both the physical challenge and the stunning Italian landscape."
@@ -1740,6 +1788,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-suisse/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.3,
     "lng": 7.0
   },
@@ -1774,6 +1823,7 @@
     "has_profile": true,
     "profile_url": "/race/la-stelvio-santini/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The La Stelvio Santini Granfondo features the legendary Stelvio Pass climb reaching 2,757 meters elevation, making it one of the few European climbs over 2,000 meters. Riders report the climb takes at least 90 minutes with only one flat rest section on the entire ascent. The final 4 kilometers are described as the hardest, where altitude over 2,500m causes severe oxygen deprivation effects. The last 1.5 kilometers require gaining 100m elevation to reach the crest. Temperature changes dramatically with altitude variations. Pacing is critical - riders shouldn't try keeping up with faster competitors. Low gearing like 39/25 is essential though even easier ratios are recommended. The route follows the same roads used by professional cyclists in the Giro d'Italia, adding to its iconic status among amateur riders seeking the ultimate climbing challenge."
   },
   {
@@ -1807,6 +1857,7 @@
     "has_profile": true,
     "profile_url": "/race/maratona-dles-dolomites/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.551,
     "lng": 11.878
   },
@@ -1840,6 +1891,7 @@
     "has_profile": true,
     "profile_url": "/race/rebeccas-private-idaho/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.6807,
     "lng": -114.3637,
     "st": "Rebecca's Private Idaho features Trail Creek Summit as its crux climb, a 20-30 minute ascent that's half paved, half dirt with six percent average grade. Riders emphasize the critical importance of staying with a good group over this summit, as the following sections are fast rolling terrain where dropped riders face long chases. The 22-mile Copper Basin Loop presents rough, washboard roads that get hot and dusty, described as a sufferfest with rolling terrain. The final 10-mile return to Trail Creek is considered the most mentally challenging section, featuring straight roads with slight uphills and brutal headwinds. Course surfaces are rocky and bumpy throughout, with washboards from vehicle traffic, but riders report 32-35mm tires are sufficient. The event includes registration and expo areas in Ketchum, with aid stations available though early ones may be skippable.",
@@ -1875,7 +1927,8 @@
     "tagline": "The only mountain bike race crossing Kenya's Great Rift Valley to Maasai Mara",
     "has_profile": true,
     "profile_url": "/race/rift-valley-odyssey/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Schleck Gran Fondo",
@@ -1908,6 +1961,7 @@
     "has_profile": true,
     "profile_url": "/race/schleck-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 49.4864,
     "lng": 6.2822
   },
@@ -1942,6 +1996,7 @@
     "has_profile": true,
     "profile_url": "/race/sea-otter-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 36.2231,
     "lng": -121.3877,
     "rwgps_id": "50233482",
@@ -1981,6 +2036,7 @@
     "has_profile": true,
     "profile_url": "/race/unbound-100/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.404,
     "lng": -96.1816,
     "st": "Unbound Gravel 200 in Emporia, Kansas features 200 miles through the Flint Hills with significant elevation and challenging terrain. The North Course is described as punchier and chunkier with massive rocks that create a destructive racing surface. Heat is a major factor that wreaks havoc on power output late in the race, often determining who cracks or breaks into top positions. The course includes sections famous for high speeds, frequent punctures, and tough gritty terrain with rocks flying everywhere. Riders report it takes 10.5 hours of intense focus with crashes and mechanicals being unpredictable race factors. The event attracts 4,000 riders from 50 states and 40 countries, making it the most competitive gravel field. Training requires completely different mentality and preparation compared to other races. Pro riders recommend road bike gearing for high speeds and chain waxing for the conditions.",
@@ -2016,6 +2072,7 @@
     "has_profile": true,
     "profile_url": "/race/bwr-san-diego/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 32.9595,
     "lng": -117.2653,
     "rwgps_id": "38370873",
@@ -2055,6 +2112,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-du-tour-femmes/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.2417,
     "lng": 5.2753
   },
@@ -2089,6 +2147,7 @@
     "has_profile": true,
     "profile_url": "/race/liege-bastogne-liege-challenge/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 50.5458,
     "lng": 5.7153
   },
@@ -2123,6 +2182,7 @@
     "has_profile": true,
     "profile_url": "/race/race-across-america/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 33.1959,
     "lng": -117.3795,
     "st": "Race Across America is a non-stop bicycle race running coast to coast from Oceanside, California to the Atlantic Coast, covering approximately 3000 miles. The race is unique as one of the longest bicycle races in the world and the only coast-to-coast race in the United States. The start in Oceanside features a bike path that allows riders to travel safely from the beach inland through the city, avoiding car traffic with police escort support. The race attracts international participation from 27-30 countries. Riders typically train for 6-8 months leading up to the event. The race has become a significant charity fundraising platform, with racers representing about 50 charities and raising approximately $2 million annually. The event is expected to take 5-6 days for completion, with riders seeking a safe and fast crossing of the country."
@@ -2157,6 +2217,7 @@
     "has_profile": true,
     "profile_url": "/race/little-sugar-mtb/",
     "discipline": "mtb",
+    "has_tire_guide": true,
     "lat": 36.3729,
     "lng": -94.2088,
     "rwgps_id": "53139731",
@@ -2194,6 +2255,7 @@
     "has_profile": true,
     "profile_url": "/race/raid-pyreneen/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 43.362,
     "lng": -1.789
   },
@@ -2227,6 +2289,7 @@
     "has_profile": true,
     "profile_url": "/race/seven/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -33.9784,
     "lng": 115.7638,
     "st": "Seven gravel race in Nannup, Western Australia features 125km with 3200m of climbing and 12 categorized climbs, making it the biggest gravel race in the Southern Hemisphere. The course starts with a chaotic first gravel sector where the surface is uneven and riders get pushed off lines. Key challenges include loose, sketchy gravel on descents due to dry conditions, and the brutal Brockman climb with 22% gradients where some riders must walk. The first major descent stretches the peloton based on confidence levels. Riders emphasize staying in the front 30 wheels during early gravel sections and picking lines carefully on loose surfaces. The race offers stunning scenery through valleys with epic views, though cameras don't capture the full beauty. Over 1600 people registered, with perfect weather conditions. Course logistics include food drop bags at the halfway stop, and accommodation books out quickly requiring early registration.",
@@ -2262,7 +2325,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/aitana-tour/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Algarve Gran Fondo",
@@ -2294,7 +2358,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/algarve-gran-fondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Alpenbrevet",
@@ -2326,7 +2391,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/alpenbrevet/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Bergen-Voss",
@@ -2358,7 +2424,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/bergen-voss/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "BWR Utah (Belgian Waffle Ride Utah)",
@@ -2390,6 +2457,7 @@
     "has_profile": true,
     "profile_url": "/race/bwr-utah/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 37.6774,
     "lng": -113.0618,
     "rwgps_id": "52703090",
@@ -2428,7 +2496,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/dartmoor-legend-ultra/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Dolomitenradrundfahrt / SuperGiroDolomiti",
@@ -2461,6 +2530,7 @@
     "has_profile": true,
     "profile_url": "/race/dolomitenradrundfahrt/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The provided transcript from the Dolomitenradrundfahrt / SuperGiroDolomiti video does not contain race-specific content or rider commentary about the event. The transcript appears to consist primarily of song lyrics and music rather than actionable intelligence about this 135-mile gravel race through East Tyrol, Austria. No information about course conditions, terrain characteristics, key challenges, gear recommendations, or race strategy was found in the available material. Additional video content with actual race commentary would be needed to provide meaningful rider intelligence for this challenging Alpine gravel event."
   },
   {
@@ -2494,6 +2564,7 @@
     "has_profile": true,
     "profile_url": "/race/dreilander-giro/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.888,
     "lng": 10.501
   },
@@ -2527,7 +2598,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/eroica-japan/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Étape du Dales",
@@ -2559,7 +2631,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/etape-du-dales/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Flandrien Ride",
@@ -2591,7 +2664,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/flandrien-ride/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Galibier Challenge",
@@ -2624,6 +2698,7 @@
     "has_profile": true,
     "profile_url": "/race/galibier-challenge/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Marmot Gran Fondo features a flat run out from Bourg d'Oisans with traffic calming measures before reaching the first climb - a reservoir dam wall. The course continues flat and undulating for 3-4 kilometers around the reservoir to the Col de Glandon start. The Glandon includes a village water stop at 5km, followed by a descent to a nasty kick over a tiny bridge leading to the steepest section where riders commonly slip chains. The summit feed station is crowded, and the descent is neutralized due to super steep initial bends requiring ambulance presence. Key advice centers on pacing - not going too fast up the Glandon. Logistics require ample time for the morning descent to the start, with thousands of riders descending from Alpe d'Huez. Early morning temperatures necessitate warm clothing even in July."
   },
   {
@@ -2657,6 +2732,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-cannes/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 43.5517,
     "lng": 7.0198,
     "st": "The provided transcript from GFNY Cannes contains only music and promotional content without any rider intelligence, course details, or race-specific information. No actionable insights about the 68.4-mile course through the French Riviera, terrain conditions, gear recommendations, or racing strategies are available from this source. The transcript appears to be from a promotional or music video rather than race coverage or rider commentary."
@@ -2692,6 +2768,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-grand-ballon/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The available transcript for GFNY Grand Ballon consists entirely of music lyrics and does not contain any rider commentary about the race experience, course conditions, or practical race information. No actionable intelligence about the 91-mile gravel race in Thann, Alsace, France could be extracted from this video content."
   },
   {
@@ -2724,7 +2801,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-la-vaujany-alpe-dhuez/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY Orcieres",
@@ -2756,7 +2834,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-orcieres/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Giro delle Dolomiti",
@@ -2789,6 +2868,7 @@
     "has_profile": true,
     "profile_url": "/race/giro-delle-dolomiti/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Based on available rider accounts from the Giro delle Dolomiti, the primary challenge mentioned is extreme heat conditions during the race. Riders emphasize the significant impact of high temperatures on this 298-mile course through South Tyrol's mountainous terrain. The repeated emphasis on heat suggests this is a major factor riders should prepare for when tackling this challenging Italian gravel race. Limited transcript content available for this event."
   },
   {
@@ -2821,7 +2901,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-mont-ventoux/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Utah",
@@ -2853,7 +2934,8 @@
     "tagline": "Ride the Wasatch Front: Conquer Nebo Loop in Utah's Gran Fondo National Series",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-utah/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Granfondo La Nucia",
@@ -2885,7 +2967,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-la-nucia/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Granfondo Livigno Alè",
@@ -2917,7 +3000,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-livigno-ale/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Granfondo Serra da Estrela",
@@ -2950,6 +3034,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-serra-da-estrela/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "No race-specific content was found in the provided transcript. The video appears to be general motivational content rather than race coverage or analysis of the Granfondo Serra da Estrela. No information about course features, terrain conditions, elevation challenges, or race logistics was available to extract from this source."
   },
   {
@@ -2982,7 +3067,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-sestriere/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GranGuanche Audax Road",
@@ -3015,6 +3101,7 @@
     "has_profile": true,
     "profile_url": "/race/granguanche-audax-road/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The GranGuanche Audax Road covers multiple Canary Islands with the major challenge being Pico de las Nieves, the highest point requiring a 45k climb from sea level. Riders describe it as one of the hardest climbs they've experienced, with technical sections requiring hike-a-bike and challenging descents. Road surfaces are poor quality, prompting recommendations for minimum 28mm tires versus typical UK setups. The heat necessitates careful nutrition planning using approved cafe stops mapped by local bike centers. Ferry crossings between islands can be rough and cause seasickness. The constant elevation changes mean riders must adapt their pacing compared to flatter terrain, building endurance through sustained climbing efforts."
   },
   {
@@ -3048,6 +3135,7 @@
     "has_profile": true,
     "profile_url": "/race/iron-horse-bicycle-classic/",
     "discipline": "road",
+    "has_tire_guide": true,
     "lat": 37.2753,
     "lng": -107.8801,
     "rwgps_id": "39499356",
@@ -3084,7 +3172,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/la-ruta-de-los-conquistadores/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "L'Ariégeoise Cyclosportive",
@@ -3116,7 +3205,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/lariegeoise-cyclosportive/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "L'Étape Bulgaria by Tour de France - Peshtera",
@@ -3149,6 +3239,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-bulgaria/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 42.0333,
     "lng": 24.2833
   },
@@ -3182,7 +3273,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/letape-piemonte/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Manali-Khardung La Cycling Championship",
@@ -3214,7 +3306,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/manali-khardungla-cycling-championship/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Migration Gravel Race",
@@ -3247,6 +3340,7 @@
     "has_profile": true,
     "profile_url": "/race/migration-gravel-race/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -1.0959,
     "lng": 35.8566,
     "rwgps_id": "45563845",
@@ -3283,7 +3377,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/mt-fuji-hill-climb/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Oregon Gran Fondo",
@@ -3316,6 +3411,7 @@
     "has_profile": true,
     "profile_url": "/race/oregon-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 43.7806,
     "lng": -123.047,
     "st": "The Oregon Gran Fondo in Cottage Grove features a challenging lollipop-style course that goes deep into the upper Smith River area and South coastal range. Riders face several significant climbs, with the biggest being Smith River Road gaining 1,000 feet over 6 miles to reach the course's highest point. The first climb hits immediately after leaving town, causing the pack to string out early and stay stretched all day. Road conditions vary, with some sections being notably rough on riders' hands and seats, making some wonder if the gravel option would be easier. The course offers multiple distance options from 31 to 117 miles, with rest stops every 16 miles providing good food and support. The event attracts nearly 500 cyclists from across the region, creating significant economic impact for the local community while maintaining a fun, supportive atmosphere rather than purely competitive racing."
@@ -3351,6 +3447,7 @@
     "has_profile": true,
     "profile_url": "/race/otztaler-radmarathon/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.966,
     "lng": 10.873
   },
@@ -3384,7 +3481,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-across-france/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Race Through Poland",
@@ -3416,7 +3514,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-through-poland/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Ride the Rockies",
@@ -3449,6 +3548,7 @@
     "has_profile": true,
     "profile_url": "/race/ride-the-rockies/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 39.5501,
     "lng": -105.7821
   },
@@ -3483,6 +3583,7 @@
     "has_profile": true,
     "profile_url": "/race/sportful-dolomiti-race/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.019,
     "lng": 11.906
   },
@@ -3516,7 +3617,8 @@
     "tagline": "UCI World Series gravel in the Swiss Alps — where the world cycling headquarters meets alpine climbing",
     "has_profile": true,
     "profile_url": "/race/the-majestics/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": true
   },
   {
     "name": "The Millars UCI Gran Fondo World Series",
@@ -3549,6 +3651,7 @@
     "has_profile": true,
     "profile_url": "/race/the-millars-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 39.986,
     "lng": -0.045
   },
@@ -3583,6 +3686,7 @@
     "has_profile": true,
     "profile_url": "/race/the-rift/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 63.7508,
     "lng": -20.2238,
     "rwgps_id": "52620636",
@@ -3620,6 +3724,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-matra/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 47.784,
     "lng": 19.94,
     "st": "The Tour de Mátra Gran Fondo is described as one of Europe's toughest gravel races and Hungary's first UCI Grand Fondo World Series qualifier. The event attracts cyclists from more than 15 countries and offers four distance options: 16 km mini fondo, 94 km medio, 161 km Grand Fondo challenge, and an individual time trial. The race schedule spans multiple days with the time trial on Friday, rest day for qualifiers, mini fondo on Saturday, and the medio and grandfondo on Sunday. All courses conclude with a traditionally prestigious mountaintop finish at Hungary's highest point. The event is open to participants with or without UCI license, and youth categories can enter free of charge to support young rider development."
@@ -3655,6 +3760,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-suisse-challenge/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Tour de Suisse Challenge features multiple routes through Switzerland's major mountain passes. The classic route covers 105km with 3000m of elevation over three major climbs all above 2000m. Key challenges include the Furka Pass (12.5km at 7.3% average), Nufenen Pass (7km at 10% with headwinds), and San Gottardo with granite cobblestones. Riders report dramatic temperature changes from 30 degrees in valleys to 14 degrees at altitude. The mental challenge becomes as significant as the physical one mid-ride. Essential gear includes low gearing like 34-28 for the sustained gradients. The route offers stunning alpine scenery but demands careful weather monitoring as climbs go directly into clouds at high elevation."
   },
   {
@@ -3688,6 +3794,7 @@
     "has_profile": true,
     "profile_url": "/race/trans-pyrenees-race/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Limited race-specific information available from this transcript, which primarily focuses on accommodation at Pyrenees Pursuits rather than race conditions. The rider mentions experiencing thick mist, heavy cloud cover, and intermittent rain during their first day of cycling in the Pyrenees. They reference the Col du Peyresourde as a destination, noting it as a Tour de France climb where crashes have occurred, including a notable incident involving Pogacar and Vingegaard. Weather conditions appear variable with foggy, misty conditions in the mountains but clearing skies possible. The transcript suggests riders should be prepared for changing mountain weather patterns during Pyrenees cycling."
   },
   {
@@ -3720,7 +3827,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/transiberica/",
-    "discipline": "bikepacking"
+    "discipline": "bikepacking",
+    "has_tire_guide": false
   },
   {
     "name": "Triple Bypass — Colorado's Three-Pass Challenge",
@@ -3753,6 +3861,7 @@
     "has_profile": true,
     "profile_url": "/race/triple-bypass/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 39.634,
     "lng": -105.317,
     "st": "The Triple Bypass is one of Colorado's premier cycling events, running from Evergreen to Avon and covering three mountain passes with 10,000 feet of climbing. Founded 28 years ago by Team Evergreen, the ride started when 20 people showed up for a club ride that eventually grew into this major challenge. The event draws 5,000 cyclists from across the country and internationally. Riders describe the route as having super fast ascents and unreal scenery through the most beautiful parts of Colorado. The event offers both single and double options, with registration available at triplebypass.org. Fire danger has occasionally forced cancellations, with alternative rides offered around Evergreen at Buchanan Park. The ride is considered a significant personal accomplishment and challenge that attracts riders who return annually to improve their performance."
@@ -3788,6 +3897,7 @@
     "has_profile": true,
     "profile_url": "/race/wicklow-200/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Wicklow 200 features a demanding 120k main route starting in Naas and tackling iconic Wicklow Mountains terrain. Riders face Sally Gap, Lugala, and Roundwood before descending to a feed stop in Laragh. The route then climbs the challenging Shay Elliott and Sleave Man before descending into Djouce and returning home. A shorter 50k option loops around lakes through Blessington Valley and Naas Valley Mount, described as testing terrain that challenges even experienced cyclists. The family-friendly 15k route follows scenic canal paths. The event accommodates riders of all abilities with multiple distance options, though even the shorter routes are noted for their challenging nature in the Wicklow Mountains landscape."
   },
   {
@@ -3820,7 +3930,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/bikingman-corsica/",
-    "discipline": "bikepacking"
+    "discipline": "bikepacking",
+    "has_tire_guide": false
   },
   {
     "name": "Belgian Waffle Ride Asheville",
@@ -3852,6 +3963,7 @@
     "has_profile": true,
     "profile_url": "/race/bwr-asheville/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.5954,
     "lng": -82.5508,
     "rwgps_id": "42567010",
@@ -3890,6 +4002,7 @@
     "has_profile": true,
     "profile_url": "/race/bwr-montana/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.677,
     "lng": -111.0429,
     "series_id": "belgian-waffle-ride",
@@ -3928,6 +4041,7 @@
     "has_profile": true,
     "profile_url": "/race/chasing-cancellara/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.4908,
     "lng": 7.7506
   },
@@ -3961,7 +4075,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/cicloturista-cerdanya/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "UCI Cyprus Gran Fondo",
@@ -3994,6 +4109,7 @@
     "has_profile": true,
     "profile_url": "/race/cyprus-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 34.769,
     "lng": 32.419,
     "st": "The UCI Cyprus Gran Fondo in Paphos serves as one of the first races in the European grand fondo calendar, making it an ideal season opener for riders seeking their first fast miles. The 63.4-mile course features what riders call killer up hills followed by great descents along scenic and amazing routes. The terrain is described as beautiful with fresh air, full of flowers and fruits, with views that improve significantly at higher elevations. International riders from various countries including Canada, Belgium, England, Sweden, Israel, Latvia, and America participate in this event. A pre-race reconnaissance camp is available where participants can ride the entire course to develop race tactics. The event offers qualification opportunities for the UCI Gran Fondo World Championships, with three different chances to qualify for time trial or road race events through consecutive races in Cyprus. Riders report completing the course in approximately two hours and describe the overall experience as brilliant with beautiful views throughout."
@@ -4029,6 +4145,7 @@
     "has_profile": true,
     "profile_url": "/race/dartmoor-classic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Riders describe Dartmoor's muddy trails as challenging and potentially treacherous, with crashes occurring early in rides due to the slippery conditions. The terrain features muddy trail sections that can catch cyclists off guard, particularly those on cross bikes which may not be optimal for the conditions. One rider experienced a significant fall just 20 minutes into their ride on the muddy terrain. The area offers scenic riding through Dartmoor National Park with a welcoming cycling community atmosphere. Riders emphasize the social aspect and family-like community feel of cycling events in the area, where the experience extends beyond just the riding itself to encompass the entire day's social interactions and camaraderie among participants."
   },
   {
@@ -4062,6 +4179,7 @@
     "has_profile": true,
     "profile_url": "/race/fred-whitton-challenge/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 54.4588,
     "lng": -3.0244,
     "st": "The Fred Whitton Challenge is a 180km event with 3,000m of climbing through England's Lake District, featuring gradients up to 33%. Riders describe it as the toughest UK sportive, with some taking 12 hours to complete while others aim for under 6 hours. Key challenges include Kirkstone Pass as the biggest climb, followed by three savage climbs in succession: Honister, Newlands, and Whinlatter. The most brutal section comes at 90 miles with back-to-back Hardknott and Wrynose passes, both nearly 30% gradient that reduce many riders to walking. The climbs are described as surgey, requiring VO2 max efforts on steep ramps with recovery between. Roads built by Romans feature gradients over 15%, with the steepest over 30%. Feed station queues can be very long, requiring backup nutrition plans. The route starts in Grasmere, passes through Ambleside, and covers rugged Lake District terrain with fast descents between climbs."
@@ -4097,6 +4215,7 @@
     "has_profile": true,
     "profile_url": "/race/gf-gavia-e-mortirolo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.257,
     "lng": 10.509
   },
@@ -4130,7 +4249,8 @@
     "tagline": "Italy's oldest gran fondo, UCI Gran Fondo World Series qualifier through the Emilia-Romagna Apennines",
     "has_profile": true,
     "profile_url": "/race/granfondo-matildica/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Granfondo Novi Sad",
@@ -4163,6 +4283,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-novi-sad/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.25,
     "lng": 19.75
   },
@@ -4196,6 +4317,7 @@
     "has_profile": true,
     "profile_url": "/race/grinduro/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.4324,
     "lng": -120.0356,
     "rwgps_id": "53291723",
@@ -4234,7 +4356,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/haervejslobet/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Haute Route Ventoux",
@@ -4267,6 +4390,7 @@
     "has_profile": true,
     "profile_url": "/race/haute-route-ventoux/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.1262,
     "lng": 5.1784,
     "st": "The Haute Route Ventoux is described as one of the most legendary Grand Fondos worldwide, featuring multiple route options including 100km, 120km, and 135km distances with around 3,200m elevation gain. The signature challenge is the final 20km climb up Mont Ventoux's Bedoin side at 8% average gradient to nearly 2,000m elevation. Riders face early race dangers including crashes on fast descents with road narrowing at nearly 60km/hour. The course includes significant climbs like the Colm at mid-distance (13km at 5% gradient) and complicated feed stations that can force long chasing efforts. Conditions are expected to be very hot with temperatures reaching mid-30s. The Bedoin side is considered the most challenging of Ventoux's three climbing routes, preferred over the shallower Soul side. The event attracts nearly 5,000 riders and is extremely crowded with heavy vehicle traffic at the summit."
@@ -4301,7 +4425,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/letape-parma/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "LoToJa Classic — Logan to Jackson",
@@ -4334,6 +4459,7 @@
     "has_profile": true,
     "profile_url": "/race/lotoja-classic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 41.7352,
     "lng": -111.8344,
     "st": "The available transcripts contain limited race-specific information about LoToJa Classic. One video captures pre-race atmosphere with riders carb-loading on Friday night and gathering at the park before the event. There are mentions of support teams and crew cars, with references to Alpine as a stop location during the race. The transcripts show family participation including a tandem rider team, and community support with crew vehicles carrying multiple team members. However, the transcripts lack detailed course information, specific terrain descriptions, gear recommendations, or pacing strategies that would be typical race intelligence. Most content focuses on local training rides in northern Utah canyons rather than the actual LoToJa race route from Logan to Jackson."
@@ -4369,6 +4495,7 @@
     "has_profile": true,
     "profile_url": "/race/mt-evans-hill-climb/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 39.7417,
     "lng": -105.5139,
     "st": "The Bob Cook Memorial Mt. Evans Hill Climb takes riders up the highest paved road in the United States, reaching approximately 14,500 feet elevation. Starting from Idaho Springs at about 7,000 feet, the race involves 7,000 feet of climbing over 27.4 miles. Riders report the climb takes about five hours to complete, with a much faster one-hour descent. Temperature is a significant factor, with conditions being notably cold at the summit, requiring riders to prepare for dramatic temperature changes throughout the climb. The race features both competitive categories including state championship divisions and attracts team participation for the challenging high-altitude effort."
@@ -4403,7 +4530,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/northcape-4000/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "RAMROD — Ride Around Mount Rainier in One Day",
@@ -4436,6 +4564,7 @@
     "has_profile": true,
     "profile_url": "/race/ramrod/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 47.2037,
     "lng": -121.9917
   },
@@ -4470,6 +4599,7 @@
     "has_profile": true,
     "profile_url": "/race/ride-across-britain/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Ride Across Britain covers 980 miles from Land's End to John O'Groats across varied British terrain. Riders describe nice country roads through rural countryside and forested areas with 17 categorized climbs throughout the route. The challenge typically takes 9-14 days for touring but can be completed in 6 days averaging 170 miles daily with 15-hour riding days. Weather progressively gets colder heading north, dropping 1-2 degrees each day. Mechanical challenges include derailleur hanger failures on rough roads. Limited food options exist on Sundays in rural areas. Aerodynamic equipment becomes effective on flatter sections at 40-45 km/h speeds. Comfort-focused bike setup is crucial for the long daily distances. The route attracts 700-800 participants and showcases beautiful British countryside with sheep-filled fields and rolling terrain."
   },
   {
@@ -4503,6 +4633,7 @@
     "has_profile": true,
     "profile_url": "/race/sea-otter-ciclobrava/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 41.9834,
     "lng": 2.8257,
     "st": "The available transcripts for Sea Otter Ciclobrava do not contain race-specific information about course conditions, terrain, or rider experiences during the actual gravel event. One transcript discusses virtual cycling platforms and connecting global cycling communities in Girona, while the other contains only music and brief phrases. No actionable intelligence about the 87-mile gravel race through Costa Brava's terrain, elevation challenges, or race day conditions can be extracted from these particular video transcripts."
@@ -4537,7 +4668,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/sierra-nevada-limite/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Struggle Dales",
@@ -4569,7 +4701,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/struggle-dales/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Tartu Rattaralli",
@@ -4602,6 +4735,7 @@
     "has_profile": true,
     "profile_url": "/race/tartu-rattaralli/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 58.373,
     "lng": 26.7294,
     "st": "The Tartu Rattaralli features a changed route starting near Estonia's National Museum rather than the traditional city center start due to road works and logistics. The race begins with immediate challenges including a tough opening climb followed by a quick descent and another climb, where the first selection typically occurs. The 128km course has only 650 meters of elevation gain, much less than major European classics, but much of the route is exposed to potential crosswinds. The race uses a wave start system instead of the traditional mass start for safety improvements, with riders grouped by ability. Around 1200 riders participate in the main distance, making it Estonia's biggest cycling event. The course goes through fields near Tartu city borders, starting from what was formerly a military airfield."
@@ -4637,6 +4771,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-of-georgia-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Tour of Georgia Gran Fondo features four timed stages with non-competitive sections between them, totaling about 90 miles and 9,000 feet of climbing. The race starts in Helen, Georgia, a German-themed mountain town. The first major challenge comes at mile 3 with a 7.2-mile, 1,500-foot climb that takes most riders around 30 minutes. The second stage features 1,700 feet of climbing that deceives riders by starting flat before becoming very steep. Riders consistently struggle with pacing this section. The third stage is flatter at just under 4 miles with 400 feet of elevation, but positioning at the start is critical for staying with groups. Drafting is essential on flatter sections, and being stuck without a group significantly impacts times. The competitive riders are described as mountain goats, with significant time gaps between ability levels."
   },
   {
@@ -4669,7 +4804,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-of-the-peak/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Trek Across Maine",
@@ -4702,6 +4838,7 @@
     "has_profile": true,
     "profile_url": "/race/trek-across-maine/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 43.9625,
     "lng": -70.1892,
     "st": "The provided transcript discusses Hall Ranch in Lyons, Colorado, which is not related to the Trek Across Maine gravel race. The transcript covers mountain bike trail riding on technical single track with rock gardens and climbing features. No information about the Trek Across Maine race, its 180-mile distance, New Gloucester location, terrain conditions, or race-specific challenges is mentioned in this transcript. The content focuses entirely on a different location and activity type."
@@ -4737,6 +4874,7 @@
     "has_profile": true,
     "profile_url": "/race/velo-vietnam-northern-frontier/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "This transcript covers cycling in northern Thailand around Chiang Mai rather than the Velo Vietnam Northern Frontier race. The rider describes mountain roads with beautiful red surfaces and steep gradients reaching 20-25 percent. Navigation is aided by Google Maps coverage of the routes. The terrain features challenging climbs requiring appropriate gearing, with recommendations for a 34-tooth rear cassette. The area offers access to native hill tribe villages and has a strong local cycling community with group rides. The riding described involves gravel and mountain terrain with significant elevation changes, though this content appears to be from a different location than the specified Vietnam race."
   },
   {
@@ -4770,6 +4908,7 @@
     "has_profile": true,
     "profile_url": "/race/bealach-mor/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The provided transcripts do not contain information about the Bealach Mór (The Bà Sportive) race in Scotland. The transcripts cover three different cycling events: a Colombian climb called Alto de letras (81km climb with extreme temperature variations from 30-degree subtropical conditions to cold summit weather), a Himalayan gravel adventure in Nepal featuring technical terrain with sketchy descents requiring dropped tire pressures, and an Italian Grand Fondo with 4,000m of climbing over 177km. These races feature challenging climbs, technical descents with poor surface conditions, and require careful pacing strategies. However, none of these events relate to the Scottish Highlands race specified, so no actionable intelligence can be extracted for the Bealach Mór event from these particular video transcripts."
   },
   {
@@ -4803,6 +4942,7 @@
     "has_profile": true,
     "profile_url": "/race/bp-ms-150-texas/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 30.6133,
     "lng": -96.3403,
     "st": "The BP MS 150 from Houston to College Station receives positive feedback from riders, with one participant noting the race experience is significantly better than Austin events. The transcript suggests there are sections where riders need to exercise caution and slow down. Participants express surprise and appreciation for being allowed access to certain areas during the race, though specific course details and terrain conditions are not detailed in the available video content."
@@ -4837,7 +4977,8 @@
     "tagline": "Conquer the Giant of Provence in a legendary summit finish",
     "has_profile": true,
     "profile_url": "/race/colnago-cycling-festival/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Formosa 900",
@@ -4869,7 +5010,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/formosa-900/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY Chile",
@@ -4902,6 +5044,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-chile/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -33.0694,
     "lng": -71.4056
   },
@@ -4935,7 +5078,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-toscana/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Giro Sardegna Gravel",
@@ -4967,6 +5111,7 @@
     "has_profile": true,
     "profile_url": "/race/giro-sardegna-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.28,
     "lng": 9.55,
     "rwgps_id": "48864427",
@@ -5004,6 +5149,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-tre-valli-varesine/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.8168,
     "lng": 8.8554
   },
@@ -5037,6 +5183,7 @@
     "has_profile": true,
     "profile_url": "/race/grinduro-france/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 48.0813,
     "lng": 6.9267,
     "rwgps_id": "47342609",
@@ -5073,6 +5220,7 @@
     "has_profile": true,
     "profile_url": "/race/grinduro-germany/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 51.1638,
     "lng": 10.4478,
     "rwgps_id": "46815624",
@@ -5112,6 +5260,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-costa-rica/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 9.8647,
     "lng": -83.918
   },
@@ -5145,7 +5294,8 @@
     "tagline": "Official Tour de France amateur cycling event in Slovakia",
     "has_profile": true,
     "profile_url": "/race/letape-slovakia/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Mammoth Tuff",
@@ -5177,6 +5327,7 @@
     "has_profile": true,
     "profile_url": "/race/mammoth-tuff/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 37.6433,
     "lng": -118.9669,
     "rwgps_id": "52694679",
@@ -5213,6 +5364,7 @@
     "has_profile": true,
     "profile_url": "/race/nordic-chase-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 61.1529,
     "lng": 8.7877,
     "st": "The Nordic Chase Gravel Edition runs from Copenhagen to Oslo covering 373 miles with 26,247 feet of elevation. The route features over 85% perfect gravel roads with excellent surface conditions and very light traffic. Riders face an immediate 800-meter climb from the starting point that brings them onto rolling Alpine plains, then flattens out with spectacular views for the next 200+ kilometers. The course offers beautiful views of mountain ranges including Hemal and Yiman National Park. Every 40-50 km there are small cafes and kiosks for resupply, though riders should check opening times as they sometimes close early. Water is readily available from fast flowing streams. Weather can be unpredictable with cold breezes even on sunny days, so extra clothing is essential. The race emphasizes community and adventure, taking riders through three countries with varied landscapes.",
@@ -5248,6 +5400,7 @@
     "has_profile": true,
     "profile_url": "/race/oregon-trail-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.06,
     "lng": -121.31,
     "rwgps_id": "51970272",
@@ -5284,7 +5437,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/the-accursed-race/",
-    "discipline": "bikepacking"
+    "discipline": "bikepacking",
+    "has_tire_guide": false
   },
   {
     "name": "TORTOUR",
@@ -5317,6 +5471,7 @@
     "has_profile": true,
     "profile_url": "/race/tortour/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 47.696,
     "lng": 8.635
   },
@@ -5351,6 +5506,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-du-mont-blanc-cyclo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.857,
     "lng": 6.617,
     "st": "The Tour du Mont-Blanc Cyclo is a 330-kilometer event with 8300 meters of elevation gain that riders call the toughest one-day cycling event in the world. The race starts at 5 AM requiring front lights, with breakfast at 3:30 AM. Key climbs include the first proper climb early in the route, Le Petit Savannah with 700 meters of elevation, and final climbs with 800 meters to the top. Temperatures reach 34-36 degrees Celsius during the day but become cooler later. Riders recommend lower gearing for the big mountain climbs and suggest 90 grams of carbs per bottle for nutrition. Pacing strategy involves deciding whether to push early in cooler conditions or save energy for the final two climbs, though heat remains a factor throughout."
@@ -5386,6 +5542,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-of-the-gila/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 32.77,
     "lng": -108.28,
     "st": "Tour of the Gila is a punishing 334-mile stage race in Silver City, New Mexico with 15,000 feet of climbing. Stage one features the Mogollon climb where crosswinds create chaos and splits, with full gas racing to the finish. The brutal stage five covers 161.9 kilometers with 3,000 meters of climbing including incredibly challenging climbs. Key sections include a second climb at mile 52 where two-thirds of the peloton gets dropped, and the cliff dwellings turnaround climb where mechanicals are costly due to high pace racing. The race attracts professional teams from around the world to this 32nd annual event. Riders emphasize smart energy management and preparation for mechanical issues on climbs, as the racing continues hard on descents making it difficult to rejoin the peloton."
@@ -5420,6 +5577,7 @@
     "has_profile": true,
     "profile_url": "/race/whiskey-off-road/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.54,
     "lng": -112.4688,
     "rwgps_id": "39231737",
@@ -5456,7 +5614,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/adac-velotour/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Alpen Challenge Lenzerheide",
@@ -5488,7 +5647,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/alpen-challenge-lenzerheide/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Amstel Gold Race Toerversie",
@@ -5521,6 +5681,7 @@
     "has_profile": true,
     "profile_url": "/race/amstel-gold-race-toerversie/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 50.8661,
     "lng": 5.8318
   },
@@ -5554,7 +5715,8 @@
     "tagline": "Desert gran fondo linking Abu Dhabi's cities with massive prizes and community spirit",
     "has_profile": true,
     "profile_url": "/race/bike-abu-dhabi-gran-fondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Chequamegon MTB",
@@ -5586,6 +5748,7 @@
     "has_profile": true,
     "profile_url": "/race/chequamegon-mtb/",
     "discipline": "mtb",
+    "has_tire_guide": true,
     "lat": 46.208,
     "lng": -91.2921,
     "rwgps_id": "43651747",
@@ -5625,6 +5788,7 @@
     "has_profile": true,
     "profile_url": "/race/cycling-shimanami/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Shimanami Kaido is a 70-kilometer coastal cycling route connecting Honshu to Shikoku via six islands and suspension bridges. Riders describe the flat sections as manageable but warn that bridge approaches involve tough, grueling climbs that can feel like hitting a wall, especially on the first Inoshima Bridge approach. The route winds scenically around coastlines rather than cutting straight through islands, with bespoke bike approaches to each bridge. Standard bikes struggle on inclines while high-tech bikes perform better but lack storage. E-bikes are recommended for less experienced riders, lasting 8-10 hours with partial recharge available at Omishima halfway point. The ride takes 4-5 hours for fast cyclists or 8-10 hours for beginners. Spring and autumn are ideal seasons, avoiding summer heat and winter conditions. Riders emphasize managing expectations carefully and choosing appropriate bikes for fitness levels."
   },
   {
@@ -5657,7 +5821,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/douro-gran-fondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY NYC",
@@ -5689,7 +5854,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-nyc/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Asheville",
@@ -5722,6 +5888,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-asheville/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 35.595,
     "lng": -82.557
   },
@@ -5755,7 +5922,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-collado-del-condor/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Jordan",
@@ -5788,6 +5956,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-jordan/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 31.5,
     "lng": 35.5,
     "st": "The Gran Fondo Jordan features the challenging Scorpions climb as its defining obstacle - a four-kilometer ascent with an 11% average gradient that riders describe as the decisive part of the race. The course takes riders through the Negev desert before hitting a cobblestone section that signals the approach of the main climb. Race strategy often involves getting into early breakaways to tackle the Scorpions climb with an advantage over the main field. The climb has a small flat section partway up where riders can recover rhythm before the final push. After the climb, there are still approximately 50 kilometers to the finish, making energy management crucial. Riders who spend extended time in breakaways may struggle to respond to final attacks in the closing kilometers. The race attracts international competition and is considered one of the most important races in the Israeli calendar."
@@ -5823,6 +5992,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-alpi-del-mare/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Granfondo Alpi del Mare in Mondovi, Piedmont presents riders with significant heat conditions according to participant accounts. Riders repeatedly emphasize the challenging heat encountered during the 68.8-mile course through the Italian Alps. The mountainous terrain of Piedmont appears to amplify temperature concerns, with multiple mentions of heat being a primary factor riders face. While specific course details are limited in available footage, the consistent emphasis on thermal conditions suggests heat management becomes a critical consideration for participants tackling this 7,451-foot elevation gain event. The alpine setting of this Tier 2 gravel race appears to create demanding weather conditions that riders must prepare for when racing through the Italian countryside."
   },
   {
@@ -5855,7 +6025,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-antalya/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "UCI Granfondo Bogotá",
@@ -5887,7 +6058,8 @@
     "tagline": "High-altitude UCI qualifier in Colombia's cycling capital",
     "has_profile": true,
     "profile_url": "/race/granfondo-bogota/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Granfondo Bulgaria",
@@ -5920,6 +6092,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-bulgaria/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 42.017,
     "lng": 23.917
   },
@@ -5953,7 +6126,8 @@
     "tagline": "Tropical UCI Gran Fondo qualifier with Caribbean climbs and sea views.",
     "has_profile": true,
     "profile_url": "/race/granfondo-la-guadeloupe/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Gunni Grinder",
@@ -5985,6 +6159,7 @@
     "has_profile": true,
     "profile_url": "/race/gunni-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.6477,
     "lng": -107.0603,
     "rwgps_id": "34138332",
@@ -6022,6 +6197,7 @@
     "has_profile": true,
     "profile_url": "/race/haleakala-cycle-to-the-sun/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 20.9206,
     "lng": -156.3745,
     "st": "No relevant race intelligence found in the provided transcripts. The transcripts contain content about DIY camping stove construction and mountain cycling in Montenegro, but do not include any information about the Cycle to the Sun Haleakala race in Maui, Hawaii. No course details, terrain conditions, gear recommendations, or race-specific advice for this 36-mile, 10,023-foot elevation gain gravel race were mentioned in the available video content."
@@ -6056,7 +6232,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/la-vaujany/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Lauf True Grit Gravel Epic",
@@ -6088,6 +6265,7 @@
     "has_profile": true,
     "profile_url": "/race/lauf-true-grit/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 37.133,
     "lng": -113.6541,
     "st": "The Lauf True Grit Gravel Epic is an 84-mile, 9000-foot elevation gain race through Santa Clara, Utah's challenging terrain. The course travels through the Beaver Dam Wash National Conservation Area, featuring technical sections so difficult that finishing is considered an accomplishment. Key challenges include the technical descent to Zen where races can be won or lost, deep river crossings that catch riders off guard, and terrain accessible only by bike. Weather can transform the course into muddy, cyclocross-like conditions with hypothermia risks, tons of puddles, and cold descents followed by hopeful road sections. Riders recommend carrying tubes for common flats, considering larger 235mm tires for better traction, and preparing for extreme weather. The race combines competitive racing with family-friendly atmosphere, taking place annually in March through some of Utah's most beautiful and remote scenery.",
@@ -6123,6 +6301,7 @@
     "has_profile": true,
     "profile_url": "/race/le-grand-du-nord/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 47.7505,
     "lng": -90.3347,
     "st": "Le Grand du Nord features challenging climbs in Minnesota's Sawtooth Range with three major ascents including a 20% grade section after the opening 6-7 mile gradual climb. The 110-mile course starts at Grand Marais YMCA with checkpoints positioned at hill bottoms requiring climbs back out. Riders describe fast gravel conditions with some chunky B sections that remain manageable for various bike types including fat bikes. The remote course winds through wooded areas with no gas stations or stores, offering Lake Superior views and potential wildlife sightings including moose and wolves. Race starts are staggered with 110-mile at 8:15am and shorter distances at 9:15am. Four bottles recommended for hydration. The scenic Grand Marais finish area provides excellent spectator viewing as riders return to town.",
@@ -6158,7 +6337,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/letape-ireland/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "L'Etape Taiwan by Tour de France",
@@ -6191,6 +6371,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-taiwan/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 23.864,
     "lng": 120.903
   },
@@ -6225,6 +6406,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-turkey/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 41.1067,
     "lng": 29.0761
   },
@@ -6258,7 +6440,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/london-edinburgh-london/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Marmotte Granfondo Pyrénées",
@@ -6291,6 +6474,7 @@
     "has_profile": true,
     "profile_url": "/race/marmotte-pyrenees/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 42.975,
     "lng": -0.098,
     "st": "The available transcript content for the Marmotte Granfondo Pyrénées is extremely limited, containing only brief fragments mentioning that it's a beautiful experience with mechanical sounds. The transcript appears to be incomplete or heavily fragmented, providing insufficient information about the 110-mile course through the Hautes-Pyrénées region of France with its 18,701 feet of elevation gain. No specific details about course features, terrain conditions, key challenges, or race atmosphere are discernible from the available content."
@@ -6326,6 +6510,7 @@
     "has_profile": true,
     "profile_url": "/race/milano-sanremo-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.0389,
     "lng": 8.4064,
     "st": "Riders describe Milan-San Remo as an epic 300-kilometer route starting at Castello Sforzesco in Milan center. The most dangerous section is the neutralization in the first 10 kilometers with trucks, potholes, and speed bumps causing crashes. Brutal headwinds make maintaining pace difficult without peloton draft. Professional riders who make the breakaway maintain steady 40k per hour pace with everyone pulling. The route requires 8 hours of daylight, necessitating very early starts. Any type of rider can win this unpredictable monument - sprinters, climbers, punchers, or time trialists. Former pro Alan Maragoni, who raced it five times, confirms breakaway wins are extremely difficult in modern racing though not impossible."
@@ -6360,6 +6545,7 @@
     "has_profile": true,
     "profile_url": "/race/monaco-gravel-race/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.8039,
     "lng": 7.4028,
     "rwgps_id": "50327918",
@@ -6397,6 +6583,7 @@
     "has_profile": true,
     "profile_url": "/race/niseko-classic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The provided transcript for the Niseko Classic does not contain coherent rider commentary about the race. The transcript appears to be fragmented with incomplete words and phrases, making it impossible to extract meaningful information about course features, terrain conditions, challenges, or rider experiences from this 87-mile gravel race in Niseko, Hokkaido, Japan with 6,562 feet of elevation gain."
   },
   {
@@ -6429,6 +6616,7 @@
     "has_profile": true,
     "profile_url": "/race/nova-eroica/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.1382,
     "lng": 11.4821,
     "rwgps_id": "39107798",
@@ -6466,6 +6654,7 @@
     "has_profile": true,
     "profile_url": "/race/omloop-het-nieuwsblad-sportive/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Omloop Het Nieuwsblad Cyclo features a technically demanding finish with multiple turns in the final kilometer. Riders face a series of right-hand turns followed by a left turn into the final 500 meters, with the first right turn leading onto narrow roads that create positioning challenges. The finale is prone to crashes and mechanical issues that can dramatically alter race outcomes, as evidenced by sprint favorite Kristoff's puncture in the closing kilometer. The narrow roads after the technical turns make positioning critical for the bunch sprint finish. Teams must control the race well through these technical sections to set up their sprinters for success."
   },
   {
@@ -6498,6 +6687,7 @@
     "has_profile": true,
     "profile_url": "/race/ouray-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.146,
     "lng": -107.7415,
     "st": "The transcripts provided do not contain information about the Ouray Gravel Grinder race in Colorado. Instead, they feature product reviews and bike builds for Parley bicycles, including the Parley TA and Parley Aura models. The videos discuss bike specifications, construction methods, and component details but do not mention the actual Ouray race event, course conditions, terrain challenges, or rider experiences from this specific gravel race. No race-specific intelligence about course difficulty, elevation challenges, surface conditions, or racing strategies for the Ouray Gravel Grinder can be extracted from these transcripts as they focus entirely on bicycle equipment reviews rather than race coverage or rider testimonials.",
@@ -6533,6 +6723,7 @@
     "has_profile": true,
     "profile_url": "/race/pirinexus-360/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.9793,
     "lng": 2.8199,
     "rwgps_id": "52671146",
@@ -6568,7 +6759,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-across-germany/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Sellaronda Bike Day",
@@ -6601,6 +6793,7 @@
     "has_profile": true,
     "profile_url": "/race/sellaronda-bike-day/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.5089,
     "lng": 11.7575
   },
@@ -6634,7 +6827,8 @@
     "tagline": "UCI Gran Fondo qualifier through Fukushima's recovery zones",
     "has_profile": true,
     "profile_url": "/race/tour-de-fukushima/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Trek 100",
@@ -6667,6 +6861,7 @@
     "has_profile": true,
     "profile_url": "/race/trek-100/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Trek 100 race transcripts focus heavily on bike setup and gear considerations rather than course-specific details. Riders discuss the importance of proper shifting technique, particularly shifting to easier gears before climbing hills and maintaining light pedal pressure during shifts. A comfortable cadence of around 90 RPM is recommended as most efficient. Equipment discussions cover high-end carbon bikes weighing 8.8-10.28 kg with electronic shifting systems like SRAM Red eTap AXS. Tubular tires with lightweight TPU inner tubes are mentioned for reduced rolling resistance. The Trek Domane with ISOSpeed decouplers is highlighted for comfort on longer rides. Pro mechanics bed in multiple saddles during pre-season to ensure consistent feel across race and training bikes. Wide-range cassettes like 10-33 tooth provide versatility for varying terrain demands typical of gravel racing."
   },
   {
@@ -6700,6 +6895,7 @@
     "has_profile": true,
     "profile_url": "/race/assault-on-mt-mitchell/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 34.9567,
     "lng": -81.9361,
     "st": "The Assault on Mt. Mitchell is a 102.7-mile ride with 10,357 feet of climbing that riders describe as one of the most brutal single-day events in the US. The race starts with a sprint pace through beautiful countryside from Spartanburg, with riders going faster in the first 80 miles than they've ever ridden. The real challenge comes in the final 20 miles of continuous climbing, which riders say is worse than the Rockies and feels endless. Weather can turn nasty with rain and hail during the climb. The event is well-organized with police support but limited to 800 riders, making it one of the hardest centuries to enter. Multiple riders compare it favorably to cross-country riding in terms of difficulty, with the climbing section described as the longest and most brutal they've experienced."
@@ -6735,6 +6931,7 @@
     "has_profile": true,
     "profile_url": "/race/axel-merckx-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Axel Merckx Gran Fondo in Penticton starts at 7 AM from Lake Shore Drive and Maid Street in downtown Penticton. The race offers three different distances, with the 160 km being the main event featuring 1600 meters of elevation gain. The course travels through vineyard terrain with spectacular views throughout. The race attracts riders of various ages, including younger participants in the 55 km Corto Fondo distance. Crashes can be a concern as noted by riders, but the post-race atmosphere is social with finishers gathering on patios for refreshments. The event combines challenging elevation with scenic vineyard landscapes characteristic of the British Columbia wine region."
   },
   {
@@ -6767,7 +6964,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/birkebeinerrittet-road/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Boone Gran Fondo",
@@ -6800,6 +6998,7 @@
     "has_profile": true,
     "profile_url": "/race/boone-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Riders describe the Boone Gran Fondo as a challenging 122km route with nearly 1,900 meters of elevation gain. The terrain requires specific gearing considerations, with one 70-year-old rider needing to swap from an 11-28 to 11-34 cassette to handle the hills. Race conditions can be hot during the event. Equipment recommendations include 28mm tires for the course. Riders report the climbing difficulty requires careful preparation, with some using hybrid pedals for easier foot placement on steep sections when going very slow speeds. The race attracts riders of various ages and abilities, with participants describing a supportive community atmosphere despite the physical demands. Electronic pumps may struggle to reach adequate pressure on course repairs. Proper preparation includes battery changes for electronic components before race day."
   },
   {
@@ -6833,6 +7032,7 @@
     "has_profile": true,
     "profile_url": "/race/cyclotour-du-leman/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Cyclotour du Léman is described by riders as having beautiful views of the lake and being well organized. Participants emphasize the community aspect, with club groups from Geneva and other Swiss cities joining together. The course presents mental challenges particularly from headwinds in the final sections, with one rider describing it as super intense, tough with a lot of pain in the end. The wind was against riders creating what one called an awesome mental challenge. Weather conditions can be perfect with nice conditions reported. Many riders participate as a fun group activity with friends and club members rather than purely competitive racing. The event is praised for its organization and scenic lakeside route."
   },
   {
@@ -6866,6 +7066,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-colombia/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 5.0224,
     "lng": -73.9871,
     "st": "The transcript provided is from the GFNY World Championship in New York City, not GFNY Bogota in Colombia. The video covers the NYC race with riders starting on the George Washington Bridge, traveling through Fort Lee and Palisades Interstate Park, with climbs including Alpine and cheese coat. The race featured international competition with Italian SWAT club dominating both men's and women's categories. However, since this transcript does not contain any information about the GFNY Bogota race in Zipaquira, Colombia, no specific intelligence about that race's course features, terrain conditions, challenges, or race day logistics can be extracted from this source."
@@ -6901,6 +7102,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-hangzhou/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 29.5333,
     "lng": 118.8833
   },
@@ -6935,6 +7137,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-medellin/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The provided transcript from the Gran Fondo Medellín race video contains only fragmented audio snippets and music segments without coherent race commentary or rider insights. No specific information about the 87-mile course through Medellín, Antioquia, Colombia is available from this source. The transcript lacks details about terrain conditions, elevation challenges, gear recommendations, or race strategy advice that would typically be found in cycling race coverage. Without substantive content about the course features, riding conditions, or participant experiences, this transcript does not provide actionable intelligence for potential race participants regarding the Gran Fondo Medellín's 7,776 feet of elevation gain or specific challenges riders might encounter on this Tier 2 gravel cycling event."
   },
   {
@@ -6968,6 +7171,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-gottardo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.511,
     "lng": 8.696
   },
@@ -7001,6 +7205,7 @@
     "has_profile": true,
     "profile_url": "/race/grasshopper-series/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.51,
     "lng": -122.81,
     "series_id": "grasshopper-adventure-series",
@@ -7039,6 +7244,7 @@
     "has_profile": true,
     "profile_url": "/race/highlands-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Highlands Gran Fondo features a challenging mix of flats and bumps across four timed segments. The signature challenge is Macca Pin climb hitting just 1.5 miles into the 100-mile course - a 4.7 mile segment averaging 2.4% grade but with steepest sections over 8% early on and numerous false flats. Riders describe extreme heat as a major factor, calling it scorching hot. The course offers crazy views but stupid hills according to finishers. The event is well-organized with good safety measures, medical support, and helpful volunteers. As a mass start group event with varying rider capabilities, traffic management becomes important early on. The terrain requires frequent shifting between chainrings due to varying grades and rolling sections that feel like time trials with punchy bumps requiring momentum maintenance."
   },
   {
@@ -7072,6 +7278,7 @@
     "has_profile": true,
     "profile_url": "/race/hottern-hell-hundred/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 33.9137,
     "lng": -98.4934,
     "st": "The Hotter'N Hell Hundred takes place in Wichita Falls, Texas, and is described as one of the largest sanctioned bicycle events in the nation. The race presents extreme heat challenges, with temperatures reaching 100-104 degrees Fahrenheit on race day. Riders emphasize the critical importance of electrolyte management, warning that drinking only water in these conditions can be dangerous. Wind conditions vary throughout the course, with some sections being particularly exposed to strong winds that can reach 20+ mph averages. While the wind provides some cooling relief from the intense heat, it creates significant resistance for pedaling. The event attracts record numbers of participants and requires extensive volunteer coordination. The combination of extreme heat, wind exposure, and the 100-mile distance creates a challenging endurance test that demands careful preparation and race-day nutrition strategy."
@@ -7106,7 +7313,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/inthanon-challenge/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "La Leggendaria Charly Gaul",
@@ -7139,6 +7347,7 @@
     "has_profile": true,
     "profile_url": "/race/la-leggendaria-charly-gaul/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.0679,
     "lng": 11.1211
   },
@@ -7173,6 +7382,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-poland/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 49.299,
     "lng": 19.949
   },
@@ -7207,6 +7417,7 @@
     "has_profile": true,
     "profile_url": "/race/pisgah-monster-cross/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.2334,
     "lng": -82.7343,
     "rwgps_id": "49409140",
@@ -7244,6 +7455,7 @@
     "has_profile": true,
     "profile_url": "/race/race-across-belgium/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Belgian racing features technical circuits with challenging climbs and crosswind conditions. The Race Across Belgium includes courses weaving through housing estates with multiple climbs, including brutal final ascents with 24 percent gradients on gravel. Riders describe the terrain as technical with varied surfaces. Weather conditions include high humidity and strong crosswinds that create challenges and potential crashes. Belgian race culture is notably more relaxed than UK racing, with riders arriving just minutes before start times rather than hours early. Prize money extends down to 30th place with decent payouts. Courses typically feature multiple laps of 7-15km circuits with closed roads and strong community support. The racing is described as highly dynamic where situations can change rapidly, requiring strategic pacing rather than aggressive early moves."
   },
   {
@@ -7276,7 +7488,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-across-benelux/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Race Across Spain",
@@ -7308,7 +7521,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-across-spain/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "RAGBRAI (Register's Annual Great Bicycle Ride Across Iowa)",
@@ -7341,6 +7555,7 @@
     "has_profile": true,
     "profile_url": "/race/ragbrai/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 42.0308,
     "lng": -93.6319,
     "st": "RAGBRAI is a 7-day recreational bike touring event across Iowa covering 400-450 miles from Missouri River to Mississippi River. The route features beautiful cornfields and charming small towns with very safe riding conditions and practically zero traffic. Daily mileage ranges from 40-80 miles. Around 20,000 riders camp in host cities each night, setting up tents in backyards, city parks and school yards. The event showcases Iowa hospitality with locals opening their homes to riders. Food is abundant throughout the route including pork chops, pie, corn, and breakfast burritos. Most riders maintain conversation pace rather than racing speed. The riding is very social with entertainment every night. Riders traditionally start by dipping rear tire in Missouri River and end by dipping front tire in Mississippi River. Camping logistics require arriving early at first-come-first-serve locations to avoid crowds."
@@ -7375,6 +7590,7 @@
     "has_profile": true,
     "profile_url": "/race/rasputitsa/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.6179,
     "lng": -71.9235,
     "rwgps_id": "33718706",
@@ -7411,7 +7627,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/ring-of-clare/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Sado Long Ride 210",
@@ -7443,7 +7660,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/sado-long-ride-210/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Seorak GranFondo",
@@ -7475,7 +7693,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/seorak-granfondo/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Styrkeprøven",
@@ -7508,6 +7727,7 @@
     "has_profile": true,
     "profile_url": "/race/styrkeproven/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 63.4305,
     "lng": 10.3951
   },
@@ -7541,6 +7761,7 @@
     "has_profile": true,
     "profile_url": "/race/the-rad/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 37.1694,
     "lng": -104.5005,
     "st": "The Rad Dirt Fest in Trinidad, Colorado features 113 miles with over 10,000 feet of elevation gain. Riders describe fast gravel conditions suitable for slick tires or narrow 38mm options. The course includes varied terrain from smooth pavement to rough two-track with rocks, sand, and mud sections. Key challenges include an early choke point at mile 3.8 where only single riders can pass between fences, creating aggressive positioning battles. The route heads through Trinidad Lake State Park's rowdy Jeep tracks, then climbs gradually at 4-6% grades that are draftable, topping out at 9000 feet around mile 65. A steep paved climb hits riders at 10 miles out and again with 10 miles to go. Descents are mostly smooth but have surprise sharp corners requiring attention. The 9am start time provides better logistics than typical 4am race starts. Roads remain open to traffic requiring riders to stay right on blind corners.",
@@ -7576,7 +7797,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-de-romandie-cyclosportive/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Tour o' the Borders",
@@ -7608,7 +7830,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-o-the-borders/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "SBS Bank Tour of Southland",
@@ -7641,6 +7864,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-of-southland/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The SBS Bank Tour of Southland spans seven stages and 900 km across New Zealand's deep south. Riders describe it as one of the toughest races on the New Zealand cycling calendar with challenging weather and tough roads throughout. Key climbs include Blackmount Hill where early breakaways typically form, and the Queen stage finale up Coronet Peak featuring 8 km of switchbacks. The Coronet climb is described as a hard slog that leaves everyone with tired legs by the bottom. Route changes include a shorter stage starting from Mosburn to aid recovery. The race features picturesque terrain through Southland with attacks typically coming on descents after major climbs. Riders emphasize survival tactics and staying close to experienced teammates to avoid trouble in the challenging conditions."
   },
   {
@@ -7673,7 +7897,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-of-thekkady/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Trans Balkan Race",
@@ -7705,7 +7930,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/trans-balkan-race/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Two Volcano Sprint",
@@ -7737,7 +7963,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/two-volcano-sprint/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "UCI Gran Fondo World Championships",
@@ -7770,6 +7997,7 @@
     "has_profile": true,
     "profile_url": "/race/uci-gran-fondo-world-championships/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 42.8684,
     "lng": 140.6873
   },
@@ -7804,6 +8032,7 @@
     "has_profile": true,
     "profile_url": "/race/947-ride-joburg/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -26.2348,
     "lng": 27.9827,
     "st": "The 947 Ride Joburg features a completely new anti-clockwise reverse route that starts and ends at FNB Stadium, a significant change from previous years when it started at Kylami racetrack. The race attracts 20,000-30,000 participants over a 97-kilometer distance through Johannesburg. Elite riders typically finish in 2 hours 15 minutes to 2 hours 30 minutes. A major challenge is heat management, with temperatures starting at 18 degrees in early morning, rising to 25 degrees mid-morning, and reaching 33 degrees when most cyclists finish. The reverse route means no one can predict finishing times since it's never been raced this direction before. The event draws diverse participants from various Johannesburg communities including riders from the Soweto Cycling Foundation. Roads are closed along the route with spectators providing support throughout the course."
@@ -7839,6 +8068,7 @@
     "has_profile": true,
     "profile_url": "/race/aids-lifecycle/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 37.7083,
     "lng": -122.4367,
     "st": "AIDS/LifeCycle is a 545-mile charity ride from San Francisco to Los Angeles with 25,000 feet of elevation gain over multiple days. Riders describe it as mentally, physically, and spiritually challenging, with daily distances around 100 miles. The event features camping logistics where participants help each other set up tents after long riding days. Training is crucial - riders recommend 4 months of preparation including group training rides, as these simulate actual ride conditions. The event attracts participants seeking personal challenges while raising money for HIV/AIDS causes. Riders emphasize the strong community spirit and supportive atmosphere throughout the multi-day journey. Mental toughness and setting incremental goals are key strategies for completing this demanding endurance event."
@@ -7874,6 +8104,7 @@
     "has_profile": true,
     "profile_url": "/race/amashova-national-classic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Amashova National Classic is described by organizers as a grueling 106 kilometer race that finishes on the Durban beachfront. Originally designed to follow the comrades route to appeal to runners wanting to try the challenge on a bicycle, the race has grown from 400 riders with one distance to multiple distance options including 35km fun ride and 65km half challenge. The race is highly competitive with 9,000 participants in recent years, featuring both local and international cyclists. Organizers emphasize well-stocked water points and properly closed roads. The event takes place in October during Durban's quiet tourism season and has joined the Gran Fondo World Tour series as the final event of the calendar year. The race concludes at the beachfront where riders can enjoy a swim after finishing."
   },
   {
@@ -7906,6 +8137,7 @@
     "has_profile": true,
     "profile_url": "/race/bwr-north-carolina/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.3187,
     "lng": -82.461,
     "rwgps_id": "52886757",
@@ -7945,6 +8177,7 @@
     "has_profile": true,
     "profile_url": "/race/cape-town-cycle-tour/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -33.9062,
     "lng": 18.4173,
     "st": "The Cape Town Cycle Tour follows a familiar peninsula route starting on the Blue Route to Muizenberg, then hitting the coastline where wind can be a major factor. Riders snake through Fishoek and Simonstown before the first real challenge at Smith ville climb. The route continues through Misty Cliffs where temperatures drop 5-6 degrees, then up Chapman's Peak described as the most beautiful road in the world. The course finishes through Sea Point after going over Suikerbossie. Race week sees Cape Town buzzing with energy as riders arrive from Johannesburg and across South Africa. Training approaches vary widely during taper week, with some riders doing their final ride days before the event while others continue high-intensity intervals. The event maintains its original purpose of getting more people cycling for commuting, not just racing, and serves as a major charity fundraising platform."
@@ -7980,6 +8213,7 @@
     "has_profile": true,
     "profile_url": "/race/death-ride/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 38.694,
     "lng": -119.774,
     "st": "The Death Ride features Monitor Pass as a major challenge, with front and back sides making up approximately 28 miles of the course. The climb starts with a brutal 10% grade that leaves many riders with no remaining gears. Key locations include Highway 89 junction near Markleeville and Topaz Junction where riders receive pass stickers. The course offers incredible support with two water stops and two full rest stops on Monitor Pass alone. A CareFlight helicopter is stationed at the summit for safety. The famous Right of Passage water station provides energetic valet-style service before 5 miles of steep climbing. The west side descent is described as the most thrilling downhill, with speeds reaching 55 mph on sweeping turns. Bike mechanics are available at Topaz Junction for repairs."
@@ -8015,6 +8249,7 @@
     "has_profile": true,
     "profile_url": "/race/dragon-ride/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 51.5577,
     "lng": -3.722,
     "st": "The Dragon Ride L'Etape Wales takes place entirely on open roads through stunning Welsh landscapes designed by ASO, the company behind the Tour de France. Riders must obey traffic laws including stopping at red lights and cycling no more than two abreast. The course features wild terrain with potential livestock and sheep on the roads that riders need to watch for. The medio Fondo distance covers 153km with two feed stations, while the grand Fondo covers 228km with four feed stations. Navigation follows a color-coded arrow system - medio Fondo riders start on yellow arrows, switch to green, then back to yellow, while grand Fondo riders follow yellow arrows only throughout. Riders are encouraged to communicate dangers like pot holes to each other and use feed stations to replenish bottles and fuel."
@@ -8049,7 +8284,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/epic-gran-canaria/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Eroica Dolomiti",
@@ -8081,7 +8317,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/eroica-dolomiti/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "In Flanders Fields Cyclo - Wevelgem",
@@ -8114,6 +8351,7 @@
     "has_profile": true,
     "profile_url": "/race/gent-wevelgem-cyclo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Gent-Wevelgem sportive features narrow winding roads with quick hard turns, undulating hills, and changing road surfaces including cobblestones and gravel sections. Key challenges include the Kimelberg climb reaching 22% grade where riders recommend low gearing like 35x28, and the Plug Streets gravel roads described as fairly tame. The course includes wind, bumpy streets, and climbs throughout. Riders can start whenever they like to manage crowds of 6,700 people on narrow roads. The area is steeped in World War I history. Feed zones offer Belgian specialties like waffles and chocolate. Local cycling culture embraces close-quarters riding with strong technical skills. The route offers distance options of 140k or 215k, finishing on the same stretch as the professional race."
   },
   {
@@ -8145,7 +8383,8 @@
     "tagline": "BE A PRO FOR A DAY in Mexico's cycling hotbed with views of Cerro del Muerto",
     "has_profile": true,
     "profile_url": "/race/gfny-aguascalientes/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY Punta del Este",
@@ -8178,6 +8417,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-punta-del-este/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -34.9636,
     "lng": -54.9491
   },
@@ -8211,7 +8451,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-uppsala/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY Villard de Lans",
@@ -8244,6 +8485,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-villard-de-lans/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The available transcript for GFNY Villard de Lans contains only music lyrics and audio without any race-specific content or rider commentary about the course, conditions, or racing experience. No actionable intelligence about this 60-mile gravel race in Villard-de-Lans, France could be extracted from the provided material."
   },
   {
@@ -8277,6 +8519,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-nirvana-antalya/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 36.8969,
     "lng": 30.7133
   },
@@ -8310,7 +8553,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-gf-do-porto/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Granfondo Vosges",
@@ -8342,7 +8586,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-vosges/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Gravel Brazil",
@@ -8374,6 +8619,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-brazil/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -26.9924,
     "lng": -48.634,
     "thumb": "/race-photos/gravel-brazil/gravel-brazil-video-1.jpg"
@@ -8409,6 +8655,7 @@
     "has_profile": true,
     "profile_url": "/race/gruyere-cycling-tour/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The transcript provided does not contain race-specific content about the Gruyère Cycling Tour. Instead, it shows visitors exploring the historic town of Gruyères, which dates back to the 1500s, including visits to the Cailler Chocolate Factory and observations about the medieval château and local attractions. The speakers mention investigating the area ahead of a Tour de France stage but do not discuss gravel cycling race conditions, course features, terrain challenges, or race-day experiences specific to the Gruyère Cycling Tour event."
   },
   {
@@ -8441,6 +8688,7 @@
     "has_profile": true,
     "profile_url": "/race/heck-of-the-north/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 47.0257,
     "lng": -91.6731,
     "st": "Heck of the North features challenging terrain including rough ATV trails that make riders wish they brought mountain bikes instead of gravel bikes. The course includes technical snowmobile trail sections with very wet, muddy conditions requiring riders to walk through multiple cold ponds barefoot. Bridge crossings have slats that can catch 38mm tires. The race takes place in late September when northern Minnesota foliage is changing colors. Riders report the ATV sections are bumpy enough that it's difficult to see rocks clearly. Course scouting is recommended to identify navigation points and problem areas. Early pacing is critical as riders report being exhausted by mile 40 when going out too hard with fast groups. Weather can be cold requiring winter layers that need to be shed as the sun comes out.",
@@ -8477,6 +8725,7 @@
     "has_profile": true,
     "profile_url": "/race/istria-granfondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.4342,
     "lng": 13.5254,
     "st": "The available transcript from the Istria Granfondo in Umag, Croatia provides very limited information about the race experience. The only clear element mentioned by riders is heat being a significant factor during the event. However, the transcript lacks detailed descriptions of the 69.6-mile course, specific terrain conditions, gear recommendations, or actionable race advice that would typically be shared in race video content. More comprehensive video transcripts would be needed to provide riders with meaningful intelligence about course features, surface conditions, key challenges along the route, pacing strategies, or logistical considerations for this Croatian gravel event."
@@ -8512,6 +8761,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-norway/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 63.4469,
     "lng": 10.395,
     "st": "L'Etape Norway by Tour de France is a 135km gran fondo with 4,500 meters of elevation gain featuring five major climbs. The race attracts approximately 15,000 participants, making it one of Europe's largest fondos. The course replicates an actual Tour de France stage route. Key challenges include a massive final climb to Alpe d'Huez that's 20 kilometers long averaging 7% grade. Riders recommend using smaller chainrings due to the extensive climbing. The race features wave starts with numbered categories. There's a significant 19km descent after the first climb that provides opportunity for nutrition and recovery. Pacing strategy involves maintaining an easy 6 watts per kilo on early climbs. The event takes place in July in the French Alps, requiring pre-race registration and offering a full event village experience for participants."
@@ -8547,6 +8797,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-slovenia/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "L'Étape Slovenia by Tour de France is a 75-mile gravel event with 5900 feet of elevation in Kranj, Slovenia. The race route passes through roads that helped shape professional cyclist Tadej Pogačar's development, as he mentions riders will cycle through his hometown of Kranj and the surrounding area. The event is positioned as offering beautiful roads through the Slovenian countryside that were formative for one of cycling's biggest stars. Limited specific course details are available from rider accounts, but the event promises scenic terrain through the region that produced world-class cycling talent."
   },
   {
@@ -8580,6 +8831,7 @@
     "has_profile": true,
     "profile_url": "/race/mt-washington-hillclimb/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.2882,
     "lng": -71.2261
   },
@@ -8613,7 +8865,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/nordsjorittet/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Nove Colli",
@@ -8646,6 +8899,7 @@
     "has_profile": true,
     "profile_url": "/race/nove-colli/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.199,
     "lng": 12.395
   },
@@ -8680,6 +8934,7 @@
     "has_profile": true,
     "profile_url": "/race/pedal-imua/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Pedal IMUA is a 60-mile gravel event in Maui starting at UA Discovery Garden in Wailuku with approximately 4,000 feet of climbing. The route features mountain passes with ocean views and jungle terrain, though some sections have narrow roads. Riders face a few short steep climbs in the northern section and a significant final climb around mile 52. Wet, tight corners pose crash risks, particularly later in the route around mile 47. The event supports Maui Family Services' Dream IMUA program for children and families in crisis. One experienced rider completed the course in 4 hours despite dealing with tire issues. The route offers stunning island scenery but requires caution on technical sections with narrow roads and potentially slippery corners."
   },
   {
@@ -8712,7 +8967,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-around-rwanda/",
-    "discipline": "bikepacking"
+    "discipline": "bikepacking",
+    "has_tire_guide": false
   },
   {
     "name": "Rad Dirt Fest",
@@ -8744,6 +9000,7 @@
     "has_profile": true,
     "profile_url": "/race/rad-dirt-fest/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.5371,
     "lng": -105.991,
     "st": "Rad Dirt Fest in Trinidad, Colorado features challenging terrain that transitions from flat plains to mountainous climbing toward the Spanish Peaks. The race starts with a punchy 20+ percent grade climb that creates early selection and visibility for the field. After 113 miles of racing, riders face a final left turn onto Main Street to reach the finish. The course includes difficult sections of deep rock gravel that riders find challenging to ride on for extended distances. Weather can be a factor with sudden storms making clay-like road surfaces sticky and slick. One particularly tough section involves highway riding with 65 mph traffic and no shoulder. The race has tactical elements beyond pure fitness, with riders playing chess match games especially at the bottom of climbs. Trinidad has developed gravel cycling tourism with curated routes for visitors. The community strongly supports the event with local businesses and volunteers partnering to make the race possible.",
@@ -8779,6 +9036,7 @@
     "has_profile": true,
     "profile_url": "/race/southern-cross-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.5328,
     "lng": -83.9846,
     "rwgps_id": "32690265",
@@ -8815,7 +9073,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-aotearoa/",
-    "discipline": "bikepacking"
+    "discipline": "bikepacking",
+    "has_tire_guide": false
   },
   {
     "name": "Vermont Overland",
@@ -8847,6 +9106,7 @@
     "has_profile": true,
     "profile_url": "/race/vermont-overland/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.6248,
     "lng": -72.519,
     "rwgps_id": "37223600",
@@ -8883,6 +9143,7 @@
     "has_profile": true,
     "profile_url": "/race/almanzo-100/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.687,
     "lng": -92.3893,
     "rwgps_id": "38583053",
@@ -8920,6 +9181,7 @@
     "has_profile": true,
     "profile_url": "/race/arlberg-giro/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 47.1279,
     "lng": 10.2683
   },
@@ -8953,6 +9215,7 @@
     "has_profile": true,
     "profile_url": "/race/bootlegger-100/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.5328,
     "lng": -83.9846,
     "rwgps_id": "45519300",
@@ -8989,7 +9252,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/bra-bra-fenix-internazionale/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Chase the Sun Norway",
@@ -9021,7 +9285,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/chase-the-sun-norway/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY Chiang Mai",
@@ -9053,7 +9318,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/chiang-mai-gran-fondo/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Copper Triangle — Colorado's Three-Pass Alpine Loop",
@@ -9086,6 +9352,7 @@
     "has_profile": true,
     "profile_url": "/race/copper-triangle/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 39.502,
     "lng": -106.149
   },
@@ -9120,6 +9387,7 @@
     "has_profile": true,
     "profile_url": "/race/crc-506-gran-fondo-costa-rica/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 9.54,
     "lng": -84.63,
     "st": "The available transcript for the CRC 506 Gran Fondo Costa Rica contains minimal intelligible content, with only brief mentions of heat and music. No specific course details, terrain descriptions, or racing insights are provided in the transcript. The race is an 87.6-mile gravel event in Jacó, Costa Rica with 2,759 feet of elevation gain, but rider experiences and course characteristics cannot be extracted from the current transcript material."
@@ -9155,6 +9423,7 @@
     "has_profile": true,
     "profile_url": "/race/cycle-oregon/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 42.439,
     "lng": -123.328
   },
@@ -9188,7 +9457,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/eroica-hispania/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY Bali",
@@ -9221,6 +9491,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-bali/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -8.5765,
     "lng": 115.4072,
     "st": "GFNY Bali features two key climbs that define the race outcome. Gage Hill, the second major climb, is a 3.5-kilometer power climb with 5.2% average gradient and maximum pitches of 8.9%. The climb has three distinct ramps at the beginning, middle, and end that all reach nearly nine percent grade. Riders approach from a sharp right-hand turn with minimal speed, making gear selection critical. This is where attacks typically happen and where previous winners made race-winning moves. Immediately after Gage Hill, riders face Cheese Cup climb following a fast descent and left turn, creating a challenging double-climb section. The course continues with rolling terrain and requires riders to navigate out of a park section described as particularly tough."
@@ -9255,7 +9526,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-bento-goncalves/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY Philippines",
@@ -9287,7 +9559,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-philippines/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Coimbra Region",
@@ -9319,7 +9592,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-coimbra/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Il Lombardia",
@@ -9352,6 +9626,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-il-lombardia/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.6983,
     "lng": 9.6773
   },
@@ -9386,6 +9661,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-pirineus/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Gran Fondo Pirineus route through the Pyrenees features a distinct elevation profile with mainly downhill terrain for the first half and all climbing packed into the end. Riders report significant weather variability, with conditions changing from sunny to gray skies and rain threats that can affect start times. Construction issues may force route diversions from the planned course. The area has limited route options to reach the coast, often bringing riders back to familiar territory. Temperature was around 19C during one rider's experience. Weather forecasts consistently showed rain inundating the area, requiring early starts to stay ahead of storms. There's a notable dangerous hard right turn near the hotel finish area where crashes have occurred."
   },
   {
@@ -9418,7 +9694,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-alpe-adria/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "BGY Airport Granfondo (Granfondo Felice Gimondi)",
@@ -9451,6 +9728,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-felice-gimondi/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.694,
     "lng": 9.67,
     "st": "The provided transcript for the BGY Airport Granfondo (Granfondo Felice Gimondi) in Bergamo, Italy contains no meaningful rider commentary or race information. The transcript consists primarily of music, applause, and fragmented words without substantive content about the 92-mile course, terrain conditions, race challenges, or rider experiences. No specific details about the race route, elevation profile, surface conditions, or race day logistics are available from this source. Additional video content would be needed to provide actionable intelligence for riders considering this Tier 2 gravel event in Lombardy."
@@ -9486,6 +9764,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-laigueglia/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "No actionable race intelligence was available in the provided transcript for Granfondo Laigueglia. The transcript appears to contain only song lyrics rather than race-specific content about the 87-mile course through Laigueglia, Liguria, Italy, or details about the 8,202 feet of elevation gain that characterizes this challenging Italian granfondo event."
   },
   {
@@ -9518,7 +9797,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-leiria/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "UCI Gran Fondo Brasil",
@@ -9550,7 +9830,8 @@
     "tagline": "South America's Premier UCI Gran Fondo Qualifier in Germany-Heritage Santa Catarina",
     "has_profile": true,
     "profile_url": "/race/granfondo-pomerode/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Gravel Burn",
@@ -9582,6 +9863,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-burn/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -26.2768,
     "lng": 30.15,
     "st": "Gravel Burn is a seven-stage, 786-800km gravel race across South Africa featuring extreme terrain variations and challenging conditions. Key obstacles include the brutal Shellot climb with rocks, stones and loose terrain that forces riders to dismount, and the 14km Prince Alfred's Pass climb reaching over 1,000m elevation. Stage one presents muddy, slippery forest sections in wet conditions cold enough to destroy brake pads. The race traverses from coastal forests through the Karu Desert to wildlife reserves, with stages including 80km tarmac sections. Riders face extreme weather from freezing nighttime temperatures that freeze tents and gear to desert heat. The event combines professional racing with a $150,000 prize purse and burn camps featuring communal dining and campfires. Terrain constantly changes making flat stages potentially the hardest, requiring strategic pacing across the week-long effort.",
@@ -9617,6 +9899,7 @@
     "has_profile": true,
     "profile_url": "/race/grinduro-california/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.931,
     "lng": -120.9536,
     "series_id": "grinduro",
@@ -9654,7 +9937,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/jedermann-rennen-koln/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "L'Étape Mexico City",
@@ -9686,6 +9970,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-mexico-city/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 19.4326,
     "lng": -99.1332
   },
@@ -9720,6 +10005,7 @@
     "has_profile": true,
     "profile_url": "/race/maraton-franja/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.056,
     "lng": 14.508
   },
@@ -9754,6 +10040,7 @@
     "has_profile": true,
     "profile_url": "/race/nxt-classic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "No relevant race content was found in the provided transcripts for the NXT Classic gravel race in Eijsden, Limburg, Netherlands. The transcripts contain content about pranks and motorcycle reviews, but do not include any information about the 93-mile gravel race, its terrain, course conditions, elevation challenges, or rider experiences that would be useful for race preparation or intelligence gathering."
   },
   {
@@ -9787,6 +10074,7 @@
     "has_profile": true,
     "profile_url": "/race/old-mutual-wealth-double-century/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Old Mutual Wealth Double Century in Swellendam, Western Cape is described by riders as a team-oriented event emphasizing camaraderie and teamwork. Participants highlight that while it's a tough journey, doing it as a team makes the experience much easier. The race is characterized as the best end-of-year party for cyclists in South Africa, focusing on bringing friends together for a great day out in the Western Cape countryside. The event is noted for its unique team format and strong community atmosphere, with riders emphasizing the social and collaborative aspects over individual competition. The race takes place in the scenic countryside around Swellendam."
   },
   {
@@ -9819,6 +10107,7 @@
     "has_profile": true,
     "profile_url": "/race/paris-to-ancaster/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.2,
     "lng": -80.3833,
     "rwgps_id": "53024230",
@@ -9856,6 +10145,7 @@
     "has_profile": true,
     "profile_url": "/race/peaks-challenge-falls-creek/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -36.862,
     "lng": 147.277,
     "st": "Peaks Challenge Falls Creek is described as equivalent to a Tour de France stage and ranked as one of the top 10 grand fondos in the world. The 235km route with 4,500m elevation gain starts with a 45-minute Alpine descent in darkness with 2,500+ riders, featuring fast flowing terrain but dangerous potholes. Tawonga Gap is a consistent 20-minute FTP test climb that riders tackle at threshold pace, followed by its cracker descent that's considered the best of the event. The Monster section includes hour-plus climbs through Hotham and frying pan areas. Hydration management is critical as riders face 7+ hour efforts. The event takes everything mentally and physically, with riders describing it as a beast that will test limits. Feed station logistics are important with riders sending emergency bags to Angler's Rest and dinner point containing extra carbs and supplies."
@@ -9891,6 +10181,7 @@
     "has_profile": true,
     "profile_url": "/race/rad-am-ring/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 50.3356,
     "lng": 6.9475
   },
@@ -9924,7 +10215,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/raul-alcala-challenge-oaxaca/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Rule of Three",
@@ -9957,6 +10249,7 @@
     "has_profile": true,
     "profile_url": "/race/rule-of-three/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.404,
     "lng": -96.1816,
     "st": "Rule of Three in Emporia, Kansas uses the same roads as Unbound Gravel, featuring the challenging Flint Hills terrain. Riders describe the North Course as particularly punchy and chunky with massive rocks that create a relentless beatdown over the 300-mile distance. The gravel feels like massive rocks that pound riders' bodies throughout the race. Key challenges include managing the rocky, chunky terrain that destroys equipment, with many races ending from flat tires, mechanicals, and broken wheels. The course demands significant preparation and respect, with high speeds and chaos in the field. Riders emphasize not starting too fast, especially from cold starts, and sticking to familiar tire pressures rather than going higher to avoid punctures. The terrain is described as way tougher than other gravel areas, requiring strong wheels and careful pacing. The race is highly unpredictable due to mechanical issues, and perfect scenarios don't exist in this 10.5-hour suffer-fest through the Flint Hills.",
@@ -9992,7 +10285,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/velomediane-criquielion/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Vermont Gran Fondo",
@@ -10025,6 +10319,7 @@
     "has_profile": true,
     "profile_url": "/race/vermont-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The provided transcript does not contain information about the Vermont Gran Fondo race. The video appears to be a casual bike ride in the Brattleboro area with a rider testing GoPro equipment and climbing a mountain, but contains no specific details about the Vermont Gran Fondo course, conditions, challenges, or race experience. No actionable intelligence about the 62-mile gravel race in Stowe, Vermont can be extracted from this content."
   },
   {
@@ -10057,7 +10352,8 @@
     "tagline": "UCI Gran Fondo qualifier through German vineyards and into France",
     "has_profile": true,
     "profile_url": "/race/3rides-gran-fondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Bluewater International Gran Fondo",
@@ -10089,7 +10385,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/bluewater-gran-fondo/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Les Cinglés du Mont Ventoux",
@@ -10122,6 +10419,7 @@
     "has_profile": true,
     "profile_url": "/race/cingles-du-mont-ventoux/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.174,
     "lng": 5.279
   },
@@ -10155,6 +10453,7 @@
     "has_profile": true,
     "profile_url": "/race/collegiate-gravel-nationals/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.3939,
     "lng": -100.8941,
     "st": "The Collegiate Gravel Nationals in Turkey, Texas featured demanding racing conditions with riders pushing exceptional power numbers throughout the 62-mile course. Power data shows normalized power outputs of 370-380 watts for 5+ hours, with climbs requiring 430-500+ watts repeatedly. The course proved punchy with multiple selection points on climbs, where riders averaged over 450 watts each time. Weather conditions were described as cooler than previous years, with mostly dry course conditions except for a few wet sections in tree-covered areas. The terrain allowed for relatively fast racing at around 38 km/hour average speeds during flatter sections, though constant elevation changes and lack of drafting opportunities made for extremely high energy demands. Multiple climbs featured 6-9 minute sustained efforts at 430+ watts, creating significant selections in the field throughout the race.",
@@ -10190,7 +10489,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/eroica-germania/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Eroica South Africa",
@@ -10222,7 +10522,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/eroica-south-africa/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Final Frontier Patagonia",
@@ -10254,7 +10555,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/final-frontier-patagonia/",
-    "discipline": "bikepacking"
+    "discipline": "bikepacking",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo & Ultra Raid Samoëns",
@@ -10286,7 +10588,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gf-samoens-ultra-raid/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY Dominican Republic",
@@ -10318,7 +10621,8 @@
     "tagline": "Be a Pro For A Day in Paradise",
     "has_profile": true,
     "profile_url": "/race/gfny-dominican-republic/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY New York",
@@ -10351,6 +10655,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-new-york/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 40.8517,
     "lng": -73.9527,
     "st": "GFNY New York features over 2500 riders starting on the George Washington Bridge. The course includes a scenic forest section with challenging cobbles that riders struggle to navigate. The key difficulty comes from the Gate Hill to Cheesecote climb combination, described as crunch time where the peloton gets shattered. Gate Hill is followed immediately by a fast one-kilometer descent, then riders turn right into Cheesecote, a 1.5-kilometer climb averaging 5.2% grade with double-digit ramps at the start. This is considered the last very steep hill and a critical attack point where riders either make differences or get dropped. After this combo, rolling hills continue to the finish. The expo features bike mechanics who help riders whose bikes need adjustment after air travel."
@@ -10386,6 +10691,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-pittsburgh/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 40.4237,
     "lng": -79.7849
   },
@@ -10419,7 +10725,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-zapopan/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Giro d'Italia Ride Like a Pro USA",
@@ -10452,6 +10759,7 @@
     "has_profile": true,
     "profile_url": "/race/giro-ride-like-a-pro-usa/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 25.7743,
     "lng": -80.3542,
     "st": "The transcripts focus on general cycling training and nutrition advice rather than the specific Giro d'Italia Ride Like a Pro USA race in Doral, Florida. Riders emphasize the importance of proper fueling for long distance events, recommending 60-120 grams of carbohydrates per hour depending on intensity and duration. The advice includes eating every 13 minutes, starting with real foods like brioche with jam in the first half and switching to energy bars and gels later. Training recommendations include high intensity interval training 2-4 times per week combined with longer endurance rides. The content stresses practicing nutrition strategies during training rides to avoid stomach issues on race day. However, no specific information about the Florida race course, terrain conditions, or race-specific challenges was found in these transcripts."
@@ -10486,7 +10794,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-hainan/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Kazakhstan",
@@ -10519,6 +10828,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-kazakhstan/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The available transcript from the Gran Fondo Kazakhstan in Almaty provides limited race-specific information. One participant expressed appreciation for the event organization and their experience returning to the race. However, the transcript lacks detailed information about course conditions, terrain challenges, specific mile markers, gear recommendations, or race day logistics that would typically inform riders preparing for this 62-mile gravel event with 3500 feet of elevation gain. More comprehensive video content would be needed to provide actionable intelligence about the course features, surface conditions, key climbs, pacing strategies, or equipment considerations for this Tier 2 gravel race in Kazakhstan."
   },
   {
@@ -10552,6 +10862,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-loutraki/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The UCI Gran Fondo Loutraki takes place in a spectacular coastal setting near Lorne. The race features an opening climb right from the start that riders describe as a key early challenge. The course includes technical descents that are described as mad fun and fast-paced. Temperature varies significantly between locations, with it being much warmer down in Lorne compared to higher elevations. Riders recommend doing race openers the day before consisting of zone three and four efforts plus sprints. Logistics can be challenging with bike travel, and mechanical issues like brake problems may arise from flights. The coastal location provides amazing views along the surf coast, making it a visually spectacular race venue despite the physical demands."
   },
   {
@@ -10585,6 +10896,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-alberto-contador/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 38.919,
     "lng": -0.123,
     "st": "The provided transcript from the Gran Fondo Alberto Contador race video does not contain rider commentary or race-specific information. The transcript consists entirely of music lyrics and crowd audio from what appears to be a highlight reel or promotional video. No actionable intelligence about the 91-mile course through Oliva, Valencia, or its 8,327 feet of elevation gain can be extracted from this source. Riders looking for course details, terrain conditions, gear recommendations, or race strategy advice will need to reference other sources, as this video appears to focus on atmosphere and music rather than technical race content."
@@ -10620,6 +10932,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-eddy-merckx/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 50.4875,
     "lng": 5.0958
   },
@@ -10653,7 +10966,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-siete-lagos/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Granfondo Yunnan",
@@ -10685,7 +10999,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-yunnan/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Highlands Gravel Classic",
@@ -10717,6 +11032,7 @@
     "has_profile": true,
     "profile_url": "/race/highlands-gravel-classic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 36.1012,
     "lng": -93.9913,
     "rwgps_id": "45297663",
@@ -10753,7 +11069,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/k2-road-ride/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Majka Gran Fondo",
@@ -10785,7 +11102,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/majka-gran-fondo/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Granfondo Sestriere — Colle delle Finestre",
@@ -10818,6 +11136,7 @@
     "has_profile": true,
     "profile_url": "/race/marmotte-granfondo-sestriere/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.948,
     "lng": 6.853
   },
@@ -10851,7 +11170,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-around-austria/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Race Around Poland",
@@ -10883,7 +11203,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-around-poland/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Rock Cobbler",
@@ -10915,6 +11236,7 @@
     "has_profile": true,
     "profile_url": "/race/rock-cobbler/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.3739,
     "lng": -119.0195,
     "rwgps_id": "45578777",
@@ -10952,6 +11274,7 @@
     "has_profile": true,
     "profile_url": "/race/suzuka-endurance-road/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Suzuka Endurance Road takes place at the legendary Suzuka Circuit, home to Japan's most popular motorsport event since 1978. Riders describe this as a challenging endurance race where heat management is crucial. The paddock setup is notably different from European events, being smaller with fewer support vehicles. Teams use specialized cooling facilities including air-conditioned rooms, ice baths, and equipment drying systems between riding stints. Riders emphasize the importance of consistency over aggressive riding, noting that many things can happen over the long distance. The Japanese organization is praised, with support staff washing and maintaining gear after every stint. The atmosphere is described as fantastic with enthusiastic fans, and the circuit holds special significance for Japanese manufacturers who view it as their home ground and a critical part of their racing philosophy."
   },
   {
@@ -10984,6 +11307,7 @@
     "has_profile": true,
     "profile_url": "/race/the-gralloch/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 56.8,
     "lng": -5.0,
     "rwgps_id": "53947683",
@@ -11021,6 +11345,7 @@
     "has_profile": true,
     "profile_url": "/race/tjejvattern/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "TjejVättern features designated garbage zones every kilometer where riders can dispose of waste rather than littering along the course, with support crews collecting trash at these specific locations. The race has a rolling start format where people continue starting throughout the day. Support vehicles follow cyclists along the route to assist with mechanical issues and injuries. Early mechanical failures can end races quickly, as demonstrated by one rider whose back axle broke after a crash just an hour into the event. The course appears scenic based on support crew observations, though specific terrain details are not described in available rider accounts."
   },
   {
@@ -11053,6 +11378,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-big-bear/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 34.2439,
     "lng": -116.9114,
     "st": "Tour de Big Bear is a 100-mile grand fondo in Big Bear Lake, California with 8,000+ feet of climbing. Riders describe the start as chaotic, zigzagging through neighborhoods before opening up. Key challenges include the first big climb at Onyx Pass around mile 43, which features a KOM/QOM timing segment from bottom to summit. The route goes around Big Bear Lake with beautiful scenery on the north and northeast sides. Cedar Falls serves as the turnaround point where riders still face 4,000 feet of climbing in the final 30 miles. Onyx Summit is described as particularly brutal. The event offers multiple distance options and includes aid stations throughout. Weather starts cold at 50-55 degrees in the morning but warms up significantly. Riders recommend starting near the front if experienced, arriving early for parking, and conserving energy for the challenging climbs."
@@ -11088,6 +11414,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-of-pembrokeshire/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Tour of Pembrokeshire features determined riders crossing the finish line in challenging conditions. Past race coverage shows riders competing through rain, with the long course being a significant test of endurance. The race appears to attract committed gravel cyclists willing to push through difficult weather conditions to complete the 105-mile distance with 10,000 feet of elevation gain through the Welsh countryside around St Davids."
   },
   {
@@ -11120,7 +11447,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/transatlanticway/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "BWR Arizona",
@@ -11152,6 +11480,7 @@
     "has_profile": true,
     "profile_url": "/race/bwr-arizona/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 33.72,
     "lng": -111.6727,
     "series_id": "belgian-waffle-ride",
@@ -11189,6 +11518,7 @@
     "has_profile": true,
     "profile_url": "/race/cyclassics-hamburg/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 53.551,
     "lng": 9.994,
     "st": "Cyclassics Hamburg features 22,000 participants making it Europe's biggest cycling competition according to riders. The race offers both 100km and 155km distance options for participants. Weather conditions in Hamburg are described as typically unpredictable German weather, though race day can feature blue skies and brilliant conditions. The event takes place in late August and includes professional racing with Eurosport coverage. The race features VIP zones and support areas for teams like Alpecin. Riders emphasize hoping for good weather conditions and minimal crashes during the event. The finish line area is well-organized with spectator zones. The race attracts both professional cyclists and amateur participants, creating a large-scale cycling festival atmosphere in Hamburg."
@@ -11223,6 +11553,7 @@
     "has_profile": true,
     "profile_url": "/race/fuego-mtb/",
     "discipline": "mtb",
+    "has_tire_guide": true,
     "lat": 36.2231,
     "lng": -121.3877,
     "rwgps_id": "50233490",
@@ -11259,6 +11590,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-hincapie/",
     "discipline": "road",
+    "has_tire_guide": true,
     "lat": 34.9684,
     "lng": -82.4417,
     "rwgps_id": "44781186",
@@ -11296,6 +11628,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-marco-pantani/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.199,
     "lng": 12.395,
     "st": "The Gran Fondo Marco Pantani takes riders through the heart of the Italian Alps with extreme elevation gain. Riders report covering 172 kilometers with 4,000 meters of climbing including three brutal climbs. The Mortirolo is described as really tough with absolutely no respite, while Santa Cristina comes as an unwelcome challenge late in the race. The course reaches altitudes above 1,700 meters with another 900 meters still to climb, passing through multiple cloud layers. Key tactical knowledge includes that the first kilometer of major climbs is deceptively easy before ramping up significantly, and riders face 5-6 kilometers of false flat sections after climbs before descents begin. Snow and cold conditions can make descents particularly challenging and potentially race-defining."
@@ -11331,6 +11664,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-mont-tremblant/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Gran Fondo Mont-Tremblant is a mass cycling event in the beautiful Mont-Tremblant region of Quebec that caters to close to 2000 cyclists. The event offers two distances: 80k for beginners and those new to the sport, and 125k for more challenging riding. Riders describe beautiful roads with stunning scenery throughout the region. The event provides police security that allows cyclists to ride safely through red lights without worrying about traffic. Feed stations provide drinks and food along the route. The atmosphere is described as having Tour de France prestige with police escorts, creating a safe and fun environment for both experienced riders and first-timers to learn group riding skills. Local communities are welcoming, with station workers expressing amazement at seeing so many cyclists together. The event concludes with food, friends, drinks and a big party celebration, following the traditional Italian gran fondo format of bringing the cycling community together."
   },
   {
@@ -11364,6 +11698,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-zadar/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The available transcripts for Gran Fondo Zadar consist primarily of music lyrics, audio fragments, and non-English content that do not provide actionable race intelligence. While the race takes place in Zadar, Croatia over 62 miles with 2800 feet of elevation gain, the video content analyzed does not contain rider commentary about course conditions, terrain features, or race strategy. The transcripts appear to be heavily music-focused with minimal spoken analysis of the actual cycling experience, route challenges, or practical advice for participants considering this Croatian gravel event."
   },
   {
@@ -11397,6 +11732,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-belgium/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 50.173,
     "lng": 4.333
   },
@@ -11430,6 +11766,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-and-tar-classic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -39.6408,
     "lng": 175.5714,
     "rwgps_id": "45397123",
@@ -11466,6 +11803,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-roubaix/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.8015,
     "lng": -75.6102,
     "rwgps_id": "53316252"
@@ -11500,6 +11838,7 @@
     "has_profile": true,
     "profile_url": "/race/grinduro-canada/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 47.5577,
     "lng": -70.5398,
     "rwgps_id": "37775773",
@@ -11537,7 +11876,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/halvvattern/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Hong Kong Cyclothon",
@@ -11569,7 +11909,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/hong-kong-cyclothon/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Jämtlandspilen",
@@ -11601,7 +11942,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/jamtlandspilen/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Les Trois Ballons",
@@ -11633,7 +11975,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/les-trois-ballons/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Pan-Mass Challenge (PMC)",
@@ -11666,6 +12009,7 @@
     "has_profile": true,
     "profile_url": "/race/pan-mass-challenge/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 42.2373,
     "lng": -71.8078
   },
@@ -11699,7 +12043,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/sovev-jerusalem/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Dekom System Sudety Tour",
@@ -11732,6 +12077,7 @@
     "has_profile": true,
     "profile_url": "/race/sudety-tour/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Dekom System Sudety Tour transcripts reveal limited specific information about this Czech gravel race. One video discusses a different mountain bike event in Lanka featuring hot, sticky conditions with technical jungle sections. That race involved dehydration, heat stroke, gear problems, and flat tires as major challenges for riders navigating technical terrain through dense jungle areas. The course was described as tough to adapt to, with conditions that could make or break qualification chances. However, the available transcripts do not contain specific details about the Broumov, Czechia course conditions, terrain characteristics, or race-specific challenges that riders would face during the 93-mile Sudety Tour event."
   },
   {
@@ -11765,6 +12111,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-lile-de-montreal/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.5017,
     "lng": -73.5673,
     "st": "The provided transcript does not contain any substantive information about the Tour de l'Île de Montréal gravel race. The transcript appears to be primarily music and fragmented conversation unrelated to cycling or race conditions. No rider intelligence regarding course features, terrain conditions, gear recommendations, or race strategy could be extracted from this source."
@@ -11800,6 +12147,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-yorkshire-sportive/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 53.959,
     "lng": -1.08,
     "st": "The Tour de Yorkshire Sportive covers 123 kilometers with significant climbing throughout the course according to rider accounts. Pre-race preparation focuses heavily on hydration strategy, with experienced riders recommending 2-3 days of pre-hydration at 2+ liters daily before the event starts. The Yorkshire terrain requires comprehensive gear preparation including multiple spare tubes, tire levers, and weather-appropriate clothing layers. Riders recommend packing arm warmers, knee warmers, leg warmers, and multiple rain cape options for changing conditions. Nutrition strategy involves carrying 9+ energy gels, more than riders initially think they need. The race attracts cyclists who view thorough preparation as essential, with emphasis on mechanical preparedness and weather contingency planning. Based in Leeds, the event showcases Yorkshire's challenging terrain requiring both climbing fitness and tactical gear selection."
@@ -11835,6 +12183,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-down-under-community-ride/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Tour Down Under Community Ride is a charity cycling event in Adelaide's southern suburbs that attracts approximately 3,000 participants on two and three-wheeled bikes. The route starts at Flinders University and follows the Southern Expressway toward McLaren Vale, with riders choosing between 25km and 100km distance options. The longer 100km route proves challenging, with riders experiencing fatigue and requiring unexpected pit stops along the way. The event serves as both a memorial ride for cyclist Amy Gillet and a road safety awareness initiative. Riders wear lycra and participate in waves, creating a significant presence on Adelaide's roads. The community aspect is strong, with the event aiming to raise over $100,000 for road safety initiatives while promoting safe cycling practices and educating both motorists and cyclists about road sharing."
   },
   {
@@ -11867,7 +12216,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/velothon-berlin/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Atlas Gran Fondo",
@@ -11899,7 +12249,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/atlas-gran-fondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Belgrade Gran Fondo",
@@ -11932,6 +12283,7 @@
     "has_profile": true,
     "profile_url": "/race/belgrade-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The transcripts mention training approaches for grand fondo events, including 100K endurance rides and post-training recovery protocols. Riders discuss taking amino acids after training, showering before eating, and waiting 20-30 minutes before consuming food after supplements. Equipment discussions focus on bike selection with full size ranges from 44 to 64, featuring aluminum, carbon fiber, and steel frame options in the $1,000-$2,000 range. Training camp conditions included rainy weather and temperatures around 10 degrees Celsius. Riders emphasize the importance of completing Strava challenges for grand fondo and climbing segments. The content suggests structured training approaches with emphasis on endurance building and proper recovery protocols for grand fondo preparation."
   },
   {
@@ -11965,6 +12317,7 @@
     "has_profile": true,
     "profile_url": "/race/bordeaux-paris-ultra-cycling/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "This historical recreation of the original 1903 Tour de France first stage from Paris to Lyon covered 467 kilometers, double the distance of modern Tour stages. Riders describe the challenge as utterly indescribably tough and one of the most ridiculous things ever done on two wheels. The original route featured terrible road conditions including cart tracks and dirt surfaces that made maintaining racing pace extremely difficult. Historical equipment included heavy bikes with unreliable back brakes, aggressive racing positions despite the ultra-distance, and limited gearing around 45-46 front chainring with 18-tooth rear. The 1903 stage started at 3:16 PM after delays due to rider complaints about poor road conditions. Only two riders finished the stage together in a breakaway, including winner Maurice Garan and an amateur underdog, highlighting the extreme difficulty and attrition rate of early Tour stages."
   },
   {
@@ -11997,7 +12350,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/deccan-cliffhanger/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Engadin Radmarathon",
@@ -12030,6 +12384,7 @@
     "has_profile": true,
     "profile_url": "/race/engadin-radmarathon/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 46.697,
     "lng": 10.094
   },
@@ -12064,6 +12419,7 @@
     "has_profile": true,
     "profile_url": "/race/eroica-california/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Eroica California features a challenging 107-mile course through Central Coast California starting at 5:00 AM from Cambria. The route includes Old Creek Road as the major climb of the day, often experienced in foggy conditions with limited visibility. Riders face steep gravel roads requiring appropriate gearing, with some noting that tall gearing makes the climbs more difficult. The course passes through Santa Rita as a significant waypoint on longer routes. Multiple food stops provide olive oil french fries and other refreshments. Riders are broken into three groups departing five to ten minutes apart, with a 5:30 AM arrival recommended for longer routes. The vintage cycling event attracts riders on period-appropriate bikes, including steel frames from the 1960s-70s with tire widths around 32mm."
   },
   {
@@ -12097,6 +12453,7 @@
     "has_profile": true,
     "profile_url": "/race/ford-ridelondon/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 51.5074,
     "lng": -0.1278,
     "st": "Riders describe Ford RideLondon as featuring nice rolling roads that aren't too hilly, making it well-suited for aero bikes. The race organization is described as perfect with ambulances, restoration points, and stewards positioned throughout. Riders are released in small groups to spread out the field and avoid large gatherings. Key challenges include hydration management, as small water bottles may be insufficient with riders running dry about 10 miles before the finish. Pacing strategy is important - riders recommend not jumping into groups too early or pushing too hard at the beginning. The course allows for high speeds on downhills where larger chainrings provide advantages. Safety awareness is emphasized given the mass participation nature. The event atmosphere is described as fantastic with riders enjoying empty roads. Logistics include early morning starts around 5 AM and organized entry areas with timed releases around 6:15-6:30."
@@ -12131,7 +12488,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-salinas/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY San Juan",
@@ -12163,7 +12521,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-san-juan/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Eilat",
@@ -12195,7 +12554,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-eilat/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo San Diego",
@@ -12227,7 +12587,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-san-diego/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Sibiu",
@@ -12260,6 +12621,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-sibiu/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The provided transcript does not contain information about the Gran Fondo Sibiu race in Transylvania, Romania. The transcript appears to be a personal story about bicycle restoration and outdoor adventure preparation, without any mention of the race event, course conditions, challenges, or rider experiences specific to this gravel cycling event. No actionable intelligence about the 93-mile course with 8,202 feet of elevation gain could be extracted from this content."
   },
   {
@@ -12292,7 +12654,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-ecuador/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GranFondo Mont Sainte-Anne",
@@ -12324,7 +12687,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-mont-sainte-anne/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Lost River Classic",
@@ -12356,6 +12720,7 @@
     "has_profile": true,
     "profile_url": "/race/lost-river-classic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.8763,
     "lng": -78.8658,
     "rwgps_id": "52228993",
@@ -12393,6 +12758,7 @@
     "has_profile": true,
     "profile_url": "/race/munsterland-giro/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 51.9607,
     "lng": 7.6261
   },
@@ -12426,7 +12792,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/pan-celtic-ultra/",
-    "discipline": "bikepacking"
+    "discipline": "bikepacking",
+    "has_tire_guide": false
   },
   {
     "name": "Prosecco Cycling (Gran Fondo Prosecco)",
@@ -12459,6 +12826,7 @@
     "has_profile": true,
     "profile_url": "/race/prosecco-cycling/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.901,
     "lng": 11.995
   },
@@ -12492,7 +12860,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-around-ireland/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "RADL GRVL",
@@ -12524,6 +12893,7 @@
     "has_profile": true,
     "profile_url": "/race/radl-grvl/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -34.9014,
     "lng": 138.8293,
     "rwgps_id": "53152471",
@@ -12561,6 +12931,7 @@
     "has_profile": true,
     "profile_url": "/race/redlands-bicycle-classic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 34.056,
     "lng": -117.183,
     "st": "The Redlands Bicycle Classic features a challenging downtown criterium with super tight turns requiring strategic positioning and coasting techniques. The course includes thousands of spectators which is rare for domestic US racing. Key challenges include the last turn and first turn of the crit course where riders bunch up and must take bad lines to control space. The race also features a mountain finish stage with cold, cloudy conditions at the summit, contrasting with the typically hot Inland Empire weather. The community strongly supports the race with excellent host housing, cramming bunk beds full of riders. The event is one of the longest continually running stage races in the country, attracting over 200 riders from across the continental US and Canada over 5 days in April."
@@ -12595,7 +12966,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/round-denmark-bike-race/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Tour de Okinawa",
@@ -12628,6 +13000,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-okinawa/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 26.5919,
     "lng": 127.9774
   },
@@ -12661,7 +13034,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/uci-gran-fondo-hangzhou/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Adelaide Epic Ride (Santos Tour Down Under)",
@@ -12694,6 +13068,7 @@
     "has_profile": true,
     "profile_url": "/race/adelaide-epic-ride/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -34.9285,
     "lng": 138.6007,
     "st": "The Adelaide Epic Ride covers approximately 100 kilometers with 1300 meters of elevation gain according to riders. The route goes from Glenelg to McLaren Vale, then continues on bike paths to Willunga before tackling Willunga Hill, which is featured in the Tour Down Under professional race. Riders describe Willunga Hill as where the real climbing starts, coming after already completing 400 meters of elevation. The Cottage Bakery in McLaren Vale is highlighted as a popular lunch stop located right next to the bike path. Riders should allow around seven hours for the full route. The event has a community atmosphere with local organizers emphasizing it's a ride rather than a race, encouraging participants to pace themselves and enjoy the experience. Mechanical issues like broken spokes can occur on the mixed terrain, so riders should be prepared for potential equipment problems during the ride."
@@ -12729,6 +13104,7 @@
     "has_profile": true,
     "profile_url": "/race/alpe-dhuzes/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.092,
     "lng": 6.071,
     "st": "Alpe d'HuZes is a multi-stage event totaling 280 kilometers with 7700+ meters of climbing staged on Alpe d'Huez. The race features three stages including a 123km opening stage, a second stage with 900m elevation, and concludes with a time trial covering approximately 1100 meters of climbing. Riders face relentless ups and downs throughout the course with total climbing approaching 4500 meters. A particularly challenging section occurs on the first major descent - a 19k descent with 10k remaining where severe leg cramping commonly strikes, affecting hamstrings, abductors, and glutes. The time trial sections demand full gas efforts with strategic rest between pushes. Riders describe the overall experience as hellish and deadly, requiring complete physical commitment. The event serves as an intense training camp preparation, pushing participants to their absolute limits across multiple days of racing."
@@ -12763,6 +13139,7 @@
     "has_profile": true,
     "profile_url": "/race/crystal-bear/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.6212,
     "lng": -84.6824,
     "rwgps_id": "50937006",
@@ -12799,6 +13176,7 @@
     "has_profile": true,
     "profile_url": "/race/dirty-french/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.3331,
     "lng": -82.9824
   },
@@ -12832,7 +13210,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/eroica-cuba/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY Bahamas",
@@ -12864,7 +13243,8 @@
     "tagline": "Ride through paradise on a flat and fast Caribbean course.",
     "has_profile": true,
     "profile_url": "/race/gfny-bahamas/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Argentina",
@@ -12896,7 +13276,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-argentina/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Başkent",
@@ -12929,6 +13310,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-baskent/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The available transcript for Gran Fondo Başkent primarily consists of music and repeated mentions of heat, suggesting hot weather conditions during this 62-mile gravel race in Ankara, Turkey. While the transcript lacks detailed course descriptions or rider commentary, the emphasis on heat indicates that temperature management may be a significant factor for participants in this Turkish gran fondo event."
   },
   {
@@ -12962,6 +13344,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-chile-uci/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Limited information available about Gran Fondo Chile from rider accounts. The available transcript contains fragmented commentary focused on race energy and maneuvering during competition, but lacks specific details about course conditions, terrain features, or practical racing advice. Riders mention the competitive atmosphere and the need for tactical positioning during the event. More comprehensive rider reports would be needed to provide detailed insights about this 62-mile gravel race in Valdivia, Los Rios, Chile with 3200 feet of elevation gain."
   },
   {
@@ -12995,6 +13378,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-florida/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 28.364,
     "lng": -82.191,
     "st": "Gran Fondo Florida in Dade City features a unique format with four timed segments over 100 miles where riders can pace comfortably between segments and push hard only during timed portions. The race starts in 5-minute waves of 20 riders from 8:00-10:00 AM rather than a mass start, with over 500 participants competing for overall and age group classifications. Riders can qualify for National Championship events through this race. Key challenges include very windy conditions that worsen throughout the morning, and cold starts in the mid-40s that warm to near 70 degrees by finish. The course begins with descents in the first 3 miles before the first timed segment, making proper warm-up difficult in cold conditions. Riders report the first segment being much harder than expected due to insufficient warm-up time. The terrain includes bike path sections and requires strategy for connecting with other riders during timed segments."
@@ -13029,7 +13413,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-bratislava/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "GranFondo Riviera Nayarit",
@@ -13061,7 +13446,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-riviera-nayarit/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Helsinki Gran Fondo",
@@ -13094,6 +13480,7 @@
     "has_profile": true,
     "profile_url": "/race/helsinki-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "This appears to be coverage of Grand Fondo Il Lombardier rather than Helsinki Gran Fondo, based on the transcript content. The race features extremely chaotic Italian Grand Fondo start conditions with dangerous bunch riding through city streets. The major challenge is a two-part climbing sequence: first the Conano climb at 5.5 km and 6.5% gradient, followed immediately by the Wall of Samano (Miro de Samano) - a brutal 2 km section at 16.5% gradient on narrow paths. Riders can avoid the wall by turning right and adding 2 km distance with easier gradients, but most elect to take on the steep challenge. The full climb sequence takes experienced riders about an hour. Early crashes occur even on straight, downhill sections. The first 10 km require extreme caution due to chaotic conditions with hundreds of cyclists navigating city road furniture."
   },
   {
@@ -13127,6 +13514,7 @@
     "has_profile": true,
     "profile_url": "/race/le-race/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -43.5321,
     "lng": 172.6362
   },
@@ -13161,6 +13549,7 @@
     "has_profile": true,
     "profile_url": "/race/levis-granfondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 38.44,
     "lng": -122.714,
     "st": "Levi's GranFondo is a 138-mile course with just under 1,400 feet of elevation gain, held in Sonoma County, California. The race features a unique profile starting with 30 miles of pancake flat terrain where riders can soft pedal and chat, averaging around 110-115 watts. The real challenge begins at mile 30 with the King's Mill climbing section, an hour-long wooded climb through redwoods with rolling pitches gaining 1,000 feet over 10 miles. Early breakaways typically get reeled in as the course naturally handles selections. The event has been running for 16 years and recently partnered with Bike Monkey to rejuvenate US road racing, implementing separate starts for women (5 minutes after men) and a no-draft rule. The 2023 edition saw strong participation with over 65-70 elite women riders in a competitive field."
@@ -13196,6 +13585,7 @@
     "has_profile": true,
     "profile_url": "/race/race-across-portugal/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Portugal offers over 1000 kilometers of amazing and barely used gravel roads from the mountainous north to the warm Algarve in the south. The N222, a 222-kilometer route named the most beautiful road in the world, presents steep climbing challenges where the outer masses start to bite. The landscape varies dramatically, featuring desert sections, ancient cities, and flatter terrain in the south. Riders should expect dusty conditions that are hard to shake from gear. The course showcases Portugal's inland diversity beyond the coastal areas most people associate with the country, offering some of the best gravel roads that many riders never knew existed."
   },
   {
@@ -13229,6 +13619,7 @@
     "has_profile": true,
     "profile_url": "/race/race-around-netherlands/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Race Around Netherlands features a challenging 10 kilometer loop format repeated 17 times for 165 kilometers total. Riders face cobbled sections just before the finish line and numerous sharp corners throughout each lap. The repetitive nature creates significant difficulty, with riders going over the same cobbles and corners 17 times. Hot weather conditions over 30 degrees Celsius add to the challenge, contributing to high attrition rates where only 65 out of 135 starters finish. The race features constant attacks and high pace throughout, with tactical positioning becoming critical when riders begin to tire and stop chasing breaks effectively. The loop format means this will never end in a field sprint, requiring riders to be in breakaways to have winning opportunities."
   },
   {
@@ -13261,6 +13652,7 @@
     "has_profile": true,
     "profile_url": "/race/sea-otter-classic-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 36.5841,
     "lng": -121.7528,
     "st": "The available transcripts for the Sea Otter Classic Gran Fondo contain minimal substantive content about the race experience. The transcripts primarily consist of music, brief conversational fragments, and sound effects rather than detailed race commentary or rider insights. No specific information about the 90-mile course through Monterey, California, the 5500 feet of elevation gain, terrain conditions, gear recommendations, or race strategies could be extracted from these particular video sources. Additional video content with more comprehensive race coverage and rider commentary would be needed to provide actionable intelligence about course challenges, surface conditions, pacing strategies, or logistical considerations for this gravel cycling event."
@@ -13296,6 +13688,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-brisbane/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -27.4679,
     "lng": 153.0281,
     "st": "Tour de Brisbane is a 68-mile metropolitan Grand Fondo showcasing Brisbane City, its parks, and bridges across the river. The course features three main sections: dangerous twisty urban sections with road furniture that riders call the danger zone, long flat speedway sections on closed motorways running through tunnels and bus terminals with hairpin turnarounds, and the Mount Cutha climb at 70km - a 2.5km ascent averaging 7% gradient that serves as the primary selection point. Wet conditions make the course especially treacherous, with numerous crashes occurring on slippery white lines. The race attracts around 7,000 participants, creating chaotic start conditions. Key infrastructure includes multiple trips through the Legacy Way tunnel, rides over the Story Bridge and Centenary Bridge, and sections on dedicated busways. Riders report needing to average high normalized power for the 3-hour duration, with successful finishers requiring around 5 watts per kilo on the climb to stay with working groups."
@@ -13330,7 +13723,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-de-yabakei/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Turkcell Granfondo Izmir",
@@ -13362,7 +13756,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/turkcell-granfondo-izmir/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Vätternrundan",
@@ -13395,6 +13790,7 @@
     "has_profile": true,
     "profile_url": "/race/vatternrundan/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 58.5371,
     "lng": 15.047,
     "st": "Vätternrundan features a staggered start system where riders continue starting throughout the day and into the next day according to support crew observations. The race implements designated garbage zones every kilometer where riders can dispose of waste, with support crews collecting trash at these specific locations rather than along the entire course. Early sections of the race see crashes, with one rider crashing within the first hour suffering scraped legs, torn clothing, and a broken rear axle that ended his race despite his willingness to continue. The course appears scenic according to support crew members. Support vehicles follow behind cyclists providing assistance and medical pickup for crashed riders. The race operates with a comprehensive support system including vehicle crews that work in shifts."
@@ -13430,6 +13826,7 @@
     "has_profile": true,
     "profile_url": "/race/vietnam-cycling-challenge/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Vietnam Cycling Challenge in Da Lat features a challenging 1.5 kilometer uphill climb around the 20km mark that leaves riders significantly out of breath. The route includes a major 30km downhill section following the main climb. Terrain becomes very slippery when wet, with riders reporting tires having almost no traction in wet conditions. Cars drive aggressively on the route. The course offers beautiful valley scenery and mountain views with foggy conditions at higher elevations. Riders report the route can be completed faster than expected, with groups finishing well ahead of schedule. Disc brakes are essential equipment for safe descending. The ride starts around 9:00 AM with planned finish around 3:30 PM, including lunch breaks and potential swimming stops. Local people are friendly and cheer for cyclists along the route."
   },
   {
@@ -13463,6 +13860,7 @@
     "has_profile": true,
     "profile_url": "/race/around-the-bay-in-a-day/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -37.8448,
     "lng": 144.9756,
     "st": "Around the Bay Melbourne is a 137-mile ride featuring dramatically different conditions on the outbound and return legs. Riders report excellent tailwind conditions for the first 100km with natural peloton formation and steady pacing opportunities. The route includes passage over Westgate Bridge and through Melbourne suburbs before reaching rural areas. At halfway, riders board a ferry crossing where staying mobile is crucial to avoid stiffening up. The final 50km presents the race's biggest challenge with severe headwinds described as borderline dangerous conditions. Wind speeds can be extreme - one year featured the windiest conditions Melbourne had seen in five years. The return leg follows familiar coastline roads. Logistics include potential parking difficulties at the start, making riding to the start line a viable option. The first hour involves navigating through traffic and rider groups before settling into steadier rhythm and nutrition patterns."
@@ -13497,6 +13895,7 @@
     "has_profile": true,
     "profile_url": "/race/atlas-mountain-race/",
     "discipline": "bikepacking",
+    "has_tire_guide": true,
     "lat": 28.3348,
     "lng": -10.3713,
     "rwgps_id": "32078944",
@@ -13533,6 +13932,7 @@
     "has_profile": true,
     "profile_url": "/race/bend-dirt-fest/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.0582,
     "lng": -121.3153,
     "st": "Riders describe Bend area gravel routes that utilize old logging railroad grades, maintaining gentle gradients that rarely exceed 2 percent. The terrain takes advantage of extensive logging roads on public lands throughout Oregon. A typical route starts from Shevlin Park area, climbing through upper Shevlin to connect with BS logging road. The warm-up section is described as uphill the whole way with one steep section at the beginning. Riders mention a steep downhill portion during the main route. The logging railroad foundation makes for very even terrain throughout most of the ride. One rider successfully used 40c Schwalbe G1R tires for the conditions. The area offers scenic riding with sunset views, and riders note this type of terrain showcases why Oregon's logging road network creates excellent gravel riding opportunities on public lands.",
@@ -13569,6 +13969,7 @@
     "has_profile": true,
     "profile_url": "/race/best-buddies-challenge-miami/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Best Buddies Challenge Miami features challenging rolling hills throughout the 150km course on beautiful country roads. Riders face a significant early climb at 25 miles - a 1.3km ascent averaging 10% grade with two more big climbs later in the race. The second-to-last climb is almost 4km long and gets difficult toward the end. The terrain is described as continuous rolling hills with substantial elevation gain. Nutrition is critical with a pit stop at 71km where riders take caffeine gels. The course runs through scenic countryside that provides some mental relief from the physical suffering of the climbs."
   },
   {
@@ -13602,6 +14003,7 @@
     "has_profile": true,
     "profile_url": "/race/cadel-evans-great-ocean-road-ride/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -38.15,
     "lng": 144.361,
     "st": "The Cadel Evans Great Ocean Road Race features mostly sealed roads in good condition with a significant downhill section lasting about 30 minutes heading down to Torquay, followed by rolling terrain. The route goes through Moriak down to Bells Beach and includes tree-lined roads. A key challenge is the Challambra climb near the end, which appears steeper than it looks on TV, particularly at the bottom and top sections. Temperature conditions can vary dramatically during the ride, with one rider experiencing 26 degrees on the coastal descent but 32 degrees on the return journey. The course includes some gravel sections at the finish line. Riders report general regrouping opportunities coming into Torquay after the downhill sections. The route passes notable landmarks including 13th Beach and finishes with a roll back into Geelong around the botanic gardens."
@@ -13636,6 +14038,7 @@
     "has_profile": true,
     "profile_url": "/race/dirty-30/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.9292,
     "lng": -85.2129,
     "rwgps_id": "53839822",
@@ -13673,6 +14076,7 @@
     "has_profile": true,
     "profile_url": "/race/etape-loch-ness/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 57.4778,
     "lng": -4.2247,
     "st": "Riders describe the Etape Loch Ness as a 104km loop around Loch Ness with 1500m of climbing, starting from Inverness. The event takes place on closed roads, which riders highlight as a major benefit and dream scenario for cycling events. The terrain includes sections with bone-shaking cobbles that cause significant vibration throughout the bike and rider. The event is well-organized with starting pens based on predicted finish times, grouping riders of similar abilities together. Riders note it attracts a wide range of participants from beginners doing their longest ride to more experienced cyclists racing at the front. The scenery around Loch Ness is described as beautiful and amazing. The main logistics challenge is the significant travel required, with one rider noting a six-hour drive from Manchester to reach the start in Inverness, making it quite a trek for those not based in Scotland."
@@ -13707,7 +14111,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/fuji-panorama-gran-fondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Firenze",
@@ -13740,6 +14145,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-firenze/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 43.763,
     "lng": 11.265,
     "st": "The available transcript from the Gran Fondo Firenze race video contains primarily music and fragmented audio without coherent rider commentary about the race experience. No specific course information, terrain descriptions, gear recommendations, or race strategy details are discernible from this transcript. The 83-mile race through Florence, Tuscany covers 6,562 feet of elevation gain, but rider insights about the specific challenges, surface conditions, or race day logistics are not available in the provided content."
@@ -13775,6 +14181,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-jasper/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 52.8737,
     "lng": -118.0814,
     "st": "Based on rider experiences in Dubai racing, the terrain features silky smooth roads where 28mm tires are sufficient and higher tire pressure can be used effectively. The dry and sandy conditions present unique challenges for equipment durability. Riders emphasize the importance of reliable gear over high-end components when traveling, recommending steel spokes for easier repairs and Vittoria Corsa tires for better puncture resistance over the Pro version. The fast, flat roads require larger gearing than compact cranksets, with 39/53 chainrings preferred over 34/50 for the high speeds. Dubai offers 200km of dedicated cycling paths with excellent logistics including convenient accommodation near cycling infrastructure. Chain maintenance is critical in the dry conditions, with hot wax lasting up to 1000km. The racing emphasizes reliability and durability over marginal performance gains due to the remote desert location and difficulty accessing bike shop services."
@@ -13810,6 +14217,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-pinarello/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.6669,
     "lng": 12.243,
     "st": "The available transcript for the Granfondo Pinarello race in Treviso, Veneto, Italy contains minimal rider commentary, consisting primarily of music, applause, and brief fragments. No specific information about the 98-mile course, 8,200 feet of elevation gain, terrain conditions, or race challenges is provided in the transcript. Riders seeking detailed intelligence about this Tier 2 gravel event would need additional video sources with more comprehensive commentary to understand course features, surface conditions, key climbs, gear recommendations, or race strategy advice."
@@ -13845,6 +14253,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-san-sebastian/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 43.3183,
     "lng": -1.9812
   },
@@ -13878,6 +14287,7 @@
     "has_profile": true,
     "profile_url": "/race/iowa-wind-and-rock/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.3348,
     "lng": -94.0136,
     "st": "This Iowa gravel ride features challenging terrain including a particularly difficult five-mile section of white rock surface that riders describe as horrific. The route passes through small Iowa towns like Exira and includes stops at local attractions such as a tree growing in the middle of a road intersection and Albert the Bull statue. Riders encounter typical Iowa gravel conditions with rocky surfaces that can be punishing on equipment. The area features rural gravel roads connecting small communities, with the terrain offering both scenic rural views and technical challenges from varied surface conditions.",
@@ -13914,6 +14324,7 @@
     "has_profile": true,
     "profile_url": "/race/lake-taupo-cycle-challenge/",
     "discipline": "road",
+    "has_tire_guide": true,
     "lat": -38.6833,
     "lng": 176.0833,
     "st": "The available transcript content for the Lake Taupo Cycle Challenge consists primarily of music or promotional content rather than substantive rider commentary about the race experience. No specific information about course features, terrain conditions, key challenges, or race atmosphere could be extracted from the provided transcript. Riders seeking intelligence about this 100-mile New Zealand event with 4000 feet of elevation gain would need to reference additional sources for actionable race preparation insights.",
@@ -13950,6 +14361,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-brazil/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -22.7396,
     "lng": -45.5913,
     "st": "The available transcripts for L'Etape Brasil by Tour de France consist entirely of promotional music videos with lyrics rather than rider commentary or race analysis. The videos emphasize themes of heat, mountains, and challenging terrain through song lyrics that mention racing the road ahead, mountains bowing to burning sun, chasing shadows, each breath being fire, asphalt whispering warnings, and summits calling through the air. While the lyrics suggest a challenging mountain course with significant heat factors and elevation changes, no specific course details, rider experiences, gear recommendations, or actionable race intelligence is provided in these promotional materials."
@@ -13985,6 +14397,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-chile/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -39.8142,
     "lng": -73.2459
   },
@@ -14019,6 +14432,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-italy-piemonte/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.0833,
     "lng": 7.5667
   },
@@ -14052,7 +14466,8 @@
     "tagline": "Experience the Tour de France in the heart of Bucharest's historic streets",
     "has_profile": true,
     "profile_url": "/race/letape-romania/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "London to Brighton Bike Ride",
@@ -14085,6 +14500,7 @@
     "has_profile": true,
     "profile_url": "/race/london-to-brighton/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 51.4575,
     "lng": -0.1483,
     "st": "The London to Brighton Bike Ride is a 55-mile iconic charity route that has been running for 155 years, leaving London's busy streets and finishing on Britain's southern coast. Riders report significant challenges with traffic lights getting out of London that slow progress and affect times. The first uphill section out of London completely shatters any groups that form, with riders describing losing their legs early on. A 6:00 a.m. start provides quieter roads which helps with pacing. Riders emphasize the importance of finding coffee and breakfast early, as those who skip nutrition report having nothing left very early in the ride. The event attracts thousands of cyclists annually and has raised millions for charity over the years. Participants consistently describe a wonderful party atmosphere and strong community spirit, with many riding for personal reasons related to heart disease. The sense of achievement upon completion is described as unbelievable by finishers."
@@ -14119,6 +14535,7 @@
     "has_profile": true,
     "profile_url": "/race/ned-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.9614,
     "lng": -105.5108,
     "rwgps_id": "38479446",
@@ -14155,7 +14572,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/pekan-classics/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Pelotonia",
@@ -14188,6 +14606,7 @@
     "has_profile": true,
     "profile_url": "/race/pelotonia/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 39.9612,
     "lng": -82.9988,
     "st": "Pelotonia is described as a well-organized 100-mile fundraising ride in Columbus, Ohio that raises money for cancer research. Riders emphasize the strong community support throughout the event, with people cheering from the sidelines making the day special. The event has raised $283 million over 15 years, with every dollar going to research at the James Cancer Hospital. Weather can be a challenge, with riders noting that rain occurs but the event continues regardless of conditions. The ride attracts participants of all ages and cycling abilities, from beginners to experienced riders. Strong organizational support and community involvement are highlighted as key features. The finish line experience is described as emotional and meaningful, focused on the collective impact rather than individual achievement. Multiple distance options are available including 25, 50, and 100-mile routes."
@@ -14222,7 +14641,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-of-oman-sportive/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "USA Cycling Gravel Nationals",
@@ -14254,6 +14674,7 @@
     "has_profile": true,
     "profile_url": "/race/usa-cycling-gravel-nationals/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.828,
     "lng": -91.304,
     "st": "USA Cycling Gravel Nationals moved from Nebraska to La Crescent, Minnesota in the driftless region. The 110-mile course features 7,500 feet of elevation gain with nine distinct climbs roughly one mile long and 500 feet high. All courses finish on the chicken ridge gravel climb through an apple orchard, ending with a final one-mile climb averaging 8 percent grade. The terrain features bluffs with flat ridges and 400-500 foot descents into valleys. Riders emphasize pre-riding is essential due to limited visibility, tight turns, and technical descents. The gravel surface is typically good unless freshly graded. The course is described as windy, tight, and hilly like a mountain bike race. Racing starts at 7 AM on Main Street during Apple Fest weekend, drawing 766 riders competing for national championship jerseys across three distance options.",
@@ -14290,6 +14711,7 @@
     "has_profile": true,
     "profile_url": "/race/utrecht-ultra/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Utrecht Ultra appears in transcripts that actually describe other cycling events rather than this specific race. The available footage shows challenging ultra-endurance cycling through remote Scottish terrain featuring narrow hiker-bike trails built straight up hillsides, critical ferry crossings with 9:30pm cutoffs, and multiple river crossings. Riders face severe weather conditions described as storms with substantial rain, requiring stops at hotels for shelter. The route passes through extremely remote areas with 60-mile stretches between refuge points over major mountain passes. Community halls provide emergency overnight accommodation. Trail angels support riders by leaving food supplies along the course. The terrain includes sketchy technical descents where tire damage is common, and riders report navigating through the middle of nowhere with limited infrastructure support."
   },
   {
@@ -14322,6 +14744,7 @@
     "has_profile": true,
     "profile_url": "/race/vapor-trail-125/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.2508,
     "lng": -106.2925,
     "rwgps_id": "48333649",
@@ -14358,7 +14781,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/veloturk-gran-fondo-cesme/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Wadi Dayqah Challenge",
@@ -14390,7 +14814,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/wadi-dayqah-challenge/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Boulder Roubaix Road Race",
@@ -14423,6 +14848,7 @@
     "has_profile": true,
     "profile_url": "/race/boulder-roubaix/",
     "discipline": "gravel",
+    "has_tire_guide": false,
     "lat": 40.07,
     "lng": -105.22
   },
@@ -14457,6 +14883,7 @@
     "has_profile": true,
     "profile_url": "/race/cape-rouleur/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -33.912,
     "lng": 19.118,
     "st": "Cape Rouleur is a multi-stage cycling event over five days through the Western Cape Winelands and coastal roads, ending in Cape Town. The route includes challenging busy intersections like the N44 and main road intersection at Somerset West, where steep approaches make traffic management difficult. Key climbs include a tough 800-meter section at Franschhoek and the final big climb on Chapman's Peak on day five. The course travels through Stellenbosch, Gordon's Bay with views of the Indian Ocean, and finishes at the V&A Waterfront in Cape Town. Road conditions are generally very good with minimal road works. The event is well-organized with lead vehicles, ride captains, motorbike marshals for traffic safety, medics, and mechanics cars supporting riders throughout each stage."
@@ -14492,6 +14919,7 @@
     "has_profile": true,
     "profile_url": "/race/cappadocia-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The available transcript for the Cappadocia Gran Fondo contains primarily music and fragmented audio without clear rider commentary about the race experience. No specific course details, terrain conditions, challenges, or actionable race intelligence could be extracted from the provided content."
   },
   {
@@ -14524,6 +14952,7 @@
     "has_profile": true,
     "profile_url": "/race/cohutta-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.7666,
     "lng": -84.7699,
     "rwgps_id": "41524803"
@@ -14558,7 +14987,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/cykelvasan/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Finnish Gravel",
@@ -14590,6 +15020,7 @@
     "has_profile": true,
     "profile_url": "/race/finnish-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 63.2468,
     "lng": 25.9209,
     "rwgps_id": "50081451",
@@ -14627,6 +15058,7 @@
     "has_profile": true,
     "profile_url": "/race/five-boro-bike-tour/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 40.7043,
     "lng": -74.0138,
     "st": "The TD Five Boro Bike Tour is a 40-mile car-free ride through all five NYC boroughs, starting in Lower Manhattan and finishing on Staten Island. The route goes through the Bronx, Queens, and Brooklyn before ending at Staten Island where riders take ferries back. With 32,000 participants across multiple waves, the event attracts both experienced cyclists and newcomers. Key challenges include numerous potholes throughout the route, especially on sections like the BQE that are normally car-only. Riders recommend starting early to avoid crowds, ensuring bikes are in good condition with proper tire pressure for the rough surfaces, and immediately getting in the ferry line after finishing to avoid long waits. The route focuses on covering all five boroughs rather than showcasing iconic NYC landmarks. The event supports bike education and safety programs for New Yorkers."
@@ -14662,6 +15094,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-bremen/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 53.1048,
     "lng": 8.8089
   },
@@ -14696,6 +15129,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-kuala-lumpur/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "No race-specific information about GFNY Kuala Lumpur is available in the provided transcript. The video appears to be personal content about birthday celebrations and sightseeing in Kuala Lumpur, with no discussion of the race course, conditions, challenges, or rider experiences from this 86-mile event in Malaysia."
   },
   {
@@ -14728,7 +15162,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-badlands/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Granfondo Moser",
@@ -14761,6 +15196,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-moser/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Granfondo Moser features multiple challenging climbs including the iconic Monte Bondone ascended twice. The first ascent covers 20 kilometers with 1300m elevation gain, averaging 6.5-6.7% with three distinct sections including steep opening and closing portions separated by an easier middle section at Castiga ideal for hydration. The second ascent from Sopramonte to the 1650m summit covers 1200m over 16k at 7-7.5% average, never dropping below 7% gradient. Riders describe beautiful paved roads with fast, non-technical descents spanning 20+ kilometers. The event starts with an extremely aggressive pace described as ballistic with multiple early crashes. Gravel sections require significant concentration and are notably harder to climb than expected. The course features pristine Tuscan white gravel sectors where moderate power feels exceptionally fast. Weather can vary significantly requiring preparation for 10-15 degree temperature swings. Strategic pacing and group positioning are crucial for managing the demanding elevation profile effectively."
   },
   {
@@ -14794,6 +15230,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-denmark/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 56.4532,
     "lng": 9.4023
   },
@@ -14827,7 +15264,8 @@
     "tagline": "South Korea's largest road cycling race in scenic Muju County[6].",
     "has_profile": true,
     "profile_url": "/race/muju-gran-fondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Neusiedlersee Radmarathon",
@@ -14860,6 +15298,7 @@
     "has_profile": true,
     "profile_url": "/race/neusiedlersee-radmarathon/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 47.7642,
     "lng": 16.8214
   },
@@ -14893,7 +15332,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-across-italy-300/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Ring of Kerry Charity Cycle",
@@ -14926,6 +15366,7 @@
     "has_profile": true,
     "profile_url": "/race/ring-of-kerry-charity-cycle/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 52.0599,
     "lng": -9.5044,
     "st": "The provided transcripts do not contain rider intelligence or race information about the Ring of Kerry Charity Cycle. The transcripts appear to be unrelated content including music lyrics and coverage of a different charity cycling event (Will Bike for Food in Western Massachusetts). No actionable intelligence about course conditions, terrain, challenges, or race strategy for the Ring of Kerry event could be extracted from these sources."
@@ -14961,6 +15402,7 @@
     "has_profile": true,
     "profile_url": "/race/seattle-to-portland/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 47.6553,
     "lng": -122.3035,
     "st": "The Seattle to Portland ride covers 206 miles with 5,100 feet of elevation gain, featuring mostly paved roads with scattered gravel sections. The main climbing challenge is Puyallup Hill at 300 feet with a 5.7% gradient, which riders describe as their chance for glory. The course includes technical sections through the JBLM area and Yelm Trail with numerous stop signs, bollards, dividers, and trail obstacles that force riders to slow down. Groups typically maintain 20-22 mph on flat sections. Weather conditions can include drizzle and wet roads. The Columbia River bridge crossing presents a significant challenge with traffic concerns. Rest stops are located at mile 20 and mile 54 in Spanaway. Starting early helps avoid crowds that typically clog trail sections. The ride finishes in Portland where restaurants may close early. Riders describe it as less crowded when starting early compared to typical STP conditions."
@@ -14996,6 +15438,7 @@
     "has_profile": true,
     "profile_url": "/race/spinneys-dubai-92/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Spinneys Dubai 92 Cycle Challenge features silky smooth roads where riders can run 28mm tires at higher pressure than usual. The course consists of fast, flat terrain that demands bigger gears - riders recommend swapping compact cranksets for 39/53 to handle high speeds. The race is part of a series with four build-up rides of 35km, 45km, 65km, and 85km leading to the main 92km event. Dubai offers 200km of dedicated cycling paths, with the Aludra cycling track starting near town square. The dry and sandy conditions favor hot-waxed chains for durability. Gear reliability is crucial due to the desert environment - steel spoke wheels and puncture-resistant tires are recommended over marginal performance gains."
   },
   {
@@ -15029,6 +15472,7 @@
     "has_profile": true,
     "profile_url": "/race/stellenbosch-cycle-tour/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "This transcript does not contain information about the Stellenbosch Cycle Tour race. Instead, it features a TEDx Talk about a 1,600-mile bicycle tour from Vancouver, Canada to Los Angeles. The speaker discusses bicycle advocacy work in Los Angeles and provides general advice about bicycle touring, mentioning that any bike with a rack can be used for touring rather than needing expensive specialized equipment. The content focuses on bicycle advocacy, community engagement through events like closing streets to cars, and bicycle repair cooperatives that teach self-maintenance skills. While cycling-related, this transcript does not provide race-specific intelligence about the Stellenbosch Cycle Tour course, terrain conditions, challenges, or race day strategies that would be relevant to competitors."
   },
   {
@@ -15062,6 +15506,7 @@
     "has_profile": true,
     "profile_url": "/race/struggle-moors/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Struggle Moors presents 4000 meters of challenging climbing over 160 kilometers, with much of it steep terrain. The race starts aggressively with an 11 percent climb and double digit gradients within the first half kilometer. Key climbs include Dunkery Beacon at the quarter distance mark and the intimidating Lim Muth Ram. The course features varied terrain from difficult steep sections to easier toll road climbs of 5-6 percent grade. Weather conditions can be harsh with rain creating muddy, miserable conditions. Mechanical issues like derailleur problems are common on the steep climbs. Riders emphasize pacing strategy, avoiding burning matches early when facing five hours and 65 miles of significant climbing ahead. The challenging nature makes this a true test of endurance cycling in the North York Moors."
   },
   {
@@ -15094,6 +15539,7 @@
     "has_profile": true,
     "profile_url": "/race/transcordilleras/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 4.0999,
     "lng": -72.9088,
     "st": "Transcordilleras is a multi-stage Colombian Andes race covering 1055 kilometers over eight stages with 28,500 meters of elevation gain. Riders describe it as crossing three cordilleras through jungle terrain with steep climbs at high altitude and humid conditions. The ride to Puerto Berrio stands out as particularly challenging due to extreme heat requiring riders to seek relief in rivers and creeks. Logistics prove as demanding as the riding itself - daily tasks include securing food, cleaning bikes, and preparing for early starts. The non-stop category can be completed in 4.5 to 5 days with minimal sleep. Colombian riders are noted for their climbing speed and altitude adaptation. The race attracts international professionals who experience genuine Colombian hospitality. Riders emphasize the need for both mental and physical preparation as the race demands every ounce of energy over the multi-day format.",
@@ -15130,6 +15576,7 @@
     "has_profile": true,
     "profile_url": "/race/whistler-granfondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 49.2827,
     "lng": -123.1207,
     "st": "The RBC GranFondo Whistler is described as an inclusive participation-focused event that welcomes riders of all abilities, from experienced cyclists to those who have never ridden or just started. The event requires extensive year-round planning with organizers working full-time starting the day after each event to prepare for the next year. Logistically, the event presents challenges as organizers must set up, execute, and tear down operations in Whistler on the same day due to time constraints. Participants describe taking time to train and enjoy the views while pushing themselves to feel accomplished. The event emphasizes participation over speed, ensuring all riders get the same experience regardless of their fitness level or completion time. Training approaches mentioned include one to two rides per week with shorter midweek rides of 50-80km and longer weekend rides over 100km with friends."
@@ -15164,7 +15611,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/white-horse-challenge/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "WYO 131",
@@ -15196,6 +15644,7 @@
     "has_profile": true,
     "profile_url": "/race/wyo-131/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.8331,
     "lng": -108.7307,
     "rwgps_id": "52579752",
@@ -15231,7 +15680,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/yangyang-gran-fondo/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "66 Degrés Sud – La Cyclo",
@@ -15263,7 +15713,8 @@
     "tagline": "A UCI Gran Fondo World Series event through the Pyrenees-Orientales wine country and mountain terrain",
     "has_profile": true,
     "profile_url": "/race/66-degres-sud/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "America's Most Beautiful Bike Ride",
@@ -15296,6 +15747,7 @@
     "has_profile": true,
     "profile_url": "/race/americas-most-beautiful-bike-ride/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 38.9628,
     "lng": -119.9419,
     "st": "The provided transcripts do not contain information about America's Most Beautiful Bike Ride in Stateline, Nevada. The transcripts include content about Italian cycling in the Dolomites, a virtual running video with music, and general cycling training advice, but contain no rider intelligence or race-specific information about the 72-mile gravel race with 4,024 feet of elevation gain in Nevada."
@@ -15330,6 +15782,7 @@
     "has_profile": true,
     "profile_url": "/race/bighorn-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.6469,
     "lng": -106.9517,
     "st": "Bighorn Gravel in Gypsum, Colorado is a challenging 85-mile race with 10,000 feet of elevation gain that tests riders at altitude from 6,300 to 11,000 feet. The course features a brutal first climb where many riders lose contact with the field, followed by rolling terrain along creek valleys with pitches that go up and level out repeatedly. Technical sections include swoopy bermed single track and a challenging two-mile downhill. Terrain varies from county roads to rugged Jeep roads that can be rotted out with ruts from weather damage. The elevation significantly impacts power output and recovery, requiring careful pacing strategies. Some sections near the summit are too steep to ride, forcing walking. The race attracts strong competition including Leadville preparation riders, and offers on-site camping with a Sunday morning start schedule.",
@@ -15365,7 +15818,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/fyn-rundt/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "GFNY Florida Sebring",
@@ -15398,6 +15852,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-florida-sebring/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "GFNY Florida Sebring features a totally flat 82-mile course through endless agricultural fields with watermelon and orange plantations. The main challenge is constant wind conditions that get worse as the morning progresses, including side winds, headwinds and occasional tailwinds. Riders emphasize the need to draft extensively and train with higher cadence in smaller gears. The course uses a loop format where 50-mile riders do one loop and longer distance riders repeat it twice. The venue is located about 30 minutes from typical Airbnb accommodations. Weather is described as perfect for riding with temperatures in the 60-70 degree range. The terrain is beautifully scenic but completely exposed with palm trees scattered throughout the flat landscape. About 500 riders participate in this tier 2 event."
   },
   {
@@ -15431,6 +15886,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-maryland-cambridge/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "GFNY Maryland Cambridge is described by riders as a very flat 95-mile course with minimal elevation gain of approximately 400 feet or less. The race features a very fast start with riders needing to position themselves at the front early to avoid making up time later. A large group of 100 or more riders typically stays together for much of the race, making breakaways difficult to establish due to strong riders at the front willing to pull the group back together. Race strategy centers around patience in the first half, sitting in the large group comfortably while saving energy for potential actions in the second half of the race. The flat terrain and group dynamics create a race where positioning and timing matter more than climbing ability."
   },
   {
@@ -15463,7 +15919,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-curacavi/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Montevideo",
@@ -15495,7 +15952,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-montevideo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Granfondo Colnago",
@@ -15528,6 +15986,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-colnago/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 45.4622,
     "lng": 10.5526
   },
@@ -15562,6 +16021,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-via-del-sale/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.264,
     "lng": 12.348
   },
@@ -15596,6 +16056,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-australia/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -34.4249,
     "lng": 150.8931,
     "st": "L'Etape Australia takes riders from bustling Wollongong through the Southern Highlands to the stunning coastal town of Kiama. The race is promoted as the most beautiful ride in Australia, located only two hours from Sydney making it accessible for family weekend trips. The event features Tour de France atmosphere with live concerts and French food, positioning itself as a family-friendly cycling experience on Australia's South Coast. The race takes place in November, offering riders a scenic route that combines urban start, highland terrain, and coastal finish. The promotional materials emphasize the destination appeal and cultural elements rather than technical course details."
@@ -15631,6 +16092,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-czech-republic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 50.0455,
     "lng": 14.4378
   },
@@ -15664,6 +16126,7 @@
     "has_profile": true,
     "profile_url": "/race/rasputitsa-spring-classic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.6179,
     "lng": -71.9235,
     "rwgps_id": "26976210",
@@ -15700,6 +16163,7 @@
     "has_profile": true,
     "profile_url": "/race/rbc-gran-fondo-banff/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 51.1784,
     "lng": -115.5708,
     "st": "The GranFondo Banff is a 142km ride through Banff National Park featuring closed roads with no traffic. The course starts with a climb up Buffalo Street and Tunnel Mountain Drive, includes a 10km neutral rollout limited to 30kmph, then transitions to the Lake Minnewanka loop. Key challenges include crossing five wildlife gates, a 10km stretch on the Trans Canada Highway where riders must stay on the shoulder, and navigating turns at Tunnel Mountain Road. The route passes major landmarks including the Banff Springs Hotel, Johnston's Canyon, and Castle Mountain, with four rest stops positioned at scenic viewpoints. Wildlife areas near bears and cougars are noted along the northern shores of Lake Minnewanka. The course features a turnaround point at the hill crest before White Horn Road to Lake Louise, with the final 7km returning through Vermillion Lakes back to Banff townsite. Riders describe excellent organization and spectacular mountain scenery throughout."
@@ -15734,7 +16198,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/surrey-rumble/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "THE EQUALIZER - Missouri State Championship",
@@ -15766,6 +16231,7 @@
     "has_profile": true,
     "profile_url": "/race/the-equalizer/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.6284,
     "lng": -91.0573,
     "st": "The St Genevieve Gravel Classic takes place in St. Genevieve, Missouri, the oldest French settlement west of the Mississippi River. The race offers multiple distance options including 18, 44, and 78-81 mile routes. A key challenge is Thunder Ridge, a levy section that's mostly grass with some gravel, where riders face about five miles of direct headwind. At mile 21, there's a significant fork where longer and shorter routes split. The terrain features beautiful countryside gravel roads through old farms and houses. Race organizers paint directional arrows on roads for navigation, which riders find more reliable than signs. The event is hosted by Trail Et with smooth check-in processes and good facilities. Weather can impact longer routes, with severe storm warnings potentially canceling extended distances for safety. The downtown area is blocked off for the event with plenty of porta-potties and organized packet pickup.",
@@ -15801,6 +16267,7 @@
     "has_profile": true,
     "profile_url": "/race/truckee-tahoe-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.3279,
     "lng": -120.1836,
     "st": "The Sagan Fondo in Truckee, California features 68-78 miles with 8000 feet of elevation gain. The course includes a notorious section called The Boneyard around mile 40, which riders describe as legitimately like rock crawling for 20 minutes that destroys your back and legs. Sharp rocks throughout the course cause frequent punctures. With 500-600 participants, dust becomes a major issue, causing chains to run dry around 40 miles in. The terrain is technical enough to break bikes and demands high volume tires. Riders report the event being feisty and more race-like than a typical gran fondo, with age group categories and podium positions. The course serves as good preparation for other technical gravel races.",
@@ -15837,6 +16304,7 @@
     "has_profile": true,
     "profile_url": "/race/uci-gran-fondo-ireland/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The available transcripts for UCI Gran Fondo Ireland do not contain specific course information or rider experiences from this particular event. The transcripts primarily feature race commentary from other cycling events including National Road Race championships with results from various age categories, and general commentary about Irish cycling events. One transcript mentions Ireland's premier cycling events and the community atmosphere with volunteers, but does not provide specific details about the Gran Fondo Ireland course, terrain conditions, or race-specific challenges that would be useful for riders preparing for this 95-mile gravel event in Sligo."
   },
   {
@@ -15869,6 +16337,7 @@
     "has_profile": true,
     "profile_url": "/race/vuelta-altas-cumbres/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -31.706,
     "lng": -65.0185,
     "st": "The available transcripts for the Vuelta Altas Cumbres race near Villa Cura Brochero, Córdoba Province, Argentina contain minimal coherent content, consisting primarily of music, applause, and fragmented words. No specific course elevation/distance detail could be extracted from these transcripts. Riders looking for detailed race intelligence about terrain conditions, gear recommendations, pacing strategies, or specific course challenges will need to seek additional sources, as these particular video transcripts do not provide actionable racing insights or detailed course descriptions.",
@@ -15904,6 +16373,7 @@
     "has_profile": true,
     "profile_url": "/race/wasatch-all-road/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.6103,
     "lng": -111.2805,
     "rwgps_id": "52063183",
@@ -15941,6 +16411,7 @@
     "has_profile": true,
     "profile_url": "/race/superior-morgul-road-race/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 39.938,
     "lng": -105.169,
     "st": "No race-specific content was found in the provided transcripts. The transcripts discuss bike comparisons between gravel bikes and road bikes, endurance road bike geometry, and triathlon bike versus road bike performance tests, but do not contain any information about the Superior Morgul Road Race, its course conditions, terrain, challenges, or rider experiences specific to this event in Superior, Boulder County, Colorado."
@@ -15975,6 +16446,7 @@
     "has_profile": true,
     "profile_url": "/race/croatan-buck-fifty/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.1068,
     "lng": -77.0399,
     "st": "The Croatan Buck Fifty features a 99% gravel course through North Carolina's Croatan National Forest with over 560 participants. Riders describe fast sandy gravel roads dominated by large potholes that create constant hazards, especially when riding in groups where visibility is limited. The terrain is notably bumpy with more potholes than previous years, causing riders to hit rim bottoms on impact. Savage Road stands out as a technical section requiring careful line selection. The mass start with 550+ people creates hectic conditions requiring extra caution. Riders mention tire pressures around 38 PSI with some considering lower pressures. Despite challenges, participants praise the inclusive atmosphere, great food, and fun gravel roads. The course conditions are described as being in good shape overall, though riders consistently underestimate the difficulty level.",
@@ -16010,6 +16482,7 @@
     "has_profile": true,
     "profile_url": "/race/crooked-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.918,
     "lng": -105.7856,
     "rwgps_id": "42969175",
@@ -16046,7 +16519,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/goteborgsgirot/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Granfondo Campagnolo Roma",
@@ -16079,6 +16553,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-campagnolo-roma/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 41.8902,
     "lng": 12.4922
   },
@@ -16113,6 +16588,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-cancun/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 21.1619,
     "lng": -86.8515
   },
@@ -16147,6 +16623,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-greece/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 37.0755,
     "lng": 22.4303,
     "st": "L'Etape Greece takes place in ancient Olympia, featuring 150 km with over 2,500 meters of elevation gain. Riders describe the course as a test of will that goes beyond typical racing, calling it a pilgrimage on two wheels. The route passes through ancient forests and travels on roads carved by history, with riders cycling in the shadows of ancient temples. The race attracts participants from across nations and generations, including amateurs, dreamers, and dedicated cyclists. The challenging elevation and historical setting create what riders describe as more than just a race, but a celebration of motion through sacred ground where gods once walked and legends took shape."
@@ -16181,6 +16658,7 @@
     "has_profile": true,
     "profile_url": "/race/maap-beechworth-granite-classic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -36.3595,
     "lng": 146.687,
     "rwgps_id": "46113189",
@@ -16217,6 +16695,7 @@
     "has_profile": true,
     "profile_url": "/race/marji-gesick/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 46.4482,
     "lng": -87.6306,
     "rwgps_id": "53265864",
@@ -16253,7 +16732,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/peaks-and-plains/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Pony Xpress",
@@ -16285,6 +16765,7 @@
     "has_profile": true,
     "profile_url": "/race/pony-xpress/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 37.1453,
     "lng": -104.6211,
     "rwgps_id": "53884002",
@@ -16320,6 +16801,7 @@
     "has_profile": true,
     "profile_url": "/race/red-granite-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.035,
     "lng": -90.0739,
     "rwgps_id": "52962151",
@@ -16356,7 +16838,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/sriwijaya-ranau-gran-fondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Valley GranFondo",
@@ -16389,6 +16872,7 @@
     "has_profile": true,
     "profile_url": "/race/valley-granfondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Valley GranFondo takes place at Eagle Acres dairy farm in Fort Langley, Fraser Valley, BC. Riders report the event has grown significantly, with about 1000 participants in previous years reaching record-breaking 1500 riders. The course features some hills throughout that riders describe as getting a little difficult, with the final 10 kilometers being particularly challenging and described as a bit of a grind. Weather conditions have been consistently favorable with beautiful warm temperatures that are neither blazing hot nor too cool, creating ideal riding conditions. The event includes good rest stops with food support along the route. Riders describe the overall experience as tough but fun, with many expressing intent to return the following year. The race starts early in the day and features a family ride component with over 100 participants."
   },
   {
@@ -16421,7 +16905,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/viana-granfondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Bike MS: New York City",
@@ -16454,6 +16939,7 @@
     "has_profile": true,
     "profile_url": "/race/bike-ms-nyc/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 40.7614,
     "lng": -74.0014,
     "st": "GFNY New York is a 135km race starting on the iconic George Washington Bridge that attracts thousands of international riders. The course is lumpy with several short climbs totaling over 2,000m of elevation, similar to an Ardennes classic. Key challenges include the Alpine climb at 18km which creates early selections from the massive field, and the Cheese coat summit around 100km where races are often decided. The route goes through Fort Lee into Palisades Interstate Park before looping north of the city. Riders describe the pace as rapid from early on, with the first categorized climb at Alpine reducing the field to just 40 riders despite its short 1.6km length. The event features both UCI pro and amateur races, with the massive amateur peloton providing significant drafting benefits. All participants must wear official GFNY jerseys. The race finishes with a celebration village in Fort Lee featuring music, food, drinks and prizes."
@@ -16489,6 +16975,7 @@
     "has_profile": true,
     "profile_url": "/race/el-tour-de-tucson/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 32.2226,
     "lng": -110.9747,
     "st": "El Tour de Tucson is described as an extremely fast 102-mile route with 2,885 feet of elevation gain, completed by front groups in under 4 hours at 25+ mph average speeds. The course features big exposed roads in desert conditions with two key climbs including Pistol Hill. Road conditions are rough with many cracks especially near the city, improving further out. Riders emphasize the importance of proper hydration in desert conditions and quality fueling for the fast pace. The race attracts over 7,000-11,000 participants making it one of the largest bike races in the US. Aid stations provide basic nutrition like bananas and orange slices but limited variety. The event has a festival atmosphere with music and massive participation. Cooler than normal temperatures were noted during recent editions."
@@ -16523,6 +17010,7 @@
     "has_profile": true,
     "profile_url": "/race/iceman-cometh/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.6781,
     "lng": -85.1003,
     "rwgps_id": "48937112",
@@ -16559,6 +17047,7 @@
     "has_profile": true,
     "profile_url": "/race/knysna-cycle-tour/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Knysna area offers challenging gravel riding through diverse terrain and remote conditions. Riders describe starting in semi-arid desert conditions before climbing over mountain ranges where vegetation changes dramatically toward the coast. The famous Prince Alfred Pass spans 88 kilometers through four different biomes with dense forest sections, making it the longest mountain pass in South Africa. Expect strong headwinds exceeding 15 km/hour that slow progress on climbs. The route alternates between tar and dirt road sections with significant gravel portions. Riders face very remote conditions with no cars seen for 90+ minutes and no neutral service support. Mechanical issues are common with punctures occurring every two hours. Early morning temperatures are cold, especially at higher elevations. The terrain includes dramatic rock formations and scenic mountain passes. This area was historically used for Cape Epic stages, indicating serious technical and physical challenges for gravel cyclists."
   },
   {
@@ -16591,7 +17080,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/krk-gran-fondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "OCBC Cycle Singapore",
@@ -16624,6 +17114,7 @@
     "has_profile": true,
     "profile_url": "/race/ocbc-cycle-singapore/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "No rider intelligence could be extracted from the available transcripts for the OCBC Cycle Singapore race. The transcripts provided do not contain relevant information about this specific cycling event, course conditions, or rider experiences at the Singapore Sports Hub venue. The available content discusses unrelated topics including ship transportation and general bicycle comparisons, rather than race-specific intelligence that would be useful for riders preparing for this 25-mile cycling event in Singapore."
   },
   {
@@ -16656,7 +17147,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/perth-hills-gran-fondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "aQuelle Tour Durban",
@@ -16689,6 +17181,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-durban/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -29.8287,
     "lng": 31.0292,
     "st": "The aQuelle Tour Durban offers spectacular coastal scenery with ocean views on one side and forest on the other, particularly beautiful sections by the bluff coming to the ocean. Riders describe the 100K course as having quite a few hills but overall nice and easy due to favorable weather conditions. The race starts cool in the morning with October being described as a beautiful, quiet time in Durban. The event features total road closure for safety and has grown from 400 riders with one distance to multiple shorter distances embracing more of the cycling community. The course is described as safe with helpful people along the route and good support. The race finishes on the beachfront allowing riders to enjoy a swim afterward. Durban's tourism industry welcomes the October timing, and the event has joined the Gran Fondo World Tour series as the final race of the calendar year."
@@ -16723,7 +17216,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-of-wessex/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "TransRockies Gravel Royale",
@@ -16755,6 +17249,7 @@
     "has_profile": true,
     "profile_url": "/race/transrockies-gravel-royale/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 55.0013,
     "lng": -125.0024,
     "rwgps_id": "52499537",
@@ -16792,6 +17287,7 @@
     "has_profile": true,
     "profile_url": "/race/amys-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -38.5428,
     "lng": 143.9756,
     "st": "Amy's Gran Fondo in Lorne, Australia features 131 kilometers of challenging terrain along the Great Ocean Road. Riders describe the course as starting with a brutal 20-minute threshold effort, followed by some downhill reprieve before tackling the final decisive climb in forest. After a crazy descent, participants face a demanding 30-kilometer stretch back along the Great Ocean Road. The race attracts around 2,000 riders and creates a vibrant community atmosphere in the heart of Lorne. Successful riders emphasize the importance of consistent nutrition, recommending two 750ml bottles with 130g carbs each and regular gel consumption to avoid bonking. The early 7 AM start time requires careful race morning logistics. The event combines competitive cycling with a meaningful cause, creating an emotional and uplifting experience for participants and spectators alike in one of the world's most scenic coastal locations."
@@ -16826,6 +17322,7 @@
     "has_profile": true,
     "profile_url": "/race/ardenne-gravel-stages/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 50.1619,
     "lng": 5.5817,
     "rwgps_id": "52808946"
@@ -16860,7 +17357,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/balatonfondo/",
-    "discipline": "gravel"
+    "discipline": "gravel",
+    "has_tire_guide": false
   },
   {
     "name": "Belgian Waffle Ride Kansas",
@@ -16892,6 +17390,7 @@
     "has_profile": true,
     "profile_url": "/race/belgian-waffle-ride-kansas/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.9719,
     "lng": -95.2359,
     "rwgps_id": "44736943",
@@ -16931,6 +17430,7 @@
     "has_profile": true,
     "profile_url": "/race/cinturon-ciclista-mallorca/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Cinturon Ciclista a Mallorca 312 is a massive 312km sportive with nearly 5,000m of elevation that takes place the last Saturday of April. Key challenges include the Sa Calobra climb, a beautiful but brutal 9.4km ascent averaging 7% grade where professionals sustain 6.5 watts per kilo for 20 minutes. Other major climbs include Femenia early in the route and Puig Major around the 55km mark. The technical Coll de Soller descent requires careful line selection as riders weave around others who may not hold their lines. Starting pens are crucial - better pens mean riding with more capable cyclists and better etiquette. The event starts at 6:30am requiring arrival at starting pens by 5:30am. Pacing strategy is critical, with experienced riders recommending keeping power under 250 watts on climbs. The event sells out in minutes and attracts 8,500+ participants annually, making it one of Europe's largest closed-road sportives."
   },
   {
@@ -16963,6 +17463,7 @@
     "has_profile": true,
     "profile_url": "/race/d2r2/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.5437,
     "lng": -72.6047,
     "rwgps_id": "53904113",
@@ -16999,6 +17500,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-worlds-amateur/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.8089,
     "lng": -96.7078,
     "st": "Gravel Worlds in Lincoln, Nebraska features a challenging 150-mile course with 11,000 feet of climbing and 87 hills throughout. Riders describe it as harder than Unbound despite being 50 miles shorter, with relentless roller coaster terrain and no flat roads. The course is 95% gravel with sections of deep gravel requiring riders to stay relaxed and let the bike float. Key logistics include no outside support - riders must be self-sufficient for mechanicals and nutrition, with only 2-3 water oases and two official checkpoints for refueling. The race attracts top talent due to a $100,000 prize purse and Graler series status. Long straight roads can create challenges with crosswinds and echelons. Towns along the route include Tui, Valparaiso, and Malcolm. Weather was favorable with low winds and humidity, though dust was present. The terrain constantly zaps riders' legs with up-and-down sections that cause speed loss over climbs followed by acceleration on descents.",
@@ -17034,6 +17536,7 @@
     "has_profile": true,
     "profile_url": "/race/haute-route-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.1885,
     "lng": 5.7245,
     "st": "Haute Route events are professionally supported multi-day stage races featuring extreme climbs across European mountain ranges. Riders face challenges like the 19km Jebel Akhdar climb in Oman with 8% average gradient and 20% ramps, and high-altitude Alpine climbs reaching 2200 meters where reduced oxygen significantly impacts power output. The Alps route covers 896 kilometers with over 22,000 meters of elevation gain across multiple stages. Each stage includes timed climbing sections with mandatory time limits riders must meet to continue. Gear recommendations include 50/34 chainrings with 11-28 or 11-30 cassettes for steep gradients. Nutrition becomes critical with larger riders needing 800-1300 grams of carbs daily. Events provide full support including marshals, neutral service, medical support, and rider briefings covering weather, climb details, and safety information. Mental challenges are common especially for first-time participants, but strong community support among riders helps people through difficult moments on climbs.",
@@ -17069,7 +17572,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/korea-epic-ride/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "La Resistance",
@@ -17101,6 +17605,7 @@
     "has_profile": true,
     "profile_url": "/race/la-resistance/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.0757,
     "lng": 5.7736,
     "st": "La Resistance features the Monte du Plato de Glier, a very steep six kilometer categorized climb that leads onto gravel roads across the plateau. The gravel section is described as strada bianchi style unmade roads, providing a different challenge for riders. The course holds deep historical significance as a memorial to 121 French resistance fighters who died on this plateau in 1944. Teams typically ride tactically on the steep climb, maintaining modest pacing to keep riders fresh despite the peloton getting thinned and stretched out. There are logistical pinch points at the top where riders collect bottles from support before transitioning to the gravel section. The plateau offers stunning scenery and riders often acknowledge the emotional importance of the location during the race.",
@@ -17137,6 +17642,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-argentina/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -31.369,
     "lng": -64.2462,
     "st": "L'Etape Argentina by Tour de France is described as the most important cycle competition worldwide coming to northern Argentina. The event features 150 km of racing with multiple competition modalities including family stage, race, and cycle sportive categories. It's positioned as an event for both amateurs and professionals, offering different participation options for various skill levels. Registration information indicates the event opens for sign-ups starting July 20th through their official website."
@@ -17172,6 +17678,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-portugal/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 41.693,
     "lng": -8.833
   },
@@ -17205,6 +17712,7 @@
     "has_profile": true,
     "profile_url": "/race/noosa-gravel-enduro/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -26.3665,
     "lng": 152.8562,
     "rwgps_id": "53692811",
@@ -17241,6 +17749,7 @@
     "has_profile": true,
     "profile_url": "/race/ride-across-indiana/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 39.4667,
     "lng": -87.4139
   },
@@ -17274,6 +17783,7 @@
     "has_profile": true,
     "profile_url": "/race/sasquatch-duro/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.2943,
     "lng": -123.1765,
     "st": "Sasquatch Duro features wet Oregon fire roads with significant elevation changes and sheltered, tree-covered sections that make it difficult to judge gaps between riders. The course has a high point at 4,400 feet and includes strategic climbs early in the race for breaking up groups. A key feature is the Sasquatch Monster Split at mile 31, described by race promoters as where the race gets interesting. The terrain allows for fast riding on fire roads with Kenda Alluvium Pro 35mm tires proving effective. The final downhill section enables rapid passing of other riders. Race conditions often include Oregon rain, adding to the challenge. With 260 riders registered, the event draws significant participation. The course rewards tactical climbing and gap management skills due to limited visibility between competitors.",
@@ -17309,6 +17819,7 @@
     "has_profile": true,
     "profile_url": "/race/spotted-horse-ultra/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.9217,
     "lng": -93.3123,
     "st": "Spotted Horse Ultra in Iowa is known for extreme challenge and variable weather conditions. Riders describe encountering dusty B-roads throughout the 150-mile course, with significant elevation changes requiring some riders to walk steep climbs. Wind is a major factor with 15-35 mph conditions creating both beneficial tailwind sections early in the race and punishing headwind stretches in the second half. The course features a mix of gravel B-roads and some pavement, finishing with the final 3/4 mile on pavement. Water resupply is available around mile 35-37. Race conditions can vary dramatically year to year, from extreme mud and cold requiring survival tactics to pleasant 70-degree weather with favorable winds. The event is held in October and organized by Sarah Cooper and Steve Fuller, with a reputation for being one of the most challenging gravel races.",
@@ -17344,6 +17855,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-nebraska/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.63,
     "lng": -100.08,
     "st": "No race-specific content found in provided transcript. The transcript appears to be from a historical documentary about Boulder Dam construction rather than gravel cycling race coverage or rider experiences from Tour de Nebraska. Unable to extract cycling-related intelligence, course conditions, terrain descriptions, or rider advice from this material.",
@@ -17380,6 +17892,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-of-cambridgeshire/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 52.5409,
     "lng": -0.3205,
     "st": "The Tour of Cambridgeshire features very flat terrain in Cambridgeshire that amplifies wind conditions significantly. Riders report that forecast winds of 12-14 mph can feel like 20+ mph due to the exposed, flat landscape. The final seven to eight miles present the biggest challenge, featuring headwinds combined with hills that create difficult conditions. Starting position strategy is important - riders should avoid being too far forward with elite racers or too far back where the pace car might catch slower finishers when roads reopen. Registration is described as easy at the East of England Showground venue. The race offers finisher medals and has a supportive community atmosphere where riders help each other with mechanical issues during the event."
@@ -17414,6 +17927,7 @@
     "has_profile": true,
     "profile_url": "/race/trans-iowa/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.6546,
     "lng": -93.4998,
     "rwgps_id": "17383528",
@@ -17451,6 +17965,7 @@
     "has_profile": true,
     "profile_url": "/race/5-mila-marche-gran-fondo/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The transcript provided for the 5 Mila Marche Gran Fondo in Porto Recanati, Italy appears to contain only music lyrics and does not include any rider commentary or race-specific information. No actionable intelligence about the 82-mile course, its 5,446 feet of elevation gain, terrain conditions, key challenges, gear recommendations, or race day tips could be extracted from this content. Riders seeking information about this Tier 3 gravel event would need additional video sources that contain actual race footage or rider commentary to gain insights about the course characteristics, surface conditions, or strategic advice for tackling this event in the Marche region of Italy."
   },
   {
@@ -17483,6 +17998,7 @@
     "has_profile": true,
     "profile_url": "/race/battenkill/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.008,
     "lng": -73.4393,
     "rwgps_id": "40538995",
@@ -17520,6 +18036,7 @@
     "has_profile": true,
     "profile_url": "/race/bowral-classic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -34.4783,
     "lng": 150.4186,
     "st": "The Bowral Classic is a challenging 150km grand fondo in New South Wales featuring 2,400m of elevation gain. Riders describe three main climbs: Oxley Hill at 36km (1.3km at 10.5% gradient), Glen Quarry at 130km (1.9km at 5.2%), and the final Mount Gibraltar at 142km (3.9km at 5%). The course is described as quite lumpy and undulating, especially for the first 36km beyond just the main climbs. Conditions can be very cold at the 6:15am start with temperatures around 9-11 degrees. The race attracts large participation with mass start waves including an elite Highlanders group. Strategy involves hitting the first 36km hard to stay with the front group, then sitting in on the flatter middle section. Key advice includes minimizing stops, carrying extra nutrition, and making predictable moves in large groups early on."
@@ -17555,6 +18072,7 @@
     "has_profile": true,
     "profile_url": "/race/clare-classic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Ring of Clare cycle features two distance options: 120km and 160km routes with 2,000 participants. Riders describe it as a coastal route with significant hills throughout Clare Valley. The major challenge is the first 80k into a tough headwind, but once riders turn, the pace increases dramatically with tailwind assistance. The terrain takes riders all the way to the coast, with the return section described as feeling like being on the edge of the world. Weather conditions can include headwinds and occasional rain. The event is noted as very well organized with good marshalling, food stations, and support throughout. Riders emphasize the challenging hill sections and the dramatic difference between the outbound headwind section and the return journey with favorable winds."
   },
   {
@@ -17587,6 +18105,7 @@
     "has_profile": true,
     "profile_url": "/race/coast-to-coast/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.6212,
     "lng": -84.6824,
     "rwgps_id": "47196412",
@@ -17623,6 +18142,7 @@
     "has_profile": true,
     "profile_url": "/race/cowichan-crusher-gravel-fondo/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 48.8259,
     "lng": -124.0563,
     "st": "The Cowichan Crusher is held in Lake Cowichan, British Columbia, featuring four different distance options from 25km to 160km. The course has been modified due to construction on the rail trail. Riders experience the beautiful Cowichan Valley Rail Trail with spectacular trestle bridges and phenomenal scenery. The terrain includes hard-packed trail sections with no motorized vehicle access, creating smooth riding conditions without washboard surfaces. Some sections become more mountain bike-like and rougher but remain rideable. The event attracts diverse participation with over 30% female riders overall and nearly 50% in shorter distances. The race moved from Duncan to Lake Cowichan for a more remote setting while maintaining access to excellent gravel riding. Conditions can vary from fast, smooth trail sections to more technical mountain bike-style terrain, requiring riders to adapt their pacing accordingly.",
@@ -17658,6 +18178,7 @@
     "has_profile": true,
     "profile_url": "/race/devils-cardigan/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -42.0351,
     "lng": 146.6367,
     "st": "The Devils Cardigan features extremely challenging terrain including the notorious Snake Pit section, described as a river bed with soft gravel, soft mud and water where bikes get stuck. The course runs from Arthur's river to Warar, with particularly gnarly rough terrain from Warar to Delerain that requires walking and features steep climbs so difficult riders say they wouldn't attempt them on mountain bikes. Weather conditions can change dramatically, with temperatures dropping and rain starting around 4 a.m. Equipment reliability is crucial as bike lights can fail unexpectedly. The course was reportedly much harder than previous years. Despite the brutal conditions, riders emphasize the strong community spirit and camaraderie, with fellow competitors providing encouragement during difficult climbs. The race leaves participants feeling isolated in remote wilderness sections but also creates lasting bonds through shared suffering.",
@@ -17693,6 +18214,7 @@
     "has_profile": true,
     "profile_url": "/race/edition-zero/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -43.5866,
     "lng": 171.2123,
     "st": "Edition Zero takes place in Waimate, South Island New Zealand, about 20 minutes from Timaru. The 140k entree distance takes around 6 hours. Key challenges include deep gravel sections starting around 6k that cause crashes, and a unique velodrome finish requiring two laps around the historic 1891 Waimate velodrome. The terrain features long straight roads with rolling hills, varying from thick to thin gravel where riders constantly search for smooth lines. The relentless straight sections and rough surface cause significant back fatigue without suspension. Riders report being able to pass others who slow down after the turnaround point, suggesting conservative pacing is effective. Hydration planning is critical with riders finishing water supplies at the halfway point. The event is praised for strong organization and community focus.",
@@ -17729,6 +18251,7 @@
     "has_profile": true,
     "profile_url": "/race/etape-caledonia/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 56.7053,
     "lng": -3.734,
     "st": "The Etape Caledonia in Pitlochry presents riders with navigation challenges and varied terrain across its 80-mile route. The course follows the John Muir Way for much of its length, starting near sea level and featuring the biggest climb through Balloch Castle Country Park - a 50m ascent early in the route. A key challenge is the narrow bridge over the Endrick Water at mile 15, a former railway bridge with metal walkway that initially appears intimidating but proves manageable. Riders report very wet conditions with morning mist around loch areas. Navigation requires close attention to signage as the route isn't always obvious, with some riders going seven miles off course. The race starts very early around 6am in darkness, requiring lights for navigation to the start line. Road closures can be inconsistent with traffic still present after supposed closure times. Feed stations may have supply issues, with reports of missing gels and energy tablets. Mechanical support is available along the route for brake adjustments and puncture repairs. Three main road crossings present additional hazards along the Scottish Highlands course."
@@ -17763,6 +18286,7 @@
     "has_profile": true,
     "profile_url": "/race/filthy-50/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.7136,
     "lng": -91.9738,
     "rwgps_id": "29153906",
@@ -17799,7 +18323,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-gdynia/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Gravel Bogotá",
@@ -17831,6 +18356,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-bogota/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 4.6534,
     "lng": -74.0836,
     "thumb": "/race-photos/gravel-bogota/gravel-bogota-video-1.jpg"
@@ -17865,6 +18391,7 @@
     "has_profile": true,
     "profile_url": "/race/karukinka/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -53.7553,
     "lng": -68.9335,
     "rwgps_id": "49200669",
@@ -17901,6 +18428,7 @@
     "has_profile": true,
     "profile_url": "/race/nyc-century/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 40.7408,
     "lng": -74.0059,
     "st": "The NYC Century/Grand Fondo takes place in one of the world's densest urban environments, bringing together nearly 3,000 athletes for a competitive yet fun ride through New York City. Riders describe cold morning start conditions that warm up throughout the event. The race combines the fast-paced energy of New York with cycling, allowing participants to experience the sights and sounds of the city while riding. The event is positioned as different from typical stage races or century rides, offering both recreational and competitive elements. Riders cross bridges wearing black jerseys and experience the unique atmosphere of cycling through America's biggest city. The inaugural event attracted international participants and is described as bringing Italian grand fondo culture to New York's urban cycling environment."
@@ -17935,6 +18463,7 @@
     "has_profile": true,
     "profile_url": "/race/oregon-coast-gravel-epic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.427,
     "lng": -124.0672,
     "rwgps_id": "50686348",
@@ -17971,6 +18500,7 @@
     "has_profile": true,
     "profile_url": "/race/paris-mountain-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.9676,
     "lng": -82.4435,
     "st": "Riders describe challenging climbs including Santa Rosa Creek, which features extremely steep sections requiring full out-of-saddle efforts with some riders walking portions. The area offers multiple climbing options including Old Creek and Santa Rita road. Santa Rita road is highlighted as gravel that's smooth enough for road bikes, described as quiet and beautiful with scenic views. The terrain around Santa Margarita offers varied surfaces from steep paved climbs to manageable gravel roads. Riders recommend tubeless tire setups and specifically mention IRC X Guards for reliability. The riding area features multiple santa-named roads with different character - some extremely challenging climbs and others more accessible gravel suitable for various bike types.",
@@ -18006,6 +18536,7 @@
     "has_profile": true,
     "profile_url": "/race/pony-xpress-gravel-160/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 37.1694,
     "lng": -104.5005,
     "st": "The Pony Express Gravel features smooth roads early with tailwinds, transitioning to challenging conditions with high 90s to 100 degree temperatures both days. Course includes lots of minimum maintenance roads, stream crossings, and steep climbs. Glass hazards present - one rider suffered tire damage from glass shard around mile 40. Route passes through small towns with gas stations for water and supply resupply. Early morning conditions are pleasant before heat and headwinds develop, creating suffer fest conditions later. Strong community spirit among riders helping each other with mechanical issues. Beautiful rural churches and scenery along the route. Two-day bikepacking option available with camping midway through.",
@@ -18041,6 +18572,7 @@
     "has_profile": true,
     "profile_url": "/race/river-city-gravel-fondo/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 50.0231,
     "lng": -125.2442,
     "rwgps_id": "50401058",
@@ -18077,6 +18609,7 @@
     "has_profile": true,
     "profile_url": "/race/ruby-roubaix/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.728,
     "lng": -115.4784,
     "rwgps_id": "53678724",
@@ -18113,6 +18646,7 @@
     "has_profile": true,
     "profile_url": "/race/the-range/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 55.0013,
     "lng": -115.0021,
     "st": "The Range rustler is an 86km gravel race in Alberta featuring mostly public gravel roads in perfect condition with quiet traffic. Key features include a decision junction where riders choose between 60km Rodeo or full rustler distance, and exclusive access to Burke Creek Ranch via private road with fast downhill section. Race starts at 8am in 20C temperatures before afternoon heat reaches mid-30s. Course has one aid station at turnaround point. Terrain feels ancient and fossil-rich through Alberta coulees. Early pace goes really fast requiring pack riding skills. Riders should come self-sufficient with food and water and plan around hot afternoon conditions.",
@@ -18149,6 +18683,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-cure/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 33.4484,
     "lng": -112.074,
     "st": "The provided transcripts do not contain information about the Tour de Cure gravel cycling race. Instead, they contain content about the Tour de France professional cycling race and Tour 21, a charity cycling event that follows the Tour de France route. The transcripts discuss Tour de France climbing stages, drafting techniques in professional cycling, and a multi-week charity ride through France's mountain ranges to raise money for leukemia research. No specific details about Tour de Cure's gravel course conditions, terrain, challenges, or race experience are mentioned in these transcripts."
@@ -18184,6 +18719,7 @@
     "has_profile": true,
     "profile_url": "/race/vuelta-cicloturista-ibiza/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The available video transcript for the Vuelta Cicloturista a Ibiza contains only fragmentary audio elements including music, applause, and disconnected words, without any substantive rider commentary or race analysis. No specific information about the 174-mile course through the Balearic Islands, terrain conditions, elevation challenges, or racing strategies could be extracted from the transcript. The video appears to be primarily visual content without detailed verbal discussion of race features, logistics, or rider experiences on Ibiza's roads and countryside."
   },
   {
@@ -18216,6 +18752,7 @@
     "has_profile": true,
     "profile_url": "/race/3-state-3-mountain-challenge/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.5795,
     "lng": -85.5905,
     "rwgps_id": "49021325",
@@ -18252,6 +18789,7 @@
     "has_profile": true,
     "profile_url": "/race/carpathian-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 46.7336,
     "lng": 24.5274,
     "st": "The Carpathian Gravel route crosses the Carpathian Mountains with challenging terrain in the first half featuring lots of ups and downs, followed by more gradual descents following a river. Riders encounter military checkpoints requiring passport verification when crossing regional boundaries (Oblast). The route includes extremely steep and fast descents that require constant braking at speeds around 10 km/h, followed by long climbs back out of valleys. Road quality varies significantly, often poor in certain areas, but the surroundings are described as stunning and gorgeous. Weather conditions include occasional downpours and mountains covered in mist. The elevation profile drops from around 900 meters to 160 meters over the latter portion. Local communities are described as very nice and welcoming despite economic challenges in the region.",
@@ -18287,6 +18825,7 @@
     "has_profile": true,
     "profile_url": "/race/dirty-hector/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.5423,
     "lng": -76.6661,
     "rwgps_id": "53033649"
@@ -18321,6 +18860,7 @@
     "has_profile": true,
     "profile_url": "/race/fools-gold-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.5328,
     "lng": -83.9846,
     "st": "Fools Gold is described by riders as normally being a mountain bike race with 38-mile and 54-mile options starting at Montaluce Winery. The course begins with asphalt riding and a fun downhill where groups stay tight, then crosses a bridge into country roads with mountain climbs and descents, followed by fast fun single track sections. However, riders warn about the rain route - when weather conditions are poor, the Department of Forestry can shut down off-road sections, converting the entire race to all gravel instead of the normal mountain bike terrain. This can catch riders off guard who come prepared for mountain biking but find themselves racing an entirely different gravel course due to weather restrictions.",
@@ -18356,7 +18896,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-paracas/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Gran Fondo Ozarks",
@@ -18388,6 +18929,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-ozarks/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 36.4001,
     "lng": -93.7392
   },
@@ -18422,6 +18964,7 @@
     "has_profile": true,
     "profile_url": "/race/gran-fondo-panama/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "The Gran Fondo Panama Ocean to Ocean event covers 68 miles from the Atlantic to Pacific Ocean with 3,600 feet of elevation gain, featuring four canal crossings including a challenging double crossing of the Atlantic Bridge with 5% grades at mile 7. The race attracts 5,000 participants from over 20 countries. Early sections experience mass-start roll-walk-stop conditions where riders can barely pedal. Roads can be damp and many cyclists pull over with flats in the opening miles. The route traverses multiple bridges including Puente Centenario and Puente de las Americas. Start time is scheduled for 6:30 AM but expect delays for opening ceremonies. Airport transfers cost around $35 via private taxi, with multiple host hotels available within walking distance of race headquarters and local restaurants."
   },
   {
@@ -18455,6 +18998,7 @@
     "has_profile": true,
     "profile_url": "/race/granfondo-charlevoix/",
     "discipline": "road",
+    "has_tire_guide": false,
     "st": "Riders describe Granfondo Charlevoix as an excellent course with good flow that maintains its character despite course changes from previous years. The race features enough climbing that lightweight hardtail bikes perform well, offering quick acceleration on climbs and out of corners. Traffic can be a concern with multiple rider categories on course, leading to faster riders lapping others three times during the event. The course is considered short enough that traffic density becomes noticeable. Riders praise the race organization and consider it one of the favorite courses in Canada. The event maintains good flow throughout despite the traffic challenges, and experienced riders recommend focusing on steady pacing rather than reactive racing tactics."
   },
   {
@@ -18487,6 +19031,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-del-fuego/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -33.0162,
     "lng": -71.5219,
     "st": "Gravel del Fuego takes place in Patagonia, Chile, in the far southern region near Antarctica. The race location is characterized by extreme wind conditions that require riders to prepare for harsh weather exposure. The area covers the southern regions of both Argentina and Chile, with riders describing it as one of the most remote locations they have ever been to for cycling. The wind conditions are particularly notable, with experienced guides recommending head protection even during warmer periods due to the constant ripping winds throughout the day. The race represents an opportunity to experience one of the most geographically isolated and challenging environments in gravel cycling.",
@@ -18522,6 +19067,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-medellin/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 6.2697,
     "lng": -75.6026,
     "st": "The Transcordilleras gravel race in Colombia crosses three mountain ranges from north to south, with elevations ranging from 200m in valleys to 3,900m in the paramo where it's cold and hard to breathe. Colombian roads come in two flavors according to riders: steep or crazy steep. The terrain features extremely rough descents that are back-pinching and arm-shaking, making riders happy when climbs begin. Key challenges include a six-mile 10% grade climb from guatape and racing through active construction zones. Riders recommend switching to larger chainrings like 44t and using 51t cassettes for the steep terrain. The race features F1-style quick stops at tiendas where locals help riders. For gear, experienced riders suggest minimal kit - one bib and jersey washed daily for multi-day events, plus essential weather protection including windbreakers and gore-tex jackets. The community aspect is strong with local support and experienced riders setting pace for groups.",
@@ -18557,6 +19103,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-suisse/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 46.3179,
     "lng": 6.9689,
     "rwgps_id": "51959894",
@@ -18593,6 +19140,7 @@
     "has_profile": true,
     "profile_url": "/race/grinduro-italy/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.0528,
     "lng": 10.8927,
     "series_id": "grinduro",
@@ -18630,6 +19178,7 @@
     "has_profile": true,
     "profile_url": "/race/kettle-mettle/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 49.4606,
     "lng": -120.5061,
     "st": "The Kettle Mettle in British Columbia features deceptive terrain that starts with calm wide gravel flats before hitting challenging climbs on Forest Service roads behind Princeton. Riders report the gravel gets looser and climbs punchier than expected, with long exposed stretches testing legs and mindset. Only a small portion uses the anticipated KVR trail, surprising many participants. The pristine gravel roads offer spectacular views of Princeton and surrounding area. The course features varied terrain that challenges riders more than expected. Rock hazards pose flatting risks for riders following too closely. The grassroots event attracts diverse age groups including many riders in their 50s and 60s, emphasizing personal achievement over speed. The race philosophy focuses on showing up and getting a good workout rather than competitive pressure, making it appealing for those transitioning from other disciplines like triathlon to gravel riding.",
@@ -18665,6 +19214,7 @@
     "has_profile": true,
     "profile_url": "/race/king-price-race-to-sun/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -28.8166,
     "lng": 24.9916,
     "st": "The King Price Race to Sun is a 165km gravel race in South Africa's Northwest Province, starting at U Resort on Hartebeestpoort Dam and finishing at Sun City. Riders describe it as the original South African gravel race that introduced the gravel scene to the country. The course features hard and fast dirt roads along the Brits canal irrigation system with 1000m of elevation gain over 100 miles. Terrain is notably rough, described as the roughest it's ever been, with constant movement required on gravel bikes. The race typically sees high early pace around 38k/hour average to the second water point. Key tactical sections include pinch points where position is critical and a small ditch/climb around 21km used for attacks. Recent route changes eliminated problematic corrugated roads and added a compact gravel section through Sadiba quail adventure center. The course is backloaded with new features in the second half. Weather conditions are typically perfect with wide roads allowing safe overtaking.",
@@ -18700,7 +19250,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/vuelta-puerto-rico/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Wörthersee Gravel Race",
@@ -18732,6 +19283,7 @@
     "has_profile": true,
     "profile_url": "/race/worthersee-gravel-race/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 46.6125,
     "lng": 14.0409,
     "rwgps_id": "50218872",
@@ -18768,6 +19320,7 @@
     "has_profile": true,
     "profile_url": "/race/3rides-aachen/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 51.1638,
     "lng": 10.4478,
     "rwgps_id": "50935310",
@@ -18804,6 +19357,7 @@
     "has_profile": true,
     "profile_url": "/race/6-hours-of-syllamo/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.8684,
     "lng": -92.1177,
     "thumb": "/race-photos/6-hours-of-syllamo/6-hours-of-syllamo-video-1.jpg"
@@ -18838,6 +19392,7 @@
     "has_profile": true,
     "profile_url": "/race/66-south-pyrenees/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.5036,
     "lng": 2.0397,
     "st": "The Pyrenees crossing presents diverse terrain that changes daily as riders move from the Mediterranean toward the Atlantic. Key challenges include the Port Caboose climb serving as the gateway back to Spain from Andorra, and sudden thunderstorms that can trap riders on exposed mountaintops requiring emergency shelter. The terrain includes rough hike-a-bike sections where shortcuts become challenging portages. Weather is highly variable with frequent rain jacket changes needed throughout the journey. Livestock including horses and cows frequently occupy roads, particularly on descents, requiring constant vigilance. The route covers approximately 1,000 kilometers over two weeks with nearly 25,000 meters of elevation gain. Camping spots near mountain refuges may be shared with curious horses that can disturb sleep. The diverse landscape and rapidly changing conditions make this a challenging multi-day adventure requiring weather preparedness and flexibility.",
@@ -18873,6 +19428,7 @@
     "has_profile": true,
     "profile_url": "/race/barry-roubaix/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.6485,
     "lng": -85.2895,
     "rwgps_id": "31249124",
@@ -18909,6 +19465,7 @@
     "has_profile": true,
     "profile_url": "/race/cheaha-challenge/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 33.8138,
     "lng": -85.7613,
     "rwgps_id": "53887891",
@@ -18946,6 +19503,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-cozumel/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 20.5104,
     "lng": -86.946,
     "st": "GFNY Cozumel attracts 1,800 international riders to San Miguel de Cozumel, Mexico for what organizers describe as an amazing race with party atmosphere. The event is held in November with perfect weather conditions on the island. Riders fly into Cozumel with bike transport, staying at a host hotel resort that offers special GFNY rates around $300 per night compared to regular $800 rates. The race weekend includes group rides to scenic locations like the east side beaches and wind surfing areas. Organizers emphasize the international community aspect, with participants coming from around the world. Early morning airport departures at 5:00 AM are common for travel logistics. The event is described as breathtaking with amazing views and vibes, making it a destination race experience combining cycling with beach resort atmosphere."
@@ -18980,6 +19538,7 @@
     "has_profile": true,
     "profile_url": "/race/grusk/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.6709,
     "lng": -79.4912
   },
@@ -19013,6 +19572,7 @@
     "has_profile": true,
     "profile_url": "/race/hot-springs-gravel-gauntlet/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.8923,
     "lng": -82.829,
     "rwgps_id": "54670830",
@@ -19049,6 +19609,7 @@
     "has_profile": true,
     "profile_url": "/race/iron-cross/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.97,
     "lng": -77.7279,
     "st": "Iron Cross in Pennsylvania is a 56-mile gravel race with significant elevation and technical challenges. The course features mixed terrain including road, gravel, soft pack, and technical single track sections. Multiple hike-a-bike sections with steep rocky climbs are a defining feature, with some climbs feeling twice as long as they actually are. Riders report needing granny gears for extended climbing sections, though single speed completion is possible. The constant elevation changes mean no drafting or pack riding - success depends entirely on individual fitness. Technical rock features require bike handling skills. The terrain switches frequently, mixing riders of different abilities throughout the race. Despite the difficulty, riders praise the supportive community atmosphere and beautiful fall scenery in Central Pennsylvania. Many first-time participants find it challenging enough that they don't return, though repeat racers appreciate both the tough reputation and positive vibe.",
@@ -19085,6 +19646,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-thailand/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 16.8211,
     "lng": 100.2659
   },
@@ -19118,6 +19680,7 @@
     "has_profile": true,
     "profile_url": "/race/little-apple-100/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.4225,
     "lng": -87.9859,
     "rwgps_id": "52324707",
@@ -19153,6 +19716,7 @@
     "has_profile": true,
     "profile_url": "/race/lost-and-found-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.8105,
     "lng": -120.4695,
     "st": "Lost and Found Gravel in Portola, California features 96-97 miles with 6,000-8,000 feet of climbing. The race starts with brutal early climbing including 16,000 feet of elevation in the first 5 miles, with steep sections hitting 12% grades before mile 9. Key challenges include a hidden left turn at mile 8.4 miles where the course transitions to dirt, and climb six around mile 33 - a 2.7-mile brutal climb with 650 feet of gain on loose, chunky gravel. Riders face a big empty valley around mile 30 with brutal headwinds that continue to the finish. The course features extremely dusty conditions that affect chain lubrication and visibility, mixed with water crossings. Terrain includes primo gravel sections, washboards, and loose gravel on climbs. Veterans recommend starting conservatively due to early climbing, positioning well in the pack for dust visibility, and bringing chain lube due to harsh conditions.",
@@ -19188,6 +19752,7 @@
     "has_profile": true,
     "profile_url": "/race/niseko-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.8047,
     "lng": 140.6873,
     "rwgps_id": "52644177",
@@ -19223,6 +19788,7 @@
     "has_profile": true,
     "profile_url": "/race/ouachita-challenge/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.5576,
     "lng": -93.6326,
     "rwgps_id": "49224473",
@@ -19259,6 +19825,7 @@
     "has_profile": true,
     "profile_url": "/race/race-to-valhalla/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.7648,
     "lng": -83.064,
     "rwgps_id": "36682023",
@@ -19295,6 +19862,7 @@
     "has_profile": true,
     "profile_url": "/race/santa-fe-century-gravelon/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.6876,
     "lng": -105.9385
   },
@@ -19328,6 +19896,7 @@
     "has_profile": true,
     "profile_url": "/race/sea-otter-europe-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.9793,
     "lng": 2.8199,
     "st": "Sea Otter Europe Gravel in Girona features a mix of nice fast gravel roads with good surface quality combined with technical sections. Riders highlight the technical descents with twisty corners as a key challenge requiring skill and bike handling. The course offers variety between fast gravel sections and more demanding technical terrain. Riders describe the gravel quality as impressive and recommend the area as an excellent destination for cycling. The technical nature of the descents with twisty corners stands out as a defining characteristic that riders need to prepare for.",
@@ -19363,7 +19932,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tallinn-gran-fondo/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Tour de Pologne Amatorów",
@@ -19396,6 +19966,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-pologne-amatorow/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 50.0647,
     "lng": 19.945
   },
@@ -19430,6 +20001,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-of-the-battenkill-road/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 43.028,
     "lng": -73.381,
     "st": "The Tour of the Battenkill Gran Fondo presents significant safety challenges, particularly at the Eagleville bridge where multiple crashes have been witnessed during race events. Riders report equipment malfunctions including wheel issues and component failures that can end races prematurely. The race route passes through Eagleville twice, requiring careful navigation through this crash-prone section. Quick wheel changes are common and riders should be prepared for mechanical issues. The men's category races cover 82 miles with tight finishes, as evidenced by a 1-second victory margin between top competitors. Safety reminders emphasize keeping control and being aware that medical assistance may not be immediately available. The challenging nature of this race demands both technical skill and mechanical preparedness from participants."
@@ -19464,6 +20036,7 @@
     "has_profile": true,
     "profile_url": "/race/trans-sylvania-epic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.97,
     "lng": -77.7279,
     "st": "Trans-Sylvania Epic is a multi-day stage race in Pennsylvania's national forests featuring 47-mile opener stages and longer 60-65 mile days with significant climbing. Day four includes 61 miles with 6000 feet of elevation gain. The course features very rocky steep climbs that riders describe as nasty, including a key 2.5 mile climb out of Woodward. Roads are generally in good condition according to experienced riders. The race includes run sections that can be challenging with road cleats. Riders describe the Pennsylvania national forests as super green, lush and beautiful. Four-wheelers on course present some safety concerns. The multi-day format creates an immersion gravel experience through scenic wooded terrain with substantial daily elevation gains and technical climbing sections.",
@@ -19499,6 +20072,7 @@
     "has_profile": true,
     "profile_url": "/race/uwharrie-forest-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.9371,
     "lng": -80.9665,
     "st": "The Uwharrie Forest trail system features the Wood Run trail with deep historical significance, following the old Fayetteville to Morganton Plank Road through the defunct town of Lawrenceville. Riders encounter Wood Run Creek crossings and multiple power line clearings between wooded sections. Fall conditions create significant leaf surfing opportunities with deep leaf coverage affecting trail surface. Recent controlled burns have left remnants throughout the forest. Key logistical notes include a rerouted trail entrance that now passes Escape rather than the old route. Hunters in orange are common during fall season. The trail connects to other Uwharrie trails including access to Kiwi Trails and connects to the broader trail network. Historical features include visible courthouse foundation remnants from the old Montgomery County seat before it was moved to Troy.",
@@ -19534,6 +20108,7 @@
     "has_profile": true,
     "profile_url": "/race/waucheesi-bike-race/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.3626,
     "lng": -84.294,
     "rwgps_id": "38315398",
@@ -19570,6 +20145,7 @@
     "has_profile": true,
     "profile_url": "/race/berryman-epic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 37.9364,
     "lng": -90.7879,
     "rwgps_id": "28761320",
@@ -19606,6 +20182,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-battle-of-sumter-forest/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.5029,
     "lng": -81.6115,
     "rwgps_id": "49042380",
@@ -19642,6 +20219,7 @@
     "has_profile": true,
     "profile_url": "/race/hellhole-gravel-grind/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 33.286,
     "lng": -79.6926
   },
@@ -19675,6 +20253,7 @@
     "has_profile": true,
     "profile_url": "/race/hungry-bear-100/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 46.208,
     "lng": -91.2921,
     "rwgps_id": "39219103",
@@ -19712,6 +20291,7 @@
     "has_profile": true,
     "profile_url": "/race/letape-dubai/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 25.186,
     "lng": 55.299
   },
@@ -19745,6 +20325,7 @@
     "has_profile": true,
     "profile_url": "/race/reliance-deep-woods/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.773,
     "lng": -86.282,
     "st": "The transcript mentions the Reliance Deep Woods as part of a broader discussion of Southeast gravel events. The race is described as featuring red clay canopy roads that provide challenging riding conditions. Riders are advised to bring climbing gear as the terrain is not flat. The event appears to be community-focused, with proceeds benefiting local programs. The race takes place in an area known for scenic riding with significant climbing challenges. The terrain includes red clay surfaces under tree canopy that riders will encounter throughout the 65-mile course with 4500 feet of elevation gain.",
@@ -19780,6 +20361,7 @@
     "has_profile": true,
     "profile_url": "/race/reliance-tennessee-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.187,
     "lng": -84.4991,
     "st": "The Reliance Tennessee gravel race features challenging terrain including dangerous bridge sections where crashes resulting in concussions and shoulder injuries have occurred. The course includes sustained climbs with 7% grades where riders slow to 7 miles per hour. Surface conditions can be hazardous, particularly tar sections that become slick when wet. The Web Brothers store serves as a key landmark and appears to be the only store in the area, making it an important logistical point. Riders are using Continental tubeless tires in 28mm widths for the varied terrain. The scenic route passes through beautiful areas that are popular with motorcycles and connects to areas like Cage Cove. The challenging nature of the course requires careful attention to technical descents and sustained climbing efforts.",
@@ -19815,6 +20397,7 @@
     "has_profile": true,
     "profile_url": "/race/rooted-vermont/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.5615,
     "lng": -72.5983,
     "rwgps_id": "40599549",
@@ -19850,6 +20433,7 @@
     "has_profile": true,
     "profile_url": "/race/safari-gravel-race/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 1.442,
     "lng": 38.4314,
     "st": "The Safari Gravel Race in Kenya's Hell's Gate National Park presents unique challenges for gravel riders. The course runs through a game reserve where wild animals like zebras, impala, giraffe and buffalo cross the road unexpectedly. Riders must navigate rough, bumpy terrain with big holes, gullies and ruts on descents, plus livestock including cows on the road. The race starts cool in the morning but becomes very hot by midday, with altitude adding difficulty. Water stops are supplemented by small shops along the course. Traffic and animals frequently travel on the wrong side of the road around blind corners. The bumpy conditions can cause mechanical issues with electronic shifting systems. Despite technical challenges, riders praise the professional race organization and vibrant local cycling community. The course features steep climbs that some riders walk, followed by long descents to the finish. Dust becomes an issue around 30km into the race. The setting in Hell's Gate National Park, where Lion King was based, provides stunning Great Rift Valley scenery.",
@@ -19885,6 +20469,7 @@
     "has_profile": true,
     "profile_url": "/race/salida-76/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.5371,
     "lng": -105.991,
     "rwgps_id": "52541765",
@@ -19921,6 +20506,7 @@
     "has_profile": true,
     "profile_url": "/race/spirit-world-100/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.3953,
     "lng": -111.7633,
     "rwgps_id": "50564820",
@@ -19958,6 +20544,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-palm-springs/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 33.8303,
     "lng": -116.5453,
     "rwgps_id": "38541342",
@@ -19993,6 +20580,7 @@
     "has_profile": true,
     "profile_url": "/race/uci-gravel-dustman/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 14.02,
     "lng": 99.53,
     "rwgps_id": "53184604",
@@ -20029,6 +20617,7 @@
     "has_profile": true,
     "profile_url": "/race/wild-horse-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.3348,
     "lng": -108.2153,
     "st": "Wild Horse Gravel is an inaugural event in De Beque, Colorado featuring two course options - a longer Alton back course with two timed segments and a shorter course with one timed segment. The event follows a grinder format where it's more of a ride than a race, though some riders take the timed segments seriously. The course features loose and rutted conditions requiring careful line choice, with the first timed segment ending in a very steep climb followed by another steep hill to the neutral water station. There's a cut-off time in De Beque for the long course. Riders encounter high desert scenery, wildlife including cows and wild horses, and several flatter open areas with expansive views. Weather starts cool requiring arm warmers but warms to low 70s Fahrenheit by late morning. The format emphasizes scenery and photography over pure racing, making it relaxing compared to traditional timed events.",
@@ -20064,6 +20653,7 @@
     "has_profile": true,
     "profile_url": "/race/wish-one-millau/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.146,
     "lng": 3.1722,
     "rwgps_id": "49327972",
@@ -20100,6 +20690,7 @@
     "has_profile": true,
     "profile_url": "/race/alentejo-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.0551,
     "lng": -7.8606,
     "rwgps_id": "53243412",
@@ -20135,6 +20726,7 @@
     "has_profile": true,
     "profile_url": "/race/bear-howard-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.1988,
     "lng": -111.6518,
     "st": "The Flagstaff area features challenging climbs including Mount Eldon Lookout Road and Mars Hill. Mount Eldon's steep section is particularly demoralizing because riders can see the full extent of climbing ahead on the wide open road. The climb gains about 3000 feet over 15 miles and is described as destroying riders even when using mountain bikes with lower gearing compared to gravel bikes. However, the descent down Mount Eldon Lookout road is considered one of the best around. Mars Hill offers another punishing climb with the worst section just past the lookout. The area requires careful pacing on climbs and riders should be prepared for mechanical issues like flats. Night riding is possible but requires proper lighting. The terrain includes gravel roads with significant elevation changes through the Flagstaff area."
@@ -20169,6 +20761,7 @@
     "has_profile": true,
     "profile_url": "/race/big-sky-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.1859,
     "lng": -109.2471,
     "rwgps_id": "38380768",
@@ -20205,6 +20798,7 @@
     "has_profile": true,
     "profile_url": "/race/dead-swede-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.7948,
     "lng": -106.8223,
     "rwgps_id": "30317261",
@@ -20241,6 +20835,7 @@
     "has_profile": true,
     "profile_url": "/race/eislek-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 49.8159,
     "lng": 6.1297,
     "rwgps_id": "51630014",
@@ -20276,6 +20871,7 @@
     "has_profile": true,
     "profile_url": "/race/flanders-legacy-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 51.0378,
     "lng": 4.2406,
     "rwgps_id": "53068383",
@@ -20312,6 +20908,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-grit-n-grind/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 56.674,
     "lng": 12.8575,
     "rwgps_id": "45904274",
@@ -20348,6 +20945,7 @@
     "has_profile": true,
     "profile_url": "/race/hell-of-hunterdon/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.5771,
     "lng": -74.9262,
     "rwgps_id": "26057641",
@@ -20383,6 +20981,7 @@
     "has_profile": true,
     "profile_url": "/race/houffa-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 50.1619,
     "lng": 5.5817,
     "st": "This transcript provides limited race-specific intelligence about the Houffa Gravel race in Belgium. The rider mentions it's their second World Gravel Series event and notes logistical planning required, being about an hour and a half away from the race location. The surrounding area is described as flatter than France with quiet roads and located around historical battle sites. However, the transcript primarily focuses on travel preparation and pre-race logistics rather than course details, terrain conditions, or race-specific challenges that would be useful for other riders preparing for this event.",
@@ -20418,6 +21017,7 @@
     "has_profile": true,
     "profile_url": "/race/king-of-the-lake/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 47.6478,
     "lng": 9.3472,
     "st": "The Lake Constance cycling route is a 250 kilometer signposted bike path that circles the lake through Germany, Austria, and Switzerland. The eastern German shore features villages, hotels, and private properties with limited lake views, while the western Swiss side runs closer to the shore with longer stretches between settlements. The route includes gravel sections that allow for easy detours and excursions. Austria's elegant city of Bregenz sits between Germany and Switzerland, offering beautiful promenades and beaches. The Rhine River delta area provides nature park wetlands for bird watching. Villages appear every few kilometers with impressive architecture, and the route offers abundant accommodation options including hotels, guest houses, campsites, restaurants, and cafes. The terrain is described as suitable for relaxing cycling and beginner bike touring rather than high-mileage days.",
@@ -20453,6 +21053,7 @@
     "has_profile": true,
     "profile_url": "/race/la-dromoise-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.7295,
     "lng": 5.2229,
     "thumb": "/race-photos/la-dromoise-gravel/la-dromoise-gravel-video-1.jpg"
@@ -20487,6 +21088,7 @@
     "has_profile": true,
     "profile_url": "/race/lauf-gritfest/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 52.4149,
     "lng": -3.5047,
     "rwgps_id": "49119810",
@@ -20524,6 +21126,7 @@
     "has_profile": true,
     "profile_url": "/race/noosa-classic/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": -26.3925,
     "lng": 153.0378,
     "st": "The Noosa Classic offers multiple distance options including 160km, 120km, and 45km routes. Riders describe the course as having hardly any cars with wide open spaces, providing a peaceful riding environment. The challenge course is 120km with just over 1,600 meters of elevation. A key difficulty comes in the final 20K where the pace can ramp up significantly, with riders mentioning tempos hitting 800 watts. Nutrition management is critical as bonking can occur around the 80K mark if riders don't pack sufficient food. The event takes place in August and offers early bird registration with incentives like free jerseys for those registering by late March."
@@ -20558,6 +21161,7 @@
     "has_profile": true,
     "profile_url": "/race/pony-express-120/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.8417,
     "lng": -96.6481,
     "st": "The Pony Express 120 in Marysville, Kansas features challenging gravel terrain on B roads and farm roads with significant elevation changes. The signature climb is Brewsky Hill, the first major ascent that rewards finishers with a free beer ticket. Riders describe the surface as dusty with good rock on flatter sections and challenging gravel overall. Weather conditions typically include hot temperatures with headwinds on the return leg. The race offers multiple distance options from 30 miles for beginners to 120 miles, with the shorter course being mostly flat while the full distance provides fast downhills and tough climbs. The event incorporates historical elements, routing through locations like Alco Springs Park and Rock Creek Station along the original Pony Express route. Marysville offers free camping at the city park, and Casey's convenience store serves as a popular pre-race fuel stop.",
@@ -20594,6 +21198,7 @@
     "has_profile": true,
     "profile_url": "/race/ride-across-wisconsin/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 44.8113,
     "lng": -91.4985
   },
@@ -20627,6 +21232,7 @@
     "has_profile": true,
     "profile_url": "/race/standard-deluxe-dirt-road-century/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 32.7354,
     "lng": -85.5791,
     "st": "The Standard Deluxe Dirt Road Century in Waverly, Alabama features punchy, short climbs rather than long sustained efforts that wreak havoc on the peloton and cause group separations. The terrain is hardly flat throughout this part of Alabama. When rain falls during the race, muddy conditions coat riders and bikes, though fenders aren't typically used. The race begins with a relaxed neutral rollout before aggressive racing develops, with leaders launching attacks in the final miles. The event allows any type of bicycle and maintains an informal, rule-free atmosphere typical of gravel racing. Organized by Terrafirma Cycling, the race offers both 60-mile and 100-mile distance options, attracting riders of various ages and abilities to Alabama's challenging gravel roads.",
@@ -20662,6 +21268,7 @@
     "has_profile": true,
     "profile_url": "/race/texas-hell-week/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 30.0552,
     "lng": -96.9139
   },
@@ -20695,6 +21302,7 @@
     "has_profile": true,
     "profile_url": "/race/veneto-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.8007,
     "lng": 11.9142,
     "thumb": "/race-photos/veneto-gravel/veneto-gravel-video-1.jpg"
@@ -20729,6 +21337,7 @@
     "has_profile": true,
     "profile_url": "/race/114-gravel-race/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.6622,
     "lng": -8.1354,
     "rwgps_id": "53045297",
@@ -20765,6 +21374,7 @@
     "has_profile": true,
     "profile_url": "/race/back-forty-highlander/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.22,
     "lng": -76.2067,
     "st": "No race-specific information was found in the provided transcripts for the Back Forty Highlander gravel race in Mississippi Station, Ontario. The transcripts contain content about tire testing, hunting adventures, and aviation activities, but do not include any rider experiences, course descriptions, or race-related intelligence for this 62-mile gravel event with 3,500 feet of elevation gain. To provide actionable intelligence for riders considering this race, transcripts from actual race participants or race coverage would be needed.",
@@ -20800,6 +21410,7 @@
     "has_profile": true,
     "profile_url": "/race/border-wars/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 33.28,
     "lng": -85.1,
     "rwgps_id": "49741722",
@@ -20836,6 +21447,7 @@
     "has_profile": true,
     "profile_url": "/race/burgr-95/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.3089,
     "lng": -89.4965,
     "rwgps_id": "22556681"
@@ -20870,6 +21482,7 @@
     "has_profile": true,
     "profile_url": "/race/burnt-bridge-classic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 48.836,
     "lng": -124.1503,
     "rwgps_id": "50773175",
@@ -20906,6 +21519,7 @@
     "has_profile": true,
     "profile_url": "/race/castellon-gravel-race/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.2519,
     "lng": -0.0615,
     "st": "The Castellon Gravel Race features intense climbing with 3,000 meters of elevation gain in under 100K, described by riders as extremely challenging. The course profile consists primarily of climbing and descending sections. Riders recommend suspension forks despite the weight penalty, noting significant time savings on descents and improved confidence on technical terrain. Mountain bike cassettes are suggested for maximum gear range on this technical race. The challenging elevation profile makes this suitable for riders who love climbing but prepare for difficulty. Tire setup recommendations include 45mm width on front for grip with slightly narrower rear tires for reduced rolling resistance. The race is part of the UCI Gravel World Series.",
@@ -20941,6 +21555,7 @@
     "has_profile": true,
     "profile_url": "/race/chino-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.7575,
     "lng": -112.4538,
     "rwgps_id": "44452406",
@@ -20977,6 +21592,7 @@
     "has_profile": true,
     "profile_url": "/race/dirty-sheets-gravel-grind/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 33.5791,
     "lng": -84.7687,
     "rwgps_id": "53420740",
@@ -21013,6 +21629,7 @@
     "has_profile": true,
     "profile_url": "/race/farmers-daughter/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.7127,
     "lng": -74.006,
     "rwgps_id": "52380212",
@@ -21049,6 +21666,7 @@
     "has_profile": true,
     "profile_url": "/race/garmin-gravel-worlds/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.8089,
     "lng": -96.7078,
     "rwgps_id": "48087626",
@@ -21085,6 +21703,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-des-flandres/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 51.0378,
     "lng": 4.2406,
     "st": "Gravel des Flandres is organized by the same team behind the pro Tour of Flanders race, featuring iconic Flemish cobbles and brilliant gravel roads. The event includes famous sections from the pro race including Oude Kwaremont, Paterberg, and finishes on the brutal cobble climb of Koppenberg. Riders face multiple distance options with splits that are easy to miss if not paying attention. Morning conditions can be quite cold with temperatures around 4 degrees Celsius at the 9:00 AM start. The event village is located in the center of Oudenaarde with early sign-on recommended due to limited breakfast options. Post-race amenities include lunch vouchers and beer. The course combines the heritage and culture of classic Belgian cycling with modern gravel racing, creating a challenging mix of cobbled climbs and gravel terrain.",
@@ -21120,6 +21739,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-fondo-louisiana/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 30.7807,
     "lng": -91.3763,
     "st": "The Gravel Fondo Louisiana in St. Francisville features a challenging 65-mile course with 3000 feet of elevation gain described by riders as continuous rolling hills throughout. The terrain includes significant climbs with potholes deep enough to cause mechanical issues like dropped chains. Key course features include a critical turn at 9.83 miles where the 20-mile group splits from longer distances, and a particularly difficult climbing section around the 13-mile marker. Riders report the back stretch as especially challenging with hard hill after hill. The event uses pace cars and cone markings for navigation. Race speeds reach 28-30 mph on flatter sections with groups that crack the whip early in the race. The elevation profile shows 2061 feet of climbing with what goes up must come down terrain characteristics.",
@@ -21155,6 +21775,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-one-fifty/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 53.1405,
     "lng": 6.4275,
     "rwgps_id": "51436606",
@@ -21191,6 +21812,7 @@
     "has_profile": true,
     "profile_url": "/race/gravelista/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -36.5986,
     "lng": 144.678,
     "rwgps_id": "53482061",
@@ -21227,6 +21849,7 @@
     "has_profile": true,
     "profile_url": "/race/hegau-gravel-race/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 47.7618,
     "lng": 8.8349,
     "st": "The Hegau Gravel Race in Singen, Germany is an extremely demanding course with no flat sections - only steep climbs and steep descents according to riders who reconned it. The climbs are short but require riding above threshold power, with minimal recovery time on equally short downhills. Riders describe it as anaerobic racing where pacing strategy is critical to avoid exploding. The descents feature very steep and twisty off-camber turns. The gravel surface quality is described as pretty good overall. This inaugural race takes place in an area with rich cycling history, having hosted mountain bike Marathon World Cups for over 20 years. Weather can be a major factor with thunderstorms and rain forecasted. Riders note this is a course where you can easily blow up, making it crucial to find the right balance between staying competitive and riding within your limits."
@@ -21261,6 +21884,7 @@
     "has_profile": true,
     "profile_url": "/race/kowtown-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.0587,
     "lng": -106.3886,
     "st": "KowTown Gravel in Kremling, Colorado features three distances with the longest reaching nearly 10,000 feet elevation and significant climbing. The course runs through working cattle ranch land owned by the Shaw family, with smooth gravel roads that are better than many paved surfaces. Key challenges include double-digit grade climbs where riders struggle with gearing, high altitude effects causing very slow 2.5 mph average pace on climbs, and reaching 9,200+ feet elevation. The terrain varies from smooth valley roads along the Colorado River to chunky dirt roads in the mountains. Riders report excellent scenery with wildlife including elk, bears, and moose, plus zero car traffic for hours. The course includes Grouse Mountain as a high point with spectacular descents. Gear recommendations include wider tires around 47-50mm for better traction on varied surfaces.",
@@ -21296,7 +21920,8 @@
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/letape-indonesia/",
-    "discipline": "road"
+    "discipline": "road",
+    "has_tire_guide": false
   },
   {
     "name": "Lone Wolf Gravel",
@@ -21328,6 +21953,7 @@
     "has_profile": true,
     "profile_url": "/race/lone-wolf-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.8202,
     "lng": -88.066,
     "st": "The provided transcripts do not contain any race-related content for the Lone Wolf Gravel race in Iron Mountain, Michigan. The transcripts appear to be music videos or songs rather than race reports or rider experiences. No information about course features, terrain conditions, challenges, gear recommendations, or race atmosphere is available from these sources.",
@@ -21363,6 +21989,7 @@
     "has_profile": true,
     "profile_url": "/race/montana-gravel-challenge/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 47.0313,
     "lng": -114.3273,
     "rwgps_id": "34532067",
@@ -21399,6 +22026,7 @@
     "has_profile": true,
     "profile_url": "/race/opelika-okey-dokey/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 32.6454,
     "lng": -85.3783,
     "rwgps_id": "52233626",
@@ -21435,6 +22063,7 @@
     "has_profile": true,
     "profile_url": "/race/purgatory-road-race/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 30.2752,
     "lng": -98.872,
     "rwgps_id": "22021155",
@@ -21471,6 +22100,7 @@
     "has_profile": true,
     "profile_url": "/race/serenissima-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.4372,
     "lng": 12.3346,
     "thumb": "/race-photos/serenissima-gravel/serenissima-gravel-video-1.jpg"
@@ -21505,6 +22135,7 @@
     "has_profile": true,
     "profile_url": "/race/switchgrass/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.3644,
     "lng": -96.8589,
     "rwgps_id": "53002568"
@@ -21539,6 +22170,7 @@
     "has_profile": true,
     "profile_url": "/race/the-grit-adventure/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 47.3984,
     "lng": -121.4144,
     "st": "The GRiT Adventure at Snoqualmie Pass features challenging descents that riders describe as gnarly and dangerous, especially in wet conditions. Multiple crashes were reported on the descents, with at least one rider developing a knee hematoma from wiping out. Rain significantly increases the difficulty and danger of the course, causing several riders to abandon the race. The event has aid stations where volunteers assist with nutrition needs, particularly electrolytes. Despite the challenging conditions, there's a supportive community atmosphere with riders helping each other and sharing advice about continuing after crashes. The race attracts both experienced and novice gravel riders, with some participants noting the technical difficulty of the terrain.",
@@ -21574,6 +22206,7 @@
     "has_profile": true,
     "profile_url": "/race/unravel-gravel-va/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 37.5004,
     "lng": -78.2469
   },
@@ -21607,6 +22240,7 @@
     "has_profile": true,
     "profile_url": "/race/wollombi-gravel-fest/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -32.93,
     "lng": 151.14,
     "st": "The Wollombi Gravel Fest takes place in Wollombi Valley, about 150 kilometers north of Sydney, starting from Myrtle and Stone Cafe. The inaugural event featured two days of riding with the first year limited to 300 participants but expanding to 1000 spots for 2025. Day one was described as longer with warmer conditions, while day two featured a shorter out-and-back course that was at least 10 degrees cooler with overcast skies providing relief from UV exposure. Pro cyclists Val Botas and Tiffany Cromwell participated and emphasized the fun, non-competitive nature of gravel riding. The event showcases a region close to Sydney that's appropriate for gravel riding, allowing riders to enjoy off-road pleasure without the usual on-road stress of reaching gravel from the city. The weekend included evening social activities with barbecues and informal talks with pro athletes, emphasizing community building through cycling.",
@@ -21642,6 +22276,7 @@
     "has_profile": true,
     "profile_url": "/race/bohemian-border-bash/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 49.7439,
     "lng": 15.3381,
     "st": "The Bohemian Border Bash is described as one of the toughest self-supported off-road races in the world, covering 1,300 km with 24,000 meters of climbing along Bohemian borderlands. The race starts fast with tarmac and light gravel sections featuring many twists and turns where riders fight for position. Key challenges include dense forest sections between checkpoints that become very difficult to navigate at night, with long hike-a-bike sections particularly around checkpoint 2, described as a rock in the middle of mountains. The Bohemian Forest area requires significant walking with riders doing more walking than riding on gravel bikes. Terrain varies from perfect forest gravel roads with fair climbing and fun descents to technical sections requiring careful navigation. Resupply opportunities are limited, especially in Germany on Sundays. Weather conditions include high humidity and cold temperatures when descending from mountains.",
@@ -21677,6 +22312,7 @@
     "has_profile": true,
     "profile_url": "/race/canmore-crux/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 51.0867,
     "lng": -115.3481,
     "rwgps_id": "46220554",
@@ -21713,6 +22349,7 @@
     "has_profile": true,
     "profile_url": "/race/cirrem/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.0797,
     "lng": -89.4337,
     "rwgps_id": "53919197"
@@ -21747,6 +22384,7 @@
     "has_profile": true,
     "profile_url": "/race/dirty-pecan/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 27.7568,
     "lng": -81.464,
     "rwgps_id": "49652081",
@@ -21783,6 +22421,7 @@
     "has_profile": true,
     "profile_url": "/race/dusty-bandita/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 47.0227,
     "lng": -113.1733,
     "rwgps_id": "51122695"
@@ -21817,6 +22456,7 @@
     "has_profile": true,
     "profile_url": "/race/essential-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.9117,
     "lng": -89.4568,
     "rwgps_id": "48038106",
@@ -21853,6 +22493,7 @@
     "has_profile": true,
     "profile_url": "/race/ghost-of-the-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 55.0013,
     "lng": -115.0021,
     "st": "Ghost of the Gravel in Alberta, Canada features terrain in the foothills with nice hills and beautiful scenery. The race has a relaxed atmosphere with bacon beats and cookie stops along the course. Riders describe it as less aggressive than extreme racing, focusing more on having a good time rather than intense competition. The course takes place on gravel roads through the foothills area with awesome terrain that riders find enjoyable. The event appears to emphasize the fun and social aspects of gravel cycling over hardcore racing mentality.",
@@ -21888,6 +22529,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-fever/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 46.818,
     "lng": 0.5458,
     "rwgps_id": "52592435"
@@ -21922,6 +22564,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-revival/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.7949,
     "lng": -87.4646,
     "rwgps_id": "49933586",
@@ -21958,6 +22601,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-roll-pecan-shaker/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 32.2835,
     "lng": -83.4668
   },
@@ -21991,6 +22635,7 @@
     "has_profile": true,
     "profile_url": "/race/gun-flint-44/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 47.7505,
     "lng": -90.3347,
     "st": "No relevant information about the Gun Flint 44 gravel race in Grand Marais, Minnesota was found in the provided transcripts. The transcripts contain content about Wu-Tang Clan music and RAGBRAI cycling event in Iowa, but do not include any rider experiences, course details, terrain conditions, or race-specific information about the Gun Flint 44 race.",
@@ -22026,6 +22671,7 @@
     "has_profile": true,
     "profile_url": "/race/heathland-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 50.6403,
     "lng": 4.6667,
     "rwgps_id": "52603358",
@@ -22062,6 +22708,7 @@
     "has_profile": true,
     "profile_url": "/race/holly-shelter-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.8869,
     "lng": -76.9973,
     "st": "Holly Shelter Gravel Grinder takes place in Holly Shelter Game Land near Hampstead, North Carolina. The course features miles and miles of dirt roads through the game land area, with Lodge Road being a major section that connects the main entrances from Hampstead toward Rocky Point. Riders need to be aware of hunting seasons and avoid riding during deer season or other major hunting periods in the game land. Heat can be a significant factor, with heat index potentially reaching 104 degrees, making hydration crucial for race day success. The terrain consists primarily of dirt roads with some pavement sections connecting different areas of the course.",
@@ -22097,6 +22744,7 @@
     "has_profile": true,
     "profile_url": "/race/homegrown-gravel-adventure/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.3679,
     "lng": -83.2157,
     "rwgps_id": "49434983",
@@ -22133,6 +22781,7 @@
     "has_profile": true,
     "profile_url": "/race/lake-country-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.1117,
     "lng": -88.4993,
     "st": "Riders describe challenging gravel racing conditions with rocky, chunky terrain that pounds arms relentlessly over 4+ hours of racing. Courses typically start with smooth, fast gravel roads where groups can work together effectively, then transition to more technical terrain. Key challenges include sandy sections in forest areas that require bike handling skills and sometimes force hiking, plus technical climbs over roots. Riders emphasize avoiding starting too fast, especially when cold starts are required after standing in age pens for 45 minutes before racing begins. Equipment reliability is crucial - many races end due to wheel failures from big hits on rocky terrain. Tire pressure strategy is important, with experienced riders recommending sticking to lower pressures despite puncture risks to maintain tire deformation and suspension benefits. Sandy trails test tired legs significantly and can dramatically slow pace in later race sections.",
@@ -22168,6 +22817,7 @@
     "has_profile": true,
     "profile_url": "/race/marly-grav/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 52.2435,
     "lng": 5.6343,
     "rwgps_id": "52812382",
@@ -22204,6 +22854,7 @@
     "has_profile": true,
     "profile_url": "/race/pickerel-buck40/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.4309,
     "lng": -89.6885
   },
@@ -22237,6 +22888,7 @@
     "has_profile": true,
     "profile_url": "/race/polish-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 50.0469,
     "lng": 19.9972,
     "st": "This transcript covers casual cycling in Kraków city rather than the Polish Gravel race. The rider describes urban cycling conditions around major tourist attractions like Wawel Castle and the main square. Key features include surprisingly bike-friendly smooth surfaces throughout the city center and compact distances between attractions. The old town presents navigation challenges with confusing cycling rules - some areas are pedestrian-only, others have limited traffic, and one-way streets where bikes can travel both directions. The rider notes that cyclists are allowed in most pedestrian areas including the main square. The medieval streets of the UNESCO World Heritage old town require careful navigation due to mixed traffic rules and varying restrictions for different vehicle types.",
@@ -22272,6 +22924,7 @@
     "has_profile": true,
     "profile_url": "/race/rad-am-ring-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 50.3413,
     "lng": 6.9519,
     "st": "No actionable race intelligence could be extracted from the available transcript. The transcript appears to contain primarily music lyrics or unclear audio rather than race-specific information about the Rad am Ring Gravel event in Nürburg, Germany. Riders seeking course details, terrain conditions, gear recommendations, or race strategy information will need to reference additional sources."
@@ -22306,6 +22959,7 @@
     "has_profile": true,
     "profile_url": "/race/the-crusher/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 46.5436,
     "lng": -87.3963,
     "st": "The Crusher in Michigan's Upper Peninsula is organized by Todd Bouquet and features two versions: the mass start and the EX (extra enhanced). The mass start is supposed to be relatively easy gravel roads but recent years have included EX-style sections with unbridged rivers, mud pits, sand, overgrown rocky tracks, and steep single track. The first 16 miles start in darkness and are fast-paced, where mechanical issues commonly surface. Riders report the actual distance being longer than advertised - 203 miles instead of the stated 175 miles. The race requires significant endurance with nearly 15 hours on course. Riders emphasize that having a partner makes the experience much better, and that staying positive after setbacks is crucial. The event has been running since 2018 and is considered an adventure that tests both physical and mental limits in Michigan's challenging terrain.",
@@ -22341,6 +22995,7 @@
     "has_profile": true,
     "profile_url": "/race/tor-divide/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 53.3158,
     "lng": -1.727,
     "st": "Riders describe the Peak District Tor Divide as a challenging 200k gravel route with 4,000m of climbing through 38 total climbs. Key challenging sections include Winn's Pass with extreme rocky conditions and 10-foot drops, The Broken Road requiring 6.6km of hike-a-bike terrain, and the unpleasant Stony Middleton climb. Terrain features very rocky technical descents that force walking, boggy sections especially after rain, and roads with extreme drop-offs. The unsupported format allows 32 hours to complete with options to sleep or ride through. Riders report completing 20% of climbing in first 30k. Mandatory kit includes 1.5 liters of water. Route shares space with walkers, horse riders, and motor bikers. Weather can bring consistent rain making conditions more challenging. Popular strategy includes overnight stops around Bakewell for two-day approach.",
@@ -22376,6 +23031,7 @@
     "has_profile": true,
     "profile_url": "/race/tour-de-gap/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.274,
     "lng": -88.4092,
     "st": "The provided transcripts do not contain content about the Tour de Gap gravel race in Fulton, Mississippi. Instead, they feature coverage of the Tour de France road cycling race, discussing professional cyclists like Jonas Vingegaard and Tadej Pogacar on mountain climbs. The transcripts cover climbing techniques, power-to-weight ratios, drafting strategies, and biomechanics adjustments used by Tour de France riders, but contain no information about the 65-mile gravel race with 3000 feet of elevation gain in Mississippi. No course features, terrain conditions, gear recommendations, or race-specific challenges for the Tour de Gap are mentioned in these video transcripts.",
@@ -22411,6 +23067,7 @@
     "has_profile": true,
     "profile_url": "/race/turnhout-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 51.3289,
     "lng": 4.93,
     "rwgps_id": "53926943",
@@ -22447,6 +23104,7 @@
     "has_profile": true,
     "profile_url": "/race/albia-holy-cow/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.0265,
     "lng": -92.8075,
     "rwgps_id": "45354264",
@@ -22483,6 +23141,7 @@
     "has_profile": true,
     "profile_url": "/race/bear-100/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.5609,
     "lng": -88.6725,
     "rwgps_id": "46661123",
@@ -22519,6 +23178,7 @@
     "has_profile": true,
     "profile_url": "/race/cedar-blitz/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.2234,
     "lng": -85.5514,
     "rwgps_id": "50732883",
@@ -22554,6 +23214,7 @@
     "has_profile": true,
     "profile_url": "/race/cow-pie-classic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.947,
     "lng": -85.0714,
     "thumb": "/race-photos/cow-pie-classic/cow-pie-classic-video-1.jpg"
@@ -22588,6 +23249,7 @@
     "has_profile": true,
     "profile_url": "/race/fairfield-harvest-rush/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.0072,
     "lng": -91.963,
     "rwgps_id": "48571775",
@@ -22625,6 +23287,7 @@
     "has_profile": true,
     "profile_url": "/race/gfny-miami/",
     "discipline": "road",
+    "has_tire_guide": false,
     "lat": 25.7617,
     "lng": -80.1918,
     "st": "GFNY Miami riders report a challenging course featuring key climbs including the Alpine climb where early positioning matters and sprint opportunities exist at the summit. The cheese coat summit is noted as a decisive point where challengers typically get dropped. The race starts on the George Washington Bridge, passes through Fort Lee, and continues into Palisades Interstate Park. Racing is described as fast and competitive with pack dynamics being crucial, as groups of nearly 30 riders with race favorites stay close behind early breakaways. The finish area features a village atmosphere in Fort Lee where riders collect medals and reunite with family. The event combines pro and amateur cyclists in an international field with intermediate sprint prizes throughout the course."
@@ -22659,6 +23322,7 @@
     "has_profile": true,
     "profile_url": "/race/glenwood-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.0469,
     "lng": -95.7425,
     "rwgps_id": "51634081",
@@ -22695,6 +23359,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-and-granite/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -28.8384,
     "lng": 152.2813,
     "st": "The Gravel and Granite race in Tenterfield, NSW features challenging terrain with significant elevation including a brutal 23% incline climb that forces many riders to walk. The course combines gravel sections with corrugations, multiple water crossings, and freshly bituminized roads that organizers warn are very slippery. Key hazards include slippery causeways with water, cattle grids requiring straight crossings, and potential wildlife encounters. The final 18 kilometers feature serious hills with 800 meters of elevation gain at the 80k mark. Strong headwinds significantly impact race difficulty. The event accommodates all skill levels with generous cutoff times and welcomes both gravel and mountain bikes. Two feed stations provide water, fruit, and supplies on the 65k course. Roads remain open to minimal car traffic. The race attracts nearly 800 participants across multiple distance options, making it the largest mass participation cycling event on the calendar for the region.",
@@ -22730,6 +23395,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-unravel-bon-jon-pass-out/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 47.8223,
     "lng": -122.8752,
     "st": "The Gravel Unravel - Bon Jon Pass Out in Quilcene, WA features extreme elevation gain starting at sea level and climbing to nearly 4,000 feet. The signature Bon Jon Pass climb hits 3,500 feet by mile 15, requiring an hour and a half of sustained climbing. Riders face 15-18 gravel climbs throughout the course, with many walking sections. Terrain includes loamy, soft ground with moss-covered roads and muddy conditions. Weather can include precipitation with temperatures starting in the 40s. The Pacific Northwest setting offers mountain views and pine forests. Riders recommend 700x44 tires in endurance casing for the sharp rocks and soft terrain, plus low gearing like 30x42 for the steep sections. Equipment security is important due to rough conditions causing mounting failures."
@@ -22764,6 +23430,7 @@
     "has_profile": true,
     "profile_url": "/race/gray-duck-grit/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.5068,
     "lng": -92.9062,
     "st": "No race-specific information available for Gray Duck Grit. The provided transcripts do not contain content related to this gravel cycling race in Cannon Falls, Minnesota. Unable to extract course details, terrain conditions, challenges, or rider experiences from the available sources."
@@ -22798,6 +23465,7 @@
     "has_profile": true,
     "profile_url": "/race/hart-hills/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.6983,
     "lng": -86.364,
     "thumb": "/race-photos/hart-hills/hart-hills-video-1.jpg"
@@ -22832,6 +23500,7 @@
     "has_profile": true,
     "profile_url": "/race/lowell-classic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.9336,
     "lng": -85.3419,
     "rwgps_id": "53079369",
@@ -22867,6 +23536,7 @@
     "has_profile": true,
     "profile_url": "/race/marys-mayhem/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -32.5981,
     "lng": 149.5886,
     "rwgps_id": "51935057",
@@ -22903,6 +23573,7 @@
     "has_profile": true,
     "profile_url": "/race/melting-mann/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.917,
     "lng": -85.9147,
     "rwgps_id": "53183899",
@@ -22938,6 +23609,7 @@
     "has_profile": true,
     "profile_url": "/race/real-west-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.6721,
     "lng": -118.7886,
     "rwgps_id": "53678735",
@@ -22974,6 +23646,7 @@
     "has_profile": true,
     "profile_url": "/race/ride-the-gravel-trails/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.6667,
     "lng": -93.0449,
     "st": "Based on rider experiences in Dakota County Minnesota, this 60-mile gravel race features predominantly hard-packed gravel surfaces that riders describe as solid enough to tap dance on, similar to North Central Florida terrain. The course runs through extensive farmland with soybean and corn fields, featuring numerous roller hills rather than flat terrain. Riders encounter diverse surface conditions including hard-packed clay, thicker gravel sections, and some loose areas along river roads. The route includes climbs that become steeper and more technical toward the end. Farm roads dominate the course with arrow-straight sections and plenty of rollers throughout. Riders should expect dust from farm equipment and school buses. The terrain varies from super hard-packed sections to areas with chatter on climbs. Multiple small towns dot the route including Welch Minnesota, with brief pavement sections between gravel segments.",
@@ -23009,6 +23682,7 @@
     "has_profile": true,
     "profile_url": "/race/spring-valley-100/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.687,
     "lng": -92.3893,
     "rwgps_id": "46674434",
@@ -23044,6 +23718,7 @@
     "has_profile": true,
     "profile_url": "/race/sunday-creek-classic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -26.6352,
     "lng": 152.6166,
     "rwgps_id": "50842659",
@@ -23080,6 +23755,7 @@
     "has_profile": true,
     "profile_url": "/race/swamp-fox-gravel-fondo/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 33.1113,
     "lng": -79.5813,
     "rwgps_id": "47892812",
@@ -23116,6 +23792,7 @@
     "has_profile": true,
     "profile_url": "/race/the-mane-event-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.7948,
     "lng": -106.8223,
     "rwgps_id": "40498983",
@@ -23152,6 +23829,7 @@
     "has_profile": true,
     "profile_url": "/race/the-watermoo/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.3373,
     "lng": -83.8842,
     "rwgps_id": "43962788",
@@ -23188,6 +23866,7 @@
     "has_profile": true,
     "profile_url": "/race/total-tomahawk-terrain/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.471,
     "lng": -89.7314,
     "st": "The provided transcripts do not contain any information about the Total Tomahawk Terrain race in Tomahawk, Wisconsin. The transcripts cover general bike maintenance topics including bike fitting techniques, cleaning procedures, and material comparisons between titanium, steel, and aluminum frames. No race-specific content about course features, terrain conditions, challenges, or rider experiences from the Total Tomahawk Terrain event appears in these video transcripts."
@@ -23222,6 +23901,7 @@
     "has_profile": true,
     "profile_url": "/race/waukon-100/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.2694,
     "lng": -91.4758,
     "rwgps_id": "51103873",
@@ -23258,6 +23938,7 @@
     "has_profile": true,
     "profile_url": "/race/clarkes-gambit/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -35.6484,
     "lng": 150.1409,
     "rwgps_id": "53220003",
@@ -23294,6 +23975,7 @@
     "has_profile": true,
     "profile_url": "/race/de-ronde-van-grampian/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.8248,
     "lng": -83.2647,
     "rwgps_id": "52132750"
@@ -23328,6 +24010,7 @@
     "has_profile": true,
     "profile_url": "/race/fast-fitty/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.5637,
     "lng": -84.8356,
     "rwgps_id": "32081488",
@@ -23364,6 +24047,7 @@
     "has_profile": true,
     "profile_url": "/race/galactic-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 36.9366,
     "lng": -107.8896,
     "rwgps_id": "46269778",
@@ -23399,6 +24083,7 @@
     "has_profile": true,
     "profile_url": "/race/grassroots-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 38.264,
     "lng": -104.6142,
     "rwgps_id": "52981802",
@@ -23435,6 +24120,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-rocks/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 54.3318,
     "lng": -0.6902,
     "rwgps_id": "53953422",
@@ -23471,6 +24157,7 @@
     "has_profile": true,
     "profile_url": "/race/great-otway-gravel-grind/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -38.5186,
     "lng": 143.7165,
     "rwgps_id": "50332000",
@@ -23507,6 +24194,7 @@
     "has_profile": true,
     "profile_url": "/race/hibernator/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.5609,
     "lng": -88.6725,
     "st": "The Hibernator takes place in Laona, Wisconsin with 30, 60, and 100-mile distance options starting from a local bar in town. The course features hard-packed dirt roads through thick pine and birch forest cover, creating beautiful scenery that showcases northern Wisconsin gravel riding. Riders report the roads had decent condition overall but can become wet and sticky after rain, with numerous potholes and puddles to navigate. The race starts on local walking and ATV trails with some blacktop sections, providing a flat easy beginning before hitting the forested hills. Key challenges include an aggressive pace increase around mile 19 where the front group drops many riders, and a critical decision point at mile 52 where the 60 and 100-mile courses intersect at the final aid station. Weather can be unpredictable with rain developing throughout race day, making conditions increasingly muddy and miserable in later miles. The course atmosphere is described as beautiful with thick forest cover, though riders should pace conservatively for longer distances to avoid cramping issues.",
@@ -23542,6 +24230,7 @@
     "has_profile": true,
     "profile_url": "/race/iowa-state-gravel-tt-championship/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.8,
     "lng": -91.8707
   },
@@ -23575,6 +24264,7 @@
     "has_profile": true,
     "profile_url": "/race/north-wales-gravel-x/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 53.1116,
     "lng": -3.3052,
     "rwgps_id": "50180883",
@@ -23611,6 +24301,7 @@
     "has_profile": true,
     "profile_url": "/race/prairie-burn-100/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.743,
     "lng": -92.724,
     "rwgps_id": "30208684",
@@ -23647,6 +24338,7 @@
     "has_profile": true,
     "profile_url": "/race/spring-thaw/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.2342,
     "lng": -86.2484,
     "st": "No race-related content found in the provided transcripts. The transcripts contain content about retail crime prevention technology, flooding along the Muskegon River in Michigan, and a hospital recovery story, but do not include any information about the Spring Thaw gravel race in Muskegon, Michigan or cycling-related content that would be useful for race preparation or intelligence.",
@@ -23682,6 +24374,7 @@
     "has_profile": true,
     "profile_url": "/race/takelma-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.9276,
     "lng": -123.2812,
     "rwgps_id": "43400256",
@@ -23718,6 +24411,7 @@
     "has_profile": true,
     "profile_url": "/race/west-coast-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.3128,
     "lng": -124.105,
     "rwgps_id": "48942508",
@@ -23753,6 +24447,7 @@
     "has_profile": true,
     "profile_url": "/race/beaver-dam-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 37.5224,
     "lng": -114.089,
     "rwgps_id": "43251943",
@@ -23789,6 +24484,7 @@
     "has_profile": true,
     "profile_url": "/race/camp-michaux-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.0056,
     "lng": -77.2069,
     "rwgps_id": "52537742"
@@ -23823,6 +24519,7 @@
     "has_profile": true,
     "profile_url": "/race/cowboy-crusher/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.8615,
     "lng": -105.872,
     "rwgps_id": "53566970"
@@ -23857,6 +24554,7 @@
     "has_profile": true,
     "profile_url": "/race/dirty-dino/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.4557,
     "lng": -109.5285,
     "rwgps_id": "47123599"
@@ -23891,6 +24589,7 @@
     "has_profile": true,
     "profile_url": "/race/forbidden-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 49.6185,
     "lng": -125.032,
     "rwgps_id": "51878707",
@@ -23927,6 +24626,7 @@
     "has_profile": true,
     "profile_url": "/race/hardwood-hustle/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 46.0197,
     "lng": -88.8179,
     "rwgps_id": "44349130"
@@ -23961,6 +24661,7 @@
     "has_profile": true,
     "profile_url": "/race/heywood-ride/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.4582,
     "lng": -93.1612,
     "st": "The Heywood is organized by Heath Creek Cycles in Northfield, Minnesota, offering both 30-mile and longer distance options. Riders emphasize being prepared for cold weather conditions that can feel much colder than expected, with temperatures in the 40s feeling like the 30s. The most challenging section is the final seven miles which features a brutal headwind that riders describe as the hardest part of the event. The race has a strong community atmosphere, with riders noting the event is more about the people and connections than just the riding itself. The course includes bridge crossings and sections through state park areas. Cold weather preparation is essential, with local tips including using buck bags for feet warmth. Wind conditions can be significant, particularly affecting the final portions of the ride.",
@@ -23996,6 +24697,7 @@
     "has_profile": true,
     "profile_url": "/race/just-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 54.7024,
     "lng": -3.2766,
     "st": "Lake District gravel riding features challenging terrain with significant elevation gain from the start. Griesdale Forest offers 200 meters of uphill climbing in the first 20 minutes on well-maintained gravel fire tracks. The terrain includes purpose-built tracks, gravel roads, and narrow roads with steep ascents and descents. During wet conditions, forest trails become waterlogged with river-like crossings that soak through regular shoes. Routes typically accommodate 200 riders with intermediate beginner difficulty suitable for gravel bikes. Weather can significantly impact events, with long routes potentially canceled for thundershowers and modified medium routes offered instead. The area features multiple route options including color-coded trails and various distance options. Social atmosphere is strong with friendly riders and community support. Feed stops provide sandwiches, coffee, and crisps around the 30-35 mile mark.",
@@ -24031,6 +24733,7 @@
     "has_profile": true,
     "profile_url": "/race/mad-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 39.3139,
     "lng": -104.0869,
     "st": "Mad Gravel takes place at Peaceful Valley Scout Ranch in Elbert County, Colorado, situated at 6,500-7,000 feet elevation on the Eastern Slope of the Front Range between Colorado Springs and Denver. The 55-mile course features fast-rolling gravel with some challenging corrugations that can sap speed and cause bikes to drift sideways. Riders report sections where the surface becomes more sand than gravel, which significantly slows progress. The course includes some single track sections described as loose and spicy. The altitude at just under 2,000 meters is noticeable and affects performance. The event is part of a 3-day Memorial Day weekend festival with camping, food vendors, live music, and family activities. Weather can impact the race, with heavy rain sometimes forcing course modifications. The venue offers spectacular views of the Colorado Front Range and high peaks.",
@@ -24066,6 +24769,7 @@
     "has_profile": true,
     "profile_url": "/race/raid-rockingham/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 42.9624,
     "lng": -71.3977,
     "rwgps_id": "51840080",
@@ -24102,6 +24806,7 @@
     "has_profile": true,
     "profile_url": "/race/salty-lizard/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.7376,
     "lng": -114.0314,
     "rwgps_id": "49813317",
@@ -24138,6 +24843,7 @@
     "has_profile": true,
     "profile_url": "/race/silver-city-century/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.1133,
     "lng": -95.6372,
     "rwgps_id": "46675307",
@@ -24174,6 +24880,7 @@
     "has_profile": true,
     "profile_url": "/race/soldier-cutoff-hillduro/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.8316,
     "lng": -95.9262,
     "rwgps_id": "47704687",
@@ -24210,6 +24917,7 @@
     "has_profile": true,
     "profile_url": "/race/trough-creek-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.3266,
     "lng": -78.1281,
     "rwgps_id": "52750788",
@@ -24246,6 +24954,7 @@
     "has_profile": true,
     "profile_url": "/race/uncle-johns-gravel-race/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.0009,
     "lng": -84.5585,
     "rwgps_id": "25106337",
@@ -24282,6 +24991,7 @@
     "has_profile": true,
     "profile_url": "/race/glengarry-games-gravel-run/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.2886,
     "lng": -74.8555,
     "rwgps_id": "52063952",
@@ -24317,6 +25027,7 @@
     "has_profile": true,
     "profile_url": "/race/gravel-unravel-why-not-chee/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 46.9809,
     "lng": -123.8893,
     "rwgps_id": "42075944"
@@ -24351,6 +25062,7 @@
     "has_profile": true,
     "profile_url": "/race/kalona-horseshoe/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.4831,
     "lng": -91.7062,
     "rwgps_id": "50701116",
@@ -24387,6 +25099,7 @@
     "has_profile": true,
     "profile_url": "/race/mid-state-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.5398,
     "lng": -79.7809,
     "rwgps_id": "47788083",
@@ -24423,6 +25136,7 @@
     "has_profile": true,
     "profile_url": "/race/muck-n-mac-fest/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 55.6083,
     "lng": -3.0638,
     "rwgps_id": "50611662",
@@ -24459,6 +25173,7 @@
     "has_profile": true,
     "profile_url": "/race/nicolet-hot-days/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.4386,
     "lng": -88.6604,
     "rwgps_id": "48037993"
@@ -24493,6 +25208,7 @@
     "has_profile": true,
     "profile_url": "/race/old-fashioned-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 43.7594,
     "lng": -91.3465,
     "rwgps_id": "51864673",
@@ -24529,6 +25245,7 @@
     "has_profile": true,
     "profile_url": "/race/ottawa-valley-gravel-experience/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.3022,
     "lng": -76.7258,
     "rwgps_id": "46966827",
@@ -24565,6 +25282,7 @@
     "has_profile": true,
     "profile_url": "/race/parker-dam-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 40.9909,
     "lng": -78.4457,
     "rwgps_id": "46635294"
@@ -24599,6 +25317,7 @@
     "has_profile": true,
     "profile_url": "/race/the-divide/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 44.4108,
     "lng": -85.3989,
     "rwgps_id": "51916854",
@@ -24634,6 +25353,7 @@
     "has_profile": true,
     "profile_url": "/race/the-insayner/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.9861,
     "lng": -89.5326,
     "rwgps_id": "46993712"
@@ -24668,6 +25388,7 @@
     "has_profile": true,
     "profile_url": "/race/thunder-bay-thriller/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 45.0176,
     "lng": -83.667,
     "rwgps_id": "52641605",
@@ -24704,6 +25425,7 @@
     "has_profile": true,
     "profile_url": "/race/wild-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": -34.0848,
     "lng": 118.3207,
     "st": "The provided transcript does not contain content related to the Wild Gravel race in Gnowangerup, Western Australia. The transcript is from a Boulder, Colorado Thursday night cruiser ride video by Ryan Van Duzer, featuring casual urban cycling rather than gravel racing. No information about the 60-mile Wild Gravel race course, terrain conditions, elevation challenges, or racing strategies is available in this transcript. The content focuses on a recreational community bike ride with no connection to the gravel racing event in Western Australia.",
@@ -24739,6 +25461,7 @@
     "has_profile": true,
     "profile_url": "/race/bald-eagle-gravel-grinder/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 41.1369,
     "lng": -77.4472,
     "rwgps_id": "50146763",
@@ -24774,6 +25497,7 @@
     "has_profile": true,
     "profile_url": "/race/dalby-grit/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 54.7024,
     "lng": -3.2766,
     "st": "Dalby Grit is a new 50-mile gravel race in Dalby Forest near York featuring 3500 feet of elevation over three laps. Riders describe steeper climbs than comparable events, with a particularly challenging steep descent followed by a steep ascent midcourse. The course includes chunky gravel sections, twisty 90-degree turns, single track designed to string out the field, and some road sections ideal for nutrition. Weather conditions include 20mph winds with potential drizzle but temperatures above 20 degrees. The race attracts around 400 riders total with 40-50 per age group, creating an intimate atmosphere. The neutralized start is described as very hard with opportunities for strong riders to gain early gaps. Course features both forest roads and sections extending into the North Yorkshire Moors, with generally less severe gravel than other major UK gravel events.",
@@ -24809,6 +25533,7 @@
     "has_profile": true,
     "profile_url": "/race/dunoon-dirt-dash/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 55.9477,
     "lng": -4.9235,
     "rwgps_id": "52742061",
@@ -24845,6 +25570,7 @@
     "has_profile": true,
     "profile_url": "/race/dusty-gravel-lacs-de-leau-dheure/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 50.169,
     "lng": 4.4126,
     "rwgps_id": "50325989"
@@ -24879,6 +25605,7 @@
     "has_profile": true,
     "profile_url": "/race/dusty-gravel-series-andenne/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 50.4896,
     "lng": 5.0587,
     "st": "The Dusty Gravel Series race in Andenne features an extremely challenging start that riders describe as really hard, where you're just trying to hang on before the pace eventually settles. The course includes technical sections with small grass pots that can catch your front wheel and cause crashes. Mechanical issues are common, with riders experiencing problems like pedals falling out and chains dropping multiple times during the race. The race is long enough that group dynamics become crucial - riders emphasize the importance of finding a good group since doing a lot of the race alone is not ideal. After the intense opening, the race typically slows down and groups form, which is when the real racing begins. The level of competition is described as high even at the amateur level, with riders using this race as qualification attempts for World Championships.",
@@ -24914,6 +25641,7 @@
     "has_profile": true,
     "profile_url": "/race/haldon-heroic/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 50.6207,
     "lng": -3.5295,
     "rwgps_id": "53823486",
@@ -24949,6 +25677,7 @@
     "has_profile": true,
     "profile_url": "/race/nanaimo-unpaved/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 49.1639,
     "lng": -123.9381,
     "st": "The Nanaimo Unpaved takes place near the motocross track and Mount Benson area, featuring gravel roads and trails. The race starts with a challenging uphill section that helps riders warm up in cold January conditions. Key features include a creek crossing where riders drop down after hanging a right. The course was described as running behind Mount Benson with some riders wanting more mud and hills for additional challenge. Weather can be cold and rainy in January, making proper clothing important. Race organizers mention fire risk concerns in hot weather. The event offers multiple distance options and has a welcoming community atmosphere. Riders recommend bringing electrolytes to avoid feeling euphoric then tired after about 45 minutes. The race starts near Dumont Trails and attracts riders from across Vancouver Island including Courtenay.",
@@ -24984,6 +25713,7 @@
     "has_profile": true,
     "profile_url": "/race/omg-oxford-ms-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 34.3664,
     "lng": -89.5188,
     "st": "Oxford Mississippi Gravel is a challenging 50-mile course with nearly 3000 feet of elevation gain and very few flat sections. The race features constant undulation with fast downhills leading straight into uphills. Key challenges include two substantial climbs immediately after the start that catch unprepared riders, requiring a good warm-up. Additional difficult climbs occur around miles 20-22 on the back side of the course. The course includes a 3-mile paved relief section from mile 28-31, but finishes with a steep climb. Riders describe narrow transitions from paved to gravel sections, particularly near a Baptist church in a low-lying muddy area. The race typically starts in freezing conditions but can warm to 50+ degrees. With 200 riders on the start line, the race atmosphere is energetic despite cold Mississippi weather conditions that feel particularly harsh due to humidity.",
@@ -25019,6 +25749,7 @@
     "has_profile": true,
     "profile_url": "/race/yorkshire-coast-dirt-dash/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 54.4874,
     "lng": -0.6155,
     "rwgps_id": "47428854",
@@ -25055,6 +25786,7 @@
     "has_profile": true,
     "profile_url": "/race/rose-city-rampage/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 30.8366,
     "lng": -83.9788,
     "rwgps_id": "45518916"
@@ -25089,6 +25821,7 @@
     "has_profile": true,
     "profile_url": "/race/rust-buster-gravel-fondo/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 35.146,
     "lng": -90.0518,
     "st": "No race-specific content available in the provided transcript. The transcript appears to be focused on bicycle restoration and maintenance rather than race coverage or rider experiences from the Rust Buster Gravel Fondo in Memphis, TN.",
@@ -25124,6 +25857,7 @@
     "has_profile": true,
     "profile_url": "/race/scratch-ankle-gravel/",
     "discipline": "gravel",
+    "has_tire_guide": true,
     "lat": 30.6324,
     "lng": -87.0397,
     "st": "Scratch Ankle is an annual gravel race in Milton, Florida, organized by Chain Busters and held in the Blackwater River State Forest area. The race offers multiple distance options including 30-mile, 60-mile, and 200-mile routes. The course features a mixture of gravel and asphalt with chunky sandy surface conditions. Riders describe encountering punchy hills throughout the course, particularly on the northern loop above Highway Four. Key landmarks include Paul Barnes Road, which marks the return from the northern section with about 5 miles to the finish. Race conditions can include significant water on course due to rain, and sandy sections appear near the finish line. The event has been running for many years and attracts riders of various skill levels, with separate start times for short and long course groups.",

--- a/wordpress/generate_prep_kit.py
+++ b/wordpress/generate_prep_kit.py
@@ -1829,15 +1829,24 @@ def build_pk_equipment(guide_sections: dict, raw: dict, rd: dict) -> str:
         raw.get("climate", {}), raw.get("weather")
     )
 
+    # Only link to /tires/ if this race actually has a generated tire guide —
+    # otherwise the crosslink 404s (see #dead-tire-crosslinks).
+    tire_crosslink_html = ""
+    if rd.get("tire_recommendations", {}).get("primary"):
+        tire_crosslink_html = (
+            '<div class="gg-guide-callout" style="margin:16px 0;padding:12px 16px;border-left:3px solid var(--gg-color-teal)">'
+            f'<p style="margin:0;font-size:14px"><strong>{_tire_crosslink_text(rd)}</strong> '
+            f'<a href="/race/{esc(rd["slug"])}/tires/" style="color:var(--gg-color-teal)">See full analysis &rarr;</a></p>'
+            '</div>'
+        )
+
     return f'''<section class="gg-pk-section">
     <div class="gg-pk-section-header">
       <span class="gg-pk-section-num">04</span>
       <h2>Equipment &amp; Packing Checklist</h2>
     </div>
     {tire_html}
-    <div class="gg-guide-callout" style="margin:16px 0;padding:12px 16px;border-left:3px solid var(--gg-color-teal)">
-      <p style="margin:0;font-size:14px"><strong>{_tire_crosslink_text(rd)}</strong> <a href="/race/{esc(rd['slug'])}/tires/" style="color:var(--gg-color-teal)">See full analysis &rarr;</a></p>
-    </div>
+    {tire_crosslink_html}
     {climate_html}
     {render_accordion(accordion_block)}
   </section>'''

--- a/wordpress/generate_state_hubs.py
+++ b/wordpress/generate_state_hubs.py
@@ -386,8 +386,10 @@ def build_faq(state: str, races: list, disc_label: str = "Gravel") -> tuple:
 def build_related_content(state: str, races: list) -> str:
     """Cross-links to coaching, tire guides, and training resources."""
     links = []
-    # Top tire guides for highest-tier races in this state
-    tire_races = sorted(races, key=lambda r: r.get("overall_score", 0), reverse=True)[:3]
+    # Top tire guides for highest-tier races in this state (only races that
+    # actually have a generated tire guide page — see #dead-tire-crosslinks)
+    tire_candidates = [r for r in races if r.get("has_tire_guide")]
+    tire_races = sorted(tire_candidates, key=lambda r: r.get("overall_score", 0), reverse=True)[:3]
     for r in tire_races:
         slug = r.get("slug", "")
         name = r.get("name", "")


### PR DESCRIPTION
auto-authored by morning-intel-triage

**Linked intel issue:** #31 (item 1 of 4)

**Evidence:** Today's `link-check.yml` re-run (after the sg-captcha fix in `47cc5ce7` landed) surfaced 20 genuine dead links, most of them `/race/{slug}/tires/` 404s — see run https://github.com/wattgod/gravel-race-automation/actions/runs/29920426202 and #31 for full detail.

**Root cause:** `wordpress/generate_state_hubs.py::build_related_content` picks the top-3-scoring races per state/region and links each to `/race/{slug}/tires/` for a "Tire Guide" crosslink, and `wordpress/generate_prep_kit.py::build_pk_equipment` always rendered a "See full analysis →" tire link — neither checked whether `tire_recommendations.primary` actually exists for that race. 543 of 757 races have a tire guide; 214 don't (per CLAUDE.md). `generate_neo_brutalist.py`'s own tire-section builders (`build_tire_picks`, `build_tire_guide_callout`) already guard on this correctly — only the state-hub and prep-kit crosslinks didn't.

**What changed and why:**
- `scripts/generate_index.py`: added `has_tire_guide` (bool) to both index-entry builders — derived from `race.get("tire_recommendations", {}).get("primary")` for profile-backed entries, hardcoded `False` for flat-DB entries (which have no profile page at all). This lets downstream generators check guide existence without loading full race JSON.
- `wordpress/generate_state_hubs.py`: filter `tire_races` to `has_tire_guide` races before taking the top 3.
- `wordpress/generate_prep_kit.py`: only render the tire-guide crosslink callout when `tire_recommendations.primary` is present; the callout's markup moved into a conditional `tire_crosslink_html` var (previously unconditional).
- `web/race-index.json`: regenerated (734 races) to carry the new field.

**Test output:**
- `python3 -m pytest tests/` (ignoring the standard PIL/dotenv/ddgs/anthropic-dependent collection failures per CLAUDE.md, none of which touch the files changed here): **5934 passed, 315 skipped, 2 failed**. The 2 failures are `test_whitepaper_fueling.py::TestDeployFunction::test_sync_whitepaper_exists` / `test_sync_whitepaper_is_callable` — pre-existing `ModuleNotFoundError: No module named 'dotenv'` in `push_wordpress.py`, unrelated to this change (also called out as pre-existing in PR #29's test output).
- `tests/test_prep_kit_generator.py` specifically: 168 passed.
- Manual verification: regenerated `web/race-index.json` and all 59 state hub pages to a scratch dir (`--output-dir /tmp/gg-statehub-test`), then grepped every emitted `/race/{slug}/tires/` crosslink against `has_tire_guide` in the fresh index — **0 of 118 emitted links now point at a raceless guide** (several did before the fix).

**Rollback:** revert this commit — restores the unconditional top-3-by-score state-hub crosslink and the always-on prep-kit tire callout (and drops `has_tire_guide` from the index, which nothing else reads).


---
_Generated by [Claude Code](https://claude.ai/code/session_01S4b7MHTfLQMnNgKWUeNDQs)_