### PR TITLE
SEO weekly update-candidates loop (GSC-only)

### DIFF
--- a/.claude/skills/seo-updates/SKILL.md
+++ b/.claude/skills/seo-updates/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: seo-updates
+description: Draft the week's 5 SEO content updates from the latest data/seo/seo-weekly-*.json artifact. Load when the operator runs /seo-updates or asks to act on the Morning Intel SEO section. Drafts diffs only — Matti gates every deploy.
+---
+
+# SEO Updates (weekly drafting session)
+
+Turns the deterministic weekly artifact into 5 concrete, gated content
+updates. The artifact found the leverage; this session supplies the judgment
+and the words. Spec: `docs/specs/seo-weekly-spec.md`.
+
+## Hard rules
+
+- **Never publish without Matti's explicit yes.** Output of this session is
+  diffs + expected impact, then a gate. No exceptions.
+- **Never hand-edit emitted HTML.** Route every edit through the source of
+  truth (table below), regenerate, preflight, deploy.
+- **GSC finds opportunities; it does not supply facts.** Any factual or
+  freshness claim you add (dates, distances, entry status) must be verified
+  against the official race source first. Unverifiable → reframe the edit so
+  it makes no new factual claim.
+- Voice: brand tokens, `wordpress/slop_rules.py` anti-slop, race-page spine
+  contract. Title/meta rewrites sell the page honestly — specificity, not
+  salesmanship.
+
+## Procedure
+
+1. **Load the artifact**: newest `data/seo/seo-weekly-*.json`. If
+   `generated_at_utc` is >8 days old, stop and tell the operator to run the
+   seo-weekly workflow (`gh workflow run seo-weekly.yml`) instead of drafting
+   from stale data.
+2. **Per candidate** (`top_candidates`, usually 5):
+   - curl the live page (cache-busted) and read what's actually there.
+   - Open the source per the routing table; read `supporting_queries` — the
+     edit should serve the whole query cluster, not just the headline query.
+   - Diagnose by `bucket`:
+     - `striking_distance` → strengthen relevance: heading/intro coverage of
+       the query, internal links from related pages, content depth.
+     - `ctr_underperformers` → rewrite `seo.title`/`seo.description` (or WP
+       meta) to match the query intent; the ranking is fine, the pitch isn't.
+     - `decliners` → refresh: stale dates/facts (verify first), thin sections,
+       lost freshness signals.
+     - `content_gaps` → propose a new page or internal-linking fix;
+       `recommended_target_path` is a suggestion, not a decision.
+3. **Draft all 5 as diffs** in the sources of truth. Present together:
+   change, reason (from artifact), expected impact (the candidate's `score` =
+   estimated 28-day click upside), and any facts you verified.
+4. **Gate.** On Matti's yes, per approved item: regenerate the page,
+   `python3 scripts/preflight_quality.py`, deploy per the `deploy-safely`
+   skill, purge SiteGround cache.
+5. **Log every decision** (applied AND skipped) — append one line per
+   candidate to `data/seo/updates-log.jsonl`:
+
+   ```json
+   {"date": "YYYY-MM-DD", "page": "/race/x/", "query": "...", "bucket": "...",
+    "action": "rewrite_title_meta", "artifact": "seo-weekly-YYYY-MM-DD.json",
+    "baseline": {"clicks": 0, "impressions": 0, "ctr": 0.021, "position": 6.2},
+    "change_summary": "...", "status": "applied"}
+   ```
+
+   The collector reads this for the 21-day cooldown and for before/after
+   measurement — an unlogged edit breaks both.
+
+## Source routing table
+
+| target_path | source of truth | apply via |
+|---|---|---|
+| `/race/<slug>/` | `race-data/<slug>.json` — `seo.title`, `seo.description`, profile fields | regenerate race page, preflight, deploy per deploy-safely |
+| `/articles/<slug>/` | article source (repo generator) | regenerate → SCP to `/articles/<slug>/` — NOT `--sync-blog` |
+| WP-native / Elementor (e.g. `/questionnaire/`, hubs) | `scripts/generate_meta_descriptions.py` for meta; Elementor widget for body | meta via script; Elementor body edits are manual/JS-API — flag, don't guess |
+| no source (most `content_gaps`) | none | propose new content or internal links; never silently invent a page |
+
+## Measurement
+
+When drafting, check `updates-log.jsonl` for entries ~4+ weeks old and
+compare their `baseline` against the current artifact's buckets for the same
+page/query — report movement (or its absence) to Matti before proposing new
+work. Changes that didn't move anything are the most important finding.

--- a/.github/workflows/seo-weekly.yml
+++ b/.github/workflows/seo-weekly.yml
@@ -1,0 +1,66 @@
+name: SEO Weekly Update-Candidates
+
+on:
+  schedule:
+    - cron: "20 11 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: seo-weekly
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install --quiet google-api-python-client google-auth
+
+      - name: Write GSC credentials
+        run: echo "$GSC_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/gsc-creds.json"
+        env:
+          GSC_SERVICE_ACCOUNT_JSON: ${{ secrets.GSC_SERVICE_ACCOUNT_JSON }}
+
+      - name: Collect weekly SEO facts
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/gsc-creds.json
+        run: python3 scripts/seo_weekly.py
+
+      - name: Validate collected artifact
+        run: python3 scripts/seo_weekly.py --validate-latest --require-all-ok
+
+      - name: Commit SEO artifact
+        run: |
+          git config user.name "seo-weekly-bot"
+          git config user.email "seo-weekly@gravelgodcycling.com"
+          git add data/seo/
+          if git diff --cached --quiet; then
+            echo "No SEO artifact changes to commit."
+          else
+            git commit -m "chore: SEO weekly update-candidates $(date -u +%Y-%m-%d)"
+            committed=0
+            for i in 1 2 3; do
+              if git pull --rebase origin main && git push; then
+                committed=1
+                break
+              fi
+              git rebase --abort || true
+              [ "$i" = "3" ] && break
+              sleep 5
+            done
+            if [ "$committed" != "1" ]; then
+              echo "::error::failed to rebase and push SEO artifact after 3 attempts"
+              exit 1
+            fi
+          fi

--- a/docs/specs/seo-weekly-spec.md
+++ b/docs/specs/seo-weekly-spec.md
@@ -1,0 +1,217 @@
+# SEO Weekly Update-Candidates Loop — Spec (r2, sol findings folded)
+
+**Goal**: every week, deterministically mine first-party GSC data for the 5
+highest-leverage content updates on gravelgodcycling.com, surface them in
+Morning Intel, and give the operator an in-session skill that drafts the
+actual edits for gated deploy.
+
+**Non-goals**: no third-party SEO data (OpenSEO/DataForSEO deferred — GSC-only
+per Matti's decision 2026-07-29); **the collector makes no LLM calls** (the
+weekly artifact and the intel section are fully deterministic; Morning Intel's
+existing `interpret()` narrative may reference the section like any other —
+that's pre-existing infra, unchanged); no automated publishing (governance: no
+public content changes without Matti's yes). RL/XC extension deferred until
+the GG loop proves out.
+
+## Architecture (mirrors the shipped AEO weekly monitor)
+
+```
+GHA cron (Mon)                       Morning Intel (daily)      Interactive session
+seo-weekly.yml ──runs──▶ scripts/seo_weekly.py                  /seo-updates skill
+                          │  GSC Search Analytics API            │ reads latest artifact
+                          │  (paginated pulls, two 28d windows)  │ inspects candidate pages
+                          ▼                                      │ drafts 5 edits as diffs
+                data/seo/seo-weekly-YYYY-MM-DD.json ──▶ collect_seo() section
+                (validated BEFORE commit)                        ▼
+                                                        Matti gates → deploy
+                                                                 ▼
+                                                data/seo/updates-log.jsonl
+                                                (cooldown + outcome tracking)
+```
+
+## 1. Collector — `scripts/seo_weekly.py`
+
+Auth: `GOOGLE_APPLICATION_CREDENTIALS` service-account JSON,
+`webmasters.readonly` scope, property **exactly** `sc-domain:gravelgodcycling.com`
+(the URL-prefix form 403s — see `reports/2026-07-29.md` §3; keep parity with
+`gsc_tracker.py:24`).
+
+**Data boundary probe**: GSC dates are Pacific-time and finalize late. Before
+building windows, pull `dimensions: ["date"]` for the last 14 days and take
+`boundary = max(date present)`. `current = [boundary-27, boundary]`,
+`prior = [boundary-55, boundary-28]`. Artifact stores `data_boundary` and both
+windows. If the probe returns no rows → hard fail.
+
+**Pulls** (× both windows, 8 total + probe):
+- `dimensions: []` — true overall totals (includes anonymized queries).
+- `dimensions: ["query"]` — true per-query totals (content_gaps input; never
+  derived by summing query+page rows, which double-counts multi-URL queries).
+- `dimensions: ["query","page"]` — page attribution (striking_distance,
+  ctr_underperformers).
+- `dimensions: ["page"]` — page totals (decliners).
+
+**Pagination**: every dimensioned pull loops `startRow += 25000` until a short
+page. Artifact records per-pull `{dimensions, window, rows, requests}` under
+`pulls`. Any API error or incomplete pull → exit 1, **no artifact written**
+(no partials, no silent caps).
+
+**Units**: CTR is stored as an API-native **fraction** (0.021) everywhere in
+the artifact and all math; positions are floats. Rendering as % happens only
+in the intel section. Schema documents this.
+
+**URL normalization**: `urllib.parse.urlsplit`. Rows whose host is not
+`gravelgodcycling.com`/`www.gravelgodcycling.com` or scheme is not https are
+excluded from buckets and counted in `noncanonical` (per-host counts).
+Canonical rows keep path only, trailing slash normalized to present (except
+`/`). Query strings/fragments stripped.
+
+**Floors** (drop early, keep artifact small): query+page rows need current
+impressions ≥ 10; per-bucket floors below.
+
+**Expected-CTR curve**: piecewise-linear interpolation over anchors
+`{1: .28, 2: .15, 3: .10, 4: .075, 5: .06, 6: .045, 7: .035, 8: .03,
+9: .025, 10: .02, 12: .02, 20: .01}`; clamp outside [1, 20] to the endpoint
+values. `expected_ctr(position: float) -> float`, unit-tested at anchor,
+midpoint, and out-of-range positions.
+
+**Candidate buckets** (each entry carries: `page`, `query` (or null),
+`clicks`, `impressions`, `ctr`, `position`, prior-window values when present,
+`score`, `reason` — plain-English one-liner):
+
+1. `striking_distance` — query+page rows, position 4–20, impressions ≥ 30.
+   `target_pos = 3 if position <= 10 else 8`.
+   `score = impressions * max(0, expected_ctr(target_pos) - ctr)`.
+2. `ctr_underperformers` — query+page rows, position ≤ 12, impressions ≥ 50,
+   `ctr < 0.4 * expected_ctr(position)`.
+   `score = impressions * (expected_ctr(position) - ctr)`.
+3. `decliners` — page-dim rows present in both windows, AND (clicks dropped
+   ≥ 40% with prior clicks ≥ 10) OR (position worsened ≥ 3.0 with impressions
+   ≥ 50 in **both** windows). `score = max(0, prior_clicks - clicks)`.
+4. `content_gaps` — query-dim rows, impressions ≥ 50, whose best-ranking
+   canonical page (from query+page rows) is `/` or `/gravel-race-search/` or
+   absent. `score = max(0, impressions * expected_ctr(5) - clicks)`. Carries
+   `recommended_target_path` (slug suggestion only; the skill decides).
+
+All scores share one unit — estimated 28-day click upside — so cross-bucket
+ranking is meaningful. `score_version: 1` stamped on the artifact; bump on
+any formula change.
+
+**Ranking → `top_candidates`**:
+1. Merge buckets; dedupe by canonical page (content_gaps dedupe by query),
+   keeping the max-score entry; attach `supporting_queries` (up to 5 other
+   qualifying queries for that page, by impressions, with their metrics) and
+   `combined_upside` (sum of that page's qualifying scores).
+2. **Cooldown**: parse `data/seo/updates-log.jsonl` (missing file = empty);
+   exclude pages with an `applied` entry newer than 21 days from
+   top_candidates (they remain in buckets). Malformed log lines are skipped
+   with a warning, never fatal.
+3. Sort: score desc, impressions desc, page asc (deterministic tie-break).
+   Take up to 5 (fewer is fine; `top_candidates` may be short or empty).
+4. Each candidate: `rank`, `bucket`, `action` (one of `improve_ranking`,
+   `rewrite_title_meta`, `refresh_content`, `create_or_link_content`),
+   `target_path`, `source_hint` (routing per §4 table), `reason`, raw
+   metrics, `supporting_queries`, `combined_upside`, `score`.
+
+**Artifact** `data/seo/seo-weekly-YYYY-MM-DD.json` (date = data_boundary):
+```json
+{
+  "schema_version": 1,
+  "score_version": 1,
+  "generated_at_utc": "...",
+  "site": "sc-domain:gravelgodcycling.com",
+  "data_boundary": "YYYY-MM-DD",
+  "current_window": {"start": "...", "end": "..."},
+  "prior_window": {"start": "...", "end": "..."},
+  "overall": {"clicks": 0, "impressions": 0, "ctr": 0.0, "position": 0.0,
+               "prior": {"clicks": 0, "impressions": 0, "ctr": 0.0, "position": 0.0}},
+  "pulls": [{"dimensions": ["query","page"], "window": "current",
+              "rows": 0, "requests": 1}],
+  "noncanonical": {"http://gravelgodcycling.com": 0},
+  "cooldown_excluded": ["/race/..."],
+  "buckets": {"striking_distance": [], "ctr_underperformers": [],
+               "decliners": [], "content_gaps": []},
+  "top_candidates": []
+}
+```
+
+**CLI**: default = collect + write. `--validate-latest` validates newest
+artifact (schema_version, required keys, window/boundary sanity,
+generated_at not future, ctr values in [0,1]); `--require-all-ok` exits 1 on
+any error. `--date` override for tests. `validate_artifact(artifact, path)`
+importable (daily_intel reuses it).
+
+## 2. Workflow — `.github/workflows/seo-weekly.yml`
+
+- `schedule: cron "20 11 * * 1"` + `workflow_dispatch`;
+  `permissions: contents: write`; timeout 15 min;
+  `concurrency: {group: seo-weekly, cancel-in-progress: false}`.
+- Steps: checkout → setup-python 3.11 → `pip install google-api-python-client
+  google-auth` → write `$GSC_SERVICE_ACCOUNT_JSON` (existing secret, proven in
+  daily-monitoring.yml) to `$RUNNER_TEMP/gsc-creds.json` → run collector →
+  **`--validate-latest --require-all-ok` BEFORE commit** → commit `data/seo/`
+  with the aeo rebase-retry ×3; on rebase conflict `git rebase --abort` and
+  fail the step explicitly.
+
+## 3. Morning Intel — `scripts/daily_intel.py`
+
+- `collect_seo(today)` mirroring `collect_aeo`: newest
+  `data/seo/seo-weekly-*.json`; states `missing` (silent, ok=True) / `ok` /
+  `stale` (>8 days) / `invalid`; stale/invalid → one BROKEN line via
+  `_collector_failures`. Validation via imported `validate_artifact`.
+- Deterministic render: overall WoW line + up to 5 top_candidates
+  (`#1 [striking_distance] /race/x — "query" pos 6.2, 480 impr, CTR 2.1% —
+  <reason>`; CTR rendered as % here only) + `Run /seo-updates to draft
+  these.` Empty top_candidates renders `no qualifying candidates this week`.
+- Add `("wattgod/gravel-race-automation", "seo-weekly.yml")` to
+  `collect_workflows` dead-man list. (Known limitation inherited from that
+  list: it reads only the latest conclusion, not `updatedAt` age — deferred,
+  same exposure as aeo.)
+
+## 4. Drafting skill — `.claude/skills/seo-updates/SKILL.md`
+
+Source-routing table (the load-bearing part — never hand-edit emitted HTML):
+
+| target_path prefix | source of truth | apply via |
+|---|---|---|
+| `/race/<slug>/` | `race-data/<slug>.json` → `seo.title`/`seo.description` (+ profile fields for content) | regenerate page (generate_neo_brutalist path), preflight, deploy per deploy-safely |
+| `/articles/<slug>/` | article source generator in repo | regenerate → SCP to `/articles/<slug>/` (NOT --sync-blog) |
+| WP-native/Elementor pages (`/questionnaire/`, hubs) | `scripts/generate_meta_descriptions.py` for meta; Elementor widget for body | flag Elementor bodies for manual/JS-API edit — do not guess |
+| anything else / content_gaps with no source | no source | propose new content or internal links; never invent a page silently |
+
+Procedure (in-session, subscription Claude, zero API keys):
+1. Read newest artifact; refuse if stale >8 days (tell operator to dispatch
+   the workflow).
+2. Per candidate: curl the live page, open its source per routing table,
+   diagnose per bucket. **Freshness/factual edits require source
+   verification** (official race site, registry) — GSC identifies the
+   opportunity, it does not supply facts.
+3. Draft the 5 edits as diffs (respect brand tokens, slop_rules, voice
+   memories, race-page spine contract). Present with expected impact.
+4. **Matti gates.** On yes: regenerate, `preflight_quality.py`, deploy,
+   purge cache.
+5. Append one JSONL line per applied update to `data/seo/updates-log.jsonl`:
+   `{"date", "page", "query", "bucket", "action", "artifact",
+   "baseline": {clicks, impressions, ctr, position}, "change_summary",
+   "status": "applied"|"skipped"}`. The collector consumes this for cooldowns
+   and for future before/after measurement.
+
+## 5. Tests — `tests/test_seo_weekly.py` (+ intel tests)
+
+No network. Cover: pagination loop (multi-page synthetic responses, per-pull
+counts), CTR-as-fraction end-to-end (a 100× unit error must fail), expected
+CTR at anchors/midpoints/out-of-range, each bucket's include/exclude edges,
+decliner floors, dedupe keeps max score + attaches supporting_queries,
+deterministic tie-break, cooldown exclusion + malformed log lines,
+content_gaps duplicate targets, host/trailing-slash normalization,
+empty/fewer-than-five top_candidates, artifact validation
+(good/missing-key/future-date/bad-window/ctr-out-of-range), collect_seo
+missing/ok/stale/invalid states, API error → no artifact file written.
+
+## Rollout
+
+1. PR from `seo-weekly` branch (worktree off origin/main; repo checkout is on
+   `bikepacking-wsg`, untouched). Tests + sol-review fold documented.
+2. Merge → `workflow_dispatch` first run → verify committed artifact
+   validates; Morning Intel renders the section next morning.
+3. First `/seo-updates` session = pilot; RL/XC cloning decision after 2–3
+   weeks of GG signal.

--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -36,6 +36,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SNAPSHOT_DIR = PROJECT_ROOT / "data" / "intel-snapshots"
 AEO_DIR = PROJECT_ROOT / "data" / "aeo"
+SEO_DIR = PROJECT_ROOT / "data" / "seo"
 
 try:
     from dotenv import load_dotenv
@@ -427,7 +428,8 @@ def collect_workflows() -> dict:
                      ("wattgod/road-race-automation", "link-check.yml"),
                      ("wattgod/road-race-automation", "checkout-monitor.yml"),
                      ("wattgod/gravel-race-automation", "regression-tests.yml"),
-                     ("wattgod/gravel-race-automation", "aeo-weekly.yml")]:
+                     ("wattgod/gravel-race-automation", "aeo-weekly.yml"),
+                     ("wattgod/gravel-race-automation", "seo-weekly.yml")]:
         try:
             r = subprocess.run(
                 ["gh", "run", "list", "--repo", repo, "--workflow", wf,
@@ -613,6 +615,92 @@ def collect_aeo(today: date | None = None) -> dict:
         }
 
 
+def _load_seo_artifact(path: Path) -> dict:
+    try:
+        artifact = json.loads(path.read_text())
+    except Exception as exc:
+        raise ValueError(f"{type(exc).__name__}: {exc}") from exc
+    try:
+        from scripts.seo_weekly import validate_artifact
+    except ImportError:
+        from seo_weekly import validate_artifact
+    errors = validate_artifact(artifact, path=path)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return artifact
+
+
+def _collect_seo(today: date | None = None) -> dict:
+    """Implementation for collect_seo; the public collector is fully fail-soft."""
+    paths = sorted(SEO_DIR.glob("seo-weekly-*.json"))
+    if not paths:
+        return {"state": "missing", "ok": True}
+    latest_path = paths[-1]
+    try:
+        latest = _load_seo_artifact(latest_path)
+    except Exception as exc:
+        return {
+            "state": "invalid",
+            "ok": False,
+            "error": f"SEO weekly artifact invalid: {str(exc)[:300]}",
+        }
+    generated_date = datetime.fromisoformat(
+        latest["generated_at_utc"].replace("Z", "+00:00")).date()
+    utc_today = today or datetime.now(timezone.utc).date()
+    age_days = (utc_today - generated_date).days
+    if age_days < 0:
+        return {
+            "state": "invalid",
+            "ok": False,
+            "error": "SEO weekly artifact invalid: generated date is in the future",
+        }
+    if age_days > 8:
+        return {
+            "state": "stale",
+            "ok": False,
+            "age_days": age_days,
+            "error": f"SEO weekly artifact stale ({age_days} days)",
+        }
+
+    overall = latest.get("overall") or {}
+    prior = overall.get("prior") or {}
+    clicks_delta = _aeo_delta(overall.get("clicks"), prior.get("clicks"))
+    impressions_delta = _aeo_delta(overall.get("impressions"), prior.get("impressions"))
+    return {
+        "state": "ok",
+        "ok": True,
+        "artifact": latest_path.name,
+        "generated_at_utc": latest["generated_at_utc"],
+        "current_window": latest["current_window"],
+        "overall": {
+            "clicks": overall.get("clicks"),
+            "impressions": overall.get("impressions"),
+            "ctr": overall.get("ctr"),
+            "position": overall.get("position"),
+            "clicks_delta": clicks_delta,
+            "clicks_delta_text": _aeo_delta_text(clicks_delta),
+            "impressions_delta": impressions_delta,
+            "impressions_delta_text": _aeo_delta_text(impressions_delta),
+        },
+        "top_candidates": latest.get("top_candidates") or [],
+    }
+
+
+def collect_seo(today: date | None = None) -> dict:
+    """Load weekly SEO facts, returning an error state instead of ever raising."""
+    try:
+        return _collect_seo(today=today)
+    except Exception as exc:
+        return {
+            "state": "invalid",
+            "ok": False,
+            "error": (
+                f"SEO weekly artifact invalid: "
+                f"{type(exc).__name__}: {str(exc)[:260]}"
+            ),
+        }
+
+
 def load_trend(days: int = 7) -> list[dict]:
     """Prior snapshots (compact) for trend context in the interpretation."""
     trend = []
@@ -716,6 +804,12 @@ def _collector_failures(collected: dict) -> list[str]:
                     f"{summary.get('label', brand)} /llms.txt DISPLACED — live file "
                     f"no longer starts with our database marker (serving: {first!r}); "
                     f"likely AIOSEO clobbered it again")
+    seo = collected.get("seo") or {}
+    if (
+            isinstance(seo, dict)
+            and seo.get("state") in {"stale", "invalid"}
+            and seo.get("ok") is False):
+        broken.append(_display(seo.get("error"), "SEO weekly artifact unavailable"))
     return broken
 
 
@@ -926,6 +1020,46 @@ def render_report(collected: dict) -> str:
             lines.append(
                 "- **Unknown agent candidates (spoofable):** "
                 + ", ".join(rendered_candidates) + ".")
+
+    seo = collected.get("seo") or {}
+    if seo.get("state") == "ok":
+        seo_overall = seo.get("overall") or {}
+        lines.extend([
+            "",
+            "## SEO (WEEKLY)",
+            (
+                f"- overall: {_display(seo_overall.get('clicks'))} clicks "
+                f"({_display(seo_overall.get('clicks_delta_text'))}), "
+                f"{_display(seo_overall.get('impressions'))} impressions "
+                f"({_display(seo_overall.get('impressions_delta_text'))})."
+            ),
+        ])
+        candidates = seo.get("top_candidates") or []
+        if candidates:
+            for candidate in candidates[:5]:
+                target = _path(candidate.get("target_path"))
+                bucket = candidate.get("bucket") or "unknown"
+                query = candidate.get("query")
+                query_part = f'"{query}" ' if query else ""
+                ctr_value = candidate.get("ctr")
+                ctr_text = (
+                    f"{float(ctr_value) * 100:.1f}%"
+                    if isinstance(ctr_value, (int, float)) else "n/a"
+                )
+                position_value = candidate.get("position")
+                position_text = (
+                    f"{float(position_value):.1f}"
+                    if isinstance(position_value, (int, float)) else "n/a"
+                )
+                lines.append(
+                    f"- #{_display(candidate.get('rank'))} [{bucket}] {target} — "
+                    f"{query_part}pos {position_text}, "
+                    f"{_display(candidate.get('impressions'))} impr, CTR {ctr_text} "
+                    f"— {_display(candidate.get('reason'), '')}"
+                )
+            lines.append("- Run /seo-updates to draft these.")
+        else:
+            lines.append("- no qualifying candidates this week.")
 
     lines.extend(["", "## BROKEN"])
     broken = []
@@ -1239,6 +1373,7 @@ def main() -> int:
         "social": _safe(collect_social),
         "workflows": _safe(collect_workflows),
         "aeo": _safe(collect_aeo),
+        "seo": _safe(collect_seo),
     }
     collected["constraint"] = compute_constraint(collected["ga4"].get("gravelgod", {}))
     try:

--- a/scripts/seo_weekly.py
+++ b/scripts/seo_weekly.py
@@ -1,0 +1,773 @@
+#!/usr/bin/env python3
+"""Deterministic weekly SEO update-candidates collector for Gravel God.
+
+Mines first-party GSC Search Analytics data for the highest-leverage content
+updates on gravelgodcycling.com. Unlike the AEO weekly monitor, this
+collector makes no LLM calls and is not fail-soft: any API error or
+incomplete pull raises, main() reports it and exits 1, and NO artifact is
+written (no partials, no silent caps — see docs/specs/seo-weekly-spec.md §1).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import os
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+ARTIFACT_DIR = PROJECT_ROOT / "data" / "seo"
+SCHEMA_VERSION = 1
+SCORE_VERSION = 1
+SITE_URL = "sc-domain:gravelgodcycling.com"
+PAGE_SIZE = 25000
+COOLDOWN_DAYS = 21
+CANONICAL_HOSTS = {"gravelgodcycling.com", "www.gravelgodcycling.com"}
+
+# Piecewise-linear expected-CTR curve, position -> expected CTR fraction.
+_EXPECTED_CTR_ANCHORS = sorted({
+    1: 0.28, 2: 0.15, 3: 0.10, 4: 0.075, 5: 0.06, 6: 0.045, 7: 0.035,
+    8: 0.03, 9: 0.025, 10: 0.02, 12: 0.02, 20: 0.01,
+}.items())
+
+_ACTION_BY_BUCKET = {
+    "striking_distance": "improve_ranking",
+    "ctr_underperformers": "rewrite_title_meta",
+    "decliners": "refresh_content",
+    "content_gaps": "create_or_link_content",
+}
+BUCKET_NAMES = tuple(_ACTION_BY_BUCKET)
+REQUIRED_KEYS = (
+    "schema_version", "score_version", "generated_at_utc", "site",
+    "data_boundary", "current_window", "prior_window", "overall",
+    "pulls", "noncanonical", "cooldown_excluded", "buckets", "top_candidates",
+)
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def get_gsc_service():
+    """Build GSC API service from GOOGLE_APPLICATION_CREDENTIALS (gsc_tracker.py parity)."""
+    creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if not creds_path:
+        raise RuntimeError("GOOGLE_APPLICATION_CREDENTIALS not set")
+
+    from google.oauth2 import service_account
+    from googleapiclient.discovery import build
+
+    creds = service_account.Credentials.from_service_account_file(
+        creds_path, scopes=["https://www.googleapis.com/auth/webmasters.readonly"]
+    )
+    return build("searchconsole", "v1", credentials=creds)
+
+
+def expected_ctr(position: float) -> float:
+    """Piecewise-linear interpolation over the anchor table; clamped at the ends."""
+    positions = [p for p, _ in _EXPECTED_CTR_ANCHORS]
+    values = [v for _, v in _EXPECTED_CTR_ANCHORS]
+    if position <= positions[0]:
+        return values[0]
+    if position >= positions[-1]:
+        return values[-1]
+    for i in range(len(positions) - 1):
+        lo_p, hi_p = positions[i], positions[i + 1]
+        if lo_p <= position <= hi_p:
+            lo_v, hi_v = values[i], values[i + 1]
+            fraction = (position - lo_p) / (hi_p - lo_p)
+            return lo_v + fraction * (hi_v - lo_v)
+    return values[-1]
+
+
+def normalize_page_url(raw_url: str) -> tuple[str | None, str | None]:
+    """Return (canonical_path, None) or (None, noncanonical_host_key)."""
+    parts = urlsplit(raw_url)
+    host = (parts.hostname or "").lower()
+    if parts.scheme != "https" or host not in CANONICAL_HOSTS:
+        return None, f"{parts.scheme}://{host}"
+    path = parts.path or "/"
+    if path != "/" and not path.endswith("/"):
+        path += "/"
+    return path, None
+
+
+def _paginated_query(
+        service, site_url: str, start: str, end: str,
+        dimensions: list[str]) -> tuple[list[dict], int]:
+    """Loop startRow += 25000 until a short page; return (rows, request_count)."""
+    rows: list[dict] = []
+    requests = 0
+    start_row = 0
+    while True:
+        resp = service.searchanalytics().query(
+            siteUrl=site_url,
+            body={
+                "startDate": start,
+                "endDate": end,
+                "dimensions": list(dimensions),
+                "rowLimit": PAGE_SIZE,
+                "startRow": start_row,
+            },
+        ).execute()
+        requests += 1
+        page = resp.get("rows") or []
+        rows.extend(page)
+        if len(page) < PAGE_SIZE:
+            break
+        start_row += PAGE_SIZE
+    return rows, requests
+
+
+def probe_data_boundary(service, run_date: date) -> date:
+    """Pull dimensions=['date'] for the last 14 days; boundary = max date present."""
+    start = (run_date - timedelta(days=13)).isoformat()
+    end = run_date.isoformat()
+    rows, _ = _paginated_query(service, SITE_URL, start, end, ["date"])
+    dates = [r["keys"][0] for r in rows if r.get("keys")]
+    if not dates:
+        raise RuntimeError("date-boundary probe returned no rows")
+    return date.fromisoformat(max(dates))
+
+
+def compute_windows(boundary: date) -> tuple[dict[str, str], dict[str, str]]:
+    current = {
+        "start": (boundary - timedelta(days=27)).isoformat(),
+        "end": boundary.isoformat(),
+    }
+    prior = {
+        "start": (boundary - timedelta(days=55)).isoformat(),
+        "end": (boundary - timedelta(days=28)).isoformat(),
+    }
+    return current, prior
+
+
+def _overall_metrics(raw_rows: list[dict]) -> dict[str, Any]:
+    if not raw_rows:
+        return {"clicks": 0, "impressions": 0, "ctr": 0.0, "position": 0.0}
+    row = raw_rows[0]
+    return {
+        "clicks": int(row.get("clicks", 0) or 0),
+        "impressions": int(row.get("impressions", 0) or 0),
+        "ctr": float(row.get("ctr", 0.0) or 0.0),
+        "position": float(row.get("position", 0.0) or 0.0),
+    }
+
+
+def _rows_query(raw_rows: list[dict]) -> list[dict]:
+    return [
+        {
+            "query": row["keys"][0],
+            "clicks": int(row.get("clicks", 0) or 0),
+            "impressions": int(row.get("impressions", 0) or 0),
+            "ctr": float(row.get("ctr", 0.0) or 0.0),
+            "position": float(row.get("position", 0.0) or 0.0),
+        }
+        for row in raw_rows
+    ]
+
+
+def _rows_query_page(raw_rows: list[dict], noncanonical: dict[str, int]) -> list[dict]:
+    out = []
+    for row in raw_rows:
+        query, page_url = row["keys"]
+        path, host_key = normalize_page_url(page_url)
+        if path is None:
+            noncanonical[host_key] = noncanonical.get(host_key, 0) + 1
+            continue
+        out.append({
+            "query": query,
+            "page": path,
+            "clicks": int(row.get("clicks", 0) or 0),
+            "impressions": int(row.get("impressions", 0) or 0),
+            "ctr": float(row.get("ctr", 0.0) or 0.0),
+            "position": float(row.get("position", 0.0) or 0.0),
+        })
+    return out
+
+
+def _rows_page(raw_rows: list[dict], noncanonical: dict[str, int]) -> list[dict]:
+    out = []
+    for row in raw_rows:
+        page_url = row["keys"][0]
+        path, host_key = normalize_page_url(page_url)
+        if path is None:
+            noncanonical[host_key] = noncanonical.get(host_key, 0) + 1
+            continue
+        out.append({
+            "page": path,
+            "clicks": int(row.get("clicks", 0) or 0),
+            "impressions": int(row.get("impressions", 0) or 0),
+            "ctr": float(row.get("ctr", 0.0) or 0.0),
+            "position": float(row.get("position", 0.0) or 0.0),
+        })
+    return out
+
+
+def _recommended_target_path(query: str) -> str:
+    slug = _SLUG_RE.sub("-", query.lower()).strip("-")
+    return f"/articles/{slug or 'topic'}/"
+
+
+def _sort_bucket(entries: list[dict]) -> list[dict]:
+    return sorted(
+        entries,
+        key=lambda e: (
+            -e["score"], -e["impressions"], e.get("page") or e.get("query") or ""),
+    )
+
+
+def build_buckets(
+        *, current_qp: list[dict], prior_qp: list[dict],
+        current_page: list[dict], prior_page: list[dict],
+        current_query: list[dict]) -> dict[str, list[dict]]:
+    """Build the four candidate buckets from normalized, floored rows."""
+    prior_qp_index = {(row["query"], row["page"]): row for row in prior_qp}
+    prior_page_index = {row["page"]: row for row in prior_page}
+    current_qp_by_query: dict[str, list[dict]] = {}
+    for row in current_qp:
+        current_qp_by_query.setdefault(row["query"], []).append(row)
+
+    striking_distance = []
+    ctr_underperformers = []
+    for row in current_qp:
+        query, page = row["query"], row["page"]
+        position, impressions, ctr, clicks = (
+            row["position"], row["impressions"], row["ctr"], row["clicks"])
+        prior_row = prior_qp_index.get((query, page))
+
+        if 4 <= position <= 20 and impressions >= 30:
+            target_pos = 3 if position <= 10 else 8
+            exp = expected_ctr(target_pos)
+            score = impressions * max(0.0, exp - ctr)
+            entry = {
+                "page": page, "query": query,
+                "clicks": clicks, "impressions": impressions,
+                "ctr": ctr, "position": position,
+                "score": score,
+                "reason": (
+                    f"'{query}' ranks {position:.1f} on {page} with "
+                    f"{impressions} impressions/28d — pushing to top "
+                    f"{target_pos} could add ~{score:.0f} clicks."
+                ),
+            }
+            if prior_row:
+                entry["prior"] = {
+                    key: prior_row[key]
+                    for key in ("clicks", "impressions", "ctr", "position")
+                }
+            striking_distance.append(entry)
+
+        if position <= 12 and impressions >= 50 and ctr < 0.4 * expected_ctr(position):
+            exp = expected_ctr(position)
+            score = impressions * (exp - ctr)
+            entry = {
+                "page": page, "query": query,
+                "clicks": clicks, "impressions": impressions,
+                "ctr": ctr, "position": position,
+                "score": score,
+                "reason": (
+                    f"'{query}' on {page} gets {ctr * 100:.1f}% CTR at position "
+                    f"{position:.1f}, well below the {exp * 100:.1f}% expected "
+                    "— rewrite title/meta."
+                ),
+            }
+            if prior_row:
+                entry["prior"] = {
+                    key: prior_row[key]
+                    for key in ("clicks", "impressions", "ctr", "position")
+                }
+            ctr_underperformers.append(entry)
+
+    decliners = []
+    for row in current_page:
+        page = row["page"]
+        prior_row = prior_page_index.get(page)
+        if not prior_row:
+            continue
+        clicks, impressions, position = row["clicks"], row["impressions"], row["position"]
+        prior_clicks = prior_row["clicks"]
+        prior_impressions = prior_row["impressions"]
+        prior_position = prior_row["position"]
+
+        clicks_dropped = (
+            prior_clicks >= 10
+            and (prior_clicks - clicks) / prior_clicks >= 0.4
+        )
+        position_worsened = (
+            impressions >= 50 and prior_impressions >= 50
+            and (position - prior_position) >= 3.0
+        )
+        if clicks_dropped or position_worsened:
+            score = float(max(0, prior_clicks - clicks))
+            decline_detail = (
+                f", position worsened {prior_position:.1f} → {position:.1f}"
+                if position_worsened else ""
+            )
+            decliners.append({
+                "page": page, "query": None,
+                "clicks": clicks, "impressions": impressions,
+                "ctr": row["ctr"], "position": position,
+                "prior": {
+                    "clicks": prior_clicks, "impressions": prior_impressions,
+                    "ctr": prior_row["ctr"], "position": prior_position,
+                },
+                "score": score,
+                "reason": (
+                    f"{page} clicks fell from {prior_clicks} to {clicks}"
+                    f"{decline_detail} — refresh content."
+                ),
+            })
+
+    content_gaps = []
+    for row in current_query:
+        query = row["query"]
+        impressions = row["impressions"]
+        if impressions < 50:
+            continue
+        matches = current_qp_by_query.get(query, [])
+        best_page = None
+        if matches:
+            best_page = min(matches, key=lambda r: r["position"])["page"]
+        if best_page in (None, "/", "/gravel-race-search/"):
+            exp = expected_ctr(5)
+            score = max(0.0, impressions * exp - row["clicks"])
+            content_gaps.append({
+                "page": None, "query": query,
+                "clicks": row["clicks"], "impressions": impressions,
+                "ctr": row["ctr"], "position": row["position"],
+                "score": score,
+                "recommended_target_path": _recommended_target_path(query),
+                "reason": (
+                    f"'{query}' gets {impressions} impressions/28d with no "
+                    f"dedicated page (best match: {best_page or 'none'}) "
+                    "— create or link content."
+                ),
+            })
+
+    return {
+        "striking_distance": _sort_bucket(striking_distance),
+        "ctr_underperformers": _sort_bucket(ctr_underperformers),
+        "decliners": _sort_bucket(decliners),
+        "content_gaps": _sort_bucket(content_gaps),
+    }
+
+
+def _source_hint(target_path: str | None) -> str:
+    if not target_path:
+        return (
+            "no source — propose new content or internal links; "
+            "never invent a page silently"
+        )
+    if target_path.startswith("/race/"):
+        return (
+            "race-data/<slug>.json → seo.title/seo.description "
+            "(+ profile fields for content); regenerate, preflight, deploy"
+        )
+    if target_path.startswith("/articles/"):
+        return (
+            "article source generator; regenerate → SCP to the article "
+            "path (NOT --sync-blog)"
+        )
+    return (
+        "WP-native/Elementor page — generate_meta_descriptions.py for "
+        "meta; Elementor widget for body; flag for manual/JS-API edit, do "
+        "not guess"
+    )
+
+
+def _group_key(bucket: str, entry: dict) -> tuple[str, str]:
+    if bucket == "content_gaps":
+        return ("query", entry["query"])
+    return ("page", entry["page"])
+
+
+def _load_cooldown_pages(
+        boundary: date, log_dir: Path) -> tuple[set[str], list[str]]:
+    """Parse updates-log.jsonl; missing file = empty. Malformed lines warn, never fail."""
+    log_path = log_dir / "updates-log.jsonl"
+    pages: set[str] = set()
+    warnings: list[str] = []
+    if not log_path.exists():
+        return pages, warnings
+    for line_number, raw_line in enumerate(log_path.read_text().splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            if not isinstance(entry, dict):
+                raise ValueError("log line is not an object")
+            page = entry["page"]
+            status = entry.get("status")
+            entry_date = date.fromisoformat(entry["date"])
+        except Exception as exc:
+            warnings.append(
+                f"malformed updates-log line {line_number}: "
+                f"{type(exc).__name__}: {exc}")
+            continue
+        if status != "applied":
+            continue
+        age_days = (boundary - entry_date).days
+        if 0 <= age_days < COOLDOWN_DAYS:
+            pages.add(page)
+    return pages, warnings
+
+
+def _rank_top_candidates(
+        buckets: dict[str, list[dict]],
+        cooldown_pages: set[str]) -> tuple[list[dict], list[str]]:
+    grouped: dict[tuple[str, str], list[tuple[str, dict]]] = {}
+    for bucket_name in BUCKET_NAMES:
+        for entry in buckets[bucket_name]:
+            key = _group_key(bucket_name, entry)
+            grouped.setdefault(key, []).append((bucket_name, entry))
+
+    candidates = []
+    for items in grouped.values():
+        items_sorted = sorted(items, key=lambda bi: bi[1]["score"], reverse=True)
+        rep_bucket, rep_entry = items_sorted[0]
+        combined_upside = sum(entry["score"] for _, entry in items)
+        supporting_queries = []
+        if rep_bucket != "content_gaps":
+            others = [
+                entry for _, entry in items_sorted[1:]
+                if entry is not rep_entry and entry.get("query")
+            ]
+            others_sorted = sorted(
+                others, key=lambda e: e["impressions"], reverse=True)[:5]
+            supporting_queries = [
+                {
+                    "query": e["query"], "clicks": e["clicks"],
+                    "impressions": e["impressions"], "ctr": e["ctr"],
+                    "position": e["position"],
+                }
+                for e in others_sorted
+            ]
+        target_path = (
+            rep_entry.get("recommended_target_path")
+            if rep_bucket == "content_gaps" else rep_entry.get("page")
+        )
+        candidate = {
+            "bucket": rep_bucket,
+            "action": _ACTION_BY_BUCKET[rep_bucket],
+            "target_path": target_path,
+            "query": rep_entry.get("query"),
+            "page": rep_entry.get("page"),
+            "source_hint": _source_hint(target_path),
+            "reason": rep_entry["reason"],
+            "clicks": rep_entry["clicks"],
+            "impressions": rep_entry["impressions"],
+            "ctr": rep_entry["ctr"],
+            "position": rep_entry["position"],
+            "score": rep_entry["score"],
+            "supporting_queries": supporting_queries,
+            "combined_upside": combined_upside,
+        }
+        if "prior" in rep_entry:
+            candidate["prior"] = rep_entry["prior"]
+        candidates.append(candidate)
+
+    candidates.sort(
+        key=lambda c: (
+            -c["score"], -c["impressions"],
+            c.get("page") or c.get("target_path") or c.get("query") or ""),
+    )
+
+    cooldown_excluded = sorted({
+        c["page"] for c in candidates
+        if c.get("page") and c["page"] in cooldown_pages
+    })
+    ranked = [
+        c for c in candidates
+        if not (c.get("page") and c["page"] in cooldown_pages)
+    ][:5]
+    for rank, candidate in enumerate(ranked, start=1):
+        candidate["rank"] = rank
+    return ranked, cooldown_excluded
+
+
+def collect_weekly(
+        now: datetime | None = None,
+        service=None,
+        output_dir: Path = ARTIFACT_DIR) -> dict[str, Any]:
+    """Run every collector eagerly; any error/incomplete pull raises (no fail-soft)."""
+    generated = now or datetime.now(timezone.utc)
+    if generated.tzinfo is None:
+        generated = generated.replace(tzinfo=timezone.utc)
+    generated = generated.astimezone(timezone.utc)
+    run_date = generated.date()
+
+    svc = service or get_gsc_service()
+    boundary = probe_data_boundary(svc, run_date)
+    current_window, prior_window = compute_windows(boundary)
+
+    pulls: list[dict[str, Any]] = []
+    noncanonical: dict[str, int] = {}
+
+    def pull(dimensions: list[str], window_name: str, window: dict[str, str]) -> list[dict]:
+        raw_rows, requests = _paginated_query(
+            svc, SITE_URL, window["start"], window["end"], dimensions)
+        pulls.append({
+            "dimensions": list(dimensions),
+            "window": window_name,
+            "rows": len(raw_rows),
+            "requests": requests,
+        })
+        return raw_rows
+
+    current_overall_raw = pull([], "current", current_window)
+    current_query_raw = pull(["query"], "current", current_window)
+    current_qp_raw = pull(["query", "page"], "current", current_window)
+    current_page_raw = pull(["page"], "current", current_window)
+    prior_overall_raw = pull([], "prior", prior_window)
+    prior_query_raw = pull(["query"], "prior", prior_window)
+    prior_qp_raw = pull(["query", "page"], "prior", prior_window)
+    prior_page_raw = pull(["page"], "prior", prior_window)
+    del prior_query_raw  # true per-query prior totals are not consumed downstream
+
+    current_overall = _overall_metrics(current_overall_raw)
+    prior_overall = _overall_metrics(prior_overall_raw)
+
+    current_query = _rows_query(current_query_raw)
+    current_qp = [
+        row for row in _rows_query_page(current_qp_raw, noncanonical)
+        if row["impressions"] >= 10
+    ]
+    current_page = _rows_page(current_page_raw, noncanonical)
+    prior_qp = _rows_query_page(prior_qp_raw, noncanonical)
+    prior_page = _rows_page(prior_page_raw, noncanonical)
+
+    buckets = build_buckets(
+        current_qp=current_qp, prior_qp=prior_qp,
+        current_page=current_page, prior_page=prior_page,
+        current_query=current_query,
+    )
+
+    cooldown_pages, cooldown_warnings = _load_cooldown_pages(boundary, output_dir)
+    for warning in cooldown_warnings:
+        print(f"warning: {warning}", file=sys.stderr)
+
+    top_candidates, cooldown_excluded = _rank_top_candidates(buckets, cooldown_pages)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "score_version": SCORE_VERSION,
+        "generated_at_utc": generated.isoformat().replace("+00:00", "Z"),
+        "site": SITE_URL,
+        "data_boundary": boundary.isoformat(),
+        "current_window": current_window,
+        "prior_window": prior_window,
+        "overall": {**current_overall, "prior": prior_overall},
+        "pulls": pulls,
+        "noncanonical": dict(sorted(noncanonical.items())),
+        "cooldown_excluded": cooldown_excluded,
+        "buckets": buckets,
+        "top_candidates": top_candidates,
+    }
+
+
+def artifact_path(artifact: dict[str, Any], output_dir: Path = ARTIFACT_DIR) -> Path:
+    return output_dir / f"seo-weekly-{artifact['data_boundary']}.json"
+
+
+def write_artifact(artifact: dict[str, Any], output_dir: Path = ARTIFACT_DIR) -> Path:
+    path = artifact_path(artifact, output_dir)
+    errors = validate_artifact(artifact, path=path)
+    if errors:
+        raise ValueError("; ".join(errors))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+    return path
+
+
+def _check_ctr(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and 0.0 <= float(value) <= 1.0
+
+
+def validate_artifact(
+        artifact: Any,
+        path: Path | None = None,
+        require_all_ok: bool = False) -> list[str]:
+    """Return contract violations; an empty list means the artifact is valid."""
+    errors: list[str] = []
+    if not isinstance(artifact, dict):
+        return ["artifact root must be an object"]
+    for key in REQUIRED_KEYS:
+        if key not in artifact:
+            errors.append(f"missing required key: {key}")
+    if artifact.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    if artifact.get("score_version") != SCORE_VERSION:
+        errors.append(f"score_version must be {SCORE_VERSION}")
+    if artifact.get("site") != SITE_URL:
+        errors.append(f"site must be {SITE_URL!r}")
+
+    try:
+        generated = datetime.fromisoformat(
+            str(artifact["generated_at_utc"]).replace("Z", "+00:00"))
+        if generated.tzinfo is None:
+            errors.append("generated_at_utc must include a timezone")
+        else:
+            now = datetime.now(timezone.utc)
+            if generated > now + timedelta(minutes=5):
+                errors.append("generated_at_utc must not be in the future")
+    except (KeyError, TypeError, ValueError):
+        errors.append("generated_at_utc must be an ISO timestamp")
+
+    boundary = None
+    try:
+        boundary = date.fromisoformat(str(artifact["data_boundary"]))
+    except (KeyError, TypeError, ValueError):
+        errors.append("data_boundary must be an ISO date")
+
+    if path is not None and boundary is not None:
+        expected_name = f"seo-weekly-{boundary.isoformat()}.json"
+        if path.name != expected_name:
+            errors.append(f"filename {path.name!r} does not match {expected_name!r}")
+
+    for window_name in ("current_window", "prior_window"):
+        window = artifact.get(window_name)
+        if not isinstance(window, dict) or set(window) != {"start", "end"}:
+            errors.append(f"{window_name} must contain start and end")
+            continue
+        try:
+            date.fromisoformat(window["start"])
+            date.fromisoformat(window["end"])
+        except (TypeError, ValueError):
+            errors.append(f"{window_name} has invalid dates")
+
+    if boundary is not None:
+        current_window = artifact.get("current_window") or {}
+        prior_window = artifact.get("prior_window") or {}
+        expected_current, expected_prior = compute_windows(boundary)
+        if current_window != expected_current:
+            errors.append("current_window does not match data_boundary")
+        if prior_window != expected_prior:
+            errors.append("prior_window does not match data_boundary")
+
+    overall = artifact.get("overall")
+    if not isinstance(overall, dict):
+        errors.append("overall must be an object")
+    else:
+        for key in ("clicks", "impressions", "ctr", "position"):
+            if key not in overall:
+                errors.append(f"overall missing {key}")
+        if "ctr" in overall and not _check_ctr(overall["ctr"]):
+            errors.append("overall.ctr must be a fraction in [0, 1]")
+        prior = overall.get("prior")
+        if not isinstance(prior, dict):
+            errors.append("overall.prior must be an object")
+        elif "ctr" in prior and not _check_ctr(prior["ctr"]):
+            errors.append("overall.prior.ctr must be a fraction in [0, 1]")
+
+    buckets = artifact.get("buckets")
+    if not isinstance(buckets, dict) or set(buckets) != set(BUCKET_NAMES):
+        errors.append("buckets must contain exactly the four bucket names")
+        buckets = {}
+    for bucket_name in BUCKET_NAMES:
+        entries = buckets.get(bucket_name, [])
+        if not isinstance(entries, list):
+            errors.append(f"buckets.{bucket_name} must be a list")
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                errors.append(f"buckets.{bucket_name} contains a non-object entry")
+                break
+            if "ctr" in entry and not _check_ctr(entry["ctr"]):
+                errors.append(f"buckets.{bucket_name} has a ctr outside [0, 1]")
+                break
+            prior_entry = entry.get("prior")
+            if (isinstance(prior_entry, dict) and "ctr" in prior_entry
+                    and not _check_ctr(prior_entry["ctr"])):
+                errors.append(f"buckets.{bucket_name} has a prior ctr outside [0, 1]")
+                break
+
+    top_candidates = artifact.get("top_candidates")
+    if not isinstance(top_candidates, list):
+        errors.append("top_candidates must be a list")
+    else:
+        if len(top_candidates) > 5:
+            errors.append("top_candidates exceeds 5")
+        for candidate in top_candidates:
+            if not isinstance(candidate, dict):
+                errors.append("top_candidates contains a non-object entry")
+                break
+            if "ctr" in candidate and not _check_ctr(candidate["ctr"]):
+                errors.append("top_candidates has a ctr outside [0, 1]")
+                break
+
+    if not isinstance(artifact.get("pulls"), list):
+        errors.append("pulls must be a list")
+    if not isinstance(artifact.get("noncanonical"), dict):
+        errors.append("noncanonical must be an object")
+    if not isinstance(artifact.get("cooldown_excluded"), list):
+        errors.append("cooldown_excluded must be a list")
+
+    if require_all_ok:
+        pulls = artifact.get("pulls")
+        if not isinstance(pulls, list) or len(pulls) != 8:
+            errors.append("pulls must contain exactly 8 entries")
+        else:
+            for pull_entry in pulls:
+                if not isinstance(pull_entry, dict) or int(pull_entry.get("requests", 0) or 0) < 1:
+                    errors.append("every pull must record at least one request")
+                    break
+    return errors
+
+
+def _validate_path(path: Path, require_all_ok: bool) -> int:
+    try:
+        artifact = json.loads(path.read_text())
+    except Exception as exc:
+        print(f"invalid artifact: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    errors = validate_artifact(artifact, path=path, require_all_ok=require_all_ok)
+    if errors:
+        for error in errors:
+            print(f"invalid artifact: {error}", file=sys.stderr)
+        return 1
+    print(f"valid artifact: {path}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--validate-latest", action="store_true",
+        help="validate the newest data/seo artifact")
+    parser.add_argument(
+        "--require-all-ok", action="store_true",
+        help="validation also requires all 8 pulls to be structurally complete")
+    parser.add_argument(
+        "--date", help="override run date (YYYY-MM-DD) for the boundary probe")
+    parser.add_argument("--output-dir", type=Path, default=ARTIFACT_DIR)
+    args = parser.parse_args()
+
+    if args.validate_latest:
+        paths = sorted(args.output_dir.glob("seo-weekly-*.json"))
+        if not paths:
+            print("invalid artifact: no SEO artifacts found", file=sys.stderr)
+            return 1
+        return _validate_path(paths[-1], args.require_all_ok)
+
+    now = None
+    if args.date:
+        now = datetime.combine(
+            date.fromisoformat(args.date), datetime.min.time(), tzinfo=timezone.utc)
+
+    try:
+        artifact = collect_weekly(now=now, output_dir=args.output_dir)
+        path = write_artifact(artifact, args.output_dir)
+    except Exception as exc:
+        print(f"ERROR: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    rel = path.relative_to(PROJECT_ROOT) if path.is_relative_to(PROJECT_ROOT) else path
+    print(f"artifact: {rel}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_seo_weekly.py
+++ b/tests/test_seo_weekly.py
@@ -1,0 +1,758 @@
+"""Contract tests for the deterministic weekly SEO update-candidates collector."""
+
+from __future__ import annotations
+
+import json
+import subprocess as subprocess_module
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+from scripts import daily_intel, seo_weekly as sw
+
+
+# ── Fake GSC service ─────────────────────────────────────────────────────
+
+class FakeGSCService:
+    """Minimal stand-in for the googleapiclient searchconsole resource.
+
+    `responses` maps (dimensions_tuple, startDate, endDate) -> list of pages
+    (each page a list of row dicts), consumed in order by startRow.
+    """
+
+    def __init__(self, responses: dict):
+        self._responses = responses
+        self.calls: list[dict] = []
+
+    def searchanalytics(self):
+        return self
+
+    def query(self, siteUrl, body):
+        self._pending = body
+        return self
+
+    def execute(self):
+        body = self._pending
+        self.calls.append(dict(body))
+        dims = tuple(body.get("dimensions", []))
+        key = (dims, body["startDate"], body["endDate"])
+        pages = self._responses.get(key, [[]])
+        start_row = body.get("startRow", 0)
+        index = start_row // sw.PAGE_SIZE
+        rows = pages[index] if index < len(pages) else []
+        return {"rows": rows}
+
+
+class FailingGSCService(FakeGSCService):
+    """Raises for one specific pull key; used for the API-error contract."""
+
+    def __init__(self, responses: dict, fail_key: tuple):
+        super().__init__(responses)
+        self.fail_key = fail_key
+
+    def execute(self):
+        body = self._pending
+        dims = tuple(body.get("dimensions", []))
+        key = (dims, body["startDate"], body["endDate"])
+        if key == self.fail_key:
+            raise RuntimeError("GSC API error")
+        return super().execute()
+
+
+def _probe_key(run_date: date) -> tuple:
+    start = (run_date - timedelta(days=13)).isoformat()
+    return (("date",), start, run_date.isoformat())
+
+
+def _base_responses(run_date: date, boundary: date):
+    """A complete, empty-rows response set for the probe + all 8 pulls."""
+    current, prior = sw.compute_windows(boundary)
+    responses = {
+        _probe_key(run_date): [[{"keys": [boundary.isoformat()]}]],
+        ((), current["start"], current["end"]): [[]],
+        (("query",), current["start"], current["end"]): [[]],
+        (("query", "page"), current["start"], current["end"]): [[]],
+        (("page",), current["start"], current["end"]): [[]],
+        ((), prior["start"], prior["end"]): [[]],
+        (("query",), prior["start"], prior["end"]): [[]],
+        (("query", "page"), prior["start"], prior["end"]): [[]],
+        (("page",), prior["start"], prior["end"]): [[]],
+    }
+    return current, prior, responses
+
+
+# ── Pagination ───────────────────────────────────────────────────────────
+
+def test_paginated_query_loops_until_short_page_and_counts_requests(monkeypatch):
+    monkeypatch.setattr(sw, "PAGE_SIZE", 2)
+    pages = [
+        [{"keys": ["a"], "clicks": 1}, {"keys": ["b"], "clicks": 2}],
+        [{"keys": ["c"], "clicks": 3}, {"keys": ["d"], "clicks": 4}],
+        [{"keys": ["e"], "clicks": 5}],
+    ]
+    service = FakeGSCService({(("query",), "2026-06-29", "2026-07-26"): pages})
+
+    rows, requests = sw._paginated_query(
+        service, sw.SITE_URL, "2026-06-29", "2026-07-26", ["query"])
+
+    assert requests == 3
+    assert [r["keys"][0] for r in rows] == ["a", "b", "c", "d", "e"]
+    assert [call["startRow"] for call in service.calls] == [0, 2, 4]
+
+
+def test_collect_weekly_records_per_pull_rows_and_requests(monkeypatch):
+    monkeypatch.setattr(sw, "PAGE_SIZE", 2)
+    run_date = date(2026, 7, 27)
+    boundary = date(2026, 7, 26)
+    current, prior, responses = _base_responses(run_date, boundary)
+    # Current query+page pull spans two pages of the (patched) page size.
+    responses[(("query", "page"), current["start"], current["end"])] = [
+        [
+            {"keys": ["q1", "https://gravelgodcycling.com/race/a"],
+             "clicks": 1, "impressions": 20, "ctr": 0.05, "position": 5.0},
+            {"keys": ["q2", "https://gravelgodcycling.com/race/b"],
+             "clicks": 1, "impressions": 20, "ctr": 0.05, "position": 5.0},
+        ],
+        [
+            {"keys": ["q3", "https://gravelgodcycling.com/race/c"],
+             "clicks": 1, "impressions": 20, "ctr": 0.05, "position": 5.0},
+        ],
+    ]
+    service = FakeGSCService(responses)
+
+    artifact = sw.collect_weekly(
+        now=datetime(2026, 7, 27, 11, 20, tzinfo=timezone.utc), service=service)
+
+    qp_pull = next(
+        p for p in artifact["pulls"]
+        if p["dimensions"] == ["query", "page"] and p["window"] == "current")
+    assert qp_pull == {
+        "dimensions": ["query", "page"], "window": "current", "rows": 3, "requests": 2}
+    assert len(artifact["pulls"]) == 8
+
+
+# ── API error / incomplete pull → no artifact ───────────────────────────
+
+def test_api_error_raises_and_writes_no_artifact(tmp_path, monkeypatch):
+    run_date = date(2026, 7, 27)
+    boundary = date(2026, 7, 26)
+    _, _, responses = _base_responses(run_date, boundary)
+    fail_key = (("page",), *sw.compute_windows(boundary)[0].values())
+    service = FailingGSCService(responses, fail_key)
+
+    with pytest.raises(RuntimeError):
+        sw.collect_weekly(
+            now=datetime(2026, 7, 27, 11, 20, tzinfo=timezone.utc),
+            service=service, output_dir=tmp_path)
+
+    assert list(tmp_path.glob("seo-weekly-*.json")) == []
+
+
+def test_main_exits_1_and_writes_nothing_on_api_error(tmp_path, monkeypatch, capsys):
+    run_date = date(2026, 7, 27)
+    boundary = date(2026, 7, 26)
+    _, _, responses = _base_responses(run_date, boundary)
+    fail_key = _probe_key(run_date)
+    service = FailingGSCService(responses, fail_key)
+
+    monkeypatch.setattr(sw, "get_gsc_service", lambda: service)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["seo_weekly.py", "--date", run_date.isoformat(),
+         "--output-dir", str(tmp_path)])
+
+    exit_code = sw.main()
+
+    assert exit_code == 1
+    assert list(tmp_path.glob("seo-weekly-*.json")) == []
+    assert "ERROR" in capsys.readouterr().err
+
+
+def test_probe_with_no_rows_hard_fails():
+    service = FakeGSCService({})
+    with pytest.raises(RuntimeError, match="no rows"):
+        sw.probe_data_boundary(service, date(2026, 7, 27))
+
+
+# ── expected_ctr piecewise-linear interpolation ─────────────────────────
+
+@pytest.mark.parametrize(("position", "expected"), [
+    (1, 0.28), (2, 0.15), (3, 0.10), (4, 0.075), (5, 0.06), (6, 0.045),
+    (7, 0.035), (8, 0.03), (9, 0.025), (10, 0.02), (12, 0.02), (20, 0.01),
+])
+def test_expected_ctr_at_anchors(position, expected):
+    assert sw.expected_ctr(position) == pytest.approx(expected)
+
+
+def test_expected_ctr_midpoints_interpolate_linearly():
+    assert sw.expected_ctr(1.5) == pytest.approx(0.28 + 0.5 * (0.15 - 0.28))
+    assert sw.expected_ctr(11) == pytest.approx(0.02)  # flat between 10 and 12
+    assert sw.expected_ctr(16) == pytest.approx(0.02 + 0.5 * (0.01 - 0.02))
+
+
+def test_expected_ctr_out_of_range_clamps_to_endpoints():
+    assert sw.expected_ctr(0.2) == pytest.approx(0.28)
+    assert sw.expected_ctr(50) == pytest.approx(0.01)
+
+
+# ── URL normalization ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(("raw", "path"), [
+    ("https://gravelgodcycling.com/race/test", "/race/test/"),
+    ("https://www.gravelgodcycling.com/race/test/", "/race/test/"),
+    ("https://gravelgodcycling.com/", "/"),
+    ("https://gravelgodcycling.com", "/"),
+    ("https://gravelgodcycling.com/race/test/?utm=1#frag", "/race/test/"),
+])
+def test_normalize_page_url_canonical_cases(raw, path):
+    normalized, host_key = sw.normalize_page_url(raw)
+    assert normalized == path
+    assert host_key is None
+
+
+@pytest.mark.parametrize(("raw", "host_key"), [
+    ("http://gravelgodcycling.com/race/test/", "http://gravelgodcycling.com"),
+    ("https://staging.gravelgodcycling.com/race/test/",
+     "https://staging.gravelgodcycling.com"),
+])
+def test_normalize_page_url_noncanonical_cases(raw, host_key):
+    normalized, key = sw.normalize_page_url(raw)
+    assert normalized is None
+    assert key == host_key
+
+
+# ── Bucket construction helpers ──────────────────────────────────────────
+
+def _qp_row(query, page, *, clicks, impressions, ctr, position):
+    return {
+        "query": query, "page": page, "clicks": clicks,
+        "impressions": impressions, "ctr": ctr, "position": position,
+    }
+
+
+def _query_row(query, *, clicks, impressions, ctr, position):
+    return {
+        "query": query, "clicks": clicks, "impressions": impressions,
+        "ctr": ctr, "position": position,
+    }
+
+
+def _page_row(page, *, clicks, impressions, ctr, position):
+    return {
+        "page": page, "clicks": clicks, "impressions": impressions,
+        "ctr": ctr, "position": position,
+    }
+
+
+def _empty_buckets(**overrides):
+    args = dict(
+        current_qp=[], prior_qp=[], current_page=[], prior_page=[],
+        current_query=[])
+    args.update(overrides)
+    return sw.build_buckets(**args)
+
+
+# ── striking_distance edges ──────────────────────────────────────────────
+
+def test_striking_distance_include_exclude_edges():
+    included = _qp_row(
+        "q", "/race/a/", clicks=1, impressions=30, ctr=0.01, position=4.0)
+    excluded_low_position = _qp_row(
+        "q", "/race/b/", clicks=1, impressions=30, ctr=0.01, position=3.9)
+    included_high_position = _qp_row(
+        "q", "/race/c/", clicks=1, impressions=30, ctr=0.01, position=20.0)
+    excluded_high_position = _qp_row(
+        "q", "/race/d/", clicks=1, impressions=30, ctr=0.01, position=20.1)
+    excluded_low_impressions = _qp_row(
+        "q", "/race/e/", clicks=1, impressions=29, ctr=0.01, position=6.0)
+
+    buckets = _empty_buckets(current_qp=[
+        included, excluded_low_position, included_high_position,
+        excluded_high_position, excluded_low_impressions,
+    ])
+
+    pages = {e["page"] for e in buckets["striking_distance"]}
+    assert pages == {"/race/a/", "/race/c/"}
+
+
+def test_striking_distance_target_position_split_at_10():
+    at_ten = _qp_row(
+        "q", "/race/at-ten/", clicks=1, impressions=30, ctr=0.01, position=10.0)
+    above_ten = _qp_row(
+        "q", "/race/above-ten/", clicks=1, impressions=30, ctr=0.01, position=10.1)
+
+    buckets = _empty_buckets(current_qp=[at_ten, above_ten])
+    by_page = {e["page"]: e for e in buckets["striking_distance"]}
+    assert by_page["/race/at-ten/"]["score"] == pytest.approx(
+        30 * max(0.0, sw.expected_ctr(3) - 0.01))
+    assert by_page["/race/above-ten/"]["score"] == pytest.approx(
+        30 * max(0.0, sw.expected_ctr(8) - 0.01))
+
+
+# ── ctr_underperformers edges ────────────────────────────────────────────
+
+def test_ctr_underperformers_include_exclude_edges():
+    exp_at_12 = sw.expected_ctr(12)
+    included = _qp_row(
+        "q", "/race/a/", clicks=1, impressions=50, ctr=0.4 * exp_at_12 - 0.0001,
+        position=12.0)
+    excluded_at_threshold = _qp_row(
+        "q", "/race/b/", clicks=1, impressions=50, ctr=0.4 * exp_at_12,
+        position=12.0)
+    excluded_position = _qp_row(
+        "q", "/race/c/", clicks=1, impressions=50, ctr=0.0001, position=12.1)
+    excluded_impressions = _qp_row(
+        "q", "/race/d/", clicks=1, impressions=49, ctr=0.0001, position=12.0)
+
+    buckets = _empty_buckets(current_qp=[
+        included, excluded_at_threshold, excluded_position, excluded_impressions,
+    ])
+
+    pages = {e["page"] for e in buckets["ctr_underperformers"]}
+    assert pages == {"/race/a/"}
+
+
+# ── decliners floors ──────────────────────────────────────────────────────
+
+def test_decliners_clicks_dropped_floor_boundaries():
+    # prior_clicks == 10, drop exactly 40% -> qualifies.
+    current_page = [_page_row(
+        "/race/a/", clicks=6, impressions=100, ctr=0.06, position=6.0)]
+    prior_page = [_page_row(
+        "/race/a/", clicks=10, impressions=100, ctr=0.10, position=6.0)]
+    buckets = _empty_buckets(current_page=current_page, prior_page=prior_page)
+    assert {e["page"] for e in buckets["decliners"]} == {"/race/a/"}
+
+
+def test_decliners_below_prior_clicks_floor_does_not_qualify_on_clicks_alone():
+    # prior_clicks == 9 (below the >=10 floor), even a 100% drop should not
+    # qualify via the clicks-dropped path; position is unchanged so the
+    # position-worsened path also does not fire.
+    current_page = [_page_row(
+        "/race/a/", clicks=0, impressions=100, ctr=0.0, position=6.0)]
+    prior_page = [_page_row(
+        "/race/a/", clicks=9, impressions=100, ctr=0.09, position=6.0)]
+    buckets = _empty_buckets(current_page=current_page, prior_page=prior_page)
+    assert buckets["decliners"] == []
+
+
+def test_decliners_position_worsened_floor_boundaries():
+    # Exactly 3.0 worse, impressions exactly 50 in both windows -> qualifies.
+    current_page = [_page_row(
+        "/race/a/", clicks=5, impressions=50, ctr=0.1, position=9.0)]
+    prior_page = [_page_row(
+        "/race/a/", clicks=5, impressions=50, ctr=0.1, position=6.0)]
+    buckets = _empty_buckets(current_page=current_page, prior_page=prior_page)
+    assert {e["page"] for e in buckets["decliners"]} == {"/race/a/"}
+
+    # 2.9 worse -> excluded.
+    current_page2 = [_page_row(
+        "/race/b/", clicks=5, impressions=50, ctr=0.1, position=8.9)]
+    prior_page2 = [_page_row(
+        "/race/b/", clicks=5, impressions=50, ctr=0.1, position=6.0)]
+    buckets2 = _empty_buckets(current_page=current_page2, prior_page=prior_page2)
+    assert buckets2["decliners"] == []
+
+    # 3.0 worse but impressions only 49 in current window -> excluded.
+    current_page3 = [_page_row(
+        "/race/c/", clicks=5, impressions=49, ctr=0.1, position=9.0)]
+    prior_page3 = [_page_row(
+        "/race/c/", clicks=5, impressions=50, ctr=0.1, position=6.0)]
+    buckets3 = _empty_buckets(current_page=current_page3, prior_page=prior_page3)
+    assert buckets3["decliners"] == []
+
+
+def test_decliners_requires_page_present_in_both_windows():
+    current_page = [_page_row(
+        "/race/new/", clicks=1, impressions=100, ctr=0.01, position=6.0)]
+    buckets = _empty_buckets(current_page=current_page, prior_page=[])
+    assert buckets["decliners"] == []
+
+
+# ── content_gaps edges + duplicate targets ──────────────────────────────
+
+def test_content_gaps_include_exclude_edges():
+    below_floor = _query_row(
+        "no impressions", clicks=0, impressions=49, ctr=0.0, position=9.0)
+    homepage_gap = _query_row(
+        "homepage query", clicks=1, impressions=50, ctr=0.02, position=9.0)
+    hub_gap = _query_row(
+        "hub query", clicks=1, impressions=50, ctr=0.02, position=9.0)
+    absent_gap = _query_row(
+        "absent query", clicks=1, impressions=50, ctr=0.02, position=9.0)
+    real_page_query = _query_row(
+        "covered query", clicks=10, impressions=100, ctr=0.10, position=3.0)
+
+    current_qp = [
+        _qp_row("homepage query", "/", clicks=1, impressions=50, ctr=0.02, position=9.0),
+        _qp_row("hub query", "/gravel-race-search/", clicks=1, impressions=50,
+                ctr=0.02, position=9.0),
+        _qp_row("covered query", "/race/real/", clicks=10, impressions=100,
+                ctr=0.10, position=3.0),
+    ]
+    buckets = _empty_buckets(
+        current_query=[below_floor, homepage_gap, hub_gap, absent_gap, real_page_query],
+        current_qp=current_qp,
+    )
+    queries = {e["query"] for e in buckets["content_gaps"]}
+    assert queries == {"homepage query", "hub query", "absent query"}
+
+
+def test_content_gaps_duplicate_recommended_targets_stay_distinct():
+    # Two different queries slugify to the same recommended_target_path;
+    # dedupe is by query, so both must survive independently.
+    row_a = _query_row("Foo Bar!", clicks=1, impressions=50, ctr=0.02, position=9.0)
+    row_b = _query_row("foo-bar", clicks=2, impressions=60, ctr=0.02, position=9.0)
+
+    buckets = _empty_buckets(current_query=[row_a, row_b])
+    assert len(buckets["content_gaps"]) == 2
+    targets = {e["recommended_target_path"] for e in buckets["content_gaps"]}
+    assert targets == {"/articles/foo-bar/"}
+    queries = {e["query"] for e in buckets["content_gaps"]}
+    assert queries == {"Foo Bar!", "foo-bar"}
+
+    top_candidates, _ = sw._rank_top_candidates(buckets, set())
+    assert len(top_candidates) == 2
+    assert {c["query"] for c in top_candidates} == {"Foo Bar!", "foo-bar"}
+
+
+# ── dedupe / supporting_queries / combined_upside / tie-break ──────────
+
+def test_dedupe_keeps_max_score_and_attaches_supporting_queries():
+    page = "/race/example/"
+    lower = _qp_row(
+        "alpha query", page, clicks=5, impressions=100, ctr=0.05, position=6.0)
+    higher = _qp_row(
+        "beta query", page, clicks=4, impressions=200, ctr=0.02, position=6.0)
+
+    buckets = _empty_buckets(current_qp=[lower, higher])
+    top_candidates, cooldown_excluded = sw._rank_top_candidates(buckets, set())
+
+    assert cooldown_excluded == []
+    assert len(top_candidates) == 1
+    candidate = top_candidates[0]
+    assert candidate["page"] == page
+    assert candidate["query"] == "beta query"  # higher score wins
+    assert candidate["score"] == pytest.approx(200 * (sw.expected_ctr(3) - 0.02))
+    assert candidate["supporting_queries"] == [{
+        "query": "alpha query", "clicks": 5, "impressions": 100,
+        "ctr": 0.05, "position": 6.0,
+    }]
+    assert candidate["combined_upside"] == pytest.approx(
+        candidate["score"] + 100 * (sw.expected_ctr(3) - 0.05))
+    assert candidate["rank"] == 1
+
+
+def test_deterministic_tie_break_by_page_ascending():
+    entries = [
+        {"page": "/race/zulu/", "query": "q1", "clicks": 1, "impressions": 50,
+         "ctr": 0.01, "position": 6.0, "score": 10.0, "reason": "r1"},
+        {"page": "/race/alpha/", "query": "q2", "clicks": 1, "impressions": 50,
+         "ctr": 0.01, "position": 6.0, "score": 10.0, "reason": "r2"},
+    ]
+    buckets = {
+        "striking_distance": entries, "ctr_underperformers": [],
+        "decliners": [], "content_gaps": [],
+    }
+    top_candidates, _ = sw._rank_top_candidates(buckets, set())
+    assert [c["page"] for c in top_candidates] == ["/race/alpha/", "/race/zulu/"]
+
+
+def test_empty_and_fewer_than_five_top_candidates():
+    empty_buckets = _empty_buckets()
+    top_candidates, cooldown_excluded = sw._rank_top_candidates(empty_buckets, set())
+    assert top_candidates == []
+    assert cooldown_excluded == []
+
+    entries = [
+        {"page": f"/race/{i}/", "query": f"q{i}", "clicks": 1, "impressions": 50,
+         "ctr": 0.01, "position": 6.0, "score": float(10 - i), "reason": "r"}
+        for i in range(3)
+    ]
+    buckets = {
+        "striking_distance": entries, "ctr_underperformers": [],
+        "decliners": [], "content_gaps": [],
+    }
+    top_candidates, _ = sw._rank_top_candidates(buckets, set())
+    assert len(top_candidates) == 3
+    assert [c["rank"] for c in top_candidates] == [1, 2, 3]
+
+
+# ── cooldown exclusion + malformed log lines ────────────────────────────
+
+def test_cooldown_excludes_recent_applied_pages_and_skips_malformed_lines(tmp_path):
+    boundary = date(2026, 7, 26)
+    log_path = tmp_path / "updates-log.jsonl"
+    log_path.write_text("\n".join([
+        json.dumps({
+            "date": "2026-07-10", "page": "/race/recent/", "query": "q",
+            "bucket": "striking_distance", "action": "improve_ranking",
+            "artifact": "seo-weekly-2026-07-05.json", "status": "applied",
+        }),
+        json.dumps({
+            "date": "2026-06-01", "page": "/race/old/", "query": "q",
+            "bucket": "decliners", "action": "refresh_content",
+            "artifact": "seo-weekly-2026-05-30.json", "status": "applied",
+        }),
+        json.dumps({
+            "date": "2026-07-20", "page": "/race/skipped/", "query": "q",
+            "bucket": "content_gaps", "action": "create_or_link_content",
+            "artifact": "seo-weekly-2026-07-19.json", "status": "skipped",
+        }),
+        "{not valid json",
+        "",
+    ]))
+
+    pages, warnings = sw._load_cooldown_pages(boundary, tmp_path)
+
+    assert pages == {"/race/recent/"}
+    assert len(warnings) == 1
+    assert "malformed" in warnings[0]
+
+
+def test_cooldown_missing_log_file_is_empty(tmp_path):
+    pages, warnings = sw._load_cooldown_pages(date(2026, 7, 26), tmp_path)
+    assert pages == set()
+    assert warnings == []
+
+
+def test_cooldown_excludes_from_top_candidates_but_buckets_keep_the_entry():
+    entry = {
+        "page": "/race/cooling/", "query": "q", "clicks": 1, "impressions": 50,
+        "ctr": 0.01, "position": 6.0, "score": 10.0, "reason": "r",
+    }
+    buckets = {
+        "striking_distance": [entry], "ctr_underperformers": [],
+        "decliners": [], "content_gaps": [],
+    }
+    top_candidates, cooldown_excluded = sw._rank_top_candidates(
+        buckets, {"/race/cooling/"})
+
+    assert top_candidates == []
+    assert cooldown_excluded == ["/race/cooling/"]
+    assert buckets["striking_distance"] == [entry]  # buckets remain untouched
+
+
+# ── Artifact validation ──────────────────────────────────────────────────
+
+def _valid_artifact(boundary_str: str = "2026-07-26") -> dict:
+    boundary = date.fromisoformat(boundary_str)
+    current, prior = sw.compute_windows(boundary)
+    return {
+        "schema_version": 1,
+        "score_version": 1,
+        "generated_at_utc": f"{boundary_str}T11:20:00Z",
+        "site": sw.SITE_URL,
+        "data_boundary": boundary_str,
+        "current_window": current,
+        "prior_window": prior,
+        "overall": {
+            "clicks": 100, "impressions": 5000, "ctr": 0.02, "position": 8.0,
+            "prior": {"clicks": 90, "impressions": 4800, "ctr": 0.0187, "position": 8.5},
+        },
+        "pulls": [
+            {"dimensions": [], "window": "current", "rows": 1, "requests": 1},
+            {"dimensions": ["query"], "window": "current", "rows": 0, "requests": 1},
+            {"dimensions": ["query", "page"], "window": "current", "rows": 0, "requests": 1},
+            {"dimensions": ["page"], "window": "current", "rows": 0, "requests": 1},
+            {"dimensions": [], "window": "prior", "rows": 1, "requests": 1},
+            {"dimensions": ["query"], "window": "prior", "rows": 0, "requests": 1},
+            {"dimensions": ["query", "page"], "window": "prior", "rows": 0, "requests": 1},
+            {"dimensions": ["page"], "window": "prior", "rows": 0, "requests": 1},
+        ],
+        "noncanonical": {},
+        "cooldown_excluded": [],
+        "buckets": {
+            "striking_distance": [], "ctr_underperformers": [],
+            "decliners": [], "content_gaps": [],
+        },
+        "top_candidates": [],
+    }
+
+
+def test_validate_artifact_good():
+    assert sw.validate_artifact(_valid_artifact()) == []
+
+
+def test_validate_artifact_missing_key():
+    artifact = _valid_artifact()
+    del artifact["cooldown_excluded"]
+    errors = sw.validate_artifact(artifact)
+    assert any("missing required key: cooldown_excluded" in e for e in errors)
+
+
+def test_validate_artifact_future_generated_at():
+    artifact = _valid_artifact()
+    artifact["generated_at_utc"] = "2099-01-01T00:00:00Z"
+    errors = sw.validate_artifact(artifact)
+    assert any("future" in e for e in errors)
+
+
+def test_validate_artifact_bad_window():
+    artifact = _valid_artifact()
+    artifact["current_window"] = {"start": "2020-01-01", "end": "2020-01-28"}
+    errors = sw.validate_artifact(artifact)
+    assert any("current_window does not match data_boundary" in e for e in errors)
+
+
+def test_validate_artifact_ctr_out_of_range_100x_unit_error():
+    artifact = _valid_artifact()
+    # A 100x unit error (percentage stored instead of fraction) must fail.
+    artifact["overall"]["ctr"] = 2.1
+    errors = sw.validate_artifact(artifact)
+    assert any("fraction" in e for e in errors)
+
+
+def test_validate_artifact_ctr_out_of_range_in_bucket_entry():
+    artifact = _valid_artifact()
+    artifact["buckets"]["striking_distance"] = [{
+        "page": "/race/a/", "query": "q", "clicks": 1, "impressions": 50,
+        "ctr": 21.0, "position": 6.0, "score": 1.0, "reason": "r",
+    }]
+    errors = sw.validate_artifact(artifact)
+    assert any("ctr outside" in e for e in errors)
+
+
+def test_validate_artifact_filename_mismatch():
+    artifact = _valid_artifact()
+    errors = sw.validate_artifact(
+        artifact, path=__import__("pathlib").Path("/tmp/seo-weekly-2020-01-01.json"))
+    assert any("does not match" in e for e in errors)
+
+
+def test_validate_artifact_require_all_ok_needs_eight_complete_pulls():
+    artifact = _valid_artifact()
+    artifact["pulls"] = artifact["pulls"][:7]
+    errors = sw.validate_artifact(artifact, require_all_ok=True)
+    assert any("exactly 8 entries" in e for e in errors)
+    assert sw.validate_artifact(artifact, require_all_ok=False) == []
+
+
+def test_write_artifact_round_trip(tmp_path):
+    artifact = _valid_artifact()
+    path = sw.write_artifact(artifact, tmp_path)
+    assert path.name == "seo-weekly-2026-07-26.json"
+    loaded = json.loads(path.read_text())
+    assert loaded == artifact
+    assert sw.validate_artifact(loaded, path=path) == []
+
+
+# ── CLI --validate-latest / --require-all-ok / --date ───────────────────
+
+def test_cli_validate_latest_on_good_artifact(tmp_path, monkeypatch, capsys):
+    artifact = _valid_artifact()
+    sw.write_artifact(artifact, tmp_path)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["seo_weekly.py", "--validate-latest", "--require-all-ok",
+         "--output-dir", str(tmp_path)])
+    assert sw.main() == 0
+    assert "valid artifact" in capsys.readouterr().out
+
+
+def test_cli_validate_latest_no_artifacts_fails(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["seo_weekly.py", "--validate-latest", "--output-dir", str(tmp_path)])
+    assert sw.main() == 1
+    assert "no SEO artifacts found" in capsys.readouterr().err
+
+
+# ── daily_intel.collect_seo states ──────────────────────────────────────
+
+def _write_seo_artifact(directory, artifact):
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"seo-weekly-{artifact['data_boundary']}.json"
+    path.write_text(json.dumps(artifact))
+    return path
+
+
+def test_collect_seo_missing_state_is_ok_and_silent(tmp_path, monkeypatch):
+    monkeypatch.setattr(daily_intel, "SEO_DIR", tmp_path)
+    result = daily_intel.collect_seo(today=date(2026, 7, 27))
+    assert result == {"state": "missing", "ok": True}
+
+
+def test_collect_seo_ok_state_and_render_with_candidates(tmp_path, monkeypatch):
+    artifact = _valid_artifact("2026-07-26")
+    artifact["overall"]["clicks"] = 120
+    artifact["overall"]["prior"]["clicks"] = 100
+    artifact["top_candidates"] = [{
+        "rank": 1, "bucket": "striking_distance", "action": "improve_ranking",
+        "target_path": "/race/x/", "query": "some query", "page": "/race/x/",
+        "source_hint": "race-data/x.json", "reason": "push it up",
+        "clicks": 12, "impressions": 480, "ctr": 0.021, "position": 6.2,
+        "score": 9.0, "supporting_queries": [], "combined_upside": 9.0,
+    }]
+    _write_seo_artifact(tmp_path, artifact)
+    monkeypatch.setattr(daily_intel, "SEO_DIR", tmp_path)
+
+    result = daily_intel.collect_seo(today=date(2026, 7, 27))
+    assert result["state"] == "ok"
+    assert result["overall"]["clicks_delta"] == 20
+
+    report = daily_intel.render_report({"seo": result})
+    assert "## SEO (WEEKLY)" in report
+    assert '#1 [striking_distance] /race/x/ — "some query" pos 6.2, 480 impr, CTR 2.1% — push it up' in report
+    assert "Run /seo-updates to draft these." in report
+
+
+def test_collect_seo_ok_state_empty_candidates_render_text(tmp_path, monkeypatch):
+    artifact = _valid_artifact("2026-07-26")
+    _write_seo_artifact(tmp_path, artifact)
+    monkeypatch.setattr(daily_intel, "SEO_DIR", tmp_path)
+
+    result = daily_intel.collect_seo(today=date(2026, 7, 27))
+    report = daily_intel.render_report({"seo": result})
+    assert "no qualifying candidates this week" in report
+
+
+def test_collect_seo_stale_state_produces_one_broken_line(tmp_path, monkeypatch):
+    artifact = _valid_artifact("2026-07-01")
+    _write_seo_artifact(tmp_path, artifact)
+    monkeypatch.setattr(daily_intel, "SEO_DIR", tmp_path)
+
+    result = daily_intel.collect_seo(today=date(2026, 7, 20))
+    assert result["state"] == "stale"
+    report = daily_intel.render_report({"seo": result})
+    assert "## SEO (WEEKLY)" not in report
+    assert report.count("SEO weekly artifact stale (19 days)") == 1
+
+
+def test_collect_seo_invalid_json_never_raises(tmp_path, monkeypatch):
+    path = tmp_path / "seo-weekly-2026-07-26.json"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json")
+    monkeypatch.setattr(daily_intel, "SEO_DIR", tmp_path)
+
+    result = daily_intel.collect_seo(today=date(2026, 7, 27))
+    assert result["state"] == "invalid"
+    assert result["ok"] is False
+    assert "SEO weekly artifact invalid" in result["error"]
+
+
+def test_collect_seo_future_generated_at_is_invalid(tmp_path, monkeypatch):
+    artifact = _valid_artifact("2026-07-26")
+    artifact["generated_at_utc"] = "2026-08-01T00:00:00Z"
+    _write_seo_artifact(tmp_path, artifact)
+    monkeypatch.setattr(daily_intel, "SEO_DIR", tmp_path)
+
+    result = daily_intel.collect_seo(today=date(2026, 7, 27))
+    assert result["state"] == "invalid"
+
+
+def test_collect_workflows_includes_seo_weekly(monkeypatch):
+    calls = []
+
+    class FakeCompleted:
+        stdout = "[]"
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return FakeCompleted()
+
+    monkeypatch.setattr(subprocess_module, "run", fake_run)
+    daily_intel.collect_workflows()
+
+    workflows = [cmd[cmd.index("--workflow") + 1] for cmd in calls]
+    assert "seo-weekly.yml" in workflows


### PR DESCRIPTION
Weekly deterministic GSC miner → ranked top-5 content-update artifact → Morning Intel section → gated /seo-updates drafting skill. Spec at docs/specs/seo-weekly-spec.md, sol-reviewed r2. 59 new tests; intel subset 204 passed; 3 full-suite failures are pre-existing on main (verified via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)