### PR TITLE
feat(quiz): give difficulty a real value instead of a constant

### DIFF
--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -40,6 +40,33 @@ REMOVED_FABRICATED_SLUGS = frozenset(
         .read_text())["tombstones"])
 
 
+# Relative contribution of each physical criterion to overall difficulty.
+# Distance and climbing dominate what makes a day hard; surface adds real
+# cost; weather and altitude are meaningful but secondary for most races.
+_DIFFICULTY_WEIGHTS = {
+    "length": 0.30,
+    "elevation": 0.30,
+    "technicality": 0.20,
+    "climate": 0.10,
+    "altitude": 0.10,
+}
+
+
+def _difficulty_composite(scores: dict) -> float | None:
+    """Weighted 1-5 difficulty from the physical criteria.
+
+    ALL five must be scored. Renormalising over whichever happen to be present
+    lets a race with only length and elevation reach 5.0 and take full "brutal"
+    credit while three dimensions are unknown — a confident number built on
+    missing data. Return None instead and let the quiz apply its own neutral
+    default. Every currently profiled race carries all five, so this costs
+    nothing today and stops a partial profile from lying later.
+    """
+    if any(not isinstance(scores.get(k), (int, float)) for k in _DIFFICULTY_WEIGHTS):
+        return None
+    return round(sum(scores[k] * w for k, w in _DIFFICULTY_WEIGHTS.items()), 2)
+
+
 def _load_migrated_road_slugs() -> frozenset[str]:
     """Return GG source slugs removed by the approved road migration.
 
@@ -264,6 +291,17 @@ def build_index_entry_from_profile(slug: str, data: dict) -> dict:
         if isinstance(val, (int, float)):
             scores[var] = int(val)
 
+    # How hard the day is, 1-5, from the physical criteria only. The race
+    # quiz asks "How hard do you want it?" and weights the answer higher than
+    # any other question, but the field it read (difficulty_composite) was
+    # never produced by anything — so every race scored 2.5 and the two
+    # hardest answers matched nothing at all.
+    #
+    # Physical demand only: prestige, value and logistics say nothing about
+    # how much the race hurts. Weights sum to 1.0 so the result stays on the
+    # same 1-5 scale as its inputs.
+    difficulty = _difficulty_composite(scores)
+
 
     entry = {
         "name": race.get("display_name") or race.get("name", slug),
@@ -277,6 +315,7 @@ def build_index_entry_from_profile(slug: str, data: dict) -> dict:
         "tier": rating.get("tier", 3),
         "overall_score": rating.get("overall_score"),
         "scores": scores,
+        "difficulty_composite": difficulty,
         "tagline": race.get("tagline", ""),
         "has_profile": True,
         "profile_url": f"/race/{slug}/",

--- a/tests/test_difficulty_composite.py
+++ b/tests/test_difficulty_composite.py
@@ -1,0 +1,123 @@
+"""difficulty_composite — the quiz's highest-weighted input.
+
+The race quiz asks "How hard do you want it?" and weights the answer at 20
+points, more than terrain (12) or region (10). It reads difficulty_composite,
+which nothing produced, so every race sat at the JS default of 2.5. Under the
+scoring bands that meant "moderate" scored 20 for every race while "hard" and
+"brutal" scored 0 for every race — the two hardest answers were discarded.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from generate_index import _DIFFICULTY_WEIGHTS, _difficulty_composite  # noqa: E402
+
+
+class TestComposite:
+    def test_weights_sum_to_one(self):
+        assert round(sum(_DIFFICULTY_WEIGHTS.values()), 6) == 1.0
+
+    def test_uses_physical_criteria_only(self):
+        # prestige/value/logistics describe the event, not how much it hurts
+        assert set(_DIFFICULTY_WEIGHTS) == {
+            "length", "elevation", "technicality", "climate", "altitude"}
+
+    def test_all_fives_is_five(self):
+        assert _difficulty_composite({k: 5 for k in _DIFFICULTY_WEIGHTS}) == 5.0
+
+    def test_all_ones_is_one(self):
+        assert _difficulty_composite({k: 1 for k in _DIFFICULTY_WEIGHTS}) == 1.0
+
+    def test_partial_scores_yield_none_not_a_confident_number(self):
+        """length+elevation alone must not reach 5.0 and take full 'brutal'
+        credit while three dimensions are unknown."""
+        assert _difficulty_composite({"length": 5, "elevation": 5}) is None
+
+    def test_none_when_nothing_physical_is_scored(self):
+        # better a neutral default in the quiz than a fabricated number
+        assert _difficulty_composite({"prestige": 5, "value": 4}) is None
+        assert _difficulty_composite({}) is None
+
+    def test_non_numeric_counts_as_missing(self):
+        scores = {k: 4 for k in _DIFFICULTY_WEIGHTS}
+        scores["length"] = "hard"
+        assert _difficulty_composite(scores) is None
+
+
+class TestIndexIsPopulated:
+    @pytest.fixture(scope="class")
+    def races(self):
+        data = json.loads((ROOT / "web" / "race-index.json").read_text())
+        return data if isinstance(data, list) else data.get("races", data)
+
+    def test_profiled_races_have_a_difficulty(self, races):
+        scored = [r for r in races if r.get("scores")]
+        missing = [r["slug"] for r in scored
+                   if not isinstance(r.get("difficulty_composite"), (int, float))]
+        assert not missing, f"{len(missing)} scored races without difficulty: {missing[:5]}"
+
+    def test_values_are_on_the_one_to_five_scale(self, races):
+        vals = [r["difficulty_composite"] for r in races
+                if isinstance(r.get("difficulty_composite"), (int, float))]
+        assert vals
+        assert min(vals) >= 1.0 and max(vals) <= 5.0
+
+    def test_actually_discriminates(self, races):
+        """A constant would make the quiz's biggest question meaningless."""
+        vals = {r["difficulty_composite"] for r in races
+                if isinstance(r.get("difficulty_composite"), (int, float))}
+        assert len(vals) > 10, f"only {len(vals)} distinct difficulty values"
+
+    def test_brutal_answer_can_match_something(self, races):
+        """The old constant 2.5 meant 'brutal' scored zero against every race."""
+        brutal = [r for r in races
+                  if isinstance(r.get("difficulty_composite"), (int, float))
+                  and r["difficulty_composite"] > 4]
+        assert brutal, "no race qualifies as brutal — the answer matches nothing"
+
+
+class TestPipelineEndToEnd:
+    """The unit tests above and the checked-in index could both be right while
+    the real entry builder never emits the field. Go through it."""
+
+    def _profile(self, **score_overrides):
+        scores = {"length": 4, "elevation": 4, "technicality": 3,
+                  "climate": 3, "altitude": 2}
+        scores.update(score_overrides)
+        return {"race": {
+            "name": "Test Race", "display_name": "Test Race",
+            "vitals": {"location": "Emporia, Kansas", "date": "2026: June 1",
+                       "distance_mi": 100, "elevation_ft": 6000},
+            "gravel_god_rating": {"tier": 2, "overall_score": 70, **scores},
+        }}
+
+    def test_entry_builder_emits_difficulty(self):
+        from generate_index import build_index_entry_from_profile
+        entry = build_index_entry_from_profile("test-race", self._profile())
+        assert entry["difficulty_composite"] == round(
+            4 * 0.30 + 4 * 0.30 + 3 * 0.20 + 3 * 0.10 + 2 * 0.10, 2)
+
+    def test_entry_builder_emits_none_on_partial(self):
+        from generate_index import build_index_entry_from_profile
+        p = self._profile()
+        del p["race"]["gravel_god_rating"]["altitude"]
+        entry = build_index_entry_from_profile("test-race", p)
+        assert entry["difficulty_composite"] is None
+
+    def test_quiz_carries_it_through_to_the_page(self):
+        """End to end: profile -> index entry -> emitted RACES array."""
+        import re
+        sys.path.insert(0, str(ROOT / "wordpress"))
+        from generate_index import build_index_entry_from_profile
+        from generate_quiz import build_quiz_page
+
+        entry = build_index_entry_from_profile("test-race", self._profile())
+        html = build_quiz_page([entry])
+        races = json.loads(re.search(r"var RACES=(\[.*?\]);", html, re.S).group(1))
+        assert races[0]["df"] == entry["difficulty_composite"]
+        assert races[0]["df"] > 0, "quiz emitted a zero difficulty"

--- a/web/race-index.json
+++ b/web/race-index.json
@@ -27,6 +27,7 @@
       "expenses": 2,
       "cultural_impact": 5
     },
+    "difficulty_composite": 4.5,
     "tagline": "4,000-5,000km self-supported across Europe. The clock never stops. The ultimate test of human endurance, navigation, and self-reliance.",
     "has_profile": true,
     "profile_url": "/race/transcontinental-race/",
@@ -62,6 +63,7 @@
       "value": 5,
       "expenses": 3
     },
+    "difficulty_composite": 4.6,
     "tagline": "2,745 miles from Banff to Mexico. The longest mountain bike time trial on earth. Self-supported. Unsupported. Unforgettable.",
     "has_profile": true,
     "profile_url": "/race/tour-divide/",
@@ -101,6 +103,7 @@
       "expenses": 4,
       "cultural_impact": 5
     },
+    "difficulty_composite": 3.8,
     "tagline": "The Super Bowl of gravel. 200 miles through Kansas Flint Hills. Where legends are made and dreams die in the dust.",
     "has_profile": true,
     "profile_url": "/race/unbound-200/",
@@ -142,6 +145,7 @@
       "expenses": 4,
       "cultural_impact": 5
     },
+    "difficulty_composite": 4.0,
     "tagline": "Europe's Unbound, one-day distance. 202km through Catalonia's Empordà plains and Gavarres massif, out and back to Girona in a day.",
     "has_profile": true,
     "profile_url": "/race/the-traka/",
@@ -179,6 +183,7 @@
       "value": 5,
       "expenses": 2
     },
+    "difficulty_composite": 5.0,
     "tagline": "530 miles of high-altitude suffering across the spine of the Rockies - 75% of starters don't finish, and that's the point.",
     "has_profile": true,
     "profile_url": "/race/colorado-trail-race/",
@@ -217,6 +222,7 @@
       "value": 5,
       "expenses": 3
     },
+    "difficulty_composite": 4.3,
     "tagline": "4,200 miles from the Pacific to the Atlantic. The longest road ultra-race on earth. Self-supported across 10 states. America, coast to coast.",
     "has_profile": true,
     "profile_url": "/race/trans-am-bike-race/",
@@ -256,6 +262,7 @@
       "expenses": 3,
       "cultural_impact": 5
     },
+    "difficulty_composite": 4.0,
     "tagline": "UCI World Championship—180km elite, rainbow jersey, fastest field in gravel, rotating locations.",
     "has_profile": true,
     "profile_url": "/race/uci-gravel-worlds/",
@@ -293,6 +300,7 @@
       "expenses": 3,
       "cultural_impact": 5
     },
+    "difficulty_composite": 4.1,
     "tagline": "350 miles of Kansas limestone hell with zero aid stations. The ultimate test of whether you actually like riding bikes or just think you do.",
     "has_profile": true,
     "profile_url": "/race/unbound-xl/",
@@ -331,6 +339,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 5.0,
     "tagline": "800km self-supported through Spanish deserts and 3,400m alpine passes. Where ultra-endurance meets extreme heat.",
     "has_profile": true,
     "profile_url": "/race/badlands/",
@@ -370,6 +379,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 4.1,
     "tagline": "The toughest 70 miles on the planet. 10,000ft of climbing. Finish at 10,400ft elevation.",
     "has_profile": true,
     "profile_url": "/race/crusher-in-the-tushar/",
@@ -409,6 +419,7 @@
       "expenses": 3,
       "cultural_impact": 4
     },
+    "difficulty_composite": 4.2,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-nove-colli/",
@@ -442,6 +453,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 4.7,
     "tagline": "The Race Across the Sky. 100 miles at 10,000+ feet. The belt buckle that defines mountain biking.",
     "has_profile": true,
     "profile_url": "/race/leadville-100/",
@@ -483,6 +495,7 @@
       "expenses": 3,
       "cultural_impact": 4
     },
+    "difficulty_composite": 3.9,
     "tagline": "The original BWR: 107 miles across 30 road and unroad sectors from Del Mar.",
     "has_profile": true,
     "profile_url": "/race/bwr-california/",
@@ -523,6 +536,7 @@
       "value": 5,
       "expenses": 3
     },
+    "difficulty_composite": 4.7,
     "tagline": "700km crossing the Alps from Italy to France on legendary military roads. Where bikepacking pilgrimage meets high-altitude adventure.",
     "has_profile": true,
     "profile_url": "/race/torino-nice-rally/",
@@ -562,6 +576,7 @@
       "expenses": 4,
       "cultural_impact": 4
     },
+    "difficulty_composite": 3.5,
     "tagline": "The Life Time Grand Prix finale—where the season ends and titles are decided on Ozark gravel.",
     "has_profile": true,
     "profile_url": "/race/big-sugar/",
@@ -603,6 +618,7 @@
       "expenses": 2,
       "cultural_impact": 4
     },
+    "difficulty_composite": 4.2,
     "tagline": "Europe's premier gravel circuit. From Girona to Kenya to Iceland, the alternative to Life Time's American hegemony.",
     "has_profile": true,
     "profile_url": "/race/gravel-earth/",
@@ -643,6 +659,7 @@
       "expenses": 2,
       "cultural_impact": 4
     },
+    "difficulty_composite": 3.7,
     "tagline": "Champagne gravel at altitude - where the pros come to play and the views will make you forget about the suffering",
     "has_profile": true,
     "profile_url": "/race/steamboat-gravel/",
@@ -682,6 +699,7 @@
       "expenses": 4,
       "cultural_impact": 4
     },
+    "difficulty_composite": 3.6,
     "tagline": "150 miles of relentless Nebraska rollers. $100K purse. Pirate swords for winners. The grassroots championship.",
     "has_profile": true,
     "profile_url": "/race/gravel-worlds/",
@@ -721,6 +739,7 @@
       "expenses": 4,
       "cultural_impact": 4
     },
+    "difficulty_composite": 3.7,
     "tagline": "The UK's biggest gravel race. 200km through Kielder Forest. Cold, wet, and utterly British.",
     "has_profile": true,
     "profile_url": "/race/dirty-reiver/",
@@ -760,6 +779,7 @@
       "expenses": 4,
       "cultural_impact": 3
     },
+    "difficulty_composite": 3.7,
     "tagline": "Fast Texas gravel. River crossings. Scorching heat. The Unbound tune-up that breaks people.",
     "has_profile": true,
     "profile_url": "/race/gravel-locos/",
@@ -799,6 +819,7 @@
       "expenses": 4,
       "cultural_impact": 5
     },
+    "difficulty_composite": 2.8,
     "tagline": "Oklahoma's weather lottery with a $100K purse and a guaranteed Bobby hug.",
     "has_profile": true,
     "profile_url": "/race/mid-south/",
@@ -838,6 +859,7 @@
       "expenses": 4,
       "cultural_impact": 3
     },
+    "difficulty_composite": 3.7,
     "tagline": "Half the climbing of San Diego. All the suffering. Plus miles of playground sand.",
     "has_profile": true,
     "profile_url": "/race/bwr-cedar-city/",
@@ -878,6 +900,7 @@
       "value": 4,
       "expenses": 2
     },
+    "difficulty_composite": 4.7,
     "tagline": "The world's toughest gravel ride where wine bottle sizes determine your suffering quota and 7,000 meters of climbing is just the appetizer.",
     "has_profile": true,
     "profile_url": "/race/jeroboam/",
@@ -916,6 +939,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.7,
     "tagline": "Idaho's most beautiful gravel race. 100 miles through the Pioneer Mountains. Not made to be easy.",
     "has_profile": true,
     "profile_url": "/race/rebeccas-private-idaho/",
@@ -954,6 +978,7 @@
       "expenses": 2,
       "cultural_impact": 4
     },
+    "difficulty_composite": 4.4,
     "tagline": "The only mountain bike race crossing Kenya's Great Rift Valley to Maasai Mara",
     "has_profile": true,
     "profile_url": "/race/rift-valley-odyssey/",
@@ -988,6 +1013,7 @@
       "expenses": 4,
       "cultural_impact": 4
     },
+    "difficulty_composite": 2.4,
     "tagline": "Festival racing on California's Central Coast. Where gravel meets expo madness.",
     "has_profile": true,
     "profile_url": "/race/sea-otter-gravel/",
@@ -1029,6 +1055,7 @@
       "expenses": 3,
       "cultural_impact": 4
     },
+    "difficulty_composite": 3.2,
     "tagline": "The little sibling that still kicks your ass. 100 miles of Flint Hills gravel—all the suffering, half the existential crisis.",
     "has_profile": true,
     "profile_url": "/race/unbound-100/",
@@ -1066,6 +1093,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.9,
     "tagline": "The OG American Spring Classic. 130 miles of kasseien-crushing brutality where 1 in 3 riders DNF, and the survivors earn their waffles.",
     "has_profile": true,
     "profile_url": "/race/bwr-san-diego/",
@@ -1106,6 +1134,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.6,
     "tagline": "New LTGP MTB race—30 miles of technical Bentonville singletrack, pairs with Big Sugar Gravel, pro field guaranteed.",
     "has_profile": true,
     "profile_url": "/race/little-sugar-mtb/",
@@ -1144,6 +1173,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 3.7,
     "tagline": "Australia's crown jewel gravel race. 125km through Western Australia's forests. Host of 2026 UCI Gravel World Championships.",
     "has_profile": true,
     "profile_url": "/race/seven/",
@@ -1181,6 +1211,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 4.1,
     "tagline": "Utah red rock adventure—188km of high-desert gravel, 1,811m elevation, June heat, waffles.",
     "has_profile": true,
     "profile_url": "/race/bwr-utah/",
@@ -1222,6 +1253,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 4.5,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/dartmoor-legend-ultra/",
@@ -1256,6 +1288,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.9,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/etape-du-dales/",
@@ -1290,6 +1323,7 @@
       "expenses": 4,
       "cultural_impact": 3
     },
+    "difficulty_composite": 3.9,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/flandrien-ride/",
@@ -1324,6 +1358,7 @@
       "expenses": 2,
       "cultural_impact": 3
     },
+    "difficulty_composite": 4.2,
     "tagline": "Four days through Kenya's Maasai Mara. Zebras on course.",
     "has_profile": true,
     "profile_url": "/race/migration-gravel-race/",
@@ -1363,6 +1398,7 @@
       "expenses": 3,
       "cultural_impact": 4
     },
+    "difficulty_composite": 3.3,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/mt-fuji-hill-climb/",
@@ -1397,6 +1433,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 4.5,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-across-france/",
@@ -1431,6 +1468,7 @@
       "expenses": 3,
       "cultural_impact": 3
     },
+    "difficulty_composite": 3.5,
     "tagline": "200km across Iceland's volcanic highlands. River crossings, lava fields, and the tectonic rift. Gravel's most otherworldly course.",
     "has_profile": true,
     "profile_url": "/race/the-rift/",
@@ -1470,6 +1508,7 @@
       "expenses": 4,
       "cultural_impact": 4
     },
+    "difficulty_composite": 4.1,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/transiberica/",
@@ -1504,6 +1543,7 @@
       "expenses": 2,
       "cultural_impact": 3
     },
+    "difficulty_composite": 4.2,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/bikingman-corsica/",
@@ -1537,6 +1577,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 4.4,
     "tagline": "Blue Ridge brutality—129 miles, 10,000 feet, Belgian-style mixed terrain in Asheville humidity.",
     "has_profile": true,
     "profile_url": "/race/bwr-asheville/",
@@ -1577,6 +1618,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.6,
     "tagline": "Montana Rockies adventure—AKA 'Hell of the Bozone': mountain gravel around Bozeman, waffles at the finish.",
     "has_profile": true,
     "profile_url": "/race/bwr-montana/",
@@ -1616,6 +1658,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.5,
     "tagline": "Where gravel racing meets enduro format - timed segments, untimed vibes, and a festival that actually delivers",
     "has_profile": true,
     "profile_url": "/race/grinduro/",
@@ -1657,6 +1700,7 @@
       "expenses": 4,
       "cultural_impact": 3
     },
+    "difficulty_composite": 3.6,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/haervejslobet/",
@@ -1691,6 +1735,7 @@
       "expenses": 3,
       "cultural_impact": 3
     },
+    "difficulty_composite": 3.4,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/northcape-4000/",
@@ -1725,6 +1770,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 4.0,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/sierra-nevada-limite/",
@@ -1759,6 +1805,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.8,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/struggle-dales/",
@@ -1793,6 +1840,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 4.1,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-of-the-peak/",
@@ -1826,6 +1874,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 3.3,
     "tagline": "Enduro-style gravel festival that debuted in France's Vosges in 2024 — status uncertain, not on Grinduro's current series calendar.",
     "has_profile": true,
     "profile_url": "/race/grinduro-france/",
@@ -1864,6 +1913,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 3.3,
     "tagline": "Enduro-style gravel festival that ran in Germany's Eifel 2022-2025 — status uncertain, not on Grinduro's current series calendar.",
     "has_profile": true,
     "profile_url": "/race/grinduro-germany/",
@@ -1904,6 +1954,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.5,
     "tagline": "UCI Gravel World Series qualifier at 8,000 feet—High Sierra alpine gravel where altitude humbles everyone.",
     "has_profile": true,
     "profile_url": "/race/mammoth-tuff/",
@@ -1942,6 +1993,7 @@
       "value": 3,
       "expenses": 5
     },
+    "difficulty_composite": 3.7,
     "tagline": "Multi-day Scandinavian adventure—Copenhagen to Oslo, 600km over 4 stages, supported with hotels and meals.",
     "has_profile": true,
     "profile_url": "/race/nordic-chase-gravel/",
@@ -1979,6 +2031,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 4.3,
     "tagline": "5 days. 5 stages. The Grand Tour of American Gravel.",
     "has_profile": true,
     "profile_url": "/race/oregon-trail-gravel/",
@@ -2018,6 +2071,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 4.4,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/the-accursed-race/",
@@ -2051,6 +2105,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.6,
     "tagline": "The OG Southwest MTB festival. Skull Valley will break you. Whiskey Row will rebuild you.",
     "has_profile": true,
     "profile_url": "/race/whiskey-off-road/",
@@ -2090,6 +2145,7 @@
       "expenses": 2,
       "cultural_impact": 4
     },
+    "difficulty_composite": 3.3,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-nyc/",
@@ -2123,6 +2179,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 4.5,
     "tagline": "High-altitude Colorado mountain gravel with 10,000 feet of climbing and thin air at 10,000 ft.",
     "has_profile": true,
     "profile_url": "/race/gunni-grinder/",
@@ -2162,6 +2219,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.8,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/la-vaujany/",
@@ -2195,6 +2253,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.9,
     "tagline": "Where the Mojave, Great Basin, and Colorado Plateau collide to humble your gravel dreams",
     "has_profile": true,
     "profile_url": "/race/lauf-true-grit/",
@@ -2232,6 +2291,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 3.1,
     "tagline": "Minnesota's North Shore gravel classic at Lake Superior—110 miles through Northwoods and Gunflint Trail terrain.",
     "has_profile": true,
     "profile_url": "/race/le-grand-du-nord/",
@@ -2270,6 +2330,7 @@
       "expenses": 3,
       "cultural_impact": 3
     },
+    "difficulty_composite": 3.3,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/london-edinburgh-london/",
@@ -2303,6 +2364,7 @@
       "value": 2,
       "expenses": 2
     },
+    "difficulty_composite": 3.8,
     "tagline": "Peille, high above Monaco—116km of steep French Alps climbs, ~2,500m elevation, iconic location.",
     "has_profile": true,
     "profile_url": "/race/monaco-gravel-race/",
@@ -2341,6 +2403,7 @@
       "value": 5,
       "expenses": 3
     },
+    "difficulty_composite": 3.4,
     "tagline": "Tuscan strade bianche—135km of iconic white roads, 2,800m elevation, medieval town charm, Italian gravel paradise.",
     "has_profile": true,
     "profile_url": "/race/nova-eroica/",
@@ -2379,6 +2442,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 4.7,
     "tagline": "Where gravel meets the sky - high-altitude suffering in Colorado's Switzerland",
     "has_profile": true,
     "profile_url": "/race/ouray-gravel-grinder/",
@@ -2416,6 +2480,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 3.8,
     "tagline": "Trans-Pyrenean ultra-gravel through volcanic zones, medieval villages, and Costa Brava coast - Spain's answer to the 200-mile question",
     "has_profile": true,
     "profile_url": "/race/pirinexus-360/",
@@ -2454,6 +2519,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.5,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-across-germany/",
@@ -2488,6 +2554,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.1,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/birkebeinerrittet-road/",
@@ -2521,6 +2588,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "The Cheq—40 years of mass start MTB chaos, 3,000+ riders, and Life Time Grand Prix glory in Wisconsin's Chequamegon National Forest.",
     "has_profile": true,
     "profile_url": "/race/chequamegon-mtb/",
@@ -2561,6 +2629,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 3.2,
     "tagline": "The OG of gravel racing - 25+ years of Northern California dirt, redwoods, and pure cycling soul.",
     "has_profile": true,
     "profile_url": "/race/grasshopper-series/",
@@ -2601,6 +2670,7 @@
       "expenses": 3,
       "cultural_impact": 3
     },
+    "difficulty_composite": 3.6,
     "tagline": "Southeast gravel classic—69 miles, 8,777 feet of technical Appalachian terrain in Pisgah National Forest.",
     "has_profile": true,
     "profile_url": "/race/pisgah-monster-cross/",
@@ -2640,6 +2710,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 4.1,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-across-spain/",
@@ -2673,6 +2744,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.4,
     "tagline": "Vermont's early season mud fest—46 miles of Class 4 roads, self-supported suffering, and guaranteed mud.",
     "has_profile": true,
     "profile_url": "/race/rasputitsa/",
@@ -2712,6 +2784,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.2,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/ring-of-clare/",
@@ -2746,6 +2819,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 4.1,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/seorak-granfondo/",
@@ -2779,6 +2853,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 4.3,
     "tagline": "High-desert climbing in southern Colorado. Spanish Peaks backdrop, 10,000+ feet of vertical.",
     "has_profile": true,
     "profile_url": "/race/the-rad/",
@@ -2817,6 +2892,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.7,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-de-romandie-cyclosportive/",
@@ -2851,6 +2927,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.7,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-of-thekkady/",
@@ -2885,6 +2962,7 @@
       "expenses": 3,
       "cultural_impact": 1
     },
+    "difficulty_composite": 4.2,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/trans-balkan-race/",
@@ -2918,6 +2996,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.8,
     "tagline": "The Hell of the East - where your gravel bike wishes it was a mountain bike and your legs wish they were someone else's.",
     "has_profile": true,
     "profile_url": "/race/bwr-north-carolina/",
@@ -2959,6 +3038,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.2,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/epic-gran-canaria/",
@@ -2992,6 +3072,7 @@
       "value": 5,
       "expenses": 3
     },
+    "difficulty_composite": 2.9,
     "tagline": "Southeast Sardinia coastal gravel—107km, fast and non-technical, Mediterranean views, May warmth.",
     "has_profile": true,
     "profile_url": "/race/giro-sardegna-gravel/",
@@ -3031,6 +3112,7 @@
       "expenses": 4,
       "cultural_impact": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-gf-do-porto/",
@@ -3064,6 +3146,7 @@
       "value": 5,
       "expenses": 3
     },
+    "difficulty_composite": 3.3,
     "tagline": "Brazilian coastal mountains—113km, 1,778m elevation, steep technical terrain in beach town paradise.",
     "has_profile": true,
     "profile_url": "/race/gravel-brazil/",
@@ -3100,6 +3183,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 3.5,
     "tagline": "Technical snowmobile-trail gravel through Minnesota's North Shore at peak fall foliage.",
     "has_profile": true,
     "profile_url": "/race/heck-of-the-north/",
@@ -3138,6 +3222,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 2.9,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/nordsjorittet/",
@@ -3172,6 +3257,7 @@
       "expenses": 2,
       "cultural_impact": 2
     },
+    "difficulty_composite": 4.3,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-around-rwanda/",
@@ -3205,6 +3291,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.6,
     "tagline": "Colorado Rockies adventure—100km of high-altitude gravel, 2,500m elevation, Salida scenery.",
     "has_profile": true,
     "profile_url": "/race/rad-dirt-fest/",
@@ -3242,6 +3329,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.6,
     "tagline": "Punchy Georgia mountain gravel with a winery finish and the best post-race party in the Southeast.",
     "has_profile": true,
     "profile_url": "/race/southern-cross-gravel/",
@@ -3281,6 +3369,7 @@
       "expenses": 2,
       "cultural_impact": 4
     },
+    "difficulty_composite": 3.1,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-aotearoa/",
@@ -3314,6 +3403,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.4,
     "tagline": "OG gravel since 2009—55 miles of Vermont pavé, 7,000 feet of climbing, and Paris-Roubaix dirt roads.",
     "has_profile": true,
     "profile_url": "/race/vermont-overland/",
@@ -3352,6 +3442,7 @@
       "value": 5,
       "expenses": 4
     },
+    "difficulty_composite": 3.2,
     "tagline": "The Granddaddy of All Gravel Races - where the movement was born, and where your legs go to die on Oriole Road.",
     "has_profile": true,
     "profile_url": "/race/almanzo-100/",
@@ -3390,6 +3481,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.9,
     "tagline": "Southeast gravel staple—100 miles, 10,000 feet of North Georgia mountains, technical descents, Dahlonega charm.",
     "has_profile": true,
     "profile_url": "/race/bootlegger-100/",
@@ -3429,6 +3521,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.3,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-philippines/",
@@ -3463,6 +3556,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.4,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-coimbra/",
@@ -3497,6 +3591,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.5,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-alpe-adria/",
@@ -3531,6 +3626,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.7,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-leiria/",
@@ -3564,6 +3660,7 @@
       "value": 5,
       "expenses": 3
     },
+    "difficulty_composite": 3.1,
     "tagline": "South African highveld classic—100km of red dirt roads, 2,500m elevation, stunning Mpumalanga scenery.",
     "has_profile": true,
     "profile_url": "/race/gravel-burn/",
@@ -3601,6 +3698,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.1,
     "tagline": "OG gravel party—timed enduro descents, untimed climbs, legendary Quincy vibes since 2015.",
     "has_profile": true,
     "profile_url": "/race/grinduro-california/",
@@ -3640,6 +3738,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "Canada's Spring Classic. 110km of mud chutes, rail trails, and chaos (70km age-band option for men 65+/women 50+). The race that eats bikes.",
     "has_profile": true,
     "profile_url": "/race/paris-to-ancaster/",
@@ -3679,6 +3778,7 @@
       "expenses": 3,
       "cultural_impact": 3
     },
+    "difficulty_composite": 3.6,
     "tagline": "300 miles on Unbound roads—Kansas Flint Hills ultra distance, self-supported, 30-40% DNF, 15-25 hours of suffering.",
     "has_profile": true,
     "profile_url": "/race/rule-of-three/",
@@ -3717,6 +3817,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 2.7,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/bluewater-gran-fondo/",
@@ -3751,6 +3852,7 @@
       "expenses": 2,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.6,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/final-frontier-patagonia/",
@@ -3785,6 +3887,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.0,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-hainan/",
@@ -3819,6 +3922,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.2,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-yunnan/",
@@ -3852,6 +3956,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.5,
     "tagline": "One of the US qualifiers for UCI Gravel World Championships. 67 miles of Ozark smashfest.",
     "has_profile": true,
     "profile_url": "/race/highlands-gravel-classic/",
@@ -3891,6 +3996,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.1,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/majka-gran-fondo/",
@@ -3925,6 +4031,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.7,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-around-austria/",
@@ -3958,6 +4065,7 @@
       "value": 5,
       "expenses": 4
     },
+    "difficulty_composite": 3.2,
     "tagline": "California's early season classic—the Cobbler course runs 75-90 miles of Central Valley rocks, dirt, and February weather roulette.",
     "has_profile": true,
     "profile_url": "/race/rock-cobbler/",
@@ -3996,6 +4104,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 4.1,
     "tagline": "Scottish Highlands ultra—200km of remote terrain, 3,500m elevation, brutal weather, 25-35% DNF.",
     "has_profile": true,
     "profile_url": "/race/the-gralloch/",
@@ -4034,6 +4143,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.1,
     "tagline": "Hell of the North Desert—100+ miles of sand, rock, and technical singletrack through Arizona's high desert.",
     "has_profile": true,
     "profile_url": "/race/bwr-arizona/",
@@ -4072,6 +4182,7 @@
       "value": 5,
       "expenses": 3
     },
+    "difficulty_composite": 2.3,
     "tagline": "USA Cycling National Championship—100km of Texas Panhandle gravel, collegiate field, wind, red dirt.",
     "has_profile": true,
     "profile_url": "/race/collegiate-gravel-nationals/",
@@ -4109,6 +4220,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 3.1,
     "tagline": "Where the major series begins and Leadville dreams are made in California sand",
     "has_profile": true,
     "profile_url": "/race/fuego-mtb/",
@@ -4146,6 +4258,7 @@
       "value": 5,
       "expenses": 2
     },
+    "difficulty_composite": 3.4,
     "tagline": "New Zealand countryside gravel, January summer warmth — the UCI 'Classic' is elite-only; amateurs enter the companion 'Slicks and Stones Gravel Assault' instead.",
     "has_profile": true,
     "profile_url": "/race/gravel-and-tar-classic/",
@@ -4184,6 +4297,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 3.7,
     "tagline": "The Hell of the East - 8,000 feet of Pocono punishment that'll make you question every life decision",
     "has_profile": true,
     "profile_url": "/race/gravel-roubaix/",
@@ -4220,6 +4334,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "Race inside a 450-million-year-old meteorite crater where the party is as legendary as the singletrack",
     "has_profile": true,
     "profile_url": "/race/grinduro-canada/",
@@ -4260,6 +4375,7 @@
       "expenses": 3,
       "cultural_impact": 3
     },
+    "difficulty_composite": 2.6,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/hong-kong-cyclothon/",
@@ -4294,6 +4410,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.6,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/jamtlandspilen/",
@@ -4328,6 +4445,7 @@
       "expenses": 4,
       "cultural_impact": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/velothon-berlin/",
@@ -4362,6 +4480,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.0,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gfny-san-juan/",
@@ -4396,6 +4515,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.5,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-san-diego/",
@@ -4429,6 +4549,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 3.7,
     "tagline": "West Virginia's Appalachian gravel grinder: 8,500 feet of relentless climbing through humid forest roads where heat management matters more than fitness.",
     "has_profile": true,
     "profile_url": "/race/lost-river-classic/",
@@ -4468,6 +4589,7 @@
       "expenses": 2,
       "cultural_impact": 4
     },
+    "difficulty_composite": 3.9,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/pan-celtic-ultra/",
@@ -4502,6 +4624,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.3,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/race-around-ireland/",
@@ -4535,6 +4658,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.4,
     "tagline": "Adelaide Hills adventure—127km of rolling Australian bush, ~2,200m elevation, South Australia gravel.",
     "has_profile": true,
     "profile_url": "/race/radl-grvl/",
@@ -4574,6 +4698,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 2.7,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/uci-gran-fondo-hangzhou/",
@@ -4607,6 +4732,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.5,
     "tagline": "192-mile overnight bikepacking odyssey from Wisconsin to Michigan's Upper Peninsula where darkness, cold, and solitude break you down and build you back.",
     "has_profile": true,
     "profile_url": "/race/crystal-bear/",
@@ -4645,6 +4771,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.4,
     "tagline": "Ohio's Appalachian suffer fest - 9,000 feet of vertical brutality in the heartland",
     "has_profile": true,
     "profile_url": "/race/dirty-french/",
@@ -4681,6 +4808,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 2.1,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-argentina/",
@@ -4715,6 +4843,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.1,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/granfondo-bratislava/",
@@ -4748,6 +4877,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 4.4,
     "tagline": "Moroccan Atlas Mountains ultra-endurance gravel race.",
     "has_profile": true,
     "profile_url": "/race/atlas-mountain-race/",
@@ -4786,6 +4916,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.2,
     "tagline": "Multi-discipline high desert festival in Bend—gravel, MTB, and trail run in one weekend.",
     "has_profile": true,
     "profile_url": "/race/bend-dirt-fest/",
@@ -4823,6 +4954,7 @@
       "value": 5,
       "expenses": 4
     },
+    "difficulty_composite": 3.0,
     "tagline": "Early season Michigan gravel with cold starts, mud risk, and MGRS community.",
     "has_profile": true,
     "profile_url": "/race/dirty-30/",
@@ -4861,6 +4993,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "340 miles of relentless Iowa gravel where the wind never stops, the terrain never flattens, and 40 hours of continuous riding reveals who you really are.",
     "has_profile": true,
     "profile_url": "/race/iowa-wind-and-rock/",
@@ -4898,6 +5031,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.3,
     "tagline": "High-altitude Front Range gravel with ghost towns and 8,000-foot starts.",
     "has_profile": true,
     "profile_url": "/race/ned-gravel/",
@@ -4937,6 +5071,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 2.7,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/pekan-classics/",
@@ -4971,6 +5106,7 @@
       "expenses": 2,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.2,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/tour-of-oman-sportive/",
@@ -5004,6 +5140,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "Stars and stripes on gravel—the national championship with open entry and a UCI Worlds pathway.",
     "has_profile": true,
     "profile_url": "/race/usa-cycling-gravel-nationals/",
@@ -5041,6 +5178,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.8,
     "tagline": "125-mile high-altitude Colorado mountain gravel in Leadville.",
     "has_profile": true,
     "profile_url": "/race/vapor-trail-125/",
@@ -5080,6 +5218,7 @@
       "expenses": 4,
       "cultural_impact": 2
     },
+    "difficulty_composite": 2.7,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/veloturk-gran-fondo-cesme/",
@@ -5114,6 +5253,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "America's spring classic. 61% dirt, 39% pavement, 100% suffering. The original Paris-Roubaix tribute race on Colorado's Front Range farm roads.",
     "has_profile": true,
     "profile_url": "/race/boulder-roubaix/",
@@ -5149,6 +5289,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.6,
     "tagline": "100-mile Georgia mountain gravel through Cohutta Wilderness.",
     "has_profile": true,
     "profile_url": "/race/cohutta-gravel-grinder/",
@@ -5185,6 +5326,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.2,
     "tagline": "The happiest gravel in the world. F1 glamour meets midnight sun in a UNESCO Geopark. Fast, flat, and fckng Finnish.",
     "has_profile": true,
     "profile_url": "/race/finnish-gravel/",
@@ -5224,6 +5366,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 2.7,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-badlands/",
@@ -5257,6 +5400,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 4.1,
     "tagline": "Colombian Andes mountain gravel adventure.",
     "has_profile": true,
     "profile_url": "/race/transcordilleras/",
@@ -5294,6 +5438,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.8,
     "tagline": "Central Wyoming ultra-distance gravel through mountain and high desert.",
     "has_profile": true,
     "profile_url": "/race/wyo-131/",
@@ -5332,6 +5477,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 3.0,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/yangyang-gran-fondo/",
@@ -5365,6 +5511,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.4,
     "tagline": "Colorado mountain gravel in Gypsum near Vail with high altitude climbing.",
     "has_profile": true,
     "profile_url": "/race/bighorn-gravel/",
@@ -5403,6 +5550,7 @@
       "expenses": 3,
       "cultural_impact": 2
     },
+    "difficulty_composite": 2.8,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-curacavi/",
@@ -5436,6 +5584,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.3,
     "tagline": "Vermont spring mud season mountain gravel in Burke.",
     "has_profile": true,
     "profile_url": "/race/rasputitsa-spring-classic/",
@@ -5474,6 +5623,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.8,
     "tagline": "Missouri State Gravel Championship through wine country — now raced in November cold.",
     "has_profile": true,
     "profile_url": "/race/the-equalizer/",
@@ -5511,6 +5661,7 @@
       "value": 2,
       "expenses": 2
     },
+    "difficulty_composite": 3.6,
     "tagline": "California Sierra Nevada/Tahoe gravel in Truckee.",
     "has_profile": true,
     "profile_url": "/race/truckee-tahoe-gravel/",
@@ -5548,6 +5699,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 3.8,
     "tagline": "Sierras de Córdoba mountain gravel through the Traslasierra Valley -- Argentina's first UCI Gravel World Series event.",
     "has_profile": true,
     "profile_url": "/race/vuelta-altas-cumbres/",
@@ -5585,6 +5737,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.4,
     "tagline": "Northern Utah mountain gravel in Wasatch Range near Park City.",
     "has_profile": true,
     "profile_url": "/race/wasatch-all-road/",
@@ -5623,6 +5776,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.6,
     "tagline": "East Coast ultra—150 miles of flat coastal gravel through Croatan National Forest, sandy terrain, 10-15 hours.",
     "has_profile": true,
     "profile_url": "/race/croatan-buck-fifty/",
@@ -5660,6 +5814,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 3.4,
     "tagline": "Colorado mountain gravel in Winter Park with high altitude climbing.",
     "has_profile": true,
     "profile_url": "/race/crooked-gravel/",
@@ -5698,6 +5853,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.4,
     "tagline": "Victorian high country gravel ride in historic gold rush territory — explicitly podium-free, not a timed race.",
     "has_profile": true,
     "profile_url": "/race/maap-beechworth-granite-classic/",
@@ -5736,6 +5892,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.2,
     "tagline": "100-mile rugged Upper Peninsula mountain bike/gravel endurance.",
     "has_profile": true,
     "profile_url": "/race/marji-gesick/",
@@ -5774,6 +5931,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.2,
     "tagline": "Remote southern Colorado gravel through Sangre de Cristo mining country.",
     "has_profile": true,
     "profile_url": "/race/pony-xpress/",
@@ -5811,6 +5969,7 @@
       "value": 5,
       "expenses": 3
     },
+    "difficulty_composite": 2.6,
     "tagline": "Wisconsin fall gravel—150/100/50 miles of rolling farmland, fall colors, and ultra-distance option.",
     "has_profile": true,
     "profile_url": "/race/red-granite-grinder/",
@@ -5849,6 +6008,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.3,
     "tagline": "30-mile Michigan mountain bike race with 4000+ riders in November.",
     "has_profile": true,
     "profile_url": "/race/iceman-cometh/",
@@ -5886,6 +6046,7 @@
       "value": 2,
       "expenses": 2
     },
+    "difficulty_composite": 3.5,
     "tagline": "British Columbia multi-stage gravel adventure.",
     "has_profile": true,
     "profile_url": "/race/transrockies-gravel-royale/",
@@ -5924,6 +6085,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 3.8,
     "tagline": "Belgian Ardennes multi-stage gravel in Vielsalm/Engreux.",
     "has_profile": true,
     "profile_url": "/race/ardenne-gravel-stages/",
@@ -5961,6 +6123,7 @@
       "expenses": 4,
       "cultural_impact": 0
     },
+    "difficulty_composite": 1.9,
     "tagline": "",
     "has_profile": true,
     "profile_url": "/race/balatonfondo/",
@@ -5994,6 +6157,7 @@
       "value": 3,
       "expenses": 4
     },
+    "difficulty_composite": 2.9,
     "tagline": "The Hell of the (Mid) West—BWR's fall Midwest edition through the Flint Hills with 72% unroad.",
     "has_profile": true,
     "profile_url": "/race/belgian-waffle-ride-kansas/",
@@ -6034,6 +6198,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "150-mile Nebraska gravel challenge in Lincoln.",
     "has_profile": true,
     "profile_url": "/race/gravel-worlds-amateur/",
@@ -6071,6 +6236,7 @@
       "value": 1,
       "expenses": 1
     },
+    "difficulty_composite": 3.7,
     "tagline": "European Alpine multi-stage gravel event.",
     "has_profile": true,
     "profile_url": "/race/haute-route-gravel/",
@@ -6108,6 +6274,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 3.1,
     "tagline": "Route de la Soif — serious Alpine gravel with brooding mountain presence in the French Alps.",
     "has_profile": true,
     "profile_url": "/race/la-resistance/",
@@ -6145,6 +6312,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "Queensland hinterland enduro with technical terrain and tourist town base.",
     "has_profile": true,
     "profile_url": "/race/noosa-gravel-enduro/",
@@ -6183,6 +6351,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.1,
     "tagline": "Western Oregon Coast Range mountain gravel in wine country.",
     "has_profile": true,
     "profile_url": "/race/sasquatch-duro/",
@@ -6220,6 +6389,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 3.1,
     "tagline": "Iowa prairie ultra-endurance gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/spotted-horse-ultra/",
@@ -6257,6 +6427,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.0,
     "tagline": "Five days of supported gravel cruising through Nebraska's rolling farmland - more family reunion than race, and that's exactly the point",
     "has_profile": true,
     "profile_url": "/race/tour-de-nebraska/",
@@ -6294,6 +6465,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "300+ mile self-supported Iowa gravel ultra-distance challenge.",
     "has_profile": true,
     "profile_url": "/race/trans-iowa/",
@@ -6332,6 +6504,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "New York rolling hills gravel in Cambridge.",
     "has_profile": true,
     "profile_url": "/race/battenkill/",
@@ -6370,6 +6543,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "Michigan ultra-distance crossing from Lake Huron to Lake Michigan.",
     "has_profile": true,
     "profile_url": "/race/coast-to-coast/",
@@ -6408,6 +6582,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.1,
     "tagline": "Vancouver Island forest roads around Lake Cowichan.",
     "has_profile": true,
     "profile_url": "/race/cowichan-crusher-gravel-fondo/",
@@ -6445,6 +6620,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "180km Massachusetts rolling hills gravel from Greenfield (Deerfield Dirt-Road Randonnée).",
     "has_profile": true,
     "profile_url": "/race/d2r2/",
@@ -6483,6 +6659,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 3.4,
     "tagline": "Tasmanian mountain gravel adventure.",
     "has_profile": true,
     "profile_url": "/race/devils-cardigan/",
@@ -6520,6 +6697,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 3.2,
     "tagline": "New Zealand South Island gravel adventure.",
     "has_profile": true,
     "profile_url": "/race/edition-zero/",
@@ -6557,6 +6735,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.0,
     "tagline": "Minnesota fall gravel—50 miles of rolling terrain, 1,000 riders, and peak autumn colors.",
     "has_profile": true,
     "profile_url": "/race/filthy-50/",
@@ -6595,6 +6774,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 3.1,
     "tagline": "Colombian Bogotá mountain gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/gravel-bogota/",
@@ -6631,6 +6811,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 3.5,
     "tagline": "Chilean Tierra del Fuego gravel adventure.",
     "has_profile": true,
     "profile_url": "/race/karukinka/",
@@ -6668,6 +6849,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.1,
     "tagline": "Central Oregon coast gravel with coastal and mountain terrain.",
     "has_profile": true,
     "profile_url": "/race/oregon-coast-gravel-epic/",
@@ -6706,6 +6888,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "South Carolina Paris Mountain gravel in Travelers Rest.",
     "has_profile": true,
     "profile_url": "/race/paris-mountain-gravel-grinder/",
@@ -6743,6 +6926,7 @@
       "value": 2,
       "expenses": 3
     },
+    "difficulty_composite": 4.3,
     "tagline": "Colorado ultra gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/pony-xpress-gravel-160/",
@@ -6780,6 +6964,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "Vancouver Island gravel through forest roads and coastal terrain.",
     "has_profile": true,
     "profile_url": "/race/river-city-gravel-fondo/",
@@ -6818,6 +7003,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 3.2,
     "tagline": "Northeast Nevada gravel in remote Ruby Mountains near Elko.",
     "has_profile": true,
     "profile_url": "/race/ruby-roubaix/",
@@ -6856,6 +7042,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 3.2,
     "tagline": "Alberta mountain gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/the-range/",
@@ -6893,6 +7080,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "Three-state mountain gravel crossing Alabama, Georgia, and Tennessee.",
     "has_profile": true,
     "profile_url": "/race/3-state-3-mountain-challenge/",
@@ -6931,6 +7119,7 @@
       "value": 4,
       "expenses": 2
     },
+    "difficulty_composite": 3.0,
     "tagline": "Romanian Carpathian mountainous gravel.",
     "has_profile": true,
     "profile_url": "/race/carpathian-gravel/",
@@ -6968,6 +7157,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "New York State Championship gravel in Finger Lakes wine country.",
     "has_profile": true,
     "profile_url": "/race/dirty-hector/",
@@ -7004,6 +7194,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "North Georgia mountain gravel in Dahlonega.",
     "has_profile": true,
     "profile_url": "/race/fools-gold-gravel-grinder/",
@@ -7041,6 +7232,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "Arkansas Ozark Mountains gravel in Eureka Springs.",
     "has_profile": true,
     "profile_url": "/race/gran-fondo-ozarks/",
@@ -7076,6 +7268,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 3.1,
     "tagline": "Chilean Patagonia gravel adventure.",
     "has_profile": true,
     "profile_url": "/race/gravel-del-fuego/",
@@ -7113,6 +7306,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 3.0,
     "tagline": "Colombian Medellín mountain gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/gravel-medellin/",
@@ -7150,6 +7344,7 @@
       "value": 2,
       "expenses": 1
     },
+    "difficulty_composite": 3.1,
     "tagline": "Wild Alpine gravel from the World Cycling Center in Aigle to the heights of Villars.",
     "has_profile": true,
     "profile_url": "/race/gravel-suisse/",
@@ -7188,6 +7383,7 @@
       "value": 2,
       "expenses": 2
     },
+    "difficulty_composite": 3.1,
     "tagline": "Tuscan hill gravel out of Massa Marittima.",
     "has_profile": true,
     "profile_url": "/race/grinduro-italy/",
@@ -7227,6 +7423,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.9,
     "tagline": "Western Canada's oldest gravel fondo on the Kettle Valley Rail Trail.",
     "has_profile": true,
     "profile_url": "/race/kettle-mettle/",
@@ -7264,6 +7461,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 3.5,
     "tagline": "South African mountain gravel stage race.",
     "has_profile": true,
     "profile_url": "/race/king-price-race-to-sun/",
@@ -7301,6 +7499,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.9,
     "tagline": "Austria's UCI Gravel World Series race on the shores of the Wörthersee.",
     "has_profile": true,
     "profile_url": "/race/worthersee-gravel-race/",
@@ -7339,6 +7538,7 @@
       "value": 2,
       "expenses": 2
     },
+    "difficulty_composite": 2.8,
     "tagline": "German mountain gravel in Winterberg/Aachen.",
     "has_profile": true,
     "profile_url": "/race/3rides-aachen/",
@@ -7377,6 +7577,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.9,
     "tagline": "6-hour Arkansas endurance on Syllamo Trail in Mountain View.",
     "has_profile": true,
     "profile_url": "/race/6-hours-of-syllamo/",
@@ -7413,6 +7614,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 3.0,
     "tagline": "UCI Gravel World Series in the Catalan Pyrénées from Font-Romeu at 1,760m.",
     "has_profile": true,
     "profile_url": "/race/66-south-pyrenees/",
@@ -7450,6 +7652,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "62-mile Michigan gravel with 1000+ riders in Hastings.",
     "has_profile": true,
     "profile_url": "/race/barry-roubaix/",
@@ -7488,6 +7691,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "Alabama Cheaha Mountain gravel in Jacksonville.",
     "has_profile": true,
     "profile_url": "/race/cheaha-challenge/",
@@ -7526,6 +7730,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "West Virginia mountain gravel in Circleville.",
     "has_profile": true,
     "profile_url": "/race/grusk/",
@@ -7561,6 +7766,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "Southeast Gravel's Appalachian leg from the town the Appalachian Trail walks through.",
     "has_profile": true,
     "profile_url": "/race/hot-springs-gravel-gauntlet/",
@@ -7599,6 +7805,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.8,
     "tagline": "Pennsylvania gravel/cyclocross with technical elements.",
     "has_profile": true,
     "profile_url": "/race/iron-cross/",
@@ -7636,6 +7843,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "Illinois' state-championship gravel race — 100K of Will County farmland speed.",
     "has_profile": true,
     "profile_url": "/race/little-apple-100/",
@@ -7673,6 +7881,7 @@
       "value": 2,
       "expenses": 2
     },
+    "difficulty_composite": 3.2,
     "tagline": "The Lost Sierra's biggest weekend — Sierra Buttes Trail Stewardship's flagship gravel fundraiser.",
     "has_profile": true,
     "profile_url": "/race/lost-and-found-gravel/",
@@ -7710,6 +7919,7 @@
       "value": 2,
       "expenses": 1
     },
+    "difficulty_composite": 2.7,
     "tagline": "Japanese Hokkaido mountain gravel.",
     "has_profile": true,
     "profile_url": "/race/niseko-gravel/",
@@ -7747,6 +7957,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "Arkansas Ouachita Mountains gravel in Mount Ida.",
     "has_profile": true,
     "profile_url": "/race/ouachita-challenge/",
@@ -7785,6 +7996,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "The hardest course in the Southeast Gravel series — Winding Stairs and the Chattooga.",
     "has_profile": true,
     "profile_url": "/race/race-to-valhalla/",
@@ -7823,6 +8035,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.5,
     "tagline": "The Santa Fe Century's gravel Saturday — mesa forest roads at 7,500 feet.",
     "has_profile": true,
     "profile_url": "/race/santa-fe-century-gravelon/",
@@ -7858,6 +8071,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Girona's UCI Gravel World Series race at the Sea Otter Europe festival.",
     "has_profile": true,
     "profile_url": "/race/sea-otter-europe-gravel/",
@@ -7895,6 +8109,7 @@
       "value": 2,
       "expenses": 2
     },
+    "difficulty_composite": 3.1,
     "tagline": "Pennsylvania multi-stage mountain gravel.",
     "has_profile": true,
     "profile_url": "/race/trans-sylvania-epic/",
@@ -7932,6 +8147,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.7,
     "tagline": "Winter gravel in the ancient Uwharries — NC Gravel Series opener country.",
     "has_profile": true,
     "profile_url": "/race/uwharrie-forest-gravel-grinder/",
@@ -7969,6 +8185,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "Southeast Tennessee's grassroots monster in the Cherokee National Forest.",
     "has_profile": true,
     "profile_url": "/race/waucheesi-bike-race/",
@@ -8007,6 +8224,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.6,
     "tagline": "Missouri Berryman Trail mixed surfaces in Potosi.",
     "has_profile": true,
     "profile_url": "/race/berryman-epic/",
@@ -8045,6 +8263,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.7,
     "tagline": "Southeast Gravel's season opener in the Sumter National Forest — river crossing included.",
     "has_profile": true,
     "profile_url": "/race/gravel-battle-of-sumter-forest/",
@@ -8083,6 +8302,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "Multi-day South Carolina gravel in Jamestown.",
     "has_profile": true,
     "profile_url": "/race/hellhole-gravel-grind/",
@@ -8118,6 +8338,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "CAMBA's northwoods century on Chequamegon fortified gravel.",
     "has_profile": true,
     "profile_url": "/race/hungry-bear-100/",
@@ -8156,6 +8377,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.6,
     "tagline": "Unmarked Cherokee National Forest gravel — just you, your GPS, and Tennessee mountains.",
     "has_profile": true,
     "profile_url": "/race/reliance-deep-woods/",
@@ -8193,6 +8415,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.7,
     "tagline": "Appalachian foothills gravel in remote southeast Tennessee.",
     "has_profile": true,
     "profile_url": "/race/reliance-tennessee-gravel/",
@@ -8230,6 +8453,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.7,
     "tagline": "Vermont rolling to mountainous gravel in Morrisville.",
     "has_profile": true,
     "profile_url": "/race/rooted-vermont/",
@@ -8267,6 +8491,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 2.6,
     "tagline": "Kenya's UCI Gravel World Series race — Hell's Gate at 6,200 feet with zebra for company.",
     "has_profile": true,
     "profile_url": "/race/safari-gravel-race/",
@@ -8304,6 +8529,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.2,
     "tagline": "Seventy-six miles at seven thousand feet — Salida's community gravel banquet.",
     "has_profile": true,
     "profile_url": "/race/salida-76/",
@@ -8342,6 +8568,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.6,
     "tagline": "The borderlands hundred — Patagonia, Arizona's sold-out-in-minutes desert classic.",
     "has_profile": true,
     "profile_url": "/race/spirit-world-100/",
@@ -8380,6 +8607,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.5,
     "tagline": "Asia's only UCI Gravel World Series stop — jungle gravel from a Khmer Empire outpost.",
     "has_profile": true,
     "profile_url": "/race/uci-gravel-dustman/",
@@ -8418,6 +8646,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "Private-ranch gravel through the Book Cliffs — roads closed to the public every other day of the year.",
     "has_profile": true,
     "profile_url": "/race/wild-horse-gravel/",
@@ -8455,6 +8684,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.7,
     "tagline": "France's UCI Gravel World Series round — the Grands Causses above the Millau Viaduct.",
     "has_profile": true,
     "profile_url": "/race/wish-one-millau/",
@@ -8493,6 +8723,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.6,
     "tagline": "Portugal's UCI Gravel World Series race through the cork-oak plains of Alentejo.",
     "has_profile": true,
     "profile_url": "/race/alentejo-gravel/",
@@ -8530,6 +8761,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 3.3,
     "tagline": "Arizona mountain gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/bear-howard-gravel/",
@@ -8566,6 +8798,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 3.5,
     "tagline": "Beartooth Pass gateway gravel with immense Montana landscapes around Red Lodge.",
     "has_profile": true,
     "profile_url": "/race/big-sky-gravel/",
@@ -8604,6 +8837,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.7,
     "tagline": "Sheridan's Bighorn-foothills hundo — Wyoming ranch gravel, four honest distances.",
     "has_profile": true,
     "profile_url": "/race/dead-swede-gravel/",
@@ -8642,6 +8876,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Luxembourg's UCI World Series race — a castle ramp, three forest laps, real climbing.",
     "has_profile": true,
     "profile_url": "/race/eislek-gravel/",
@@ -8679,6 +8914,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Leuven's UCI World Series race on the 2024 Worlds course — first qualifier for 2027.",
     "has_profile": true,
     "profile_url": "/race/flanders-legacy-gravel/",
@@ -8717,6 +8953,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.2,
     "tagline": "Sweden's UCI World Series Saturday — farmland, forest doubletrack, and Nordic grit outside Halmstad.",
     "has_profile": true,
     "profile_url": "/race/gravel-grit-n-grind/",
@@ -8755,6 +8992,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "Rolling New Jersey hills gravel in Hunterdon County.",
     "has_profile": true,
     "profile_url": "/race/hell-of-hunterdon/",
@@ -8792,6 +9030,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.6,
     "tagline": "Houffalize's UCI World Series lap race — Saint Roch every lap, Ardennes all day.",
     "has_profile": true,
     "profile_url": "/race/houffa-gravel/",
@@ -8829,6 +9068,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "German Lake Constance rolling gravel.",
     "has_profile": true,
     "profile_url": "/race/king-of-the-lake/",
@@ -8866,6 +9106,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.8,
     "tagline": "Vineyard passages and Vercors cliff views through the Drôme and Bez valleys of France.",
     "has_profile": true,
     "profile_url": "/race/la-dromoise-gravel/",
@@ -8902,6 +9143,7 @@
       "value": 2,
       "expenses": 2
     },
+    "difficulty_composite": 3.0,
     "tagline": "Welsh mountain gravel in Cambrian Mountains.",
     "has_profile": true,
     "profile_url": "/race/lauf-gritfest/",
@@ -8940,6 +9182,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "120-mile Kansas farmland/prairie gravel in Marysville.",
     "has_profile": true,
     "profile_url": "/race/pony-express-120/",
@@ -8977,6 +9220,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "Alabama dirt roads from a new home in Opelika.",
     "has_profile": true,
     "profile_url": "/race/standard-deluxe-dirt-road-century/",
@@ -9014,6 +9258,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.4,
     "tagline": "Multi-day Texas gravel summer challenge in Warda.",
     "has_profile": true,
     "profile_url": "/race/texas-hell-week/",
@@ -9049,6 +9294,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.6,
     "tagline": "Italian Veneto hilly gravel in Asolo.",
     "has_profile": true,
     "profile_url": "/race/veneto-gravel/",
@@ -9085,6 +9331,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Portuguese rolling gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/114-gravel-race/",
@@ -9123,6 +9370,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.2,
     "tagline": "Rural Ontario gravel through farmland and forest roads.",
     "has_profile": true,
     "profile_url": "/race/back-forty-highlander/",
@@ -9160,6 +9408,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Creek crossings and red-clay gravel along the Georgia-Alabama border.",
     "has_profile": true,
     "profile_url": "/race/border-wars/",
@@ -9198,6 +9447,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.6,
     "tagline": "Wisconsin northwoods gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/burgr-95/",
@@ -9234,6 +9484,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.3,
     "tagline": "Cowichan Valley wine country gravel on Vancouver Island.",
     "has_profile": true,
     "profile_url": "/race/burnt-bridge-classic/",
@@ -9272,6 +9523,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Spanish Castellon gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/castellon-gravel-race/",
@@ -9309,6 +9561,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "Central Arizona high desert gravel in Chino Valley.",
     "has_profile": true,
     "profile_url": "/race/chino-grinder/",
@@ -9347,6 +9600,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Rolling Georgia gravel near Atlanta in Chattahoochee Hills.",
     "has_profile": true,
     "profile_url": "/race/dirty-sheets-gravel-grind/",
@@ -9385,6 +9639,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Rocky bridges and rolling farm gravel through upstate New York countryside.",
     "has_profile": true,
     "profile_url": "/race/farmers-daughter/",
@@ -9423,6 +9678,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Nebraska rolling farmland gravel in Lincoln.",
     "has_profile": true,
     "profile_url": "/race/garmin-gravel-worlds/",
@@ -9461,6 +9717,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Belgian Flanders rolling gravel.",
     "has_profile": true,
     "profile_url": "/race/gravel-des-flandres/",
@@ -9498,6 +9755,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Louisiana rolling hills gravel in St. Francisville.",
     "has_profile": true,
     "profile_url": "/race/gravel-fondo-louisiana/",
@@ -9535,6 +9793,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Dutch flat gravel in Roden, Drenthe.",
     "has_profile": true,
     "profile_url": "/race/gravel-one-fifty/",
@@ -9573,6 +9832,7 @@
       "value": 3,
       "expenses": 1
     },
+    "difficulty_composite": 2.3,
     "tagline": "Victorian rolling gravel in Australia.",
     "has_profile": true,
     "profile_url": "/race/gravelista/",
@@ -9611,6 +9871,7 @@
       "value": 2,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "German rolling gravel in Singen.",
     "has_profile": true,
     "profile_url": "/race/hegau-gravel-race/",
@@ -9647,6 +9908,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.9,
     "tagline": "KowTown Gravel. 60 miles of gravel through Kremmling.",
     "has_profile": true,
     "profile_url": "/race/kowtown-gravel/",
@@ -9684,6 +9946,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.5,
     "tagline": "Upper Peninsula Michigan wilderness gravel in Iron Mountain.",
     "has_profile": true,
     "profile_url": "/race/lone-wolf-gravel/",
@@ -9721,6 +9984,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.9,
     "tagline": "Montana Gravel Challenge. 65 miles of gravel through Huson.",
     "has_profile": true,
     "profile_url": "/race/montana-gravel-challenge/",
@@ -9759,6 +10023,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Rolling Alabama gravel in east Alabama's Opelika.",
     "has_profile": true,
     "profile_url": "/race/opelika-okey-dokey/",
@@ -9797,6 +10062,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Texas Hill Country gravel in Fredericksburg.",
     "has_profile": true,
     "profile_url": "/race/purgatory-road-race/",
@@ -9835,6 +10101,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.0,
     "tagline": "Italian flat to rolling gravel near Venice.",
     "has_profile": true,
     "profile_url": "/race/serenissima-gravel/",
@@ -9871,6 +10138,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Kansas Flint Hills gravel in Leonardville.",
     "has_profile": true,
     "profile_url": "/race/switchgrass/",
@@ -9907,6 +10175,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "Washington Cascades gravel adventure.",
     "has_profile": true,
     "profile_url": "/race/the-grit-adventure/",
@@ -9944,6 +10213,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.7,
     "tagline": "Virginia state championship gravel race.",
     "has_profile": true,
     "profile_url": "/race/unravel-gravel-va/",
@@ -9979,6 +10249,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "NSW valley gravel festival in historic Wollombi.",
     "has_profile": true,
     "profile_url": "/race/wollombi-gravel-fest/",
@@ -10016,6 +10287,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Czech rolling to hilly gravel.",
     "has_profile": true,
     "profile_url": "/race/bohemian-border-bash/",
@@ -10053,6 +10325,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.9,
     "tagline": "Canadian mountain gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/canmore-crux/",
@@ -10091,6 +10364,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Rolling Illinois farmland gravel in rural Roubaix.",
     "has_profile": true,
     "profile_url": "/race/cirrem/",
@@ -10127,6 +10401,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.9,
     "tagline": "Women-only Montana gravel in grizzly country — bear spray required near Ovando.",
     "has_profile": true,
     "profile_url": "/race/dusty-bandita/",
@@ -10163,6 +10438,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.3,
     "tagline": "Self-supported gravel through unmarked Wisconsin forest roads near Ringle.",
     "has_profile": true,
     "profile_url": "/race/essential-gravel/",
@@ -10201,6 +10477,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.5,
     "tagline": "Alberta prairie gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/ghost-of-the-gravel/",
@@ -10238,6 +10515,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "French rolling gravel in Châtellerault.",
     "has_profile": true,
     "profile_url": "/race/gravel-fever/",
@@ -10274,6 +10552,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Rolling Tennessee gravel in rural Hickman County.",
     "has_profile": true,
     "profile_url": "/race/gravel-revival/",
@@ -10312,6 +10591,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Rolling Georgia gravel in central Georgia's Hawkinsville.",
     "has_profile": true,
     "profile_url": "/race/gravel-roll-pecan-shaker/",
@@ -10347,6 +10627,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.0,
     "tagline": "Grand Marais, Minnesota 44-mile rolling gravel.",
     "has_profile": true,
     "profile_url": "/race/gun-flint-44/",
@@ -10384,6 +10665,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Belgian heathland gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/heathland-gravel/",
@@ -10422,6 +10704,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Coastal plain gravel in southeast North Carolina's Holly Shelter Game Land.",
     "has_profile": true,
     "profile_url": "/race/holly-shelter-gravel-grinder/",
@@ -10459,6 +10742,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Rolling Georgia gravel in rural west Georgia.",
     "has_profile": true,
     "profile_url": "/race/homegrown-gravel-adventure/",
@@ -10497,6 +10781,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.3,
     "tagline": "70 miles of kettle moraine lake-country gravel through Oconomowoc, Wisconsin.",
     "has_profile": true,
     "profile_url": "/race/lake-country-gravel/",
@@ -10534,6 +10819,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.6,
     "tagline": "Short, steep, and intense gravel through Limburg hills and Château Marly, Netherlands.",
     "has_profile": true,
     "profile_url": "/race/marly-grav/",
@@ -10572,6 +10858,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.0,
     "tagline": "Wisconsin 40-mile rolling gravel.",
     "has_profile": true,
     "profile_url": "/race/pickerel-buck40/",
@@ -10607,6 +10894,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Polish rolling gravel in Kraków.",
     "has_profile": true,
     "profile_url": "/race/polish-gravel/",
@@ -10644,6 +10932,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.7,
     "tagline": "Formula 1 arena start, then gravel circuits around the Nürburgring's Green Hell.",
     "has_profile": true,
     "profile_url": "/race/rad-am-ring-gravel/",
@@ -10680,6 +10969,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.5,
     "tagline": "Remote Upper Peninsula Michigan wilderness gravel.",
     "has_profile": true,
     "profile_url": "/race/the-crusher/",
@@ -10717,6 +11007,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.7,
     "tagline": "UK Peak District gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/tor-divide/",
@@ -10754,6 +11045,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Mississippi rolling hills gravel in Fulton.",
     "has_profile": true,
     "profile_url": "/race/tour-de-gap/",
@@ -10791,6 +11083,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Belgian Turnhout gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/turnhout-gravel/",
@@ -10829,6 +11122,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Mormon Trail history and cattle encounters on Monroe County's pastoral Iowa gravel.",
     "has_profile": true,
     "profile_url": "/race/albia-holy-cow/",
@@ -10867,6 +11161,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.5,
     "tagline": "Northern Wisconsin Northwoods gravel century.",
     "has_profile": true,
     "profile_url": "/race/bear-100/",
@@ -10905,6 +11200,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.2,
     "tagline": "Central Michigan farmland gravel in Ionia.",
     "has_profile": true,
     "profile_url": "/race/cow-pie-classic/",
@@ -10941,6 +11237,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 1.7,
     "tagline": "Red clay tunnels and pecan orchards through Florida's panhandle backcountry.",
     "has_profile": true,
     "profile_url": "/race/dirty-pecan/",
@@ -10979,6 +11276,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.0,
     "tagline": "Harvest-season B-road gravel through Jefferson County — more backroads than most Iowa rides.",
     "has_profile": true,
     "profile_url": "/race/fairfield-harvest-rush/",
@@ -11017,6 +11315,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Iowa's original gravel series race, 30 minutes from Omaha through rolling western Iowa farmland.",
     "has_profile": true,
     "profile_url": "/race/glenwood-gravel/",
@@ -11055,6 +11354,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.8,
     "tagline": "Creek crossings and national park granite country near Tenterfield, Australia.",
     "has_profile": true,
     "profile_url": "/race/gravel-and-granite/",
@@ -11092,6 +11392,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.7,
     "tagline": "Washington mountain gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/gravel-unravel-bon-jon-pass-out/",
@@ -11128,6 +11429,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Southeast Minnesota gravel in Cannon Falls near Twin Cities.",
     "has_profile": true,
     "profile_url": "/race/gray-duck-grit/",
@@ -11164,6 +11466,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.0,
     "tagline": "Hart Hills. 55 miles of gravel through Hart.",
     "has_profile": true,
     "profile_url": "/race/hart-hills/",
@@ -11200,6 +11503,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "West Michigan gravel in Lowell near Grand Rapids.",
     "has_profile": true,
     "profile_url": "/race/lowell-classic/",
@@ -11237,6 +11541,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.8,
     "tagline": "Ancient rock formations and gold-country backroads through Mudgee, New South Wales.",
     "has_profile": true,
     "profile_url": "/race/marys-mayhem/",
@@ -11275,6 +11580,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.2,
     "tagline": "Southwest Michigan spring thaw gravel in Vandalia.",
     "has_profile": true,
     "profile_url": "/race/melting-mann/",
@@ -11312,6 +11618,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.3,
     "tagline": "Eastern Oregon high desert gravel in Pendleton wheat country.",
     "has_profile": true,
     "profile_url": "/race/real-west-gravel/",
@@ -11350,6 +11657,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Trail variety and rolling countryside gravel through Dakota County, Minnesota.",
     "has_profile": true,
     "profile_url": "/race/ride-the-gravel-trails/",
@@ -11387,6 +11695,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.8,
     "tagline": "100 miles of self-supported gravel through Minnesota's Bluff Country.",
     "has_profile": true,
     "profile_url": "/race/spring-valley-100/",
@@ -11424,6 +11733,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "Queensland hinterland gravel through dairy country.",
     "has_profile": true,
     "profile_url": "/race/sunday-creek-classic/",
@@ -11462,6 +11772,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "South Carolina coastal forest gravel in Francis Marion NF.",
     "has_profile": true,
     "profile_url": "/race/swamp-fox-gravel-fondo/",
@@ -11500,6 +11811,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "Wyoming mountain gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/the-mane-event-gravel/",
@@ -11538,6 +11850,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Southeast Michigan gravel in Dexter near Ann Arbor.",
     "has_profile": true,
     "profile_url": "/race/the-watermoo/",
@@ -11576,6 +11889,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.2,
     "tagline": "Northern Wisconsin Northwoods gravel in Tomahawk.",
     "has_profile": true,
     "profile_url": "/race/total-tomahawk-terrain/",
@@ -11612,6 +11926,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 3.0,
     "tagline": "100 miles through Iowa's Driftless region with 5,000 feet of climbing and river valley gravel.",
     "has_profile": true,
     "profile_url": "/race/waukon-100/",
@@ -11650,6 +11965,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "West Michigan gravel in Cedar Springs near Grand Rapids.",
     "has_profile": true,
     "profile_url": "/race/cedar-blitz/",
@@ -11687,6 +12003,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Private terrain, Bald Mountain singletrack, and Lake Orion views through Oakland County.",
     "has_profile": true,
     "profile_url": "/race/de-ronde-van-grampian/",
@@ -11723,6 +12040,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Shaded canopy, Lacey Lake views, and fast Michigan farmland gravel near Charlotte.",
     "has_profile": true,
     "profile_url": "/race/fast-fitty/",
@@ -11761,6 +12079,7 @@
       "value": 4,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "New Mexico desert gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/galactic-grinder/",
@@ -11798,6 +12117,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.6,
     "tagline": "Red-rock canyons and Wet Mountain Range views on Pueblo, Colorado gravel.",
     "has_profile": true,
     "profile_url": "/race/grassroots-gravel/",
@@ -11836,6 +12156,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.4,
     "tagline": "Gravel Rocks. 55 miles of gravel through North York Moors.",
     "has_profile": true,
     "profile_url": "/race/gravel-rocks/",
@@ -11874,6 +12195,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.7,
     "tagline": "Jurassic rainforest and tall tree ferns near Great Ocean Road in Victoria, Australia.",
     "has_profile": true,
     "profile_url": "/race/great-otway-gravel-grind/",
@@ -11912,6 +12234,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.2,
     "tagline": "Northern Wisconsin cooler-season Northwoods gravel.",
     "has_profile": true,
     "profile_url": "/race/hibernator/",
@@ -11949,6 +12272,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Iowa state championship gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/iowa-state-gravel-tt-championship/",
@@ -11984,6 +12308,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.4,
     "tagline": "Reservoir loops and forest climbing through Clocaenog Forest in North Wales.",
     "has_profile": true,
     "profile_url": "/race/north-wales-gravel-x/",
@@ -12022,6 +12347,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "Prairie Burn 100. 100 miles of gravel through Grinnell.",
     "has_profile": true,
     "profile_url": "/race/prairie-burn-100/",
@@ -12060,6 +12386,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Early-season Michigan gravel when the roads are still thawing near Muskegon.",
     "has_profile": true,
     "profile_url": "/race/spring-thaw/",
@@ -12097,6 +12424,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.4,
     "tagline": "Oregon mountain gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/takelma-gravel-grinder/",
@@ -12135,6 +12463,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.4,
     "tagline": "Oregon coast gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/west-coast-gravel/",
@@ -12172,6 +12501,7 @@
       "value": 4,
       "expenses": 2
     },
+    "difficulty_composite": 2.0,
     "tagline": "Nevada desert gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/beaver-dam-gravel-grinder/",
@@ -12210,6 +12540,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "State forest singletrack and technical gravel through Michaux near Gardners, Pennsylvania.",
     "has_profile": true,
     "profile_url": "/race/camp-michaux-gravel-grinder/",
@@ -12246,6 +12577,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.4,
     "tagline": "Bushranger-country gravel with a tidal river crossing near Nelligen, Australia.",
     "has_profile": true,
     "profile_url": "/race/clarkes-gambit/",
@@ -12284,6 +12616,7 @@
       "value": 4,
       "expenses": 2
     },
+    "difficulty_composite": 2.3,
     "tagline": "Oregon Trail backcountry and open prairie gravel through remote western Wyoming.",
     "has_profile": true,
     "profile_url": "/race/cowboy-crusher/",
@@ -12320,6 +12653,7 @@
       "value": 4,
       "expenses": 2
     },
+    "difficulty_composite": 2.0,
     "tagline": "Ashley National Forest gravel climbing to 10,100 feet in Utah's dinosaur country.",
     "has_profile": true,
     "profile_url": "/race/dirty-dino/",
@@ -12356,6 +12690,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.4,
     "tagline": "Canadian coastal gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/forbidden-gravel/",
@@ -12394,6 +12729,7 @@
       "value": 4,
       "expenses": 4
     },
+    "difficulty_composite": 2.2,
     "tagline": "Remote Wisconsin hardwood forest gravel in tiny Nelma.",
     "has_profile": true,
     "profile_url": "/race/hardwood-hustle/",
@@ -12430,6 +12766,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Heywood Ride. 50 miles of gravel through Northfield.",
     "has_profile": true,
     "profile_url": "/race/heywood-ride/",
@@ -12467,6 +12804,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.4,
     "tagline": "UK Lake District gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/just-gravel/",
@@ -12504,6 +12842,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.1,
     "tagline": "Colorado plains gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/mad-gravel/",
@@ -12541,6 +12880,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "New Hampshire local gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/raid-rockingham/",
@@ -12579,6 +12919,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.0,
     "tagline": "Moondust and volcanic terrain through the Silver Island Mountains near Wendover, Utah.",
     "has_profile": true,
     "profile_url": "/race/salty-lizard/",
@@ -12617,6 +12958,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 2.5,
     "tagline": "Century ride featuring the Wabash Trace Trail through Silver City, Iowa.",
     "has_profile": true,
     "profile_url": "/race/silver-city-century/",
@@ -12655,6 +12997,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Loess Hills gravel along the Soldier River Cutoff in western Iowa.",
     "has_profile": true,
     "profile_url": "/race/soldier-cutoff-hillduro/",
@@ -12693,6 +13036,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 2.2,
     "tagline": "Three distances and family festival vibes through Trough Creek State Park gravel.",
     "has_profile": true,
     "profile_url": "/race/trough-creek-gravel-grinder/",
@@ -12731,6 +13075,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Uncle John's Gravel Race. 50 miles of gravel through St Johns.",
     "has_profile": true,
     "profile_url": "/race/uncle-johns-gravel-race/",
@@ -12769,6 +13114,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.2,
     "tagline": "Dalby Grit. 50 miles of gravel through Dalby Forest.",
     "has_profile": true,
     "profile_url": "/race/dalby-grit/",
@@ -12806,6 +13152,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Rolling gravel through Highland Games country in Maxville, Ontario.",
     "has_profile": true,
     "profile_url": "/race/glengarry-games-gravel-run/",
@@ -12843,6 +13190,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Washington coastal gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/gravel-unravel-why-not-chee/",
@@ -12879,6 +13227,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Kalona Horseshoe. 50 miles of gravel through Kalona.",
     "has_profile": true,
     "profile_url": "/race/kalona-horseshoe/",
@@ -12917,6 +13266,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Gates, switchbacks, and quiet farm country gravel in central Pennsylvania.",
     "has_profile": true,
     "profile_url": "/race/mid-state-gravel-grinder/",
@@ -12955,6 +13305,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 1.9,
     "tagline": "Muck n Mac Fest. 55 miles of gravel through Traquair House.",
     "has_profile": true,
     "profile_url": "/race/muck-n-mac-fest/",
@@ -12993,6 +13344,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Waist-deep river ford and dispersed forest camping in Wisconsin's Nicolet National Forest.",
     "has_profile": true,
     "profile_url": "/race/nicolet-hot-days/",
@@ -13029,6 +13381,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Old Fashioned Gravel. 55 miles of gravel through Hokah.",
     "has_profile": true,
     "profile_url": "/race/old-fashioned-gravel/",
@@ -13067,6 +13420,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Logging roads and K&P Rail Trail through Ontario's rural backcountry near Calabogie.",
     "has_profile": true,
     "profile_url": "/race/ottawa-valley-gravel-experience/",
@@ -13105,6 +13459,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "State park forest roads through rural Clearfield County, Pennsylvania.",
     "has_profile": true,
     "profile_url": "/race/parker-dam-gravel-grinder/",
@@ -13141,6 +13496,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Manistee National Forest gravel and two-track through northern Michigan.",
     "has_profile": true,
     "profile_url": "/race/the-divide/",
@@ -13178,6 +13534,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Snowmobile trails and logging roads through northern Wisconsin's state forest near Sayner.",
     "has_profile": true,
     "profile_url": "/race/the-insayner/",
@@ -13214,6 +13571,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Two-track and singletrack near Lake Huron's Thunder Bay in northern Michigan.",
     "has_profile": true,
     "profile_url": "/race/thunder-bay-thriller/",
@@ -13252,6 +13610,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 2.2,
     "tagline": "Australian remote gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/wild-gravel/",
@@ -13289,6 +13648,7 @@
       "value": 4,
       "expenses": 3
     },
+    "difficulty_composite": 1.6,
     "tagline": "Clear streams and mountain ridges through central Pennsylvania's Bald Eagle Valley.",
     "has_profile": true,
     "profile_url": "/race/bald-eagle-gravel-grinder/",
@@ -13326,6 +13686,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 1.9,
     "tagline": "Dunoon Dirt Dash. 45 miles of gravel through Dunoon.",
     "has_profile": true,
     "profile_url": "/race/dunoon-dirt-dash/",
@@ -13364,6 +13725,7 @@
       "value": 4,
       "expenses": 2
     },
+    "difficulty_composite": 1.9,
     "tagline": "Belgian local gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/dusty-gravel-lacs-de-leau-dheure/",
@@ -13400,6 +13762,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 1.9,
     "tagline": "Belgian Ardennes singletrack and Mosane valley terrain near Andenne.",
     "has_profile": true,
     "profile_url": "/race/dusty-gravel-series-andenne/",
@@ -13437,6 +13800,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 1.9,
     "tagline": "Technical bridleways and forest trails through Devon's Haldon Forest, UK.",
     "has_profile": true,
     "profile_url": "/race/haldon-heroic/",
@@ -13474,6 +13838,7 @@
       "value": 4,
       "expenses": 2
     },
+    "difficulty_composite": 1.9,
     "tagline": "Vancouver Island coastal forest gravel and mountain terrain near Nanaimo, BC.",
     "has_profile": true,
     "profile_url": "/race/nanaimo-unpaved/",
@@ -13511,6 +13876,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 1.9,
     "tagline": "Holly Springs National Forest gravel through rolling Mississippi hill country.",
     "has_profile": true,
     "profile_url": "/race/omg-oxford-ms-gravel/",
@@ -13548,6 +13914,7 @@
       "value": 3,
       "expenses": 2
     },
+    "difficulty_composite": 1.9,
     "tagline": "UK Yorkshire coast gravel challenge.",
     "has_profile": true,
     "profile_url": "/race/yorkshire-coast-dirt-dash/",
@@ -13586,6 +13953,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 1.6,
     "tagline": "Southern Georgia backroad gravel through the Rose City of Thomasville.",
     "has_profile": true,
     "profile_url": "/race/rose-city-rampage/",
@@ -13622,6 +13990,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 1.6,
     "tagline": "Faulkner-country delta gravel and spring floods through Memphis, Tennessee backroads.",
     "has_profile": true,
     "profile_url": "/race/rust-buster-gravel-fondo/",
@@ -13659,6 +14028,7 @@
       "value": 3,
       "expenses": 3
     },
+    "difficulty_composite": 1.4,
     "tagline": "Longleaf pine ecosystem gravel through Blackwater and Conecuh National Forests.",
     "has_profile": true,
     "profile_url": "/race/scratch-ankle-gravel/",


### PR DESCRIPTION
The quiz asks **"How hard do you want it?"** and weights the answer at **20 points** — more than terrain (12) or region (10). It scored that off `difficulty_composite`, a field **nothing in the repo has ever produced**. Every race sat at the JS default of 2.5, and the bands collapse from there:

| answer | points awarded |
|---|---|
| moderate | +20 to **every** race |
| easy | +10 to **every** race |
| hard | **0 to every race** |
| brutal | **0 to every race** |

The two hardest answers were silently discarded. A rider could say they live for Type 2 fun and it changed nothing about their results.

## The composite

`scripts/generate_index.py` now derives it from the **physical criteria only** — prestige, value and logistics say nothing about how much a race hurts:

```
length .30   elevation .30   technicality .20   climate .10   altitude .10
```

Weights sum to 1.0 so the output stays on the same 1–5 scale as its inputs.

**All five must be present.** Renormalising over whichever happen to be scored would let a race with only length and elevation reach 5.0 and take full "brutal" credit on three unknown dimensions — a confident number built on missing data. Partial profiles return `None` and the quiz keeps its own neutral default. Every profiled race currently carries all five, so **no value changes today**; this only stops a partial profile from lying later.

## Result

370/370 populated, range 1.4–5.0, mean 2.93, 33 distinct values.

- **Hardest:** Colorado Trail Race 5.0, Badlands 5.0, Leadville 100 4.7, Torino Nice Rally 4.7
- **Easiest:** Scratch Ankle Gravel 1.4, Rust Buster Gravel Fondo 1.6

The answers now discriminate — `brutal` gives full marks to 34 races and zero to 290, where before it gave zero to all 370.

## Tests

14 tests covering the formula, the missing-data behaviour, and the full path from profile → `build_index_entry_from_profile()` → emitted `RACES` array. Adversarially verified as load-bearing: reverting the generator change breaks both the builder and the profile→page assertions.

`tests/`: **6960 passed, 327 skipped, 0 failed.**

Reviewed by GPT-5.6-sol — **GO, no findings**, after an earlier NO-GO that correctly caught the renormalisation flaw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)