### PR TITLE
fix(email): repair broken greeting, link the guide chapter in welcome day-0

### DIFF
--- a/mission_control/routers/webhooks.py
+++ b/mission_control/routers/webhooks.py
@@ -21,6 +21,22 @@ _EMAIL_RE = re.compile(r"^[^@\s]{1,64}@[^@\s]{1,255}$")
 _MAX_NAME_LEN = 200
 _MAX_SOURCE_LEN = 100
 
+# Gravel guide chapter title -> URL slug. Mirrors the "id" field of each chapter
+# in guide/gravel-guide-content.json, which generate_guide_cluster.py uses as the
+# directory name under /guide/. Kept as a literal rather than imported so
+# Mission Control does not take a runtime dependency on the wordpress/ package;
+# if a chapter is renamed there, update this map or the link is silently dropped.
+GRAVEL_GUIDE_CHAPTER_SLUGS = {
+    "what is gravel racing?": "what-is-gravel-racing",
+    "race selection": "race-selection",
+    "training fundamentals": "training-fundamentals",
+    "workout execution": "workout-execution",
+    "nutrition & fueling": "nutrition-fueling",
+    "mental training & race tactics": "mental-training-race-tactics",
+    "race week protocol": "race-week",
+    "post-race & beyond": "post-race",
+}
+
 # In-memory rate limiter: {ip: [timestamp, ...]}
 _rate_buckets: dict[str, list[float]] = defaultdict(list)
 _RATE_LIMIT = 30       # max requests per window
@@ -198,6 +214,15 @@ async def subscriber_webhook(
     if _chapter:
         source_data["guide_chapter"] = _chapter
         source_data["wb_guide"] = _chapter
+        # Welcome day-0 asks how a chapter landed; without a link back there is
+        # nowhere for the reader to go, which reads as a promised-but-missing
+        # attachment. Titles do not slugify reliably ("Race Week Protocol" ->
+        # race-week), so map explicitly and emit nothing when unrecognised
+        # rather than linking a 404. Gravel only — road/xc welcome templates
+        # do not render wb_guide_url.
+        _slug = GRAVEL_GUIDE_CHAPTER_SLUGS.get(_chapter.casefold())
+        if _slug and brand == "gravelgod":
+            source_data["wb_guide_url"] = f"https://gravelgodcycling.com/guide/{_slug}/?unlocked=1"
     elif isinstance(_viewed, list) and _viewed:
         # short human-readable list for the template: "Unbound, SBT GRVL"
         names = [str(v).strip()[:60] for v in _viewed if str(v).strip()][:5]

--- a/mission_control/services/sequence_engine.py
+++ b/mission_control/services/sequence_engine.py
@@ -395,15 +395,27 @@ def _render_template(template_name: str, enrollment: dict) -> str:
     # Replace placeholders with enrollment data
     source_data = enrollment.get("source_data") or {}
     html = _apply_conditionals(html, source_data)
-    replacements = {
-        "{contact_name}": enrollment.get("contact_name", ""),
-        "{contact_email}": enrollment.get("contact_email", ""),
-        "{first_name}": enrollment.get("contact_name", "").split()[0] if enrollment.get("contact_name") else "there",
-    }
-    # Add source_data replacements
+    # Most templates open with a bare address ("Roberto —"). A missing name used
+    # to fall through to the "there" fallback and render "there —", which reads
+    # like a broken merge field. {greeting} carries the dash so the nameless case
+    # degrades to "Hey —" instead. {first_name} keeps the old fallback for the
+    # one template that addresses inline ("Hi {first_name},").
+    _first = enrollment.get("contact_name", "").split()[0] if enrollment.get("contact_name") else ""
+
+    # source_data is attacker-adjacent (it originates from the intake worker
+    # payload), so it is applied FIRST and the identity fields overwrite it.
+    # Otherwise a source_data key named "greeting" or "contact_email" would
+    # silently redefine who the email is addressed to.
+    replacements = {}
     for key, val in source_data.items():
         if val is not None:
             replacements[f"{{{key}}}"] = str(val)
+    replacements.update({
+        "{contact_name}": enrollment.get("contact_name", ""),
+        "{contact_email}": enrollment.get("contact_email", ""),
+        "{first_name}": _first or "there",
+        "{greeting}": f"{_first} —" if _first else "Hey —",
+    })
 
     for placeholder, value in replacements.items():
         html = html.replace(placeholder, value)

--- a/mission_control/templates/emails/sequences/anti_pitch.html
+++ b/mission_control/templates/emails/sequences/anti_pitch.html
@@ -18,7 +18,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>This is the sales email I warned you about. One short follow-up in a few days, then I'm done.</p>
 {{^race_name}}    <p>If you don't have a race on the calendar — if you just ride to ride — you don't need this. Close the email, enjoy your bike. The free stuff stays free either way.</p>
     <p>If you do have one circled, here's the pitch, and it isn't workouts. Workouts are free. The internet is drowning in them.</p>

--- a/mission_control/templates/emails/sequences/checkin_week2.html
+++ b/mission_control/templates/emails/sequences/checkin_week2.html
@@ -18,7 +18,7 @@
       <h1>Gravel God</h1>
     </div>
     <div class="body">
-      <p>{first_name} — two weeks in. Three things I want to know:</p>
+      <p>{greeting} two weeks in. Three things I want to know:</p>
       <p>Do the numbers feel right? Is the schedule surviving your actual week? Does anything hurt?</p>
       <p>One line back is plenty. If Tuesday keeps not happening, Tuesday is wrong — not you.</p>
       <p>— Matti</p>

--- a/mission_control/templates/emails/sequences/countdown_16w.html
+++ b/mission_control/templates/emails/sequences/countdown_16w.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — {race_name} is sixteen weeks out. That's the full window.</p>
+    <p>{greeting} {race_name} is sixteen weeks out. That's the full window.</p>
     <p>Are you where you wanted to be, training-wise? If not, tell me what your week actually looks like — I'll tell you what I'd do with the time you've got.</p>
     <p>— Matti</p>
     <div class="footer">Matti Rowe &middot; Gravel God Cycling &middot; <a href="https://gravelgodcycling.com">gravelgodcycling.com</a></div>

--- a/mission_control/templates/emails/sequences/countdown_8w.html
+++ b/mission_control/templates/emails/sequences/countdown_8w.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — eight weeks to {race_name}. Still enough time to do real work, not enough to waste any.</p>
+    <p>{greeting} eight weeks to {race_name}. Still enough time to do real work, not enough to waste any.</p>
     <p>How's the training been going? Tell me your weekly hours and I'll give you my honest read on what's possible from here.</p>
     <p>— Matti</p>
     <div class="footer">Matti Rowe &middot; Gravel God Cycling &middot; <a href="https://gravelgodcycling.com">gravelgodcycling.com</a></div>

--- a/mission_control/templates/emails/sequences/essay_sweet_spot.html
+++ b/mission_control/templates/emails/sequences/essay_sweet_spot.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>The most popular training zone in cycling started as a doodle.</p>
     <p>In 2004, Andy Coggan — legitimately one of the smartest people in power-based training — sketched a hypothetical, unitless graph of training efficiency versus intensity. No data on it. By his own description, &ldquo;only ever intended as conveying a concept.&rdquo; A coach named Frank Overton looked at that napkin scratch, named its peak &ldquo;the Sweet Spot,&rdquo; attached 88&ndash;94% of FTP to it, and built a 20-year business on the result.</p>
     <p>A generation of cyclists internalized that riding at Sweet Spot is the hack that makes you faster, faster. The opposite is true — not because I'm a convincing person, but scientifically, repeatedly, demonstrably.</p>

--- a/mission_control/templates/emails/sequences/fueling_mistake.html
+++ b/mission_control/templates/emails/sequences/fueling_mistake.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>Pop quiz, no stakes: how many gels do you think an 8-hour gravel race actually takes?</p>
     <p>Most people guess eight, maybe ten. The arithmetic says twenty-four: 75g of carbs an hour for 8 hours is 600 grams of carbohydrate. Almost nobody carries anything close — which is why the most common way to waste six months of training isn't fitness. It's arithmetic.</p>
     <p>The four people who bonk at mile 80 (I have personally been all four):</p>

--- a/mission_control/templates/emails/sequences/honest_ratings.html
+++ b/mission_control/templates/emails/sequences/honest_ratings.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>Scratch Ankle Gravel, in Milton, Florida, holds the lowest score in the entire database: 36 out of 100.</p>
     <p>That number isn't an insult. The course is flat, the field is small, the organization is regional — and if you live in the Florida panhandle you should absolutely do it. It's cheap, it's pleasant, it's gravel. The 36 just means: don't book a flight.</p>
     <p>Here's why I'm showing you my least impressive race instead of Unbound: a rating system is only useful if it's willing to be rude. Every race in the database gets scored on the same 15 things — length, elevation, technicality, prestige, field depth, what it costs to get there. A 97 and a 36 are measured with the same ruler. When every race is &ldquo;epic,&rdquo; no race is.</p>

--- a/mission_control/templates/emails/sequences/nps_request.html
+++ b/mission_control/templates/emails/sequences/nps_request.html
@@ -20,7 +20,7 @@
       <h1>Gravel God</h1>
     </div>
     <div class="body">
-      <p>{first_name} — did {race_name} happen? How did it go?</p>
+      <p>{greeting} did {race_name} happen? How did it go?</p>
       <p>I want the real version — where the plan helped and where it was useless. The part that stings a little is the part I can fix.</p>
       <p>— Matti</p>
     </div>

--- a/mission_control/templates/emails/sequences/offseason_note.html
+++ b/mission_control/templates/emails/sequences/offseason_note.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — happy offseason. You bored yet?</p>
+    <p>{greeting} happy offseason. You bored yet?</p>
     <p>Happy with last year? What went well, what went badly?</p>
     <p>I'm always curious how people approach the offseason.</p>
     <p>— Matti</p>

--- a/mission_control/templates/emails/sequences/progress_update.html
+++ b/mission_control/templates/emails/sequences/progress_update.html
@@ -20,7 +20,7 @@
       <h1>Gravel God</h1>
     </div>
     <div class="body">
-      <p>{first_name} — you're in the boring middle now. How's it feeling?</p>
+      <p>{greeting} you're in the boring middle now. How's it feeling?</p>
       <p>Recovery week is coming. When it arrives, let it be easy — that's where the fitness actually shows up.</p>
       <p>— Matti</p>
     </div>

--- a/mission_control/templates/emails/sequences/purchase_welcome.html
+++ b/mission_control/templates/emails/sequences/purchase_welcome.html
@@ -20,7 +20,7 @@
       <h1>Gravel God</h1>
     </div>
     <div class="body">
-      <p>{first_name} — got your questionnaire. I'm building around your course, your FTP, and the hours you actually have. You'll have it inside 48 hours.</p>
+      <p>{greeting} got your questionnaire. I'm building around your course, your FTP, and the hours you actually have. You'll have it inside 48 hours.</p>
       <p>One thing: if anything about your life changes — schedule, knee, race date — just reply. The plan bends.</p>
       <p>— Matti</p>
     </div>

--- a/mission_control/templates/emails/sequences/quiz_results_recap.html
+++ b/mission_control/templates/emails/sequences/quiz_results_recap.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — the finder gave you matches. Which ones are you actually considering?</p>
+    <p>{greeting} the finder gave you matches. Which ones are you actually considering?</p>
     <p>Send me the shortlist and I'll tell you where I think the quiz got it right — and where it might have missed for you.</p>
     <p>— Matti</p>
     <div class="footer">Matti Rowe &middot; Gravel God Cycling &middot; <a href="https://gravelgodcycling.com">gravelgodcycling.com</a></div>

--- a/mission_control/templates/emails/sequences/race_deep_dive.html
+++ b/mission_control/templates/emails/sequences/race_deep_dive.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — while {race_name} is on your mind: where do long races usually get you — the start too fast, the middle too boring, or the last hour?</p>
+    <p>{greeting} while {race_name} is on your mind: where do long races usually get you — the start too fast, the middle too boring, or the last hour?</p>
     <p>Genuinely curious. The answer changes what I'd tell you to work on.</p>
     <p>— Matti</p>
     <div class="footer">Matti Rowe &middot; Gravel God Cycling &middot; <a href="https://gravelgodcycling.com">gravelgodcycling.com</a></div>

--- a/mission_control/templates/emails/sequences/race_prep_tips.html
+++ b/mission_control/templates/emails/sequences/race_prep_tips.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — thanks for grabbing {{#race_name}}the {race_name} prep kit{{/race_name}}{{^race_name}}the prep kit{{/race_name}}. Did it cover what you needed?</p>
+    <p>{greeting} thanks for grabbing {{#race_name}}the {race_name} prep kit{{/race_name}}{{^race_name}}the prep kit{{/race_name}}. Did it cover what you needed?</p>
     <p>Any questions about the race, just hit reply — happy to help.</p>
     <p>— Matti</p>
     <div class="footer">Matti Rowe &middot; Gravel God Cycling &middot; <a href="https://gravelgodcycling.com">gravelgodcycling.com</a></div>

--- a/mission_control/templates/emails/sequences/race_week_mistakes.html
+++ b/mission_control/templates/emails/sequences/race_week_mistakes.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>Race week is where good training goes to die. Your fitness is locked in — it was decided weeks ago. The only thing left to win this week is arriving rested, organized, and calm. And yet.</p>
     <p>Things people do during race week that I am begging you not to do:</p>
     <p><strong>One more hard session.</strong> Thursday's &ldquo;fitness test&rdquo; doesn't add fitness. It just spends Saturday's legs. And if you feel sluggish on an easy spin mid-week — that's the taper working, not fitness leaving. Heavy legs on Thursday are normal.</p>

--- a/mission_control/templates/emails/sequences/repitch.html
+++ b/mission_control/templates/emails/sequences/repitch.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>The promised follow-up, and then I'll drop it.</p>
     <p>If you're on the fence, the question that should decide it isn't &ldquo;will this make me faster&rdquo; — that part is math and consistency. It's this: what happens in week six, when work explodes, the kid gets sick, and you miss five days?</p>
     <p>A static plan handles the bad week by pretending it didn't happen. You come back, stare at a week that no longer fits your life, and quietly abandon the whole thing. (Ask me how I know.)</p>

--- a/mission_control/templates/emails/sequences/road_anti_pitch.html
+++ b/mission_control/templates/emails/sequences/road_anti_pitch.html
@@ -18,7 +18,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>This is the sales email. One short follow-up next week. Then the subject is closed.</p>
 {{^race_name}}    <p>If there is no race on your calendar, no purchase is justified. Stop reading. The database is free either way.</p>
     <p>If there is: every source of training on the internet{{/race_name}}{{#race_name}}    <p>{race_name} is on your calendar, so the who-is-this-for section is skipped. The relevant fact: every source of training on the internet{{/race_name}} — free plans, spreadsheets, adaptive software — shares one property. It models the rider. Fatigue, zones, missed sessions. It does not model the event. It does not know whether your race climbs 1,000 meters or 4,000, whether the decisive climb arrives at kilometer 30 or kilometer 130, or what eating schedule survives either. The output is fitness in a generic shape. Races are not generic.</p>

--- a/mission_control/templates/emails/sequences/road_checkin_week2.html
+++ b/mission_control/templates/emails/sequences/road_checkin_week2.html
@@ -18,7 +18,7 @@
       <h1>ROADIE LABS</h1>
     </div>
     <div class="body">
-      <p>{first_name} — two weeks in. Three data points, one line each:</p>
+      <p>{greeting} two weeks in. Three data points, one line each:</p>
       <p>Numbers right or wrong? Schedule holding? Anything hurting?</p>
       <p>If Tuesday keeps failing, Tuesday is mis-specified. Not you.</p>
       <p>— Matti</p>

--- a/mission_control/templates/emails/sequences/road_countdown_16w.html
+++ b/mission_control/templates/emails/sequences/road_countdown_16w.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — {race_name} is sixteen weeks out. That is the full training window.</p>
+    <p>{greeting} {race_name} is sixteen weeks out. That is the full training window.</p>
     <p>Are you where you planned to be? If not, send your actual weekly hours. We will tell you what the time is good for.</p>
     <p>— Matti</p>
     <div class="footer">Roadie Labs &middot; <a href="https://roadielabs.com">roadielabs.com</a></div>

--- a/mission_control/templates/emails/sequences/road_countdown_8w.html
+++ b/mission_control/templates/emails/sequences/road_countdown_8w.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — eight weeks to {race_name}. Enough time to do real work. Not enough to waste.</p>
+    <p>{greeting} eight weeks to {race_name}. Enough time to do real work. Not enough to waste.</p>
     <p>How has training gone? Send your weekly hours for an honest read on what is possible from here.</p>
     <p>— Matti</p>
     <div class="footer">Roadie Labs &middot; <a href="https://roadielabs.com">roadielabs.com</a></div>

--- a/mission_control/templates/emails/sequences/road_fueling_math.html
+++ b/mission_control/templates/emails/sequences/road_fueling_math.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>A question with a numeric answer: how many gels does a 7-hour gran fondo actually require?</p>
     <p>Most riders would guess eight. The arithmetic says roughly 21: 75g of carbohydrate per hour for 7 hours is 525 grams. Most start with four and a plan to &ldquo;grab something at the feed zones.&rdquo;</p>
     <p class="section">WHAT THE DATA SAYS</p>

--- a/mission_control/templates/emails/sequences/road_honest_ratings.html
+++ b/mission_control/templates/emails/sequences/road_honest_ratings.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>The lowest score in the Roadie Labs database is 44 out of 100: L'Étape Indonesia. It is the only race, out of 427, rated Local — the bottom tier.</p>
     <p>This is not a takedown. If you live near the course, ride it. The 44 means one specific thing: do not board a plane for it. The climbing is modest, the field is thin, and the logistics are hard — and if you're flying that far, the database will show you what else that ticket buys.</p>
     <p>Why lead with our least flattering number? Because a rating system is only informative if it can say no. Every race here is scored on the same 15 criteria — distance, climbing, prestige, field depth, organization, what it costs to get there. The 90s (L'Etape du Tour, Maratona dles Dolomites) and the 44 are measured with the same ruler. A database where everything scores 85 is a brochure.</p>

--- a/mission_control/templates/emails/sequences/road_nps_request.html
+++ b/mission_control/templates/emails/sequences/road_nps_request.html
@@ -20,7 +20,7 @@
       <h1>ROADIE LABS</h1>
     </div>
     <div class="body">
-      <p>{first_name} — did the race happen? How did it go?</p>
+      <p>{greeting} did the race happen? How did it go?</p>
       <p>We want the unpolished version — what the plan got right, what it got wrong. The part that stings is the part that gets fixed.</p>
       <p>— Matti</p>
     </div>

--- a/mission_control/templates/emails/sequences/road_offseason_note.html
+++ b/mission_control/templates/emails/sequences/road_offseason_note.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — offseason. How did the year go?</p>
+    <p>{greeting} offseason. How did the year go?</p>
     <p>What worked, what did not? We are always curious how people run the offseason.</p>
     <p>— Matti</p>
     <div class="footer">Roadie Labs &middot; <a href="https://roadielabs.com">roadielabs.com</a></div>

--- a/mission_control/templates/emails/sequences/road_prep_variables.html
+++ b/mission_control/templates/emails/sequences/road_prep_variables.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — thanks for grabbing {{#race_name}}the {race_name} prep notes{{/race_name}}{{^race_name}}the prep notes{{/race_name}}. Did they cover what you needed?</p>
+    <p>{greeting} thanks for grabbing {{#race_name}}the {race_name} prep notes{{/race_name}}{{^race_name}}the prep notes{{/race_name}}. Did they cover what you needed?</p>
     <p>Questions about the race, hit reply.</p>
     <p>— Matti</p>
     <div class="footer">Roadie Labs &middot; <a href="https://roadielabs.com">roadielabs.com</a></div>

--- a/mission_control/templates/emails/sequences/road_progress_update.html
+++ b/mission_control/templates/emails/sequences/road_progress_update.html
@@ -20,7 +20,7 @@
       <h1>ROADIE LABS</h1>
     </div>
     <div class="body">
-      <p>{first_name} — you are in the middle of the build. How is it holding?</p>
+      <p>{greeting} you are in the middle of the build. How is it holding?</p>
       <p>A recovery week is coming. Let it be easy. That is where the adaptation happens.</p>
       <p>— Matti</p>
     </div>

--- a/mission_control/templates/emails/sequences/road_purchase_welcome.html
+++ b/mission_control/templates/emails/sequences/road_purchase_welcome.html
@@ -20,7 +20,7 @@
       <h1>ROADIE LABS</h1>
     </div>
     <div class="body">
-      <p>{first_name} — questionnaire received. The plan is being built from your course, your FTP, and your actual hours. Delivery inside 48 hours.</p>
+      <p>{greeting} questionnaire received. The plan is being built from your course, your FTP, and your actual hours. Delivery inside 48 hours.</p>
       <p>If anything changes — schedule, body, race date — reply. The plan gets rebuilt around it.</p>
       <p>— Matti</p>
     </div>

--- a/mission_control/templates/emails/sequences/road_quiz_recap.html
+++ b/mission_control/templates/emails/sequences/road_quiz_recap.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — the finder gave you matches. Which ones are actually in contention?</p>
+    <p>{greeting} the finder gave you matches. Which ones are actually in contention?</p>
     <p>Send the shortlist. We will tell you where the quiz is right and where it probably is not.</p>
     <p>— Matti</p>
     <div class="footer">Roadie Labs &middot; <a href="https://roadielabs.com">roadielabs.com</a></div>

--- a/mission_control/templates/emails/sequences/road_race_deep_dive.html
+++ b/mission_control/templates/emails/sequences/road_race_deep_dive.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — while {race_name} is on your list: where do long races usually get you — the start, the middle, or the last hour?</p>
+    <p>{greeting} while {race_name} is on your list: where do long races usually get you — the start, the middle, or the last hour?</p>
     <p>The answer changes what to work on. Genuinely asking.</p>
     <p>— Matti</p>
     <div class="footer">Roadie Labs &middot; <a href="https://roadielabs.com">roadielabs.com</a></div>

--- a/mission_control/templates/emails/sequences/road_race_week.html
+++ b/mission_control/templates/emails/sequences/road_race_week.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>Race week adds nothing. It can only subtract. Your fitness was decided weeks ago; the remaining job is arriving with it intact. Accordingly, a list of don'ts:</p>
     <p><strong>Don't test your fitness.</strong> Thursday's &ldquo;openers that became a full effort&rdquo; doesn't measure anything except how Saturday will now feel (worse). Heavy legs on an easy mid-week spin are the taper working, not fitness leaving.</p>
     <p><strong>Don't debut equipment.</strong> New tires, new saddle, new chainring, new shoes. Each one is an experiment, and the race is the worst possible laboratory.</p>

--- a/mission_control/templates/emails/sequences/road_repitch.html
+++ b/mission_control/templates/emails/sequences/road_repitch.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>The promised follow-up. After this, the subject is closed.</p>
     <p>An honest defect in our pricing: it pays you to wait. $15 per week of training means a plan bought 14 weeks out costs $210. The same decision made a month later costs $150. Waiting is $60 cheaper.</p>
     <p>What the $60 buys back: nothing. Weeks-to-race are a fixed stock. The weeks lost to waiting come off the front of the plan — the base weeks, where aerobic volume is built. Base does not compress, and no arrangement of the remaining weeks reconstructs it. Waiting does not lower the price. It lowers the plan.</p>

--- a/mission_control/templates/emails/sequences/road_week1.html
+++ b/mission_control/templates/emails/sequences/road_week1.html
@@ -19,7 +19,7 @@
       <h1>ROADIE LABS</h1>
     </div>
     <div class="body">
-      <p>{first_name} — how did the first rides feel?</p>
+      <p>{greeting} how did the first rides feel?</p>
       <p>If the answer is &ldquo;easy&rdquo;: correct. That is calibration. Do not add volume to it.</p>
       <p>— Matti</p>
     </div>

--- a/mission_control/templates/emails/sequences/road_welcome_followup.html
+++ b/mission_control/templates/emails/sequences/road_welcome_followup.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — did you pick a race, or still comparing?</p>
+    <p>{greeting} did you pick a race, or still comparing?</p>
     <p>If it is down to two, send both. That is a solvable problem.</p>
     <p>— Matti</p>
     <div class="footer">Roadie Labs &middot; <a href="https://roadielabs.com">roadielabs.com</a></div>

--- a/mission_control/templates/emails/sequences/road_welcome_value.html
+++ b/mission_control/templates/emails/sequences/road_welcome_value.html
@@ -13,24 +13,24 @@
 <body>
   <div class="container">
 {{#wb_guide}}
-    <p>{first_name} — thanks for reading the guide. How was the chapter on {wb_guide}?</p>
+    <p>{greeting} thanks for reading the guide. How was the chapter on {wb_guide}?</p>
     <p>Questions, hit reply. That is what it is for.</p>
 {{/wb_guide}}
 {{#wb_trail}}
-    <p>{first_name} — you were looking at {wb_trail}. Riding one of them, or comparing?</p>
+    <p>{greeting} you were looking at {wb_trail}. Riding one of them, or comparing?</p>
     <p>How is training going?</p>
 {{/wb_trail}}
 {{#wb_race}}
-    <p>{first_name} — you were on the {wb_race} page. Is that the target?</p>
+    <p>{greeting} you were on the {wb_race} page. Is that the target?</p>
     <p>How is training going?</p>
 {{/wb_race}}
 {{^any_context}}
 {{^offseason}}
-    <p>{first_name} — what race are you getting ready for?</p>
+    <p>{greeting} what race are you getting ready for?</p>
     <p>How is training going?</p>
 {{/offseason}}
 {{#offseason}}
-    <p>{first_name} — offseason. How did last year go?</p>
+    <p>{greeting} offseason. How did last year go?</p>
     <p>What worked, what did not? We are always curious how people run the offseason.</p>
 {{/offseason}}
 {{/any_context}}

--- a/mission_control/templates/emails/sequences/road_win_back.html
+++ b/mission_control/templates/emails/sequences/road_win_back.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{{#race_name}}{first_name} — a while back you were looking at {race_name}. Did you end up riding it?{{/race_name}}{{^race_name}}{first_name} — a while back you were comparing races in the database. Did you end up riding one this year?{{/race_name}}</p>
+    <p>{{#race_name}}{greeting} a while back you were looking at {race_name}. Did you end up riding it?{{/race_name}}{{^race_name}}{greeting} a while back you were comparing races in the database. Did you end up riding one this year?{{/race_name}}</p>
     <p>What is next on the calendar?</p>
     <p>— Matti</p>
     <div class="footer">Roadie Labs &middot; <a href="https://roadielabs.com">roadielabs.com</a></div>

--- a/mission_control/templates/emails/sequences/sober_breathing.html
+++ b/mission_control/templates/emails/sequences/sober_breathing.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>Nothing is for sale in this email.</p>
     <p>When panic or pain spikes mid-race, your breathing shortens and your decisions get worse. The countermeasure is mechanical: inhale for 6 seconds, hold for 2, exhale for 7. The long exhale stimulates the parasympathetic nervous system — the same system that slows your heart rate when you sleep. Three to five cycles is usually enough to get your head back.</p>
     <p>Two rules. First, practice it on easy rides now — mile 100 is a bad place to try anything for the first time. Second, pair it with a pre-planned phrase. When &ldquo;I can't do this&rdquo; shows up, your brain treats it as permission to quit; replace it with direction — &ldquo;smooth circles,&rdquo; &ldquo;fuel now, decide later.&rdquo; Focus on execution rather than pain.</p>

--- a/mission_control/templates/emails/sequences/sober_pacing.html
+++ b/mission_control/templates/emails/sequences/sober_pacing.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>Every long gravel race follows the same three-act structure. The terrain varies; the pattern does not.</p>
     <p><strong>Act one, the opening 10&ndash;15%:</strong> chaos. Fresh legs, nervous energy, a crowded course. The race cannot be won here, but it can be lost here. Your job is restraint.</p>
     <p><strong>Act two, the middle 50&ndash;60%:</strong> order returns. Groups stabilize and the pace starts to feel manageable, sometimes easy. Do not be fooled — this is the setup for act three. Your job is rhythm: fuel on schedule, hold your numbers, make no emotional decisions.</p>

--- a/mission_control/templates/emails/sequences/sober_pitch.html
+++ b/mission_control/templates/emails/sequences/sober_pitch.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>This sequence contains two sales emails. This is the first; the second is a short follow-up in three days. After that, the topic is closed unless you raise it.</p>
     <p>What I sell is not workouts — workouts are free. It is the outcome: you get faster on the hours you actually have, the bike fits inside your life instead of competing with it, and you arrive at your race prepared instead of hopeful.</p>
     <p>The mechanism is a custom training plan. Inputs: your race's actual course profile, your FTP, the hours you can genuinely train. Output: every workout from your start date to your start line, delivered within 48 hours, as files that load into Zwift or your head unit, with pacing and fueling for your course.</p>

--- a/mission_control/templates/emails/sequences/sober_repitch.html
+++ b/mission_control/templates/emails/sequences/sober_repitch.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>Second and final note about the training plan, as promised.</p>
     <p>The question worth deciding on: what happens when life interrupts training? Most plans are static documents. Miss a week and the document does not adjust — you either pretend the week happened or abandon the plan. Most people abandon the plan.</p>
     <p>This one comes with me attached. You reply to an email, and the remaining weeks get adjusted around what actually happened. The product is not the workouts — workouts are everywhere, free. The product is a plan that still fits on the day your circumstances change.</p>

--- a/mission_control/templates/emails/sequences/sober_scoring.html
+++ b/mission_control/templates/emails/sequences/sober_scoring.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} —</p>
+    <p>{greeting}</p>
     <p>Every race in the database is scored on the same fifteen criteria — length, elevation, technicality, prestige, field depth, value, what it costs to get there, and eight more — each rated 1 to 5, summed into a score out of 100. A 97 and a 36 come from the same ruler. The database does not grade on a curve.</p>
     <p>How to read the result: Tier 1 (80+) and Tier 2 (60+) justify travel. Tier 3 (45+) is a regional pick — go if it's within a few hours. Tier 4 is a local training day with a number plate, and there is nothing wrong with that, as long as you didn't book a flight for it.</p>
     <p>The point of scoring races this way is that you plan a season around the numbers. Pick one race worth traveling for, support it with local ones, and give the big one the 12&ndash;16 weeks of preparation it deserves.</p>

--- a/mission_control/templates/emails/sequences/week1_tips.html
+++ b/mission_control/templates/emails/sequences/week1_tips.html
@@ -19,7 +19,7 @@
       <h1>Gravel God</h1>
     </div>
     <div class="body">
-      <p>{first_name} — how did the first rides feel?</p>
+      <p>{greeting} how did the first rides feel?</p>
       <p>If the answer is &ldquo;too easy&rdquo; — good. That's calibration, not a mistake. Don't add extra. I've made that mistake enough times for both of us.</p>
       <p>— Matti</p>
     </div>

--- a/mission_control/templates/emails/sequences/welcome_followup.html
+++ b/mission_control/templates/emails/sequences/welcome_followup.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{first_name} — did you land on a race, or still shopping?</p>
+    <p>{greeting} did you land on a race, or still shopping?</p>
     <p>If you're stuck between two, send me both. Picking is half the fun.</p>
     <p>— Matti</p>
     <div class="footer">Matti Rowe &middot; Gravel God Cycling &middot; <a href="https://gravelgodcycling.com">gravelgodcycling.com</a></div>

--- a/mission_control/templates/emails/sequences/welcome_value.html
+++ b/mission_control/templates/emails/sequences/welcome_value.html
@@ -13,24 +13,24 @@
 <body>
   <div class="container">
 {{#wb_guide}}
-    <p>{first_name} — thanks for grabbing the guide. How did you like the chapter on {wb_guide}?</p>
-    <p>Any more questions there, just hit reply — happy to help.</p>
+    <p>{greeting} thanks for reading the guide. How did you like the chapter on {wb_guide}?</p>
+    <p>{{#wb_guide_url}}You can pick it back up here: <a href="{wb_guide_url}">{wb_guide}</a>.{{/wb_guide_url}} Any more questions there, just hit reply — happy to help.</p>
 {{/wb_guide}}
 {{#wb_trail}}
-    <p>{first_name} — saw you checking out {wb_trail}. Racing one of them, or still deciding?</p>
+    <p>{greeting} saw you checking out {wb_trail}. Racing one of them, or still deciding?</p>
     <p>How's training going so far?</p>
 {{/wb_trail}}
 {{#wb_race}}
-    <p>{first_name} — saw you on the {wb_race} page. Is that the one you're getting ready for?</p>
+    <p>{greeting} saw you on the {wb_race} page. Is that the one you're getting ready for?</p>
     <p>How's training going?</p>
 {{/wb_race}}
 {{^any_context}}
 {{^offseason}}
-    <p>{first_name} — what race are you getting ready for?</p>
+    <p>{greeting} what race are you getting ready for?</p>
     <p>How's training going?</p>
 {{/offseason}}
 {{#offseason}}
-    <p>{first_name} — happy offseason. You bored yet?</p>
+    <p>{greeting} happy offseason. You bored yet?</p>
     <p>Happy with last year? What went well, what went badly? I'm always curious how people approach the offseason.</p>
 {{/offseason}}
 {{/any_context}}

--- a/mission_control/templates/emails/sequences/win_back_value.html
+++ b/mission_control/templates/emails/sequences/win_back_value.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <div class="container">
-    <p>{{#race_name}}{first_name} — a while back you were looking at {race_name}. Did you end up racing it?{{/race_name}}{{^race_name}}{first_name} — a while back you were poking around the race database. Did you end up racing this year?{{/race_name}}</p>
+    <p>{{#race_name}}{greeting} a while back you were looking at {race_name}. Did you end up racing it?{{/race_name}}{{^race_name}}{greeting} a while back you were poking around the race database. Did you end up racing this year?{{/race_name}}</p>
     <p>Either way I'm curious how the season's going. What's next on your calendar?</p>
     <p>— Matti</p>
     <div class="footer">Matti Rowe &middot; Gravel God Cycling &middot; <a href="https://gravelgodcycling.com">gravelgodcycling.com</a></div>

--- a/mission_control/templates/emails/sequences/xc_offseason_note.html
+++ b/mission_control/templates/emails/sequences/xc_offseason_note.html
@@ -13,7 +13,7 @@
 <body>
   <div class="container">
 
-    <p>{first_name} — offseason. How did the winter go?</p>
+    <p>{greeting} offseason. How did the winter go?</p>
     <p>What worked, what did not? I'm always curious how skiers approach the summer.</p>
 
     <p>— Matti</p>

--- a/mission_control/templates/emails/sequences/xc_welcome_followup.html
+++ b/mission_control/templates/emails/sequences/xc_welcome_followup.html
@@ -13,7 +13,7 @@
 <body>
   <div class="container">
 
-    <p>{first_name} — did you land on a race, or still weighing options?</p>
+    <p>{greeting} did you land on a race, or still weighing options?</p>
     <p>If it is down to two, send both. Snow reliability usually settles the argument.</p>
 
     <p>— Matti</p>

--- a/mission_control/templates/emails/sequences/xc_welcome_value.html
+++ b/mission_control/templates/emails/sequences/xc_welcome_value.html
@@ -14,24 +14,24 @@
   <div class="container">
 
     {{#wb_guide}}
-    <p>{first_name} — thanks for reading the guide. How was the section on {wb_guide}?</p>
+    <p>{greeting} thanks for reading the guide. How was the section on {wb_guide}?</p>
     <p>Questions, hit reply. Happy to help.</p>
     {{/wb_guide}}
     {{#wb_trail}}
-    <p>{first_name} — saw you looking at {wb_trail}. Skiing one of them, or comparing?</p>
+    <p>{greeting} saw you looking at {wb_trail}. Skiing one of them, or comparing?</p>
     <p>How is training going?</p>
     {{/wb_trail}}
     {{#wb_race}}
-    <p>{first_name} — you were on the {wb_race} page. Is that the one you're pointing at?</p>
+    <p>{greeting} you were on the {wb_race} page. Is that the one you're pointing at?</p>
     <p>How is training going?</p>
     {{/wb_race}}
     {{^any_context}}
     {{^offseason}}
-    <p>{first_name} — what race are you getting ready for?</p>
+    <p>{greeting} what race are you getting ready for?</p>
     <p>How is the season going so far?</p>
     {{/offseason}}
     {{#offseason}}
-    <p>{first_name} — offseason. How did last winter go?</p>
+    <p>{greeting} offseason. How did last winter go?</p>
     <p>What worked, what did not? I'm always curious how skiers spend the summer.</p>
     {{/offseason}}
     {{/any_context}}

--- a/mission_control/templates/emails/sequences/xc_win_back.html
+++ b/mission_control/templates/emails/sequences/xc_win_back.html
@@ -13,7 +13,7 @@
 <body>
   <div class="container">
 
-    <p>{{#race_name}}{first_name} — a while back you were looking at {race_name}. Did you end up skiing it?{{/race_name}}{{^race_name}}{first_name} — a while back you were comparing races in the database. Did you end up racing last winter?{{/race_name}}</p>
+    <p>{{#race_name}}{greeting} a while back you were looking at {race_name}. Did you end up skiing it?{{/race_name}}{{^race_name}}{greeting} a while back you were comparing races in the database. Did you end up racing last winter?{{/race_name}}</p>
     <p>What is next on the calendar?</p>
 
     <p>— Matti</p>

--- a/mission_control/tests/conftest.py
+++ b/mission_control/tests/conftest.py
@@ -225,6 +225,24 @@ class FakeDB:
         self.store.clear()
 
 
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """The webhook rate limiter is module-level state keyed by client IP, and
+    every test hits the same TestClient IP. Without this the suite silently
+    accumulates toward the 30-req/60s cap and whichever test happens to be
+    ~31st starts failing with 429 — a failure that looks like it belongs to
+    the test that tripped it rather than to the ones before it.
+    """
+    try:
+        from mission_control.routers.webhooks import _rate_buckets
+    except Exception:  # router not importable in some focused runs
+        yield
+        return
+    _rate_buckets.clear()
+    yield
+    _rate_buckets.clear()
+
+
 @pytest.fixture
 def fake_db():
     """Provides a clean in-memory DB and patches supabase_client._table."""

--- a/mission_control/tests/test_sequence_engine.py
+++ b/mission_control/tests/test_sequence_engine.py
@@ -143,9 +143,10 @@ class TestRenderTemplate:
             "contact_email": "sarah@example.com",
             "source_data": {"race_name": "Unbound 200"},
         })
-        assert "Sarah" in html  # {first_name} replaced
+        assert "Sarah" in html  # {greeting} resolved to the first name
         assert "Gravel God" in html  # template content present
-        assert "{first_name}" not in html  # placeholder replaced
+        assert "{greeting}" not in html  # placeholder replaced
+        assert "{first_name}" not in html
 
     def test_raises_on_missing_template(self, fake_db):
         from mission_control.services.sequence_engine import _render_template
@@ -163,6 +164,142 @@ class TestRenderTemplate:
         })
         assert isinstance(html, str)
         assert len(html) > 100
+
+
+class TestGreeting:
+    """A nameless lead used to render 'there —', which reads as a broken merge
+    field and cost a real reply ('no guide attached?'). {greeting} carries the
+    dash so the nameless case degrades to 'Hey —'."""
+
+    def test_named_lead_addressed_by_first_name(self, fake_db):
+        from mission_control.services.sequence_engine import _render_template
+
+        html = _render_template("welcome_value", {
+            "contact_name": "Roberto Hofman", "contact_email": "r@x.com",
+            "source_data": {"wb_guide": "Race Selection", "any_context": "1"},
+        })
+        assert "Roberto —" in html
+        assert "{greeting}" not in html
+
+    def test_nameless_lead_never_renders_there_dash(self, fake_db):
+        from mission_control.services.sequence_engine import _render_template
+
+        html = _render_template("welcome_value", {
+            "contact_name": "", "contact_email": "r@x.com",
+            "source_data": {"wb_guide": "Race Selection", "any_context": "1"},
+        })
+        assert "Hey —" in html
+        assert "there —" not in html
+        assert "{greeting}" not in html
+
+    def test_no_template_uses_bare_first_name_address(self, fake_db):
+        """The 'there —' shape is `{first_name} —`. Only sober_welcome may use
+        {first_name}, and it addresses inline ('Hi {first_name},')."""
+        from pathlib import Path
+
+        tdir = Path(__file__).resolve().parent.parent / "templates" / "emails" / "sequences"
+        offenders = [p.name for p in tdir.glob("*.html") if "{first_name} —" in p.read_text()]
+        assert offenders == [], f"use {{greeting}} instead: {offenders}"
+
+    def test_greeting_renders_in_every_template_that_uses_it(self, fake_db):
+        from pathlib import Path
+        from mission_control.services.sequence_engine import _render_template
+
+        tdir = Path(__file__).resolve().parent.parent / "templates" / "emails" / "sequences"
+        for p in sorted(tdir.glob("*.html")):
+            if "{greeting}" not in p.read_text():
+                continue
+            for name in ("Roberto Hofman", ""):
+                html = _render_template(p.stem, {
+                    "contact_name": name, "contact_email": "r@x.com", "source_data": {},
+                })
+                assert "{greeting}" not in html, f"{p.name} leaked {{greeting}} (name={name!r})"
+                assert "there —" not in html, f"{p.name} rendered 'there —' (name={name!r})"
+
+
+class TestGuideChapterLink:
+    """welcome_value asks how a chapter landed; without a link back there is
+    nowhere to go, which reads as a promised-but-missing attachment."""
+
+    def test_links_chapter_when_url_known(self, fake_db):
+        from mission_control.services.sequence_engine import _render_template
+
+        html = _render_template("welcome_value", {
+            "contact_name": "Roberto Hofman", "contact_email": "r@x.com",
+            "source_data": {
+                "wb_guide": "Race Selection", "any_context": "1",
+                "wb_guide_url": "https://gravelgodcycling.com/guide/race-selection/?unlocked=1",
+            },
+        })
+        assert 'href="https://gravelgodcycling.com/guide/race-selection/?unlocked=1"' in html
+        assert "pick it back up" in html
+
+    def test_no_link_and_no_marker_when_chapter_unrecognised(self, fake_db):
+        from mission_control.services.sequence_engine import _render_template
+
+        html = _render_template("welcome_value", {
+            "contact_name": "Jen", "contact_email": "j@x.com",
+            "source_data": {"wb_guide": "Some Renamed Chapter", "any_context": "1"},
+        })
+        assert "wb_guide_url" not in html
+        assert "pick it back up" not in html
+        assert "/guide/" not in html
+
+    def test_slug_map_matches_guide_content_json(self, fake_db):
+        """webhooks.py holds a literal copy of the chapter ids to avoid a runtime
+        dependency on wordpress/. If the guide is re-chaptered, this catches the
+        drift instead of silently dropping the link."""
+        import ast
+        import json
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parent.parent.parent
+        src = (root / "mission_control" / "routers" / "webhooks.py").read_text()
+        mapping = next(
+            ast.literal_eval(n.value)
+            for n in ast.parse(src).body
+            if isinstance(n, ast.Assign)
+            and getattr(n.targets[0], "id", "") == "GRAVEL_GUIDE_CHAPTER_SLUGS"
+        )
+        content = json.loads((root / "guide" / "gravel-guide-content.json").read_text())
+        real = {c["title"].casefold(): c["id"] for c in content["chapters"]}
+        assert mapping == real
+
+    def test_source_data_cannot_override_identity_fields(self, fake_db):
+        """source_data comes from the intake worker payload. A key named
+        'greeting' must not be able to redefine who the email addresses."""
+        from mission_control.services.sequence_engine import _render_template
+
+        html = _render_template("welcome_value", {
+            "contact_name": "Roberto Hofman", "contact_email": "r@x.com",
+            "source_data": {
+                "wb_guide": "Race Selection", "any_context": "1",
+                "greeting": "OVERRIDE —", "first_name": "OVERRIDE",
+                "contact_name": "OVERRIDE", "contact_email": "attacker@example.com",
+            },
+        })
+        assert "Roberto —" in html
+        assert "OVERRIDE" not in html
+        assert "attacker@example.com" not in html
+
+    def test_utm_injection_preserves_unlocked_param(self, fake_db):
+        """The chapter URL already carries ?unlocked=1, so the UTM appender must
+        use & — otherwise the link lands on a still-locked chapter."""
+        from mission_control.services.sequence_engine import (
+            _inject_utm_params, _render_template,
+        )
+
+        html = _render_template("welcome_value", {
+            "contact_name": "Roberto Hofman", "contact_email": "r@x.com",
+            "source_data": {
+                "wb_guide": "Race Selection", "any_context": "1",
+                "wb_guide_url": "https://gravelgodcycling.com/guide/race-selection/?unlocked=1",
+            },
+        })
+        final = _inject_utm_params(html, "welcome_v1", "A", 0, brand="gravelgod")
+        assert "/guide/race-selection/?unlocked=1&utm_source=" in final
+        assert "?unlocked=1?" not in final
+        assert "unlocked=1&amp;utm" not in final  # not double-escaped into the href
 
 
 class TestRecordEvent:
@@ -486,6 +623,7 @@ class TestRenderPlaceholderFallback:
         html = _render_template("race_deep_dive", enrollment)
         assert "{race_name}" not in html
         assert "your race" in html
+        assert "{greeting}" not in html
         assert "{first_name}" not in html
 
     def test_all_sequence_templates_exist(self, fake_db):

--- a/mission_control/tests/test_webhooks.py
+++ b/mission_control/tests/test_webhooks.py
@@ -298,6 +298,39 @@ class TestFriendRegisterEnrollment:
         assert "wb_trail" not in sd and "wb_race" not in sd
         assert sd.get("any_context") == "1"
 
+    def test_recognised_gravel_chapter_gets_unlock_url(self, client, fake_db):
+        """A recognised chapter title yields a link back into the guide — the
+        thing whose absence read as a missing attachment."""
+        self._enroll(client, {
+            "email": "wb-ch-known@example.com", "source": "training_guide",
+            "guide_chapter": "Race Selection",
+        })
+        sd = self._source_data(fake_db, "wb-ch-known@example.com")
+        assert sd["wb_guide_url"] == (
+            "https://gravelgodcycling.com/guide/race-selection/?unlocked=1"
+        )
+
+    def test_unrecognised_chapter_gets_no_url(self, client, fake_db):
+        """Better no link than a 404 — titles are free text from the page."""
+        self._enroll(client, {
+            "email": "wb-ch-unknown@example.com", "source": "training_guide",
+            "guide_chapter": "Some Renamed Chapter",
+        })
+        sd = self._source_data(fake_db, "wb-ch-unknown@example.com")
+        assert sd.get("wb_guide") == "Some Renamed Chapter"
+        assert "wb_guide_url" not in sd
+
+    @pytest.mark.parametrize("brand", ("roadielabs", "xcskilabs"))
+    def test_non_gravel_brands_never_get_gravel_guide_url(self, client, fake_db, brand):
+        """Chapter titles could collide across brands; the URL is gravel-only."""
+        email = f"wb-ch-{brand}@example.com"
+        self._enroll(client, {
+            "email": email, "source": "training_guide",
+            "guide_chapter": "Race Selection", "brand": brand,
+        })
+        sd = self._source_data(fake_db, email)
+        assert "wb_guide_url" not in sd
+
     def test_wb_branch_trail_beats_race(self, client, fake_db):
         self._enroll(client, {
             "email": "wb-trail@example.com", "source": "race_profile",


### PR DESCRIPTION
## Why

A paying-funnel lead replied **"Thanks for the reply, however no guide attached?"** to the day-0 welcome email.

Nothing was forgotten. The email he received was the automated `welcome_value` send, and three defects stacked to imply a file that was never part of the funnel:

```
there — thanks for grabbing the guide. How did you like the chapter on Race Selection?
Any more questions there, just hit reply — happy to help.
```

1. **`{first_name}` fell back to the literal `"there"`** while 48 templates address with a bare `{first_name} —`, producing `there —`. That fallback was written for `sober_welcome.html` (`Hi {first_name},` → "Hi there,"), which is correct; every other template adopted a different convention around it. 63 occurrences across all three brands — several templates rendered a paragraph consisting only of `there —`.
2. **"thanks for grabbing the guide"** implies a download. The guide is eight web chapters, and Mission Control has no attachment capability at all (no `MIMEBase` / `add_attachment` anywhere). `road_welcome_value.html` and `xc_welcome_value.html` already said "reading" — gravel was the outlier.
3. **No link back.** The email asked how a chapter landed and contained only a footer link to the homepage.

## What changed

- `sequence_engine.py` — new `{greeting}` token: `"Roberto —"` when a name was captured, `"Hey —"` when not. Mirrors the existing convention in `scripts/draft_race_reply.py:89`.
- **48 templates** — `{first_name} —` → `{greeting}`. `sober_welcome.html` deliberately untouched.
- `welcome_value.html` — "grabbing" → "reading", plus a link back to the chapter.
- `webhooks.py` — `GRAVEL_GUIDE_CHAPTER_SLUGS` → `wb_guide_url`. The map is explicit because titles don't slugify reliably (`"Race Week Protocol"` → `race-week`, `"Post-Race & Beyond"` → `post-race`). An unrecognised title emits **no link rather than a 404**, and the URL is gravel-only.

Renders as:

> Roberto — thanks for reading the guide. How did you like the chapter on Race Selection?
> You can pick it back up here: [Race Selection]. Any more questions there, just hit reply — happy to help.

Nameless: `Hey — thanks for reading the guide.`

## Also fixed

- **Reserved-key shadowing.** `source_data` (worker-supplied) was applied *after* the identity fields, so a key named `greeting` or `contact_email` could redefine who an email addresses. Not reachable from current producers, but a live footgun. Precedence is now inverted.
- **Test-suite rate limiter.** Adding webhook tests tipped the suite past the 30-req/60s cap and broke an unrelated test with a 429 — the suite had been sitting just under it, so any new webhook test would have done this. Autouse fixture in `conftest.py`.

## Verification

- **284 non-triage Mission Control tests pass.** (`test_triage.py` / `test_triage_tahoe.py` fail with pre-existing 401s from admin auth middleware — unrelated, untouched by this change.)
- **Mutation-tested**: reinstating the `there —` fallback fails 2 of the new tests, so the guard catches the original bug rather than passing vacuously.
- All 8 mapped chapter URLs verified live (200).
- 11 regression tests added, including cross-brand isolation and UTM-append behaviour (the chapter URL already carries `?unlocked=1`, so the appender must use `&`).

Reviewed adversarially by GPT-5.6-sol: **NO-GO** on the first pass — it correctly caught the reserved-key shadowing and two tests I had made vacuous/misgrouped. **GO** after fixes.

## Known, deliberately out of scope

- `generate_prep_kit.py:2667` shows a **`FREE DOWNLOAD`** badge on what is a `{slug}.html` web page — the same trap as "grabbing", on a higher-traffic surface. Needs a site regen + deploy.
- Email-link unlocks record as `unlock("email_form")` in GA4 — reporting debt, not functional.
- `/guide/` pillar ships a stale bundle with no `?unlocked=1` handler. Nothing points there; it's why the email links a chapter URL instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)