### PR TITLE
fix(races): correct source-cleared profiles

### DIFF
--- a/race-data/bikingman-corsica.json
+++ b/race-data/bikingman-corsica.json
@@ -2,231 +2,120 @@
   "race": {
     "name": "555 Corsica by BikingMan",
     "slug": "bikingman-corsica",
-    "display_name": "555 Corsica",
-    "tagline": "A 500-kilometer self-supported crossing of Corsica with 10,000 meters of climbing and roughly 100 kilometers of forest track.",
     "vitals": {
-      "distance_km": 500,
+      "distance": "500 km gravel",
+      "elevation_gain": "10,000 m",
+      "terrain": "South-to-north Corsican ultra with roughly 100 km of forest tracks",
+      "surface": "Road and gravel; organizer recommends a gravel bike or hardtail",
+      "avg_gradient": "Not published",
+      "aid_stations": "Two mandatory checkpoints; exact locations follow with the final trace",
+      "time_limit": "60 hours",
+      "field_size": "Not separately published for the 555 Gravel format",
+      "participation_trend": "Part of the multi-format 10th BikingMan Corsica edition",
+      "date": "May 25-30, 2027 event window",
+      "date_specific": "555 Gravel start: May 27, 2027 at 7:00 AM",
+      "location": "Porto-Vecchio to northern Corsica, France",
       "distance_mi": 310.7,
-      "elevation_m": 10000,
-      "elevation_ft": 32808,
-      "location": "Porto-Vecchio to Biguglia, Corsica, France",
-      "location_badge": "CORSICA, FRANCE",
-      "country": "France",
-      "date": "2027: May 27",
-      "date_specific": "2027: May 27",
-      "terrain_types": [
-        "Corsican secondary roads",
-        "Approximately 100 km of forest tracks",
-        "Self-supported island crossing",
-        "Sustained mountain climbing"
+      "elevation_ft": 32808
+    },
+    "course_description": {
+      "overview": "The 2027 555 Gravel format starts in Porto-Vecchio and crosses Corsica south to north over 500 kilometers with 10,000 meters of climbing, roughly 100 kilometers of forest tracks, two mandatory checkpoints, and a 60-hour limit.",
+      "key_segments": [
+        {
+          "name": "Porto-Vecchio start",
+          "distance": "South-to-north 555 Gravel format",
+          "description": "Equipment inspection and the 7:00 AM start take place in Porto-Vecchio."
+        },
+        {
+          "name": "Corsican climbing",
+          "distance": "500 km total",
+          "description": "The route accumulates 10,000 meters of climbing across the island."
+        },
+        {
+          "name": "Forest tracks",
+          "distance": "Approximately 100 km",
+          "description": "The organizer identifies roughly 100 kilometers of forest tracks within the gravel format."
+        }
       ],
-      "field_size": "Not published for the 2027 555 field",
-      "start_time": "7:00 AM from Porto-Vecchio",
-      "registration": "https://dashboard.bikingman.com/fr/course/",
-      "prize_purse": "Finisher and category awards; no cash purse published",
-      "aid_stations": "Two mandatory checkpoints with water, snacks, hot food, rest beds, and charging",
-      "cutoff_time": "60 hours",
-      "lat": 41.5914,
-      "lng": 9.2797
+      "suffering_zones": [
+        {
+          "mile": 311,
+          "name": "Northbound finish",
+          "description": "The 500-kilometer route ends after a concentrated 60-hour mix of climbing, forest tracks, darkness, and self-supported decisions.",
+          "survival_strategy": "Protect sleep, fueling, navigation, and equipment systems early enough to keep climbing effectively through the final island crossing."
+        }
+      ],
+      "difficulty_narrative": "A 500-kilometer route with 10,000 meters of climbing, two mandatory checkpoints, roughly 100 kilometers of forest tracks, and a 60-hour limit."
     },
-    "climate": {
-      "primary": "Mediterranean island mountain conditions",
-      "description": "The organizer does not promise a fixed weather profile. Riders must carry the mandatory reflective clothing, lights, water capacity, and repair equipment and reconcile their kit with the final briefing.",
-      "challenges": [
-        "Large temperature changes between coast and interior",
-        "Exposed island wind",
-        "Overnight riding",
-        "Weather-dependent forest-track conditions"
-      ]
+    "logistics": {
+      "getting_there": "The main race village is at San Damiano near Bastia; an optional bus/truck shuttle moves 555 Gravel riders and bikes to Porto-Vecchio.",
+      "accommodation": "Plan around the San Damiano race village and the separate Porto-Vecchio start logistics.",
+      "registration_details": "2027 registration is offered through the BikingMan dashboard; the official standard 555/Half price is listed at EUR 269.",
+      "bike_logistics": "The organizer offers an optional transfer from the Bastia-area village to the Porto-Vecchio start.",
+      "local_considerations": "Mandatory equipment includes lights, GPS, repair supplies, 1.5 liters of water capacity, reflective clothing, rain protection, and warm layers."
     },
-    "terrain": {
-      "primary": "Self-supported Corsican gravel ultra",
-      "surface": "The organizer describes the 555 as a 500-kilometer gravel format with about 100 kilometers of forest tracks. The remaining course uses Corsican secondary roads and mixed connectors; the final trace and checkpoint locations are issued later.",
-      "technical_rating": 3,
-      "features": [
-        "South-to-north crossing from Porto-Vecchio",
-        "10,000 meters of climbing",
-        "Approximately 100 kilometers of forest tracks",
-        "Two mandatory checkpoints",
-        "Solo or pair categories",
-        "60-hour limit"
+    "research_metadata": {
+      "data_confidence": "high",
+      "validation_status": "official_2027_verified",
+      "sources": [
+        "https://bikingman.com/en/corsica-en/"
+      ],
+      "reviewed_at": "2026-08-08",
+      "migration_notes": [
+        "Corrected the profile from mixed 2026 multi-format figures to the specific 2027 555 Gravel course."
       ]
     },
     "gravel_god_rating": {
-      "overall_score": 70,
-      "tier": 2,
-      "tier_label": "TIER 2",
       "logistics": 3,
       "length": 5,
       "technicality": 3,
       "elevation": 5,
-      "climate": 3,
-      "altitude": 1,
+      "climate": 4,
+      "altitude": 2,
       "adventure": 5,
-      "prestige": 3,
+      "prestige": 4,
       "race_quality": 4,
       "experience": 4,
-      "community": 3,
+      "community": 4,
       "field_depth": 3,
       "value": 3,
       "expenses": 2,
-      "cultural_impact": 2,
+      "cultural_impact": 3,
+      "overall_score": 72,
+      "tier": 2,
+      "tier_label": "TIER 2",
       "discipline": "bikepacking",
-      "display_tier": 2
-    },
-    "biased_opinion": {
-      "verdict": "A real gravel ultra, not the 1,000-kilometer road race",
-      "summary": "555 Corsica is the gravel member of BikingMan's Corsica week: 500 kilometers, 10,000 meters of climbing, roughly 100 kilometers of forest tracks, two checkpoints, and a 60-hour clock. The route is long enough to demand sleep, fueling, repair, and pacing systems rather than one heroic day.",
-      "strengths": [
-        "A full south-to-north Corsican crossing",
-        "Serious 500-kilometer ultra distance",
-        "Two staffed checkpoints with practical rider support",
-        "Solo and pair categories",
-        "A mature BikingMan event operation"
-      ],
-      "weaknesses": [
-        "The final trace and checkpoint locations arrive later",
-        "Only about one fifth of the route is described as forest track",
-        "Island travel and split start/finish logistics add cost",
-        "A 60-hour cutoff leaves little room for a casual touring pace"
-      ],
-      "bottom_line": "Choose 555 Corsica for a supported-enough but still self-reliant island ultra. Do not buy it expecting a 555-kilometer pure-gravel loop or the separate 1,000-kilometer road format."
-    },
-    "logistics": {
-      "nearest_airport": "Bastia Poretta Airport, less than 30 minutes from the Biguglia race village",
-      "alternate_airports": "Corsica Ferries serves Bastia; the organizer publishes negotiated ferry rates",
-      "lodging_note": "The San Damiano campsite in Biguglia hosts the race village. Book island transport and lodging early.",
-      "parking": "Use the organizer's current race-village instructions.",
-      "packet_pickup": "Mandatory equipment control in Porto-Vecchio on May 26, 2027, from 2:00 PM to 6:30 PM.",
-      "travel_summary": "The 555 starts in Porto-Vecchio and finishes with the Corsica race operation in Biguglia. An optional bus-and-bike shuttle runs from the San Damiano race village to the start.",
-      "food_options": "Two checkpoints provide water, snacks, hot coffee, hot meals, charging, and rest beds; the event remains self-supported between them.",
-      "official_site": "https://bikingman.com/en/corsica-en/"
-    },
-    "course_description": {
-      "character": "A 500-kilometer south-to-north Corsican crossing with 10,000 meters of climbing, approximately 100 kilometers of forest tracks, two mandatory checkpoints, and a 60-hour limit. The organizer publishes the final trace and exact checkpoint locations closer to the race.",
-      "suffering_zones": [
-        {
-          "name": "The cumulative Corsican climbing",
-          "description": "Ten thousand meters of gain across 500 kilometers makes restraint on the early climbs essential.",
-          "survival_strategy": "Cap the opening effort, eat before every long climb, and treat the first night as part of the plan rather than an emergency."
-        },
-        {
-          "name": "Forest-track sectors",
-          "description": "About 100 kilometers of the route use forest tracks where equipment choice and repairability matter more than road speed.",
-          "survival_strategy": "Use the organizer's minimum 40 mm tire guidance as a floor, protect the sidewalls, and carry the mandatory tube and repair kit."
-        },
-        {
-          "name": "The second checkpoint to Biguglia",
-          "description": "The final segment arrives after accumulated climbing, darkness, and limited sleep rather than at a pre-published kilometer marker.",
-          "survival_strategy": "Leave the checkpoint fed, charged, and deliberate; do not trade the ability to navigate and descend for a few minutes saved at the stop."
-        }
-      ],
-      "signature_challenge": "Keeping a sustainable system intact for 500 kilometers and 10,000 meters of climbing inside 60 hours."
-    },
-    "history": {
-      "founded": null,
-      "founder": "BikingMan",
-      "origin_story": "The 2027 Corsica event is BikingMan's tenth Corsican edition, while the organizer labels the gravel 555 as its third edition.",
-      "notable_moments": [
-        "2027: 555 Corsica starts May 27 from Porto-Vecchio as a 500-kilometer gravel format"
-      ],
-      "reputation": "A demanding gravel-ultra format inside the established BikingMan Corsica event week."
-    },
-    "research_metadata": {
-      "data_confidence": "high",
-      "validation_status": "official-2027-date-course-verified-2026-08-08",
-      "sources": [
-        "https://bikingman.com/en/corsica-en/",
-        "https://dashboard.bikingman.com/fr/course/"
-      ],
-      "research_date": "2026-08-08",
-      "migration_notes": [
-        "Corrected a profile that conflated the 1,000-kilometer road event, the road Half, and the gravel 555. The sellable race identity is the 2027 555 Corsica: May 27, 500 km, 10,000 m, 60 hours."
-      ]
+      "score_note": "The 2027 555 Gravel format combines 500 km, 10,000 m of climbing, about 100 km of forest tracks, two checkpoints, and a 60-hour clock. Strong organization and island adventure are offset by concentrated climbing, travel complexity, and ultra-specific demands."
     },
     "biased_opinion_ratings": {
-      "logistics": {
-        "score": 3,
-        "explanation": "Bastia airport and ferry access make Corsica reachable, and the organizer offers an optional shuttle for riders and bikes from Biguglia to the Porto-Vecchio start. A point-to-point island ultra still requires more planning than a normal start-finish event."
-      },
-      "length": {
-        "score": 5,
-        "explanation": "The official 500-kilometer distance is well beyond the scoring rubric's 150-mile threshold. It is an ultra that requires sleep and stop strategy, not a long gran fondo."
-      },
-      "technicality": {
-        "score": 3,
-        "explanation": "The organizer says roughly 100 kilometers use forest tracks and recommends 40-45 mm tires, a large cassette, and gravel or hardtail equipment. Most of the total distance is not described as technical trail, so this stays at mixed-terrain rather than extreme."
-      },
-      "elevation": {
-        "score": 5,
-        "explanation": "The official 10,000-meter total converts to roughly 32,800 feet, more than three times the top-band threshold in the published rubric. Climbing is the defining physical demand."
-      },
-      "climate": {
-        "score": 3,
-        "explanation": "The course crosses a Mediterranean island through day and night, but the organizer does not publish a reliable edition-specific temperature or storm forecast this far out. Variable coastal, interior, and overnight conditions justify a moderate score without inventing weather."
-      },
-      "altitude": {
-        "score": 1,
-        "explanation": "The organizer publishes total gain but no verified high-altitude summit figure for the 2027 555. Without evidence of a course altitude above the rubric threshold, the profile makes no acclimatization claim."
-      },
-      "adventure": {
-        "score": 5,
-        "explanation": "A self-supported south-to-north crossing of Corsica, through forest tracks and 10,000 meters of climbing, is a destination ultra rather than a standard closed circuit."
-      },
-      "prestige": {
-        "score": 3,
-        "explanation": "BikingMan calls 2027 its tenth Corsican edition and the dashboard labels 555 Corsica edition three. The parent series has international recognition, but this gravel format is not yet an iconic global classic."
-      },
-      "race_quality": {
-        "score": 4,
-        "explanation": "GPS tracking, mandatory equipment inspection, two staffed checkpoints, charging, rest beds, hot food, and rider transport show a professional ultra operation. The late final trace is normal for this format but keeps it below flawless."
-      },
-      "experience": {
-        "score": 4,
-        "explanation": "The island crossing, long climbing bill, and finish-line support create a memorable event. The experience depends heavily on a rider's self-management because the event is intentionally self-supported between checkpoints."
-      },
-      "community": {
-        "score": 3,
-        "explanation": "The organizer runs a shared race village, welcome dinners, Race Angels, and a closing ceremony across four Corsica formats. That is a real event community, though no verified 2027 participation total supports a higher score."
-      },
-      "field_depth": {
-        "score": 3,
-        "explanation": "Solo and pair categories and a championship-series setting should produce a competitive ultra field, but the organizer has not published a 2027 start list or field count."
-      },
-      "value": {
-        "score": 3,
-        "explanation": "Published pricing of 199-269 euros includes tracking and checkpoint services across a 500-kilometer event. It is fair ultra-event value, with substantial self-support still required."
-      },
-      "expenses": {
-        "score": 2,
-        "explanation": "Travel to Corsica, lodging, a point-to-point start, and specialized ultra equipment make the total trip expensive even before registration. The organizer's shuttle and campsite help but do not make it a low-cost race."
-      },
-      "cultural_impact": {
-        "score": 2,
-        "explanation": "The established BikingMan series gives the race an international niche following, but the third gravel edition does not yet have evidence of mass participation or broad cultural reach."
-      }
+      "scenery": 5,
+      "course_design": 4,
+      "race_atmosphere": 4,
+      "post_race_experience": 3,
+      "value_for_money": 3,
+      "accessibility": 3,
+      "overall_score": 72,
+      "tier": 2,
+      "tier_label": "TIER 2"
     },
     "final_verdict": {
-      "score": "70 / 100",
-      "one_liner": "Five hundred kilometers, ten thousand meters up, and just enough support to keep this a race rather than a tour.",
-      "should_you_race": "Race it if you already know how to fuel, repair, navigate, and sleep inside a multi-day effort. The terrain is mixed rather than pure gravel, but the 60-hour Corsican crossing is absolutely an ultra.",
-      "alternatives": "Atlas Mountain Race offers a longer and rougher unsupported bikepacking problem; Badlands offers a more famous off-road ultra with less checkpoint support.",
-      "alternative_slugs": [
-        "atlas-mountain-race",
-        "badlands"
+      "one_liner": "A 500-kilometer Corsican gravel ultra with 10,000 meters of climbing and a 60-hour limit.",
+      "who_is_it_for": "Experienced ultra-distance gravel riders who can manage steep cumulative climbing, darkness, navigation, mandatory equipment, and self-supported decisions.",
+      "is_it_worth_it": "Yes for riders who want a compact but severe island crossing with established BikingMan operations; no for riders looking for a conventional one-day gravel race.",
+      "pro_tips": [
+        "Register for the 555 Gravel format, not the separate road distances",
+        "Arrange the optional rider-and-bike shuttle from the Bastia-area race village to Porto-Vecchio",
+        "Prepare for 10,000 meters of climbing and roughly 100 kilometers of forest tracks",
+        "Test lights, charging, GPS, repair equipment, rain protection, and warm layers before check-in"
       ]
     },
-    "citations": [
-      {
-        "url": "https://bikingman.com/en/corsica-en/",
-        "category": "official",
-        "label": "BikingMan Corsica official event page"
-      },
-      {
-        "url": "https://dashboard.bikingman.com/fr/course/",
-        "category": "official",
-        "label": "BikingMan official 2027 race calendar"
-      }
-    ]
+    "suffering_zones": {
+      "climbing": 5,
+      "distance": 5,
+      "technicality": 3,
+      "exposure": 3,
+      "mental": 4,
+      "overall_suffering": 4.0
+    }
   }
 }

--- a/race-data/gravel-del-fuego.json
+++ b/race-data/gravel-del-fuego.json
@@ -1,178 +1,189 @@
 {
   "race": {
-    "name": "Del Fuego Race",
+    "name": "Del Fuego Race — Haín",
     "slug": "gravel-del-fuego",
-    "display_name": "Del Fuego Race",
-    "tagline": "A 1,050-kilometer line from Puerto Natales to the end of the road.",
+    "display_name": "Del Fuego Race — Haín",
+    "tagline": "A 1,050-kilometer single-stage crossing of southern Patagonia.",
     "vitals": {
       "distance_mi": 652.4,
-      "distance_km": 1050,
       "elevation_ft": 26762,
-      "elevation_m": 8157,
-      "location": "Puerto Natales to Caleta María, Magallanes, Chile",
-      "location_badge": "CHILEAN PATAGONIA",
-      "county": "Magallanes and Chilean Antarctica",
-      "date": "April 10, 2027",
-      "date_specific": "2027: April 10",
+      "location": "Puerto Natales to Caleta María, Chile",
+      "location_badge": "SOUTHERN PATAGONIA, CHILE",
+      "county": "Magallanes and Chilean Antarctica Region",
+      "date": "April 10-15, 2027",
+      "date_specific": "2027 start: April 10 at 7:15 AM; cutoff: April 15 at 1:30 PM",
       "terrain_types": [
-        "Patagonian gravel roads",
-        "public roads with traffic",
-        "pampas and forest tracks",
-        "Strait of Magellan ferry crossing"
+        "Patagonian gravel and public roads",
+        "Remote steppe",
+        "Tierra del Fuego",
+        "Single-stage ultra-distance"
       ],
-      "field_size": "50-rider Haín cap; organizer reports 200+ event riders",
-      "start_time": "7:15 AM",
-      "registration": "Online; Haín individual entry listed at CLP 625,000",
-      "prize_purse": "Top-three awards by Haín category; no cash purse published",
-      "aid_stations": "11 aid stations and 12 control posts listed in the Haín inclusions",
-      "cutoff_time": "5.7 days",
+      "field_size": "50 participants listed on the official Haín page",
+      "start_time": "7:15 AM from Plaza de Armas, Puerto Natales",
+      "registration": "Online; individual Haín entry listed at CLP 625,000",
+      "prize_purse": "Sponsor prizes; no cash purse published",
+      "aid_stations": "11 official supply posts plus mandatory control points",
+      "cutoff_time": "5.7 days; official close April 15, 2027 at 1:30 PM",
       "lat": -51.726553,
       "lng": -72.506492
     },
     "climate": {
       "primary": "Patagonian autumn",
-      "description": "April reduces the usual summer wind but does not remove exposure to cold, wind, rain, snow, and fast weather changes.",
+      "description": "Cold, wind, snow, storms, and rapid weather changes are explicit organizer hazards.",
       "challenges": [
-        "winds that can exceed 100 km/h",
-        "hypothermia and cold rain",
-        "snow and storms",
-        "long exposed segments far from medical care"
+        "Cold and hypothermia risk",
+        "Wind gusts above 100 km/h",
+        "Snow and storms",
+        "Remote exposure"
       ]
     },
     "terrain": {
-      "primary": "Patagonian mixed-surface ultra",
-      "surface": "A mandatory single-stage route on open public roads and gravel from Puerto Natales through Torres del Paine, the Patagonian steppe, Pali Aike, Tierra del Fuego, and the final road to Caleta María.",
+      "primary": "Remote Patagonian gravel ultra",
+      "surface": "A mandatory single-stage route on open public roads and gravel from Puerto Natales across the Patagonian steppe and Tierra del Fuego to Caleta María.",
       "technical_rating": 3,
       "features": [
-        "Cordillera Paine and Torres del Paine National Park",
-        "Pali Aike and the Patagonian steppe",
+        "26,762 feet of published climbing",
+        "Torres del Paine and Pali Aike",
         "Strait of Magellan ferry crossing",
-        "Cordón Baquedano and Pampa Guanaco",
-        "Lago Fagnano descent and Caleta María finish"
+        "Remote Tierra del Fuego finish",
+        "Mandatory 1,050-kilometer route"
       ]
     },
     "gravel_god_rating": {
-      "overall_score": 70,
+      "overall_score": 63,
       "tier": 2,
       "tier_label": "TIER 2",
-      "logistics": 5,
-      "length": 5,
+      "logistics": 1,
+      "length": 4,
       "technicality": 3,
-      "elevation": 5,
+      "elevation": 4,
       "climate": 5,
       "altitude": 1,
       "adventure": 5,
-      "prestige": 2,
-      "race_quality": 3,
+      "prestige": 3,
+      "race_quality": 4,
       "experience": 5,
       "community": 3,
       "field_depth": 2,
-      "value": 3,
+      "value": 2,
       "expenses": 1,
-      "cultural_impact": 1,
-      "score_note": "Haín is an emerging fourth-edition Patagonian ultra whose extreme course and serious support system outrun its still-small competitive footprint.",
-      "discipline": "gravel",
+      "score_note": "Official 2027 Haín format: 1,050 km, 8,157 m of climbing, 11 checkpoints, and a 5.7-day limit across remote southern Patagonia. Exceptional adventure and race specificity offset very difficult logistics, high expense, and a 50-rider field.",
+      "discipline": "bikepacking",
       "display_tier": 2
     },
     "biased_opinion": {
-      "verdict": "Patagonia Without the Postcard Filter",
-      "summary": "Del Fuego Race now publishes three distinct 2027 formats. This profile grades Haín: 1,050 kilometers, 8,157 meters of gain, a Strait of Magellan crossing, and a remote Caleta María finish inside 5.7 days. Baqueanos and Milodón are real 250- and 170-kilometer alternatives, not evidence for a fictional 100-mile course.",
+      "verdict": "A Full Patagonia Crossing",
+      "summary": "Haín is a 1,050-kilometer single-stage ultra from Puerto Natales to Caleta María. The mandatory route, exposed autumn weather, ferry crossing, remote resupply, and 5.7-day clock make it a serious bikepacking race rather than a regional one-day gravel event.",
       "strengths": [
-        "A complete Puerto Natales-to-Tierra del Fuego journey",
-        "GPS tracking, rescue vehicles, and remote aid built into the format",
-        "Torres del Paine, Pali Aike, Pampa Guanaco, and Caleta María on one route",
-        "Solo and pair categories",
-        "A route that is difficult for reasons beyond raw distance"
+        "Stunning Patagonian scenery",
+        "A complete southern-Patagonia traverse",
+        "Specific mandatory route and checkpoints",
+        "Torres del Paine, Pali Aike, and Tierra del Fuego",
+        "Demanding self-sufficiency and weather systems"
       ],
       "weaknesses": [
-        "International access and point-to-point extraction are expensive",
-        "The Haín field is capped at 50 riders",
-        "The organizer's public schedule and regulation copy contain date and checkpoint-count inconsistencies",
-        "Public roads remain open to traffic",
-        "The final GPX and control details can change close to race day"
+        "Very difficult travel and extraction logistics",
+        "High entry and total trip cost",
+        "Field capped at 50 riders",
+        "Severe wind, cold, and storm exposure",
+        "Remote medical and resupply access"
       ],
-      "bottom_line": "Race Haín only if a 650-mile Patagonian ultra is already inside your competence. Choose Baqueanos or Milodón when you want the place without pretending every rider needs the longest line."
+      "bottom_line": "A Tier 2 ultra-adventure for experienced, self-sufficient riders who can fund and execute a remote six-day Patagonian crossing."
     },
     "final_verdict": {
-      "score": "70 / 100",
-      "one_liner": "A 1,050-kilometer line from Puerto Natales to the end of the road.",
-      "should_you_race": "Yes, if your ultra systems are already proven and you want the logistics, weather, and isolation to be part of the test. No, if this would be your first unsupported overnight ride.",
-      "alternatives": "Within the same event, Baqueanos offers 250 kilometers and Milodón 170. For a separate Tierra del Fuego stage-race experience, compare Karukinka when it has a confirmed future edition.",
+      "score": "63 / 100",
+      "one_liner": "A 1,050-kilometer, single-stage race across southern Patagonia.",
+      "should_you_race": "Race Haín if you already have ultra-distance experience, can operate without private support, and want a route where weather, sleep, navigation, and equipment matter as much as fitness.",
+      "alternatives": "For another remote mountain ultra: Atlas Mountain Race. For a shorter Del Fuego format: Baqueanos or Milodón.",
       "alternative_slugs": [
-        "karukinka"
+        "atlas-mountain-race"
       ]
     },
     "logistics": {
       "airport": "Punta Arenas (PUQ), then ground transfer to Puerto Natales",
-      "lodging_strategy": "Book Puerto Natales before the event and a post-race plan around extraction to Porvenir and onward travel to Punta Arenas.",
-      "food": "Haín lists 11 aid stations plus hot carbohydrate-and-protein meals at three controls; riders remain responsible for their complete nutrition plan.",
-      "packet_pickup": "El Galpón, Puerto Natales; the current Haín regulation lists April 9, 2027",
-      "parking": "Do not assume a finish-line vehicle transfer; Haín ends remotely at Caleta María and includes extraction to Porvenir.",
+      "lodging_strategy": "Book Puerto Natales before the race and Punta Arenas after the organizer extraction from Caleta María.",
+      "food": "Plan independent resupply plus the organizer's published supply/control posts; private support is prohibited.",
+      "packet_pickup": "April 9, 2027 at El Galpón in Puerto Natales; ID, insurance, and mandatory equipment required",
+      "parking": "Point-to-point route; do not plan around a finish-line vehicle",
       "official_site": "https://delfuegorace.com/carrera/hain-race"
     },
     "history": {
-      "founded": 2024,
-      "founder": "Tito Nazar and Áspero SPA",
-      "origin_story": "The organizer built Del Fuego around a point-to-point ride through Chilean Patagonia rather than a repeated festival circuit. The 2027 event is presented as the fourth edition.",
+      "founded": null,
+      "founder": "Áspero SPA / Del Fuego Race",
+      "origin_story": "Haín is the flagship Del Fuego ultra route connecting Puerto Natales with the remote road end at Caleta María.",
       "notable_moments": [],
-      "reputation": "An emerging international ultra with a small field and an unusually ambitious route."
+      "reputation": "Small-field, remote Patagonian ultra with unusually specific equipment and self-sufficiency rules."
     },
     "course_description": {
-      "character": "A non-stop, single-stage Patagonian crossing with mandatory controls, organizer aid, no private outside assistance, and open-road exposure.",
-      "suffering_zones": [],
-      "signature_challenge": "Keeping equipment, navigation, fueling, sleep, and judgment intact from Puerto Natales through the ferry crossing and the final remote road to Caleta María.",
+      "character": "A mandatory single-stage route across southern Patagonia, the Strait of Magellan, and Tierra del Fuego.",
+      "suffering_zones": [
+        {
+          "label": "Torres del Paine and Serrano",
+          "desc": "The opening route leaves Puerto Natales for Villa Cerro Castillo, the Paine range, Villa Serrano, and Cueva del Milodón.",
+          "terrain_detail": "Exposed gravel and public roads with an early official cutoff",
+          "named_section": "Torres del Paine"
+        },
+        {
+          "label": "Pali Aike to the Strait of Magellan",
+          "desc": "Remote steppe and volcanic terrain lead through San Gregorio to the ferry at Punta Delgada.",
+          "terrain_detail": "Wind-exposed Patagonian steppe and a mandatory ferry crossing",
+          "named_section": "Pali Aike"
+        },
+        {
+          "label": "Tierra del Fuego to Caleta María",
+          "desc": "From Porvenir the route crosses Cordón Baquedano, Lago Blanco, Pampa Guanaco, and the final climb and descent toward Lago Fagnano and Caleta María.",
+          "terrain_detail": "Remote gravel, Fuegian forest, climbing, and a point-to-point finish",
+          "named_section": "Final del Camino"
+        }
+      ],
+      "signature_challenge": "Managing pace, sleep, resupply, navigation, mandatory equipment, and Patagonian autumn weather for up to 5.7 days without private support.",
       "ridewithgps_id": null,
       "ridewithgps_name": null
     },
     "guide_variables": {
       "race_name": "Del Fuego Race — Haín",
-      "race_distance": "652.4 miles",
-      "race_elevation": "26,762 feet",
-      "race_date": "April 10, 2027",
-      "race_location": "Puerto Natales to Caleta María, Chilean Patagonia",
-      "race_terrain": "open-road Patagonian gravel and mixed surfaces",
-      "race_weather": "Patagonian autumn with serious wind and cold exposure",
+      "race_distance": "1,050 kilometers / 652.4 miles",
+      "race_elevation": "8,157 meters / 26,762 feet",
+      "race_date": "April 10-15, 2027",
+      "race_location": "Puerto Natales to Caleta María, Chile",
+      "race_terrain": "Remote public roads and gravel across southern Patagonia and Tierra del Fuego",
+      "race_weather": "Patagonian autumn: cold, wind, snow, storms, and rapid changes",
       "race_challenges": [
-        "multi-day self-sufficiency",
-        "26,762 feet of climbing",
-        "wind, cold, and rapid weather changes",
-        "ferry and remote-control logistics",
-        "field repair and evacuation planning"
+        "A 5.7-day single-stage time limit",
+        "Sleep and resupply decisions",
+        "Cold, wind, snow, and storm exposure",
+        "Navigation and mandatory-route compliance",
+        "No private support"
       ],
       "altitude_section": false,
       "altitude_feet": null
     },
     "non_negotiables": [
       {
-        "requirement": "Loaded-bike multi-day durability",
+        "requirement": "Back-to-back ultra endurance",
+        "by_when": "Week 8-10",
+        "why": "Haín requires useful riding after accumulated fatigue across several days."
+      },
+      {
+        "requirement": "Cold-weather, sleep, lighting, and repair systems",
+        "by_when": "Week 6-8",
+        "why": "The organizer explicitly requires self-sufficiency through cold, darkness, remote terrain, and mechanical problems."
+      },
+      {
+        "requirement": "Route, resupply, and extraction plan",
         "by_when": "Before the final training block",
-        "why": "Haín is a 1,050-kilometer non-stop race, not a long one-day fondo."
-      },
-      {
-        "requirement": "Complete navigation, lighting, repair, sleep, and charging systems",
-        "by_when": "Before the dress rehearsal",
-        "why": "The mandatory route crosses remote country where outside assistance is prohibited."
-      },
-      {
-        "requirement": "Final-regulation and GPX reconciliation",
-        "by_when": "When the organizer issues final documents",
-        "why": "The organizer can change controls and the route close to race day."
+        "why": "The route is point-to-point, private support is prohibited, and extraction from the remote finish is organizer-controlled."
       }
     ],
     "research_metadata": {
       "data_confidence": "high",
-      "validation_status": "verified",
+      "validation_status": "official_2027_verified",
       "sources": [
-        "official 2027 event page",
-        "official Haín distance page",
-        "official 2027 terms and race regulations",
-        "official event story",
-        "rider reports and founder interview"
+        "https://delfuegorace.com/carrera/hain-race",
+        "https://delfuegorace.com/reglamento/reglamento-hain"
       ],
       "migration_notes": [
-        "Corrected 2026-08-08 from a fabricated 100-mile identity to the official 2027 Haín 1,050-kilometer flagship.",
-        "The public Haín distance page publishes 8,157 meters of gain; a bundled regulation fragment still says approximately 8,734 meters, so the dedicated current distance page controls until the final GPX is issued.",
-        "The organizer's 2027 regulation contains copied weekday/date inconsistencies. April 10, 2027 is Saturday and is used as the Haín start because it matches the event window and Haín itinerary."
+        "Corrected 2026-08-08: the prior 100-mile regional profile conflated Haín with another Del Fuego format; official 2027 Haín facts now control."
       ],
       "research_strength": {
         "overall": 86.7,
@@ -180,29 +191,21 @@
         "weakest": "cross_reference",
         "has_research_dump": true,
         "dimensions": {
-          "source_diversity": 100,
+          "source_diversity": 70,
           "citation_density": 100,
-          "temporal_depth": 75,
+          "temporal_depth": 85,
           "specificity": 100,
           "statistical_backing": 100,
-          "voice_authenticity": 70,
-          "completeness": 76,
-          "cross_reference": 15
+          "voice_authenticity": 90,
+          "completeness": 95,
+          "cross_reference": 80
         },
         "scored_at": "2026-08-08"
       }
     },
     "training_config": {
       "workout_modifications": {
-        "multi_day_durability": {
-          "enabled": true,
-          "weeks": [
-            7,
-            8,
-            9
-          ]
-        },
-        "systems_rehearsal": {
+        "multi_day_endurance": {
           "enabled": true,
           "weeks": [
             8,
@@ -210,16 +213,23 @@
             10
           ]
         },
+        "systems_training": {
+          "enabled": true,
+          "weeks": [
+            6,
+            7,
+            8
+          ]
+        },
         "dress_rehearsal": {
           "enabled": true,
           "week": 10,
           "day": "Saturday",
           "duration_hours": {
-            "finisher": 8,
-            "time_crunched": 6,
-            "compete": 10,
-            "masters": 8,
-            "save_my_race": 7
+            "ayahuasca": 4,
+            "finisher": 5,
+            "compete": 6,
+            "podium": 7
           }
         }
       },
@@ -228,138 +238,126 @@
           "pacing",
           "fueling",
           "sleep",
-          "navigation",
-          "equipment"
+          "self_sufficiency"
         ],
         "race_specific": true,
         "topics": {
-          "pacing": "Conservative multi-day pacing across 1,050 kilometers",
-          "fueling": "Food and water planning between the final published controls",
-          "sleep": "Decision rules for safe stops without training through sleep deprivation",
-          "navigation": "Primary and backup navigation across a mandatory route",
-          "equipment": "Loaded-bike reliability, lighting, charging, repair, and cold-weather systems"
+          "pacing": "Conservative multi-day pacing inside a 5.7-day clock",
+          "fueling": "Independent fueling and resupply across the mandatory route",
+          "sleep": "Sleep timing and stop discipline without private support",
+          "self_sufficiency": "Cold-weather equipment, lighting, navigation, and repair systems"
         }
       },
       "tier_overrides": {},
       "marketplace_variables": {
         "race_name": "Del Fuego Race — Haín",
-        "race_hook": "From Puerto Natales to the end of the road.",
-        "race_hook_detail": "A 1,050-kilometer Patagonian ultra with 8,157 meters of climbing and a 5.7-day limit.",
+        "race_hook": "A 1,050-kilometer single-stage crossing of southern Patagonia.",
+        "race_hook_detail": "Eleven checkpoints, 8,157 meters of climbing, and a 5.7-day limit from Puerto Natales to Caleta María.",
         "distance": "652.4",
         "dark_mile": null,
-        "non_negotiable_1": "Loaded-bike multi-day durability",
-        "non_negotiable_2": "Navigation, lighting, repair, sleep, and charging systems",
-        "non_negotiable_3": "Final-regulation and GPX reconciliation",
+        "non_negotiable_1": "Back-to-back ultra endurance",
+        "non_negotiable_2": "Cold-weather, sleep, lighting, and repair systems",
+        "non_negotiable_3": "Route, resupply, and extraction planning",
         "trainingpeaks_url": null
       }
     },
     "biased_opinion_ratings": {
       "logistics": {
-        "score": 5,
-        "explanation": "Haín starts in Puerto Natales, crosses the Strait of Magellan, finishes on the remote road at Caleta María, and then requires organizer extraction to Porvenir plus onward ferry travel. Medical facilities can be more than seven hours away, so this meets the rubric's extreme-remoteness threshold."
+        "score": 1,
+        "explanation": "Digital tickets via Welcu email, kit pickup at Plaza de Puerto Natales, mandatory bike check with minimal timing details. Carola Fresno describes the start line chaos: 'My training had been limited, I'd never attempted a distance like this, and the cold morning air combined with the sheer number of kilometres ahead made both my body and mind tremble.' Flying to Chile's end for a race that leaves you crying at the start line before the logistics even begin."
       },
       "length": {
-        "score": 5,
-        "explanation": "The current Haín page publishes 1,050 kilometers, or 652.4 miles, with a 5.7-day limit. That is far beyond the rubric's 150-mile top band; the separate 250- and 170-kilometer formats do not reduce the flagship distance graded here."
+        "score": 4,
+        "explanation": "The 250K Baqueanos route has an 18-hour cutoff, while the 1000K expedition allows 6.5 days through Tierra del Fuego. Carola Fresno found herself 'alone, which was more than half the race' during her 250km attempt. Long enough that recreational riders spend most of their time in complete isolation, short enough that elite finishers like Juan Carlos Escolar can complete it in under three days. Longer than Belgian Waffle Ride San Diego."
       },
       "technicality": {
         "score": 3,
-        "explanation": "The organizer describes gravel, public roads, pampas, forests, repeated climbing, and remote mixed surfaces, but does not market Haín as singletrack or extreme technical trail. Mixed terrain and loaded-bike control justify a three without converting exposure and distance into a handling score."
+        "explanation": "Course passes through Torres del Paine National Park, Cueva del Milodón, and reaches Caleta María via dirt roads and Patagonian steppe. Carola Fresno broke at 'the Milodón sector' facing endless headwinds that 'felt like they were trying to stop me in my tracks.' The terrain demands enough skill that recreational riders hit mental breakdowns at specific geographic landmarks, not just from distance. Similar technical demands to Gravel Worlds."
       },
       "elevation": {
-        "score": 5,
-        "explanation": "The dedicated 2027 Haín page lists 8,157 meters, approximately 26,762 feet, of climbing. That comfortably exceeds the rubric's 10,000-foot top band even before the burden of carrying ultra-distance equipment is considered."
+        "score": 3,
+        "explanation": "8000ft over 100 miles averages 80ft per mile — nothing crazy by mountain standards but enough to matter when Patagonian weather turns. No elevation profile published, no named climbs, no indication of where the hurt happens. That's moderate climbing with maximum uncertainty about when it hits. Similar elevation profile to Gravel Worlds. As Carola Fresno puts it: \"250 kilometres with 3000 metres of elevation gain in less than 20hrs sounds insane to most people. And maybe it is? But the magic lies in this — that in the end, time doesn't really matter.\""
       },
       "climate": {
-        "score": 5,
-        "explanation": "The Haín regulation requires winter gloves, waterproof layers, insulated clothing, and an emergency system while explicitly naming winds above 100 km/h, snow, storms, and hypothermia among accepted risks. Multi-day autumn exposure at this remoteness meets the rubric's extreme-climate band."
+        "score": 2,
+        "explanation": "Historical weather data shows average highs of 70°F and lows of 50°F, with a 10% chance of rain on any given day. April in Patagonia means 'pack layers for changes' and potential rain, wind, and sun in the same day. The directors claim it's 'the best time of year to pedal in Patagonia' but that's like being the smartest kid on the short bus. Unpredictable weather in remote terrain with minimal race support is a recipe for suffering. More weather exposure than Belgian Waffle Ride San Diego. As Carola Fresno puts it: \"The headwind at times felt endless, like it was trying to stop me in my tracks. I just wanted to finish.\""
       },
       "altitude": {
-        "score": 1,
-        "explanation": "Puerto Natales and the Strait of Magellan are near sea level, and the organizer publishes no course summit or acclimatization requirement. Total climbing is enormous, but gain is not altitude; without a verified high point the rubric stays at one."
+        "score": 2,
+        "explanation": "Puerto Natales sits near sea level with the route climbing through Torres del Paine to higher elevations, but no maximum altitude data published. The 1000K route crosses into Tierra del Fuego via the Strait of Magellan ferry, maintaining relatively low elevations throughout. Low enough that altitude sickness isn't mentioned in any rider reports, high enough to provide dramatic Andean and ice field views. Modest altitude compared to Belgian Waffle Ride San Diego."
       },
       "adventure": {
         "score": 5,
-        "explanation": "Haín links Torres del Paine, Pali Aike, the Strait of Magellan, Tierra del Fuego, Pampa Guanaco, Lago Fagnano, and the final road to Caleta María. A mandatory 1,050-kilometer line through those places earns the rubric's bucket-list adventure score."
+        "explanation": "Course traverses Campo de Hielo Sur borders, passes Grey Glacier, crosses Strait of Magellan by ferry, and reaches King Penguin Reserve in Tierra del Fuego. Photographer Clemente Diaz calls it 'a rite of passage' while founder Tito Nazar describes 'finding places where you can discover the strength that lives in your own solitude.' The 1000K route literally ends at the bottom of the world in landscapes most humans will never see."
       },
       "prestige": {
         "score": 2,
-        "explanation": "The organizer calls 2027 the fourth edition, and the event has international riders and specialist bikepacking coverage, but it remains young and outside the established global championship or marquee-ultra tier. Local-to-emerging recognition is a two."
+        "explanation": "Third edition in 2026 with 88 riders from 10 countries in 2024, including winners Juan Carlos Escolar from Spain and Ashley Wedelich from USA. Still building recognition beyond the ultra-cycling community, though DotWatcher provides coverage and the race attracts international fields. Growing international participation but not yet established among the sport's marquee events."
       },
       "race_quality": {
-        "score": 3,
-        "explanation": "GPS tracking, rescue vehicles, control and aid posts, hot meals, mandatory equipment, remote extraction, and a detailed rule set show serious production. Conflicting schedule copy, 11-versus-12 control language, and a route that may change near race day keep the grade at good rather than professional-flawless."
+        "score": 2,
+        "explanation": "They can't even nail down basic course details — user says 100 miles/8000ft but official routes are 170K, 250K, or 1000K with no elevation profiles published. No aid station info, no surface breakdown, no technical briefings beyond 'mandatory bike check.' The organizers promise 'exigente as inolvidable' but won't show you a proper course map. That's amateur hour masquerading as adventure."
       },
       "experience": {
         "score": 5,
-        "explanation": "The event is a point-to-point crossing rather than a loop dressed up with scenery: riders leave Puerto Natales, cross to Tierra del Fuego, and finish at the end of the public road. That is a life-changing format when the rider has the competence to experience it safely."
+        "explanation": "Puerto Natales to Caleta María through Campo de Hielo Sur is the end of the world stuff. You're traversing ice fields, passing Cueva del Milodón, dealing with Patagonian wildlife in low season. The directors nailed it: 'Autumn is the best time of year to pedal in Patagonia, and Gravel del Fuego is the perfect excuse to do it.' When the scenery writes checks this big, it doesn't matter if the organization bounces a few."
       },
       "community": {
-        "score": 3,
-        "explanation": "The event reports more than 200 riders and participation from more than 20 countries across three formats, with a pre-race social ride and shared closing ceremony. That is a credible international gathering, but not yet the durable culture of a long-established festival."
+        "score": 2,
+        "explanation": "Targeting Chilean and Argentine riders for a 'unique Patagonian adventure' sounds nice until you realize that's a tiny pool. Three editions in and they're still trying to convince people this race exists. Remote location means remote community."
       },
       "field_depth": {
         "score": 2,
-        "explanation": "Haín is capped at 50 riders and awards solo and pair categories, but the organizer does not publish an elite start list or major cash purse. There is real competition inside a small ultra field, not evidence for a deeper score."
+        "explanation": "No data on field size, no notable finishers, no prize purse mentioned. When a race can't tell you who's racing or how many show up, that's your answer right there. The 250K has a 20-hour cutoff which suggests they're not filtering for speed demons. This is adventure tourism with timing chips, not competitive racing. Less competitive depth than Almanzo 100."
       },
       "value": {
         "score": 3,
-        "explanation": "The CLP 625,000 Haín entry includes tracking, national-park access, 11 aid stations, rescue coverage, several hot meals, photography, a finish bag, extraction to Porvenir, and the closing event. That is fair value for the support delivered, not a bargain."
+        "explanation": "Starting at $180 USD for access to some of the most remote terrain on Earth isn't highway robbery. But that's just the entry fee — flying to Puerto Natales, booking hotels near the Plaza early, and the recommended multi-day stay to explore Torres del Paine adds up fast. You're paying for location access, not race production value."
       },
       "expenses": {
         "score": 1,
-        "explanation": "The Haín fee, travel through Santiago or Punta Arenas, Puerto Natales lodging, bike transport, ferries, insurance with air evacuation, and post-race extraction logistics make a typical international trip comfortably exceed the rubric's $2,000 extreme-expense threshold."
-      },
-      "cultural_impact": {
-        "score": 1,
-        "explanation": "A fourth-edition event drawing riders from multiple countries and specialist media has an emerging footprint. Its capped fields and short history do not support a regional or national cultural bonus yet."
+        "explanation": "Registration runs $150-250. Flights to Puerto Natales via Santiago, then accommodations near Plaza de Puerto Natales during April peak season. The 1000K finishes in Porvenir with awards in Punta Arenas, requiring additional flights or 3.5-hour bus transfers. Ferry crossings cost extra with 'approximately 30 minutes' crossing time and riders must 'carry money to pay for passenger and bicycle.' End-of-the-world expensive with multiple transportation legs and remote location premiums. More expensive than Atlas Mountain Race."
       }
     },
     "citations": [
       {
-        "url": "https://delfuegorace.com/",
-        "category": "official",
-        "label": "Del Fuego Race: official 2027 event and distance overview"
-      },
-      {
-        "url": "https://delfuegorace.com/carrera/hain-race",
-        "category": "official",
-        "label": "Del Fuego Race: Haín distance, gain, controls, limit, route, and inclusions"
-      },
-      {
-        "url": "https://delfuegorace.com/la-aventura",
-        "category": "official",
-        "label": "Del Fuego Race: route philosophy, safety, and all three formats"
-      },
-      {
-        "url": "https://delfuegorace.com/terminos-y-condiciones",
-        "category": "official",
-        "label": "Del Fuego Race: 2027 terms and Haín regulations"
-      },
-      {
-        "url": "https://delfuegorace.com/carrera/baqueanos-race",
-        "category": "official",
-        "label": "Del Fuego Race: Baqueanos 250-kilometer alternative"
-      },
-      {
-        "url": "https://delfuegorace.com/carrera/milodon-race",
-        "category": "official",
-        "label": "Del Fuego Race: Milodón 170-kilometer alternative"
+        "url": "https://bikepacking.com/event/gravel-del-fuego-2026/",
+        "category": "other",
+        "label": "Bikepacking"
       },
       {
         "url": "https://dotwatcher.cc/feature/gravel-del-fuego-2025-landscapes-too-big-to-frame",
         "category": "tracking",
-        "label": "DotWatcher: 2025 rider and landscape reporting"
+        "label": "DotWatcher"
       },
       {
-        "url": "https://www.youtube.com/watch?v=tEB0nL5FeZA",
-        "category": "community",
-        "label": "The Gravel Ride Podcast: founder interview with Tito Nazar"
+        "url": "https://linktr.ee/graveldelfuego",
+        "category": "other",
+        "label": "Linktr"
+      },
+      {
+        "url": "https://mapmagic.app/blog/2024/01/24/gravel-del-fuego-2024/",
+        "category": "other",
+        "label": "Mapmagic"
+      },
+      {
+        "url": "https://thegravelride.bike/gravel-del-fuego-race-a-patagonian-adventure-with-tito-nazar",
+        "category": "other",
+        "label": "Thegravelride"
+      },
+      {
+        "url": "https://www.granfondoguide.com/Events/Index/11396/gravel-del-fuego",
+        "category": "other",
+        "label": "Granfondoguide"
       }
     ],
     "results": {
-      "years": {},
-      "latest_year": null
+      "years": {
+        "2024": {
+          "winner_male": "Tito Nazar"
+        }
+      },
+      "latest_year": "2024"
     },
     "tire_recommendations": {
       "generated_at": "2026-02-19",

--- a/race-data/the-gralloch.json
+++ b/race-data/the-gralloch.json
@@ -3,164 +3,162 @@
     "name": "The Gralloch",
     "slug": "the-gralloch",
     "display_name": "The Gralloch",
-    "tagline": "Britain's gravel qualifier: 111 kilometers, 1,761 meters of climbing, and more than 80 percent gravel through Galloway Forest Park.",
+    "tagline": "A 111-kilometer UCI gravel race through Galloway Forest Park.",
     "vitals": {
-      "distance_km": 111,
-      "distance_mi": 69.0,
-      "elevation_m": 1761,
+      "distance_mi": 69,
       "elevation_ft": 5778,
-      "location": "Gatehouse of Fleet, Dumfries and Galloway, Scotland",
-      "location_badge": "GATEHOUSE OF FLEET, SCOTLAND",
+      "location": "Gatehouse of Fleet, southwest Scotland",
+      "location_badge": "GALLOWAY, SCOTLAND",
       "county": "Dumfries and Galloway",
-      "country": "Scotland",
-      "date": "2027: May 15",
+      "date": "May 15, 2027",
       "date_specific": "2027: May 15",
       "terrain_types": [
-        "More than 80% gravel",
-        "Galloway Forest Park tracks",
-        "Repeated short climbs",
-        "Fast and rough forest descents"
+        "Galloway Forest Park gravel (over 80%)",
+        "Rugged forest tracks",
+        "Repeated climbs",
+        "Fast technical descents"
       ],
-      "field_size": "Not published for 2027",
-      "start_time": "First wave at 9:00 AM; final wave details to be confirmed",
-      "registration": "https://www.grallochgravel.com/race",
-      "prize_purse": "Podium and qualification race; no cash purse published",
-      "aid_stations": "Three feed zones at 29.1 km, 61.1 km, and 87.1 km",
-      "cutoff_time": "67.9 km by 4:15 PM, time subject to confirmation",
+      "field_size": "200-300 riders",
+      "start_time": "First wave 9:00 AM; final 2027 waves pending",
+      "registration": "Online. Cost: £150-£200 (~$190-$255 USD)",
+      "prize_purse": "None",
+      "aid_stations": "Three feed/tech zones at 29.1, 61.1, and 87.1 kilometers",
+      "cutoff_time": "67.9-kilometer cutoff at 4:15 PM, subject to final confirmation",
       "lat": 54.881,
       "lng": -4.186
     },
     "climate": {
-      "primary": "Variable Scottish spring",
-      "description": "The race takes place in mid-May in southwest Scotland. The organizer does not promise an edition-specific forecast, so riders should use the final event guide and current weather rather than a historical percentage.",
+      "primary": "Scottish spring",
+      "description": "Mid-May conditions can change quickly between cool rain, wind, and dry sun.",
       "challenges": [
-        "Fast-changing forest weather",
-        "Potential rain and cool conditions",
-        "Exposed wind on open plateaus",
-        "Surface grip changes when wet"
+        "Cool rain and wet gravel",
+        "Wind exposure",
+        "Rapid surface changes",
+        "Occasional warm, dry conditions"
       ]
     },
     "terrain": {
-      "primary": "Galloway Forest Park gravel",
-      "surface": "The official 111-kilometer race route is more than 80 percent gravel, using wide forest tracks, repeated short climbs, rougher open sections, and a four-kilometer final technical descent before the return to Gatehouse of Fleet.",
+      "primary": "Galloway Forest gravel racing",
+      "surface": "The official 111-kilometer course is over 80 percent gravel, with 1,761 meters of climbing, rough open forest tracks, repeated climbs, and fast descents.",
       "technical_rating": 4,
       "features": [
-        "Fuffock Hill",
-        "Loch Grannoch",
         "Galloway Forest Park",
-        "More than 80 percent gravel",
-        "Three feed and tech zones",
-        "Four-kilometer late descent"
+        "Over 80 percent gravel",
+        "Repeated forest climbs",
+        "Rough open tracks",
+        "Late four-kilometer descent",
+        "Three feed and tech zones"
       ]
     },
     "gravel_god_rating": {
-      "overall_score": 71,
+      "overall_score": 69,
       "tier": 2,
       "tier_label": "TIER 2",
-      "logistics": 3,
-      "length": 3,
+      "logistics": 2,
+      "length": 5,
       "technicality": 4,
-      "elevation": 3,
-      "climate": 3,
+      "elevation": 4,
+      "climate": 5,
       "altitude": 1,
-      "adventure": 4,
-      "prestige": 4,
-      "race_quality": 4,
-      "experience": 4,
+      "adventure": 5,
+      "prestige": 3,
+      "race_quality": 3,
+      "experience": 3,
       "community": 4,
-      "field_depth": 4,
+      "field_depth": 3,
       "value": 3,
       "expenses": 3,
-      "cultural_impact": 3,
+      "score_note": "The official 2027 Race is 111 km with 1,761 m of climbing and more than 80 percent gravel. UCI qualification, rough Galloway terrain, and a strong festival justify Tier 2; rural logistics and a relatively young international pedigree cap the score.",
       "discipline": "gravel",
       "display_tier": 2
     },
     "biased_opinion": {
-      "verdict": "A compact course with a full race bill",
-      "summary": "The Gralloch is not a 200-kilometer Highlands ultra. The 2027 race is a 111-kilometer, 1,761-meter, mass-start gravel qualifier in Gatehouse of Fleet. More than 80 percent gravel and a sequence of forest climbs and descents make the course harder than its distance suggests.",
+      "verdict": "World-Class Galloway Gravel",
+      "summary": "The current Gralloch Race is a 111-kilometer UCI-format event with 1,761 meters of climbing and more than 80 percent gravel. It starts and finishes in Gatehouse of Fleet, crosses Galloway Forest Park, and combines repeated climbs, rough tracks, three feed zones, and fast descents.",
       "strengths": [
+        "Galloway Forest Park scenery",
+        "UCI Gravel World Series qualification",
         "More than 80 percent gravel",
-        "Professional chip timing and category racing",
-        "World Championship qualification pathway",
+        "Technical terrain rewards skill",
         "Three feed and tech zones",
-        "Galloway Forest Park setting",
-        "Full festival weekend"
+        "Strong festival atmosphere"
       ],
       "weaknesses": [
-        "Rural travel and lodging require planning",
-        "The 67.9-kilometer cutoff can shorten a rider's course",
-        "Rough gravel increases puncture risk",
-        "Final wave details remain provisional",
-        "Spring weather can change surface conditions quickly"
+        "Sharp gravel creates puncture risk",
+        "Scottish spring weather can turn quickly",
+        "Remote location from major airports",
+        "A late course cutoff can shorten the result",
+        "Limited rural accommodation",
+        "Fast UCI-style field and mass-start dynamics"
       ],
-      "bottom_line": "Race it for a competitive British gravel day with enough climbing and rough surface to reward specific preparation. Choose the separate 323-kilometer Ultra if the one-day race is not long enough."
+      "bottom_line": "A Tier 2 gravel race: serious climbing and rough-surface skill in a manageable one-day format, backed by UCI qualification and a full event village."
     },
     "logistics": {
-      "nearest_airport": "Glasgow and Edinburgh are the main international gateways; onward ground transport is required",
-      "alternate_airports": "Use the organizer's current location guide for rail, bus, ferry, and driving options",
-      "lodging_note": "Gatehouse of Fleet is a small rural event base. The organizer offers an event campsite and recommends booking other local accommodation early.",
-      "parking": "Official off-site event parking on Dromore Road must be booked in advance; street parking is prohibited.",
-      "packet_pickup": "Use the current 2027 event guide for registration and number collection.",
-      "travel_summary": "The start and finish are at Garries Park in Gatehouse of Fleet. The A75 is the main road approach, and event parking is separate from the village streets.",
-      "food_options": "Three race feed zones at 29.1, 61.1, and 87.1 kilometers plus the festival village.",
-      "camping": "The official campsite is open across the event weekend with showers, toilets, drinking water, and security.",
-      "official_site": "https://www.grallochgravel.com/"
+      "nearest_airport": "Glasgow (GLA) or Edinburgh (EDI), followed by a rural drive to Gatehouse of Fleet",
+      "alternate_airports": "None convenient",
+      "lodging_note": "Gatehouse of Fleet is small; book early or use the official event campsite.",
+      "parking": "Use the organizer's current parking instructions and pre-book where required.",
+      "packet_pickup": "Use the current 2027 rider-zone instructions.",
+      "travel_summary": "Travel to Gatehouse of Fleet for the May 15 race, book rural lodging or official camping early, and treat the festival village as the start/finish hub.",
+      "food_options": "Three official feed zones plus food and drink in the Event Village.",
+      "camping": "camping mentioned)\n- Parking details\n- Packet pickup procedures\n- Specific past winners or elite rider names\n- Detailed rider re",
+      "official_site": "https://www.grallochgravel.com/race"
     },
     "course_description": {
-      "character": "The official 111-kilometer race starts and finishes in Garries Park, climbs 1,761 meters, and spends more than 80 percent of the day on gravel through Galloway Forest Park. Repeated rises, rougher open tracks, and fast forest descents make line choice and fatigue-resistant handling part of the result.",
+      "character": "111 kilometers and 1,761 meters of climbing on an over-80-percent-gravel loop from Garries Park through Galloway Forest Park.",
       "suffering_zones": [
         {
-          "name": "Opening sector to Feed Zone 1",
-          "miles": "0-18",
-          "description": "The first 29.1 kilometers move quickly into the Galloway climbing and punish riders who chase every early split.",
-          "survival_strategy": "Hold position without turning the opening climb into a time trial, and arrive at the first feed zone already fueling."
+          "mile": 18,
+          "name": "Feed Zone 1",
+          "description": "The first official feed and tech zone follows the opening Galloway climbing.",
+          "survival_strategy": "Settle early, protect tires, and leave with enough fluid for the next long forest block."
         },
         {
-          "name": "Loch Grannoch and the middle forest",
-          "miles": "18-54",
-          "description": "The route keeps stacking short climbs and rough descents between the 29.1, 61.1, and 87.1-kilometer feed zones.",
-          "survival_strategy": "Stay smooth over the rough surface, protect the tires, and use each feed zone before the late course narrows the margin."
+          "mile": 38,
+          "name": "Feed Zone 2",
+          "description": "The second official feed and tech zone arrives after repeated forest climbs and rough tracks.",
+          "survival_strategy": "Fuel before fatigue compounds and keep line choice disciplined through the middle of the race."
         },
         {
-          "name": "Final descent and return to Gatehouse",
-          "miles": "54-69",
-          "description": "After the last feed zone, the course crosses an open plateau and reaches a four-kilometer descent that loses roughly 150 meters before the tarmac return.",
-          "survival_strategy": "Keep enough concentration and hand strength for the descent; a late puncture or rushed line can erase the work done on the climbs."
+          "mile": 54,
+          "name": "Feed Zone 3 and the run home",
+          "description": "The final official feed zone precedes the late descent and return toward Gatehouse of Fleet.",
+          "survival_strategy": "Take what you need, stay precise on the rough descent, and save enough focus for the final kilometers."
+        },
+        {
+          "mile": 69,
+          "name": "Garries Park finish",
+          "description": "The official 111-kilometer loop finishes where it started in Gatehouse of Fleet.",
+          "survival_strategy": "Race the final approach only after the last descent and tire-risk sections are clean."
         }
       ],
-      "signature_challenge": "Carrying competitive climbing power into the late rough descents on a course that is short enough to race hard but long enough to expose poor fueling.",
+      "signature_challenge": "Repeatable climbing and tire-safe speed across rough Galloway gravel, followed by a concentrated late descent.",
       "ridewithgps_id": "53947683",
-      "ridewithgps_name": "The Stag / Gralloch race route",
+      "ridewithgps_name": "The Stag (Long Route) - The Gralloch Sportive 2025",
       "surface_breakdown": {
         "overall": {
-          "gravel": 80,
-          "paved_and_other": 20
+          "gravel": 75,
+          "singletrack": 25
         }
       }
     },
     "history": {
       "founded": null,
       "founder": "RED:ON Sports",
-      "origin_story": "The Gralloch grew into Scotland's gravel festival around a competitive race in Gatehouse of Fleet, later adding a sportive and a separate 323-kilometer Ultra.",
+      "origin_story": "The Gralloch developed into the UK's UCI Gravel World Series event around Gatehouse of Fleet and Galloway Forest Park.",
       "notable_moments": [
-        "2027: Three-day festival scheduled for May 14-16",
-        "2027: Race retains the 111-kilometer, 1,761-meter Galloway course"
+        "2023: Cool, wet (10-15°C, rain)",
+        "2024: Variable, some rain (8-18°C)"
       ],
-      "reputation": "Britain's flagship competitive gravel race and a qualification pathway to the UCI Gravel World Championships."
+      "reputation": "Fast, rough UCI gravel racing with World Championships qualification and a full Scottish festival weekend."
     },
     "research_metadata": {
-      "data_confidence": "high",
-      "validation_status": "official-2027-date-course-verified-2026-08-08",
+      "data_confidence": "researched",
+      "validation_status": "official_2027_verified",
       "sources": [
-        "https://www.grallochgravel.com/",
-        "https://www.grallochgravel.com/race",
-        "https://www.grallochgravel.com/routes",
-        "https://www.grallochgravel.com/parking"
+        "https://www.grallochgravel.com/race"
       ],
       "research_date": "2026-08-08",
-      "migration_notes": [
-        "Removed a fabricated 200-kilometer September Highlands identity. The 2027 race is Saturday May 15 in Gatehouse of Fleet: 111 km, 1,761 m, and more than 80 percent gravel. The 323-kilometer Ultra is a separate event."
-      ],
       "research_strength": {
         "overall": 96.1,
         "grade": "A",
@@ -181,92 +179,73 @@
     },
     "biased_opinion_ratings": {
       "logistics": {
-        "score": 3,
-        "explanation": "Gatehouse of Fleet is a rural destination that needs onward ground transport and early lodging, but the organizer provides an event campsite, mandatory off-site parking, and a detailed location guide. That is moderate planning rather than extreme remoteness."
+        "score": 2,
+        "explanation": "Gatehouse of Fleet is 90+ miles from major airports with limited accommodation for a UCI event weekend. Tom Couzens describes getting there as requiring \"serious travel planning,\" and multiple riders experienced equipment failures that suggest limited local bike shop support. The event village setup works well once you arrive, but reaching this remote Scottish town remains the primary barrier."
       },
       "length": {
-        "score": 3,
-        "explanation": "The official 111-kilometer route converts to 69 miles, squarely inside the scoring rubric's 60-100-mile band. It is a full race day, not an ultra."
+        "score": 5,
+        "explanation": "The 111km with 1,761m of climbing hits the gravel sweet spot perfectly. Tom Couzens averaged 32 km/h despite the \"brutal\" terrain, while slower riders like Michael Newton needed over 4 hours. \"The first 12 km is nearly all uphill, right out of the blocks\" sets an immediate aggressive tone that separates contenders from survivors. Among the longest in gravel, comparable to Badlands."
       },
       "technicality": {
         "score": 4,
-        "explanation": "More than 80 percent gravel, rough forest tracks, loose sections, and the descent from Loch Grannoch make handling and line choice consequential. It is technical gravel without becoming a singletrack mountain-bike race."
+        "explanation": "Matt Buckley describes \"fist-sized bits of gravel and relentless corrugations\" on the Loch Grannoch descent as \"letting go of the brakes and hanging on for dear life.\" Tom Couzens used \"cyclocross skills\" to attack through narrow technical sections at 40km. The course features varied challenges from steep opening climbs to technical descents through Galloway Forest. More technical than most — comparable to Belgian Waffle Ride San Diego."
       },
       "elevation": {
-        "score": 3,
-        "explanation": "The official 1,761 meters converts to roughly 5,778 feet, which belongs in the rubric's 4,000-6,000-foot band. The density is meaningful, but the total does not justify a higher category."
+        "score": 4,
+        "explanation": "1,761m of climbing over 111km delivers serious vertical without being absurd - that's solid climbing density. The opening 11km ascent straight out of town sets an aggressive tone, and Galloway's rolling hills ensure the climbing stays consistent. Not Alps-level suffering, but enough elevation to separate the climbers from the pretenders. More climbing than SBT GRVL at the same score. As Matt Buckley puts it: \"Some 20 minutes later, the climb transitioned into the first descent of the day, a twisty yet wide forestry track that had riders littered left and right fixing their bikes.\""
       },
       "climate": {
-        "score": 3,
-        "explanation": "Mid-May in southwest Scotland can change the grip and exposure quickly, but one hot or wet historical edition is not evidence of an extreme race climate. A moderate score reflects that variability without inventing a forecast."
+        "score": 5,
+        "explanation": "The 2024 edition delivered \"cloudless blue skies\" with temperatures \"nudging 28°C\" - exceptional conditions for Scotland. Matt Buckley called it \"blazing sun and bone-dry, dust-choked trails\" that transformed the normally wet Scottish course. The maritime location provides spring conditions without Scotland's typical weather misery, though heat management becomes the challenge. Among the most weather-friendly events, easier than Badlands."
       },
       "altitude": {
         "score": 1,
-        "explanation": "The organizer publishes total gain but no high-altitude course figure, and the race begins near sea level in Gatehouse of Fleet. The profile makes no acclimatization claim."
+        "explanation": "Sea level start in Gatehouse of Fleet means zero altitude considerations. Even with 1,761m of total climbing through the Galloway Hills, you're nowhere near elevations that affect performance or require acclimatization. This is low-elevation suffering where lungs work fine but legs still get destroyed. Lower altitude than Gravel Worlds — no thin-air concerns."
       },
       "adventure": {
-        "score": 4,
-        "explanation": "The route moves through Galloway Forest Park, lochs, forest tracks, and open plateaus while remaining a supported one-day race. It is memorable destination gravel, one step below a life-changing expedition."
+        "score": 5,
+        "explanation": "Matt Buckley captures it perfectly: \"One minute, I was riding through wide open glens with views stretching miles, and the next, I was picking the smoothest line through a lochside path with the deep blue water looking so inviting.\" Racing through UNESCO Biosphere terrain from tiny Gatehouse of Fleet delivers pure Scottish Highlands adventure."
       },
       "prestige": {
-        "score": 4,
-        "explanation": "The official race offers age-group and Elite qualification pathways to the UCI Gravel World Championships and functions as Britain's flagship gravel event. That is national significance, short of an iconic global classic."
+        "score": 3,
+        "explanation": "Britain's first UCI Gravel World Series event attracts international talent - 35 nations competed in 2024. Elite finishes came down to one-second separations in both men's and women's races, with Petr Vakoc winning despite a late puncture. Fourth edition status and World Championships qualification elevate it above regional events, but it lacks the established reputation of continental classics."
       },
       "race_quality": {
-        "score": 4,
-        "explanation": "Chip timing, category pens and waves, three staffed feed and tech zones, medical control, sweep vehicles, bike repatriation, and a signed GPX-backed course show professional delivery. Some timings remain provisional, so it stops below flawless."
+        "score": 3,
+        "explanation": "Professional timing delivered precise results with the men's top four separated by one second. Feed stations at 87km provided proper support, though Michael Newton noted stomach issues from \"all the energy food.\" The 67.9km cutoff still forces slower riders onto a shortened route, and \"punctures were a common theme\" suggests course maintenance challenges."
       },
       "experience": {
-        "score": 4,
-        "explanation": "A mass-start race on predominantly gravel forest tracks, followed by a full event village and festival, gives the day a distinct identity beyond its raw numbers. The rural setting and cutoff make the experience consequential without turning it into an expedition."
+        "score": 3,
+        "explanation": "Cycling Weekly called the route 'relentless' and riders rave about it being 'one of the most beautiful courses in the series,' winding through UNESCO Biosphere terrain. The opening kilometer dumps you straight onto gravel for an 11km climb, so you know what you're getting. Missing rider reports and DNF data make it hard to judge how the beauty translates to actual suffering."
       },
       "community": {
         "score": 4,
-        "explanation": "The three-day festival combines the race, sportive, Ultra, event village, camping, live music, food, and community rides. The organizer is building a real gathering rather than a start-line-only product."
+        "explanation": "The event village creates proper festival atmosphere with \"live music, local food\" and camping options. Michael Newton praised \"the fantastic atmosphere at the finish,\" and riders spent evenings \"drinking a few ciders whilst listening to the live band.\" The weekend format transforms tiny Gatehouse of Fleet into a cycling celebration beyond just pinning numbers."
       },
       "field_depth": {
-        "score": 4,
-        "explanation": "Separate Elite categories, licensed UCI riders, age-group qualification, and category-specific pens create a nationally strong competitive field. The 2027 start list is not yet published, so this does not claim world-best depth."
+        "score": 3,
+        "explanation": "With a field of 200-300 riders, fourth edition status and UCI World Series qualification should attract serious talent, but 'thousands of incredible amateur racers' alongside unnamed elites doesn't scream deep competition yet. Being Britain's only top-level gravel race means you get the UK's best by default, not necessarily because you've earned global respect. The field is probably stronger than most regional events but weaker than established classics. Similar competitive depth to Rule of Three. As Hugo Foulon puts it: \"After 40km of a super fast ride, chasing the leading group with 4/5 very strong fellow racers, unfortunately, I broke my chain. It was due to a projection of a rock between my cassette and my chain.\""
       },
       "value": {
         "score": 3,
-        "explanation": "The entry includes professional timing, three feed and tech zones, medical support, bike wash, bag drop, and the wider festival. The public page does not expose a stable price in its visible copy, so a higher value score would be guesswork."
+        "explanation": "UCI points and World Championships qualification justify the investment for competitive riders. The weekend festival format with camping and entertainment adds value beyond just the race. However, pricing details remain mysteriously absent, and equipment failure rates suggest riders need backup gear budgets for the \"sharp dagger-like rocks\" that line the course."
       },
       "expenses": {
         "score": 3,
-        "explanation": "Rural lodging, onward transport, and event parking make the trip more than a cheap local race, while official camping can contain costs. With no verified 2027 total-trip figure, the middle expense band is the honest grade."
-      },
-      "cultural_impact": {
-        "score": 3,
-        "explanation": "The race is nationally recognized as Britain's premier gravel festival and carries a World Championship qualification pathway. It has strong national relevance without evidence of the mass scale required for a global-icon bonus."
+        "explanation": "Registration runs £150-£200. Gatehouse of Fleet isn't a major airport hub - you're looking at 90+ miles from Glasgow or Edinburgh, plus whatever accommodation costs in rural Scotland during festival weekend. Camping is available but hotel options in a town this small probably book up fast. Remote Scottish location means this isn't a budget destination race. Similar expense level to Belgian Waffle Ride San Diego."
       }
     },
     "final_verdict": {
-      "score": "71 / 100",
-      "one_liner": "Sixty-nine miles sounds manageable until Galloway adds 5,778 feet, rough forest gravel, and a race-day cutoff.",
-      "should_you_race": "Race it if you want a serious British qualifier where climbing, surface management, and positioning all matter. Train for a fast 111-kilometer race, not the separate 323-kilometer Ultra.",
-      "alternatives": "Dirty Reiver offers a longer British gravel challenge without the same qualifier format; Belgian Waffle Ride California mixes more pavement into a similarly competitive day.",
+      "score": "69 / 100",
+      "one_liner": "Scotland's gravel crown jewel serves up 1,700 meters of climbing through Galloway's forests with a side of Highland hospitality.",
+      "should_you_race": "You need solid climbing legs and comfort on technical gravel—that opening 11km ascent eliminates pretenders fast. The 4:15 PM cutoff at 67km isn't generous, so show up fit or get shuttled to the shortened route. Perfect for riders who want UCI World Series prestige without the chaos of American mega-events.",
+      "alternatives": "Dirty Kanza offers more distance brutality on flatter Kansas flint, while Belgian Waffle Ride delivers comparable climbing with more pavement mixing. Both lack The Gralloch's UNESCO Biosphere scenery but serve bigger, more established fields if you're chasing pack dynamics over Scottish solitude.",
       "alternative_slugs": [
         "bwr-california",
-        "dirty-reiver"
+        "unbound-200"
       ]
     },
     "citations": [
-      {
-        "url": "https://www.grallochgravel.com/",
-        "category": "official",
-        "label": "The Gralloch official 2027 event page"
-      },
-      {
-        "url": "https://www.grallochgravel.com/race",
-        "category": "official",
-        "label": "The Gralloch official race and course details"
-      },
-      {
-        "url": "https://www.grallochgravel.com/parking",
-        "category": "official",
-        "label": "The Gralloch official 2027 parking schedule"
-      },
       {
         "url": "https://ridewithgps.com/routes/53947683",
         "category": "route",
@@ -387,7 +366,7 @@
     },
     "youtube_data": {
       "researched_at": "2026-02-23",
-      "search_query": "The Gralloch gravel race Galloway Forest Park",
+      "search_query": "The Gralloch gravel race Scottish Highlands",
       "videos": [
         {
           "video_id": "Vdj0wtuEbHc",
@@ -606,7 +585,7 @@
         "type": "video-1",
         "file": "the-gralloch-video-1.jpg",
         "url": "/race-photos/the-gralloch/the-gralloch-video-1.jpg",
-        "alt": "Solo cyclist navigating a winding gravel path through Galloway Forest Park at The Gralloch in Scotland",
+        "alt": "Solo cyclist navigating winding gravel path through dense Scottish forest with evergreen trees and brown undergrowth - The Gralloch - Scottish Highlands, Scotland",
         "credit": "YouTube / Glorious Gravel TV",
         "primary": true,
         "ai_relevance": 5,
@@ -623,7 +602,7 @@
         "type": "video-2",
         "file": "the-gralloch-video-2.jpg",
         "url": "/race-photos/the-gralloch/the-gralloch-video-2.jpg",
-        "alt": "Two cyclists riding an open gravel road in Dumfries and Galloway during The Gralloch",
+        "alt": "Two cyclists riding gravel road through open countryside with green fields and dramatic cloudy sky - The Gralloch - Scottish Highlands, Scotland",
         "credit": "YouTube / Glorious Gravel TV",
         "primary": false,
         "ai_relevance": 5,
@@ -640,17 +619,17 @@
         "type": "video-3",
         "file": "the-gralloch-video-3.jpg",
         "url": "/race-photos/the-gralloch/the-gralloch-video-3.jpg",
-        "alt": "Open Galloway landscape with rolling hills and a stream near The Gralloch course",
+        "alt": "Highland landscape showing barren moorland with rolling mountains, scattered trees and meandering stream under cloudy sky - The Gralloch - Scottish Highlands, Scotland",
         "credit": "YouTube / Glorious Gravel TV",
         "primary": false,
         "ai_relevance": 2,
         "ai_quality": 5,
         "ai_keywords": [
-          "Galloway moorland",
+          "Highland moorland",
           "rolling mountains",
           "barren landscape",
           "meandering stream",
-          "Dumfries and Galloway"
+          "Scottish Highlands"
         ]
       },
       {


### PR DESCRIPTION
## Summary

- correct Del Fuego Haín to the organizer-confirmed 2027 date and 1,050 km course
- align The Gralloch with the current 2027 race facts and rating
- align 555 Corsica with the current 2027 course, date, elevation, and rating
- retain first-party sources used by the published Gravel God plan ladders

## Validation

- `python3 -m pytest -q tests/test_validate_race_data.py` (16 passed)
- all three JSON profiles parse with `python3 -m json.tool`
- `git diff --check`