### PR TITLE
intel-fix: llms.txt sg-captcha false positive

### DIFF
--- a/scripts/aeo_weekly.py
+++ b/scripts/aeo_weekly.py
@@ -15,6 +15,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -45,6 +46,11 @@ DEFAULT_LOG_CEILING_BYTES = 500 * 1024 * 1024
 SSH_TIMEOUT_SECONDS = 270
 MAX_UNKNOWN_CANDIDATES = 15
 MAX_UNKNOWN_SAMPLE_CHARS = 120
+
+# Same backoff SiteGround's sg-captcha needs elsewhere in this repo
+# (scripts/check_links.py CHALLENGE_BACKOFF) — a fast retry doesn't reliably
+# clear a rate-based challenge.
+LLMS_CHALLENGE_BACKOFF = (20, 45)  # seconds to wait before each retry
 
 BRANDS = {
     "gravelgod": {
@@ -493,7 +499,18 @@ def _merge_unknown_candidates(
     )[:MAX_UNKNOWN_CANDIDATES]
 
 
-def check_llms_marker(brand: str, timeout: int = 20) -> dict[str, Any]:
+def _fetch_llms_head(url: str, timeout: int) -> str:
+    import urllib.request
+
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "gg-aeo-weekly/1 (self-check)"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read(4096).decode("utf-8", "replace")
+
+
+def check_llms_marker(
+        brand: str, timeout: int = 20,
+        backoff: tuple[float, ...] = LLMS_CHALLENGE_BACKOFF) -> dict[str, Any]:
     """Verify the live /llms.txt still serves OUR database file.
 
     Born from the Jul 24 regression: AIOSEO regenerates a physical llms.txt
@@ -502,16 +519,24 @@ def check_llms_marker(brand: str, timeout: int = 20) -> dict[str, Any]:
     ours. chmod 444 on the server is the defense; this is the dead-man that
     catches the next silent displacement (renders as BROKEN in Morning
     Intel via the stale/invalid path).
-    """
-    import urllib.request
 
+    Retries (with the same backoff as scripts/check_links.py) on a
+    non-matching first response: SiteGround's sg-captcha can transiently
+    challenge this checker's non-browser UA (redirect to
+    /.well-known/sgcaptcha/), which looks identical to a real displacement
+    but clears on a later request. Since this check runs weekly, one
+    transient hit would otherwise mislabel a whole week of daily reports.
+    """
     meta = BRANDS[brand]
     url = f"https://{meta['domain']}/llms.txt"
-    req = urllib.request.Request(
-        url, headers={"User-Agent": "gg-aeo-weekly/1 (self-check)"})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        head = resp.read(4096).decode("utf-8", "replace")
     marker = str(meta["llms_marker"])
+    head = ""
+    for pause in (0.0, *backoff):
+        if pause:
+            time.sleep(pause)
+        head = _fetch_llms_head(url, timeout)
+        if head.lstrip("﻿\n\r ").startswith(marker):
+            break
     ok = head.lstrip("﻿\n\r ").startswith(marker)
     return {
         "status": "ok" if ok else "displaced",

--- a/tests/test_aeo_weekly.py
+++ b/tests/test_aeo_weekly.py
@@ -121,6 +121,49 @@ def test_log_collector_mocks_one_ssh_call_with_timeout(monkeypatch):
     assert kwargs["timeout"] == 270
 
 
+def test_llms_marker_check_retries_past_a_transient_captcha_challenge(
+        monkeypatch):
+    captcha_head = (
+        '<html><head><link rel="icon" href="data:;">'
+        '<meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?r=%2Fllms.txt">'
+        '</head></html>'
+    )
+    real_head = "# Gravel God Race Database\n\n> The definitive gravel race database.\n"
+    responses = [captcha_head, captcha_head, real_head]
+    calls = []
+    sleeps = []
+
+    def fake_fetch(url, timeout):
+        calls.append((url, timeout))
+        return responses[len(calls) - 1]
+
+    monkeypatch.setattr(aeo_weekly, "_fetch_llms_head", fake_fetch)
+    monkeypatch.setattr(aeo_weekly.time, "sleep", lambda s: sleeps.append(s))
+
+    result = aeo_weekly.check_llms_marker("gravelgod", backoff=(20, 45))
+
+    assert result["status"] == "ok"
+    assert len(calls) == 3
+    assert sleeps == [20, 45]
+
+
+def test_llms_marker_check_reports_displaced_after_exhausting_retries(
+        monkeypatch):
+    captcha_head = (
+        '<html><head><link rel="icon" href="data:;">'
+        '<meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?r=%2Fllms.txt">'
+        '</head></html>'
+    )
+
+    monkeypatch.setattr(
+        aeo_weekly, "_fetch_llms_head", lambda url, timeout: captcha_head)
+    monkeypatch.setattr(aeo_weekly.time, "sleep", lambda s: None)
+
+    result = aeo_weekly.check_llms_marker("gravelgod", backoff=(0, 0))
+
+    assert result["status"] == "displaced"
+
+
 def test_ga4_collector_uses_two_reports_and_filters_sources_in_python(
         monkeypatch):
     class Value:


### PR DESCRIPTION
auto-authored by morning-intel-triage

**Linked intel issue:** #53

**Evidence:** Today's (2026-08-04) intel snapshot flagged `/llms.txt` as "displaced" on all three brands (gravelgod, roadielabs, xcski) — the DO TODAY item — sourced from last Monday's `aeo-weekly.yml` artifact (`aeo-weekly-2026-08-03.json`), which is reused all week by daily intel. Live re-check right now shows all three currently serve the correct file (200, correct marker) under both a bot UA and a browser UA, repeated 3x each. This is the same SiteGround sg-captcha false-positive pattern already diagnosed and fixed for `check_links.py` in #28 / commit `47cc5ce7` — a single-shot request from a non-browser UA gets soft-blocked and returns a captcha redirect page that reads identically to a real displacement. It is not a repeat of the real Jul 24 AIOSEO-clobber regression (different signature: plugin content vs. captcha redirect).

**What changed and why:** `check_llms_marker` in `scripts/aeo_weekly.py` was a single-shot fetch. Since this check only runs weekly, one transient sg-captcha hit poisons a full week of daily BROKEN flags. Ported the same retry-with-backoff convention already established in `scripts/check_links.py` (`CHALLENGE_BACKOFF = (20, 45)`) into `check_llms_marker`: it now retries up to twice with 20s/45s backoff before declaring `displaced`, clearing transient challenges while still catching a real, persistent displacement.

**Test output:**
```
tests/test_aeo_weekly.py — 27 passed (includes 2 new tests: retries past a transient captcha challenge; still reports displaced after exhausting retries)

Full suite (python3 -m pytest tests/, PIL/anthropic/ddgs-dependent files ignored per CLAUDE.md):
4 failed, 6223 passed, 326 skipped, 12 warnings in 151.07s
— the 4 failures are pre-existing and unrelated (test_index_integrity.py x2,
  test_whitepaper_fueling.py x2 — missing `dotenv` module in this sandbox);
  identical failure set before and after this change.
```
Also executed `check_llms_marker` live for gravelgod and roadie post-fix — both return `status: ok`.

**Rollback note:** Revert this branch's single commit; `check_llms_marker` reverts to a single-shot check with no behavior change beyond that (no schema/consumer changes elsewhere).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8HpCVowS5B5hZHZNim51R)_