### PR TITLE
fix(data): refresh Nannup downstream artifacts

### DIFF
--- a/briefs/uci-gravel-worlds-brief.md
+++ b/briefs/uci-gravel-worlds-brief.md
@@ -1,44 +1,33 @@
-# UCI Gravel World Championships — Synthesis Brief
+# UCI Gravel World Championships — 2026 Nannup Synthesis Brief
 
 ## VITALS
 - **Name:** UCI Gravel World Championships
-- **Location:** Rotating (2024: Heerlen, Netherlands)
-- **Date:** October annually
-- **Distance:** ~180 km (elite), ~140 km (age group)
-- **Elevation:** ~2,500 m (elite)
-- **Field:** 1,000+ riders (elite + age group)
-- **Entry:** €100-€150 (~$110-$165 USD), UCI license required
-- **Founded:** 2022 (Veneto, Italy inaugural)
+- **Location:** Nannup, Western Australia, Australia
+- **Dates:** October 10–11, 2026
+- **Primary plan race day:** Sunday, October 11 — elite men and men 19–49
+- **Primary course:** 143 km / 88.9 mi; 3,713 m / 12,182 ft
+- **Other category courses:** 125 km / 77.7 mi; 90 km / 55.9 mi
+- **Surface:** At least 80% gravel
+- **Entry:** Qualification required; qualified riders receive a UCI invitation and registration link
 
 ## COURSE
-180 km elite, 140 km age group. 70% gravel, 30% paved. Varies by location. 2024 Heerlen (Netherlands)—rolling terrain, technical sections. Technical rating: 4/5.
+The long course opens with 9 km of undulating pavement before moving onto varied Blackwood Valley gravel. The organizer describes short, steep climbs that arrive in close succession. The long course adds an eastern loop; all categories share the final 27 km southern loop and the same finish in Nannup.
 
 ## WEATHER
-October: 10-20°C, 40% rain. Historical: 2022 (cool/dry, 12-18°C), 2023 (variable, 10-20°C), 2024 (cool/wet, 10-15°C, rain).
+The organizer lists average October temperatures of 10–21°C / 49–69°F. The course stays at low altitude, but riders should prepare for a cool start, a milder afternoon, remote forest exposure, and changing conditions across a long day.
 
-## EQUIPMENT
-**Tires:** 35-40mm tubeless (WTB Resolute, Panaracer GK). **Gearing:** 1x or compact double, low gears. **Other:** Tubeless, full waterproofs, layers, lights (long day).
-
-## DNF FACTORS
-20-30% (elite), 15-25% (age group). Causes: distance (180 km elite), weather (October rain, cold), technical terrain (varies by location), elevation (2,500 m elite).
-
-## COMMUNITY
-UCI World Championship. Elite + age group. 1,000+ riders. Fastest field in gravel. UCI license required. Rotating locations.
+## EQUIPMENT AND TRAINING DEMANDS
+- Climbing density and repeatability are the defining demands.
+- Use gearing that supports repeated steep climbs after several hours of accumulated fatigue.
+- Train confident descending on varied gravel while tired.
+- Rehearse fueling for a course with 3,713 m of ascent in only 143 km.
+- Do not assume the old European course, distance, or weather profile applies.
 
 ## SCORING
-1. Course Challenge — 5/5  
-2. Scenery — 4/5  
-3. Organization — 5/5  
-4. Community — 5/5  
-5. Amenities — 5/5  
-6. Value — 4/5  
-7. Accessibility — 3/5  
-8. Beginner-Friendly — 1/5  
-9. Competitive Field — 5/5  
-10. Unique Character — 5/5  
-11. Trail Conditions — 4/5  
-12. Weather Risk — 4/5  
-13. Prestige — 5/5  
-14. Post-Race Experience — 5/5  
+The current transparent rubric yields **83/100, Tier 1**. Prestige, field depth, community, race quality, experience, adventure, and elevation are elite. Qualification, travel expense, and incomplete final technical-guide details reduce accessibility and value.
 
-**Sum:** 60/70 | **Overall Score:** 86 | **Prestige:** 5 | **Tier:** 1
+## SOURCES
+- 2026 organizer course page: https://gravelchampswesternaustralia.com/courses/
+- 2026 organizer program: https://gravelchampswesternaustralia.com/wp-content/uploads/2026/01/The-Program-v12-1.pdf
+- 2026 organizer rider FAQ: https://gravelchampswesternaustralia.com/riders/faq/
+- UCI competition record: https://www.uci.org/competition-details/2026/GRA/78584

--- a/scripts/fetch_rwgps_routes.py
+++ b/scripts/fetch_rwgps_routes.py
@@ -290,7 +290,7 @@ def build_search_queries(race_name: str, location: str) -> list:
     clean_name = re.sub(r'^THE\s+', '', race_name, flags=re.IGNORECASE).strip()
 
     if location:
-        # Strip parenthetical content: "Rotating (2024: Heerlen, Netherlands)" → "Rotating"
+        # Strip parenthetical content: "Emporia (Lyon County, Kansas)" → "Emporia"
         loc_clean = re.sub(r'\([^)]*\)', '', location).strip().rstrip(',').strip()
         parts = [p.strip() for p in loc_clean.split(',') if p.strip()]
 

--- a/scripts/geocode_races.py
+++ b/scripts/geocode_races.py
@@ -32,7 +32,7 @@ MANUAL_COORDS = {
     "gravel-earth": (41.9794, 2.8214),                  # Girona, Spain (HQ)
     "grinduro": (38.4324, -120.0356),                  # Quincy, CA (flagship)
     "transcontinental-race": (48.2082, 16.3738),       # Vienna (common start)
-    "uci-gravel-worlds": (45.2083, 5.7148),            # Grenoble, France (2025)
+    "uci-gravel-worlds": (-33.9784, 115.7638),         # Nannup, Western Australia (2026)
     "uci-gravel-suisse": (46.3188, 6.9746),            # Aigle, Switzerland
     "uci-gravel-dustman": (50.6292, 3.0573),           # Lille, France
     # Vague locations

--- a/tests/test_uci_gravel_worlds_nannup_2026.py
+++ b/tests/test_uci_gravel_worlds_nannup_2026.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from scripts.geocode_races import MANUAL_COORDS
+
 
 ROOT = Path(__file__).resolve().parents[1]
 RATING_KEYS = (
@@ -79,3 +81,28 @@ def test_nannup_index_and_training_preview_match_the_profile() -> None:
     assert "Heerlen" not in preview_text
     assert "8,202" not in preview_text
     assert "112 miles" not in preview_text
+
+
+def test_nannup_machine_readable_derivatives_cannot_regress_to_europe() -> None:
+    dates = json.loads((ROOT / "web" / "race-dates.json").read_text(encoding="utf-8"))
+    # The public countdown starts with the two-day championship weekend; the
+    # plan itself targets the Sunday long-course categories.
+    assert dates["uci-gravel-worlds"] == "2026-10-10"
+    assert MANUAL_COORDS["uci-gravel-worlds"] == (-33.9784, 115.7638)
+
+    llms = (ROOT / "web" / "llms-full.txt").read_text(encoding="utf-8")
+    worlds_section = llms.split("### UCI Gravel World Championships", 1)[1].split(
+        "\n### ", 1
+    )[0]
+    assert "83/100 | 88.9 mi | 12,182 ft | Nannup" in worlds_section
+
+    brief = (ROOT / "briefs" / "uci-gravel-worlds-brief.md").read_text(
+        encoding="utf-8"
+    )
+    video_briefs = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted((ROOT / "video-briefs").glob("*/uci-gravel-worlds.json"))
+    )
+    current_derivatives = brief + worlds_section + video_briefs
+    for stale_fact in ("Heerlen", "Grenoble", "112 mi", "8,202 ft"):
+        assert stale_fact not in current_derivatives

--- a/video-briefs/roast/uci-gravel-worlds.json
+++ b/video-briefs/roast/uci-gravel-worlds.json
@@ -10,12 +10,12 @@
     300
   ],
   "estimated_duration_sec": 225,
-  "estimated_spoken_words": 193,
+  "estimated_spoken_words": 186,
   "story_arc": "expose: pitch → reality → data → verdict",
   "primary_trope": {
-    "name": "extreme_length",
-    "hook_text": "Only a handful of races score 5/5 on Length. UCI Gravel World Championships is one.",
-    "mechanism": "Curiosity gap (specific) — knowing a perfect score exists but not why triggers dopamine anticipation."
+    "name": "expose",
+    "hook_text": "UCI Gravel World Championships has a dirty secret the brochure won't tell you.",
+    "mechanism": "Cognitive dissonance — viewer believed X was good, specific counter-evidence triggers emotional demand for resolution."
   },
   "retention_targets": {
     "30s_hold": ">70%",
@@ -34,24 +34,18 @@
       "avatar_pose": "mustache_twirl",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
           "type": "youtube_search",
-          "query": "Rotating (2024: Heerlen, Netherlands) drone",
+          "query": "Nannup, Western Australia, Australia drone",
           "use": "B-roll: location"
         },
         {
           "type": "youtube_search",
-          "query": "Rotating (2024: Heerlen, Netherlands) landscape",
+          "query": "Nannup, Western Australia, Australia landscape",
           "use": "B-roll: location"
         }
       ],
@@ -82,14 +76,8 @@
       "avatar_pose": "skeptical",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
@@ -122,7 +110,7 @@
           "Rainbow jersey (elite winners)",
           "Fastest field in gravel (van der Poel, Vos, Vermeersch, Ferrand-Prévot)",
           "Elite + age group categories",
-          "Rotating international locations",
+          "First edition outside Europe",
           "Well-organized (UCI)",
           "World Championship podium ceremony"
         ]
@@ -140,14 +128,8 @@
       "avatar_pose": "facepalm",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
@@ -157,7 +139,7 @@
         },
         {
           "type": "youtube_search",
-          "query": "gravel cycling Varies by location—rolling technical terrain",
+          "query": "gravel cycling Undulating Blackwood Valley gravel and repeated steep climbs",
           "use": "B-roll: terrain"
         }
       ],
@@ -183,11 +165,11 @@
       "content_data": {
         "weaknesses": [
           "UCI license required",
-          "International travel (rotating locations)",
-          "Long distance (180 km elite)",
-          "Weather (October rain 40%, cold)",
-          "20-30% DNF (elite)",
-          "Expensive (€100-€150 + travel)"
+          "Remote Western Australia travel",
+          "Qualification required",
+          "3,713 m of climbing on the long course",
+          "Final GPX and technical guide are still pending",
+          "Category-dependent course and race day"
         ]
       },
       "narration_wpm": 8.0
@@ -197,7 +179,7 @@
       "label": "THE NUMBERS DON'T LIE",
       "time_range": "1:50-2:50",
       "duration_sec": 60,
-      "narration": "The scores that tell the real story. Altitude. 1 out of 5. Sea level. Your lungs get a day off. All host locations remain at low European elevations. Logistics. 3 out of 5. Adequate. The word was invented for this. Joy Franco describes qualifying for Team USA as \"the privilege of a lifetime,\" though riders \"paid our own way\" for this World Championship. Expenses. 3 out of 5. Mid-range expenses. Budget a proper race weekend. Rotating locations mean international flights, hotels that know they can gouge World Championship visitors.",
+      "narration": "The scores that tell the real story. Altitude. 1 out of 5. Sea level. Your lungs get a day off. The 2026 course ranges from roughly 100 to 300 metres above sea level. Expenses. 1 out of 5. Bring a second mortgage and strong opinions about hotels. For the international audience, Western Australia means long-haul flights, bike transport, a rental car or event transfer, and lodging in Busselton or the surrounding region. Climate. 2 out of 5. Weather cooperates more often than not. The organizer lists average October temperatures from 10°C to 21°C (49°F to 69°F).",
       "text_on_screen": "THE DATA",
       "visual": "Score cards — lowest 3 dimensions with explanations",
       "avatar_pose": "thinking",
@@ -222,24 +204,24 @@
           "max": 5
         },
         {
-          "dimension": "Logistics",
-          "score": 3,
+          "dimension": "Expenses",
+          "score": 1,
           "max": 5
         },
         {
-          "dimension": "Expenses",
-          "score": 3,
+          "dimension": "Climate",
+          "score": 2,
           "max": 5
         }
       ],
-      "narration_wpm": 89.0
+      "narration_wpm": 96.0
     },
     {
       "id": "verdict",
       "label": "THE BOTTOM LINE",
       "time_range": "2:50-3:30",
       "duration_sec": 40,
-      "narration": "UCI Gravel Worlds is World Championship. 180 km elite, rainbow jersey, fastest field in gravel. If you want World Championship prestige and UCI license, this is it. If you need domestic/local, skip it. International travel required but World Championship makes it worth it. Elite + age group categories.",
+      "narration": "If you qualified, Nannup is the assignment: prepare for dense climbing, remote gravel, and a world-title field. If you did not qualify, this is not a race you can simply add to the calendar.",
       "text_on_screen": "UCI World Championship—Rainbow Jersey — 83/100",
       "visual": "Verdict card + final tier badge",
       "avatar_pose": "thumbs_up",
@@ -257,14 +239,14 @@
         25
       ],
       "editing_note": "PAYOFF. Close the open loop from the hook. Avatar delivers final take directly to camera. End ABRUPTLY — never signal 'we're wrapping up.' MrBeast rule: cut to CTA mid-energy.",
-      "narration_wpm": 72.0
+      "narration_wpm": 51.0
     },
     {
       "id": "cta",
       "label": "CTA",
       "time_range": "3:30-3:45",
       "duration_sec": 15,
-      "narration": "Full breakdown. All 14 dimensions. Free prep kit. Link in bio.",
+      "narration": "Full breakdown. All 15 dimensions. Free prep kit. Link in bio.",
       "text_on_screen": "gravelgodcycling.com/race/uci-gravel-worlds",
       "visual": "URL overlay + engagement question",
       "avatar_pose": "pointing",
@@ -302,11 +284,11 @@
       "duration_sec": 1.5
     }
   ],
-  "thumbnail_prompt": "South Park style flat cutout character, dramatic pose, 'UCI Gravel World Championships' bold text, tier badge 'THE ICONS', high contrast red/yellow/white, cycling gear, handlebar mustache --ar 16:9 --cref [CHARACTER_URL]",
+  "thumbnail_prompt": "South Park style flat cutout character, skeptical squinting, red warning flags background, 'UCI Gravel World Championships' bold text, tier badge 'THE ICONS', high contrast red/yellow/white, cycling gear, handlebar mustache --ar 16:9 --cref [CHARACTER_URL]",
   "narration_feasibility": {
-    "total_words": 193,
+    "total_words": 186,
     "total_duration_sec": 225,
-    "overall_wpm": 51.5,
+    "overall_wpm": 49.6,
     "warnings": [],
     "feasible": true
   },

--- a/video-briefs/should-you-race/uci-gravel-worlds.json
+++ b/video-briefs/should-you-race/uci-gravel-worlds.json
@@ -10,12 +10,12 @@
     720
   ],
   "estimated_duration_sec": 585,
-  "estimated_spoken_words": 481,
+  "estimated_spoken_words": 551,
   "story_arc": "promise → course → data-staircase → pro/con → verdict → alternatives",
   "primary_trope": {
-    "name": "extreme_length",
-    "hook_text": "Only a handful of races score 5/5 on Length. UCI Gravel World Championships is one.",
-    "mechanism": "Curiosity gap (specific) — knowing a perfect score exists but not why triggers dopamine anticipation."
+    "name": "expose",
+    "hook_text": "UCI Gravel World Championships has a dirty secret the brochure won't tell you.",
+    "mechanism": "Cognitive dissonance — viewer believed X was good, specific counter-evidence triggers emotional demand for resolution."
   },
   "retention_targets": {
     "1min_hold": ">70%",
@@ -28,20 +28,14 @@
       "label": "HOOK + PROMISE",
       "time_range": "0:00-0:15",
       "duration_sec": 15,
-      "narration": "Should you race UCI Gravel World Championships? I rated 328 gravel races on 14 dimensions. UCI Gravel World Championships scored 83 out of 100. The Icons tier. Here's what that actually means for your season.",
+      "narration": "Should you race UCI Gravel World Championships? I rated 328 gravel races on 15 dimensions. UCI Gravel World Championships scored 83 out of 100. The Icons tier. Here's what that actually means for your season.",
       "text_on_screen": "Should You Race UCI Gravel World Championships?",
       "visual": "Title card + tier badge + avatar",
       "avatar_pose": "presenting",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
@@ -76,20 +70,14 @@
       "label": "THE COURSE",
       "time_range": "0:15-1:15",
       "duration_sec": 60,
-      "narration": "UCI Gravel World Championships. Rotating (2024: Heerlen, Netherlands). 112 mi. 180 km elite, 140 km age group. 70% gravel, 30% paved. Varies by location. Technical rating: 4/5.",
-      "text_on_screen": "UCI Gravel World Championships | Rotating (2024: Heerlen, Netherlands) | 112 mi",
+      "narration": "UCI Gravel World Championships. Nannup, Western Australia, Australia. 88.9 mi. The long course packs 3.7 thousand metres of climbing into 143 kilometres. The organizer describes wide gravel roads, varied unpaved surfaces, and climbs that are seldom long but arrive steeply and in quick succession. All categories share the same start, finish, and final 27 km southern loop.",
+      "text_on_screen": "UCI Gravel World Championships | Nannup, Western Australia, Australia | 88.9 mi",
       "visual": "Route map + terrain footage",
       "avatar_pose": "presenting",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
@@ -116,14 +104,14 @@
         40
       ],
       "editing_note": "Let the course breathe. Show the route map, then cut to terrain-specific B-roll. This is the SETUP phase — grounding the viewer before the data analysis. Pacing: 25-40 sec cuts.",
-      "narration_wpm": 27.0
+      "narration_wpm": 57.0
     },
     {
       "id": "scores_top",
       "label": "THE SCORES — Top 8",
       "time_range": "1:15-4:15",
       "duration_sec": 180,
-      "narration": "Let's go through the scores. Length. 5 out of 5. Ultra distance. Bring lights and a plan. Elite women race 131km, elite men 180km—distances that create real selection. Adventure. 5 out of 5. Full expedition mode. Genuine backcountry. Prestige. 5 out of 5. Bucket list tier. The name speaks for itself. This is the World Championship. Race Quality. 5 out of 5. Best-in-class race production. 180km elite distance with 2,500m of climbing separates pretenders from contenders fast. Experience. 5 out of 5. This race ruins other races for you. Racing for rainbow stripes changes everything—the nerves, the tactics, the suffering. Community. 5 out of 5. Family reunion energy. Everyone belongs. Elite and age group categories racing the same brutal course creates instant respect. Field Depth. 5 out of 5. Deepest field in gravel. Murderer's row. The top ten in both elite races consisted entirely of WorldTour riders—van der Poel, Vos, Vermeersch, Mohorič, Pidcock racing alongside age group qualifiers. Technicality. 4 out of 5. Bike handling matters here. Practice your descents. Course varies by location but maintains World Championship standards.",
+      "narration": "Let's go through the scores. Elevation. 5 out of 5. Mountainous. Your granny gear will earn its keep. The provisional long course publishes 3,713 metres (12,182 feet) of gain in 143 kilometres. Adventure. 5 out of 5. Full expedition mode. Genuine backcountry. The first Gravel World Championships outside Europe sends a qualified international field into the remote forests and farmland of Western Australia's Blackwood Valley. Prestige. 5 out of 5. Bucket list tier. The name speaks for itself. This is the discipline's UCI World Championship, awarding elite and age-group rainbow jerseys. Race Quality. 5 out of 5. Best-in-class race production. UCI championship production, qualification standards, separate elite and age-group titles, and category-specific courses place this at the top of the race-quality scale. Experience. 5 out of 5. This race ruins other races for you. A qualification-only chance to race for an age-group or elite rainbow jersey on the same Nannup weekend is the defining competitive experience in the discipline. Community. 5 out of 5. Family reunion energy. Everyone belongs. Qualified age-group riders and national-team elites converge on one championship weekend, with community rides and fan zones built around the host region. Field Depth. 5 out of 5. Deepest field in gravel. Murderer's row. National-team selection fills the elite races, while age-group riders must qualify through the UCI Gravel World Series. Logistics. 4 out of 5. One less thing to worry about. Nannup is roughly three hours by car from Perth Airport, while the nearest regional airport is about 45 minutes away.",
       "text_on_screen": "14 DIMENSIONS",
       "visual": "Score cards — 8 expanded dimensions",
       "avatar_pose": "thinking",
@@ -143,7 +131,7 @@
       "editing_note": "PROGRESSIVE RHYTHM: start tight (15-20 sec per dimension), slow down for the most interesting scores (30-40 sec). Each score: number appears, brief pause, explanation. Avatar reacts to extreme scores (5/5 = chef_kiss, 1/5 = facepalm). RE-ENGAGEMENT at 3:00 mark: insert a surprising score reveal or a meme reaction to break the pattern.",
       "evidence_data": [
         {
-          "dimension": "Length",
+          "dimension": "Elevation",
           "score": 5,
           "max": 5
         },
@@ -178,7 +166,7 @@
           "max": 5
         },
         {
-          "dimension": "Technicality",
+          "dimension": "Logistics",
           "score": 4,
           "max": 5
         }
@@ -189,14 +177,14 @@
         "suggested_clip": "avatar reaction to most extreme score",
         "duration_sec": 2
       },
-      "narration_wpm": 59.7
+      "narration_wpm": 83.7
     },
     {
       "id": "scores_remaining",
       "label": "THE SCORES — Also Scored",
       "time_range": "4:15-5:00",
       "duration_sec": 45,
-      "narration": "The rest. Quick-fire. Elevation. 4 out of 5. Mountain passes on the menu. Climate. 4 out of 5. Conditions will test your kit choices. Value. 4 out of 5. Strong value proposition. Logistics. 3 out of 5. Adequate. The word was invented for this. Expenses. 3 out of 5. Mid-range expenses. Budget a proper race weekend. Altitude. 1 out of 5. Sea level. Your lungs get a day off.",
+      "narration": "The rest. Quick-fire. Technicality. 4 out of 5. Bike handling matters here. Practice your descents. Length. 3 out of 5. Proper race distance. Enough to hurt. Value. 3 out of 5. Reasonable price for what's offered. Climate. 2 out of 5. Weather cooperates more often than not. Altitude. 1 out of 5. Sea level. Your lungs get a day off. Expenses. 1 out of 5. Bring a second mortgage and strong opinions about hotels.",
       "text_on_screen": null,
       "visual": "Quick-fire score list — remaining 6 dimensions",
       "avatar_pose": "counting",
@@ -216,37 +204,37 @@
       "editing_note": "FAST PACING — 7 seconds per dimension. Quick-fire energy change from the deep analysis above. This is a PATTERN INTERRUPT through pacing shift.",
       "evidence_data": [
         {
-          "dimension": "Elevation",
+          "dimension": "Technicality",
           "score": 4,
           "max": 5
         },
         {
-          "dimension": "Climate",
-          "score": 4,
+          "dimension": "Length",
+          "score": 3,
           "max": 5
         },
         {
           "dimension": "Value",
-          "score": 4,
-          "max": 5
-        },
-        {
-          "dimension": "Logistics",
           "score": 3,
           "max": 5
         },
         {
-          "dimension": "Expenses",
-          "score": 3,
+          "dimension": "Climate",
+          "score": 2,
           "max": 5
         },
         {
           "dimension": "Altitude",
           "score": 1,
           "max": 5
+        },
+        {
+          "dimension": "Expenses",
+          "score": 1,
+          "max": 5
         }
       ],
-      "narration_wpm": 92.0
+      "narration_wpm": 98.7
     },
     {
       "id": "strengths",
@@ -259,14 +247,8 @@
       "avatar_pose": "thumbs_up",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
@@ -299,7 +281,7 @@
           "Rainbow jersey (elite winners)",
           "Fastest field in gravel (van der Poel, Vos, Vermeersch, Ferrand-Prévot)",
           "Elite + age group categories",
-          "Rotating international locations",
+          "First edition outside Europe",
           "Well-organized (UCI)",
           "World Championship podium ceremony"
         ]
@@ -332,11 +314,11 @@
       "content_data": {
         "weaknesses": [
           "UCI license required",
-          "International travel (rotating locations)",
-          "Long distance (180 km elite)",
-          "Weather (October rain 40%, cold)",
-          "20-30% DNF (elite)",
-          "Expensive (€100-€150 + travel)"
+          "Remote Western Australia travel",
+          "Qualification required",
+          "3,713 m of climbing on the long course",
+          "Final GPX and technical guide are still pending",
+          "Category-dependent course and race day"
         ]
       },
       "meme_insert": {
@@ -358,19 +340,13 @@
       "avatar_pose": "presenting",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
           "type": "youtube_search",
-          "query": "Rotating (2024: Heerlen, Netherlands) travel guide",
+          "query": "Nannup, Western Australia, Australia travel guide",
           "use": "B-roll: logistics"
         },
         {
@@ -394,7 +370,7 @@
       "editing_note": "Utility section. Lower energy, practical value. Hybrid Tempo: alternate fast logistics items (10-15 sec) with slow map visuals (30 sec).",
       "content_data": {
         "logistics": [
-          "Entry: €100-€150"
+          "Entry: $2,000"
         ]
       },
       "narration_wpm": 8.0
@@ -404,7 +380,7 @@
       "label": "VERDICT",
       "time_range": "7:30-8:30",
       "duration_sec": 60,
-      "narration": "Verdict: UCI World Championship—Rainbow Jersey. You need a UCI license, the fitness for nearly five hours of World Championship pace racing. And the mental fortitude to suffer in front of 1 thousand+ of the world's fastest gravel riders. The course changes annually, so you're gambling on terrain, but if you can't handle 2.5 thousandm of climbing and October weather in Europe, stay home. This isn't about participation. it's about proving you belong with the global elite.",
+      "narration": "Verdict: UCI World Championship—Rainbow Jersey. If you qualified, yes. but train for the course you actually have: 143 kilometres, 3.7 thousand metres of climbing, at least 80 percent gravel. And almost no recovery between steep efforts. If you did not qualify, this is not an open-entry bucket-list race.",
       "text_on_screen": "UCI World Championship—Rainbow Jersey — 83/100",
       "visual": "Verdict badge + full scorecard summary",
       "avatar_pose": "thumbs_up",
@@ -422,14 +398,14 @@
         40
       ],
       "editing_note": "CLOSE THE MAIN LOOP. 0.5s silence before verdict. Tier badge slams in. Avatar delivers final take. DO NOT signal 'wrapping up' — maintain energy.",
-      "narration_wpm": 76.0
+      "narration_wpm": 48.0
     },
     {
       "id": "alternatives",
       "label": "ALTERNATIVES",
       "time_range": "8:30-9:15",
       "duration_sec": 45,
-      "narration": "If UCI Gravel World Championships isn't quite right for you. Unbound 200 gives you similar distance and prestige without the UCI bureaucracy and European travel costs. If you want that strade bianche experience more predictably, hit L'Eroica or Strade Bianche Gran Fondo where the terrain stays consistent and the October weather won't ruin your expensive European vacation.",
+      "narration": "If UCI Gravel World Championships isn't quite right for you. SEVEN uses the same Nannup terrain as a UCI Gravel World Series qualifier and is the direct course analogue. Unbound 200 offers comparable global prestige with open-entry pathways, but it is much longer and far flatter per mile.",
       "text_on_screen": "ALTERNATIVES",
       "visual": "Race cards for alternative races",
       "avatar_pose": "shrug",
@@ -447,7 +423,7 @@
         40
       ],
       "editing_note": "Bonus value — viewers who reach this point are highly engaged. Cross-reference other videos/races.",
-      "narration_wpm": 76.0
+      "narration_wpm": 64.0
     },
     {
       "id": "cta",
@@ -499,11 +475,11 @@
       "duration_sec": 1.5
     }
   ],
-  "thumbnail_prompt": "South Park style flat cutout character, dramatic pose, 'UCI Gravel World Championships' bold text, tier badge 'THE ICONS', high contrast red/yellow/white, cycling gear, handlebar mustache --ar 16:9 --cref [CHARACTER_URL]",
+  "thumbnail_prompt": "South Park style flat cutout character, skeptical squinting, red warning flags background, 'UCI Gravel World Championships' bold text, tier badge 'THE ICONS', high contrast red/yellow/white, cycling gear, handlebar mustache --ar 16:9 --cref [CHARACTER_URL]",
   "narration_feasibility": {
-    "total_words": 481,
+    "total_words": 551,
     "total_duration_sec": 585,
-    "overall_wpm": 49.3,
+    "overall_wpm": 56.5,
     "warnings": [],
     "feasible": true
   },

--- a/video-briefs/suffering-map/uci-gravel-worlds.json
+++ b/video-briefs/suffering-map/uci-gravel-worlds.json
@@ -10,7 +10,7 @@
     30
   ],
   "estimated_duration_sec": 34,
-  "estimated_spoken_words": 31,
+  "estimated_spoken_words": 87,
   "story_arc": "hook-sequential-zones-loop",
   "primary_trope": {
     "name": "countdown",
@@ -28,20 +28,14 @@
       "label": "HOOK",
       "time_range": "0:00-0:05",
       "duration_sec": 5,
-      "narration": "Here's where UCI Gravel World Championships breaks you. 112 mi. Zone by zone.",
+      "narration": "Here's where UCI Gravel World Championships breaks you. 88.9 mi. Zone by zone.",
       "text_on_screen": "UCI Gravel World Championships — Where It Hurts",
       "visual": "Full route map, then zoom into first zone",
       "avatar_pose": "suffering",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
@@ -72,23 +66,17 @@
     },
     {
       "id": "zone_1",
-      "label": "ZONE 1: Mile ?",
+      "label": "ZONE 1: Mile 6",
       "time_range": "0:05-0:13",
       "duration_sec": 8,
-      "narration": "Mile ?. Unknown. ",
-      "text_on_screen": "MILE ?: Unknown",
+      "narration": "Mile 6. End of the paved opener. Nine undulating paved kilometres invite a fast, nervous start before the race commits to the.",
+      "text_on_screen": "MILE 6: End of the paved opener",
       "visual": "Route map with zone marker animation",
       "avatar_pose": "pointing",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
@@ -98,7 +86,7 @@
         },
         {
           "type": "youtube_search",
-          "query": "gravel cycling Varies by location—rolling technical terrain",
+          "query": "gravel cycling Undulating Blackwood Valley gravel and repeated steep climbs",
           "use": "B-roll: terrain"
         }
       ],
@@ -115,27 +103,21 @@
         3
       ],
       "editing_note": "Zone marker 1 appears on map. Progressive color intensity (green→yellow→red).",
-      "narration_wpm": 22.5
+      "narration_wpm": 165.0
     },
     {
       "id": "zone_2",
-      "label": "ZONE 2: Mile ?",
+      "label": "ZONE 2: Mile 48",
       "time_range": "0:13-0:21",
       "duration_sec": 8,
-      "narration": "Mile ?. Unknown. ",
-      "text_on_screen": "MILE ?: Unknown",
+      "narration": "Mile 48. Long-course eastern loop. The 143 km course adds an eastern extension to the already climbing-heavy 125 km medium route.",
+      "text_on_screen": "MILE 48: Long-course eastern loop",
       "visual": "Route map with zone marker animation",
       "avatar_pose": "pointing",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
@@ -145,7 +127,7 @@
         },
         {
           "type": "youtube_search",
-          "query": "gravel cycling Varies by location—rolling technical terrain",
+          "query": "gravel cycling Undulating Blackwood Valley gravel and repeated steep climbs",
           "use": "B-roll: terrain"
         }
       ],
@@ -162,27 +144,21 @@
         3
       ],
       "editing_note": "Zone marker 2 appears on map. Progressive color intensity (green→yellow→red).",
-      "narration_wpm": 22.5
+      "narration_wpm": 157.5
     },
     {
       "id": "zone_3",
-      "label": "ZONE 3: Mile ?",
+      "label": "ZONE 3: Mile 72",
       "time_range": "0:21-0:29",
       "duration_sec": 8,
-      "narration": "Mile ?. Unknown. ",
-      "text_on_screen": "MILE ?: Unknown",
+      "narration": "Mile 72. Final southern loop. Every category finishes on the same final 27 km loop, including two more climbs after the long.",
+      "text_on_screen": "MILE 72: Final southern loop",
       "visual": "Route map with zone marker animation",
       "avatar_pose": "suffering",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
@@ -192,7 +168,7 @@
         },
         {
           "type": "youtube_search",
-          "query": "gravel cycling Varies by location—rolling technical terrain",
+          "query": "gravel cycling Undulating Blackwood Valley gravel and repeated steep climbs",
           "use": "B-roll: terrain"
         }
       ],
@@ -209,7 +185,7 @@
         3
       ],
       "editing_note": "Zone marker 3 appears on map. Progressive color intensity (green→yellow→red). [RIFF HERE] after final zone reveal.",
-      "narration_wpm": 22.5
+      "narration_wpm": 165.0
     },
     {
       "id": "cta",
@@ -245,9 +221,9 @@
   "meme_inserts": [],
   "thumbnail_prompt": "South Park style cartoon cyclist in agony, route map background, red zone markers, 'UCI Gravel World Championships' text --ar 9:16 --cref [CHARACTER_URL]",
   "narration_feasibility": {
-    "total_words": 31,
+    "total_words": 87,
     "total_duration_sec": 34,
-    "overall_wpm": 54.7,
+    "overall_wpm": 153.5,
     "warnings": [],
     "feasible": true
   },

--- a/video-briefs/tier-reveal/uci-gravel-worlds.json
+++ b/video-briefs/tier-reveal/uci-gravel-worlds.json
@@ -10,12 +10,12 @@
     35
   ],
   "estimated_duration_sec": 33,
-  "estimated_spoken_words": 79,
+  "estimated_spoken_words": 74,
   "story_arc": "hook-setup-evidence-reveal-loop",
   "primary_trope": {
-    "name": "extreme_length",
-    "hook_text": "Only a handful of races score 5/5 on Length. UCI Gravel World Championships is one.",
-    "mechanism": "Curiosity gap (specific) — knowing a perfect score exists but not why triggers dopamine anticipation."
+    "name": "expose",
+    "hook_text": "UCI Gravel World Championships has a dirty secret the brochure won't tell you.",
+    "mechanism": "Cognitive dissonance — viewer believed X was good, specific counter-evidence triggers emotional demand for resolution."
   },
   "retention_targets": {
     "3s_hold": ">65%",
@@ -28,10 +28,10 @@
       "label": "HOOK",
       "time_range": "0:00-0:05",
       "duration_sec": 5,
-      "narration": "Only a handful of races score 5/5 on Length. UCI Gravel World Championships is.",
-      "text_on_screen": "Only a handful of races score 5/5 on Length.",
+      "narration": "UCI Gravel World Championships has a dirty secret the brochure won't tell you.",
+      "text_on_screen": "UCI Gravel World Championships has a dirty secret the brochure won't tell you.",
       "visual": "Bold text overlay + avatar reaction",
-      "avatar_pose": "shocked",
+      "avatar_pose": "skeptical",
       "broll_sources": [],
       "music_bpm": [
         120,
@@ -46,38 +46,32 @@
         3
       ],
       "editing_note": "Pattern interrupt. Maximum visual stimulation. Text appears word-by-word (kinetic typography).",
-      "psych_mechanism": "Curiosity gap (specific) — knowing a perfect score exists but not why triggers dopamine anticipation.",
-      "narration_wpm": 168.0
+      "psych_mechanism": "Cognitive dissonance — viewer believed X was good, specific counter-evidence triggers emotional demand for resolution.",
+      "narration_wpm": 156.0
     },
     {
       "id": "setup",
       "label": "SETUP",
       "time_range": "0:05-0:10",
       "duration_sec": 5,
-      "narration": "UCI Gravel World Championships. Rotating (2024: Heerlen, Netherlands). 112 mi.",
-      "text_on_screen": "UCI Gravel World Championships | Rotating (2024: Heerlen, Netherlands)",
+      "narration": "UCI Gravel World Championships. Nannup, Western Australia, Australia. 88.9 mi.",
+      "text_on_screen": "UCI Gravel World Championships | Nannup, Western Australia, Australia",
       "visual": "Race card with location pin + route preview",
       "avatar_pose": "presenting",
       "broll_sources": [
         {
-          "type": "rwgps",
-          "id": "53011652",
-          "url": "https://ridewithgps.com/routes/53011652",
-          "use": "Route map overlay"
-        },
-        {
           "type": "race_website",
-          "url": "https://www.uci.org",
+          "url": "https://gravelchampswesternaustralia.com/",
           "use": "Hero image, branding reference"
         },
         {
           "type": "youtube_search",
-          "query": "Rotating (2024: Heerlen, Netherlands) drone",
+          "query": "Nannup, Western Australia, Australia drone",
           "use": "B-roll: location"
         },
         {
           "type": "youtube_search",
-          "query": "Rotating (2024: Heerlen, Netherlands) landscape",
+          "query": "Nannup, Western Australia, Australia landscape",
           "use": "B-roll: location"
         }
       ],
@@ -101,7 +95,7 @@
       "label": "EVIDENCE",
       "time_range": "0:10-0:22",
       "duration_sec": 12,
-      "narration": "Length. 5 out of 5. Ultra distance. Bring lights and a plan. Adventure. 5 out of 5. Full expedition mode. Genuine backcountry. Prestige. 5 out of 5. Bucket list tier. The name speaks for itself.",
+      "narration": "Elevation. 5 out of 5. Mountainous. Your granny gear will earn its keep. Adventure. 5 out of 5. Full expedition mode. Genuine backcountry. Prestige. 5 out of 5. Bucket list tier.",
       "text_on_screen": "Score cards cycling",
       "visual": "Animated score cards — one per dimension",
       "avatar_pose": "thinking",
@@ -121,7 +115,7 @@
       "editing_note": "Each dimension gets 4-5 seconds. Visual change on EVERY score. Use Von Restorff: if any score is 5/5 or 1/5, isolate it visually (different color flash, avatar reaction shot). [RIFF HERE] after any extreme score.",
       "evidence_data": [
         {
-          "dimension": "Length",
+          "dimension": "Elevation",
           "score": 5,
           "max": 5
         },
@@ -136,8 +130,7 @@
           "max": 5
         }
       ],
-      "narration_wpm": 175.0,
-      "wpm_warning": "Beat 'evidence': 175WPM (35w/12s) — too_fast"
+      "narration_wpm": 155.0
     },
     {
       "id": "reveal",
@@ -187,7 +180,7 @@
         3
       ],
       "editing_note": "Design for LOOP: the final frame should visually connect back to the hook frame. On TikTok, seamless loops = replays = the strongest algorithmic signal.",
-      "engagement_question": "What race deserves a perfect Length score?",
+      "engagement_question": "Is UCI Gravel World Championships overrated or worth every dollar?",
       "narration_wpm": 96.0
     }
   ],
@@ -195,19 +188,17 @@
     "excited",
     "pointing",
     "presenting",
-    "shocked",
+    "skeptical",
     "thinking"
   ],
   "meme_inserts": [],
-  "thumbnail_prompt": "South Park style flat cutout character, dramatic pose, 'UCI Gravel World Championships' bold text, tier badge 'THE ICONS', high contrast red/yellow/white, cycling gear, handlebar mustache --ar 9:16 --cref [CHARACTER_URL]",
+  "thumbnail_prompt": "South Park style flat cutout character, skeptical squinting, red warning flags background, 'UCI Gravel World Championships' bold text, tier badge 'THE ICONS', high contrast red/yellow/white, cycling gear, handlebar mustache --ar 9:16 --cref [CHARACTER_URL]",
   "narration_feasibility": {
-    "total_words": 79,
+    "total_words": 74,
     "total_duration_sec": 33,
-    "overall_wpm": 143.6,
-    "warnings": [
-      "Beat 'evidence': 175WPM (35w/12s) — too_fast"
-    ],
-    "feasible": false
+    "overall_wpm": 134.5,
+    "warnings": [],
+    "feasible": true
   },
   "content_pillars": "Tier List / Rankings (flagship, highest engagement)",
   "cross_platform_notes": {

--- a/web/llms-full.txt
+++ b/web/llms-full.txt
@@ -1,7 +1,7 @@
 # Gravel God Race Database — Full Context
 
-> 369 gravel, MTB, and bikepacking races rated on 14 base dimensions plus a Cultural Impact bonus.
-> Produced by Gravel God (gravelgodcycling.com). Generated: 2026-08-10
+> 372 gravel, MTB, and bikepacking races rated on 14 base dimensions plus a Cultural Impact bonus.
+> Produced by Gravel God (gravelgodcycling.com). Generated: 2026-08-13
 
 ## Scoring Methodology
 
@@ -18,7 +18,7 @@ Tier assignment:
 - Tier 4 (Roster): score < 45
 - Prestige 4 promotes one tier (but not into T1)
 
-## Tier 1 & Tier 2 Races (159 races)
+## Tier 1 & Tier 2 Races (160 races)
 
 ### Transcontinental Race
 Tier 1 | Score: 97/100 | 3100 mi | 210,000 ft | Across Europe (route changes annually) | July | bikepacking
@@ -68,13 +68,6 @@ Profile: https://gravelgodcycling.com/race/trans-am-bike-race/
 Markdown: https://gravelgodcycling.com/race/trans-am-bike-race.md
 
 The longest self-supported bike race on earth—4,200+ miles from Pacific to Atlantic, crossing 10 states, no support crews, pure transcontinental adventure. A 4,200+ mile expedition from Pacific to Atlantic following the historic TransAmerica Bicycle Trail. The route passes through 10 states, crossing the Continental Divide in Colorado and the Appalachian Mountains in Virginia. Surface is roughly 90% paved—quiet county roads, bike paths, and low-traffic highways. The character evolves dramatically: Pacific Northwest forests, Rocky Mountain passes, endless Kansas plains, Ozark rollercoasters, Ohio River farmland, and steep Appalachian ridges. This is America condensed into one transcontinental ride. Signature challenge: The complete American experience—4,200 miles coast to coast through every landscape, every climate, every mental state across 2-5 weeks of self-supported suffering. Trans Am Bike Race is the longest self-supported bike race on earth—4,200+ miles from the Pacific to Atlantic, completely self-supported, across 10 states and every American landscape. While Tour Divide claims the crown for toughest mountain bike ultra, Trans Am is the road equivalent: pure expedition cycling at maximum distance. The mostly-paved route is more accessible technically but no less demanding physically—175,000 feet of climbing over 2-5 weeks will humble any cyclist. With the historic TransAmerica Trail as its backbone and 50 years of trail angel culture, this is America's great cycling pilgrimage. Yes if you have serious ultra-endurance experience and can commit 2-5 weeks to crossing America. Yes if you can handle complete self-sufficiency across 4,200 miles. Yes if you want the ultimate American cycling pilgrimage. Skip if you haven't completed multi-day self-supported events. Skip if 200+ mile days for weeks on end sounds impossible. Skip if Kansas wind and Appalachian rollercoasters would break your spirit.
-
-### UCI Gravel World Championships
-Tier 1 | Score: 90/100 | 112 mi | 8,202 ft | Rotating (2024: Heerlen, Netherlands) | October | gravel
-Profile: https://gravelgodcycling.com/race/uci-gravel-worlds/
-Markdown: https://gravelgodcycling.com/race/uci-gravel-worlds.md
-
-The only gravel race where you can actually call yourself World Champion—if you can handle 180km of whatever terrain the UCI throws at you. 180 km elite, 140 km age group. 70% gravel, 30% paved. Varies by location. Technical rating: 4/5. Signature challenge: 180 km elite + World Championship field + October weather. Rainbow jersey. UCI Gravel World Championships is World Championship—180 km elite, 140 km age group. Founded 2022. 70% gravel, 30% paved. Rotating locations (2022-2023 Italy, 2024 Netherlands). 1,000+ riders (elite + age group). October autumn conditions (10-20°C, 40% rain). UCI license required (€100-€150 / $110-$165). If you want World Championship rainbow jersey and fastest field in gravel, this is it. If you need domestic/local race, skip it. International destination, prestige 5. You need a UCI license, the fitness for nearly five hours of World Championship pace racing, and the mental fortitude to suffer in front of 1,000+ of the world's fastest gravel riders. The course changes annually, so you're gambling on terrain, but if you can't handle 2,500m of climbing and October weather in Europe, stay home. This isn't about participation—it's about proving you belong with the global elite.
 
 ### Badlands
 Tier 1 | Score: 89/100 | 497 mi | 52,493 ft | Granada, Andalusia, Spain | August | bikepacking
@@ -166,6 +159,13 @@ Profile: https://gravelgodcycling.com/race/mid-south/
 Markdown: https://gravelgodcycling.com/race/mid-south.md
 
 The early-season gravel race with the biggest heart and the most unpredictable conditions. The current main route covers 106.9 miles and 6,506 feet of climbing. It is fast and tactical when dry and can become a mud slog when Oklahoma red clay is wet. Signature challenge: The weather lottery. You train for months but Oklahoma decides what race you're riding. The Mid South is what happens when someone builds a gravel race around unreasonable hospitality instead of unreasonable suffering. Bobby Wintle hugs every finisher. The DFL gets the biggest trophy. The community shows up like their lives depend on it. And the weather? The weather does whatever Oklahoma wants. When it's dry, you get a blazing-fast tactical race. When it's wet, you get an unrideable mud nightmare. Either way, you finish to live music, local beer, and a town that genuinely wants you there. This isn't the hardest gravel race. It's not the longest. But it might be the one with the biggest heart. If you value community, celebration, and authentic hospitality over predictable racing conditions—yes, absolutely. If you need to know what you're getting into before you commit—maybe reconsider. The Mid South is chaos wrapped in a Bobby hug. Some years it's fast and perfect. Some years it's a mud disaster. Some years it gets cancelled by wildfires. But the people who come back year after year aren't coming for the course—they're coming for the experience. Show up ready for anything. Leave with stories. Non-negotiables: Weather adaptation training for unpredictable conditions (cold, heat, wind); Red clay handling skills and mud preparation; Wind exposure training on exposed ridgelines
+
+### UCI Gravel World Championships
+Tier 1 | Score: 83/100 | 88.9 mi | 12,182 ft | Nannup, Western Australia, Australia | October | gravel
+Profile: https://gravelgodcycling.com/race/uci-gravel-worlds/
+Markdown: https://gravelgodcycling.com/race/uci-gravel-worlds.md
+
+The only gravel start line where 12,182 feet of Nannup climbing is merely the price of getting to race for a rainbow jersey. The long course packs 3,713 metres of climbing into 143 kilometres. The organizer describes wide gravel roads, varied unpaved surfaces, and climbs that are seldom long but arrive steeply and in quick succession. All categories share the same start, finish, and final 27 km southern loop. Signature challenge: Absorbing 3,713 metres of ascent when the climbs are short, steep, and too tightly spaced to offer meaningful recovery. The 2026 UCI Gravel World Championships bring the rainbow-jersey race to Nannup for the first edition outside Europe. The primary men's long course is a provisional 143 km with 3,713 m of climbing and at least 80% gravel; other categories race 125 km or 90 km. Qualification is mandatory. This is a world-title start line on a genuinely severe climbing course, not an open-entry destination fondo. If you qualified, yes—but train for the course you actually have: 143 kilometres, 3,713 metres of climbing, at least 80 percent gravel, and almost no recovery between steep efforts. If you did not qualify, this is not an open-entry bucket-list race.
 
 ### Belgian Waffle Ride Cedar City
 Tier 1 | Score: 81/100 | 117 mi | 5,940 ft | Cedar City, Utah | June | gravel
@@ -539,11 +539,11 @@ Markdown: https://gravelgodcycling.com/race/tour-of-thekkady.md
 India's must-do Gran Fondo: TdF climbs meet Kerala paradise. A scenic rollercoaster of relentless climbs through Kerala's lush plantations, serene lakes, iconic dams, and wildlife-rich forests, blending Tour de France-style elevation with tropical tranquility on smooth, low-traffic roads. Signature challenge: The 3000m+ elevation gain over 145km, replicating TdF stage difficulty amid Kerala's ever-changing landscapes from backwaters to highland forests.
 
 ### Trans Balkan Race
-Tier 2 | Score: 73/100 | 839 mi | 65,000 ft | Sezana, Slovenia to Kotor, Montenegro | June | gravel
+Tier 2 | Score: 73/100 | 870 mi | 98,425 ft | Dinaric Alps, Slovenia to Montenegro | May | bikepacking
 Profile: https://gravelgodcycling.com/race/trans-balkan-race/
 Markdown: https://gravelgodcycling.com/race/trans-balkan-race.md
 
-Brutal self-supported bikepacking epic carving the Dinaric Alps' wild heart.
+Brutal self-supported bikepacking epic carving the Dinaric Alps' wild heart. A 1400 km self-supported line through the Dinaric Alps with 30,000 meters of ascent and 82 percent off-road riding. The organizer describes remote mountain regions, karst plateaus, forests, mud, scarce water, and long gaps between resupply; scale and self-management matter more than technical tricks. Signature challenge: Ten days to absorb 30,000 meters of ascent while solving food, water, sleep, navigation, weather, and mechanical problems without third-party support.
 
 ### Belgian Waffle Ride North Carolina
 Tier 2 | Score: 71/100 | 100 mi | 8,000 ft | Hendersonville, North Carolina | — | gravel
@@ -860,6 +860,13 @@ Markdown: https://gravelgodcycling.com/race/jamtlandspilen.md
 
 Ultimate Swedish road ultra for endurance junkies craving value-packed suffering. A demanding road ultra looping through Jämtland's forested hills and lake-dotted plains around Östersund, blending steady climbs with fast rollers on smooth tarmac. Signature challenge: The 'Jämtland Wall' - a 2-mile grind at 7% average near the 100-mile mark, often deciding the race in crosswinds.
 
+### Pyrénées Catalanes Gravel Tour
+Tier 2 | Score: 67/100 | 62.1 mi | 7,500 ft | Font-Romeu, Pyrénées-Orientales, France | September | gravel
+Profile: https://gravelgodcycling.com/race/pyrenees-catalanes-gravel-tour/
+Markdown: https://gravelgodcycling.com/race/pyrenees-catalanes-gravel-tour.md
+
+A young UCI qualifier with grown-up altitude and 7,500 feet of climbing in only 62 miles. A three-loop, high-altitude UCI qualifier from Font-Romeu. The eastern loop reaches Col du Calvaire and returns at 39 km; the southern loop adds a 10 km climb and returns at 76 km; the final northern loop reaches Pic de la Calma at 2,006 m before a downhill finish. Signature challenge: Arriving at the final 25 km with enough climbing power left for Pic de la Calma, then descending cleanly to Font-Romeu after a day spent near 6,000 feet. Do not read 100 km and expect a friendly half-day. The course packs 2,286 metres of climbing into three loops, never drops below meaningful altitude, and saves its highest point for the final 12 km. It is a young race, but the UCI field and Pyrenean course are already legitimate. Race it if UCI age-group stakes and a compact mountain course appeal to you. Skip it if you cannot arrive with either altitude exposure or a conservative pacing plan. Non-negotiables: Climbing density; Altitude pacing; Descending under fatigue
+
 ### Velothon Berlin
 Tier 2 | Score: 67/100 | 99 mi | 2,000 ft | Berlin, Germany | July | gravel
 Profile: https://gravelgodcycling.com/race/velothon-berlin/
@@ -1131,7 +1138,7 @@ Markdown: https://gravelgodcycling.com/race/wasatch-all-road.md
 
 Regional Utah mountain gravel with high altitude and significant climbing in Wasatch Range. The organizer-published Bigfoot flagship is 82 miles with 10,560 feet of gain and 77% gravel on the western slope of the Uinta Range. Signature challenge: 10,560 feet of climbing from a start near 5,800 feet, with the current route reaching approximately 10,068 feet on the Uinta western slope. Wasatch All-Road offers a genuine mountain gravel challenge with high altitude and massive climbing in the beautiful Wasatch Range. Heber City is a resort-adjacent town with proximity to Park City and Salt Lake City, providing good access and amenities. The course is challenging with 10,560 feet of climbing from a 5,600-foot start. It's a well-organized regional event with a moderate field. If you're in Utah or the Wasatch Front and want a mountain gravel challenge—yes, it's a well-organized event with genuine altitude and climbing. If you're traveling from far away—there are more prestigious mountain events elsewhere. Non-negotiables: Altitude preparation; Climbing strength; Thunderstorm awareness
 
-## Tier 3 & Tier 4 Races (210 races)
+## Tier 3 & Tier 4 Races (212 races)
 
 Each race's Markdown mirror is at https://gravelgodcycling.com/race/{slug}.md — the Slug column below gives {slug}.
 
@@ -1148,6 +1155,7 @@ Each race's Markdown mirror is at https://gravelgodcycling.com/race/{slug}.md �
 | R3G3 | r3g3 | 3 | 59 | 104.2 mi | 8,909 ft | Griffith, Ontario, Canada | May | gravel |
 | Red Granite Grinder | red-granite-grinder | 3 | 59 | 150 mi | 2,800 ft | Athens, Wisconsin (Central Wisconsin) | October | gravel |
 | Wyścig Niepołomice | wyscig-niepolomice | 3 | 59 | 61.5 mi | 889 ft | Niepołomice, Małopolska, Poland | September | gravel |
+| The Gravel of Marathon | gravel-of-marathon | 3 | 57 | 75.2 mi | 6,627 ft | Marathon, Attica, Greece | November | gravel |
 | Iceman Cometh | iceman-cometh | 3 | 57 | 30 mi | 2,000 ft | Kalkaska, Michigan | November | gravel |
 | Nanaimo Unpaved | nanaimo-unpaved | 3 | 57 | 68.8 mi | — | Nanaimo, British Columbia, Canada | June | gravel |
 | Reliance Tennessee Gravel | reliance-tennessee-gravel | 3 | 57 | 70 mi | 8,100 ft | Reliance, Tennessee | April | gravel |
@@ -1171,8 +1179,9 @@ Each race's Markdown mirror is at https://gravelgodcycling.com/race/{slug}.md �
 | Devils Cardigan | devils-cardigan | 3 | 54 | 66 mi | 7,545 ft | Derby, Tasmania | June | gravel |
 | Edition Zero | edition-zero | 3 | 54 | 154 mi | 11,500 ft | Waimate, New Zealand | November | gravel |
 | Filthy 50 | filthy-50 | 3 | 54 | 50.9 mi | 3,251 ft | Lanesboro, Minnesota | October | gravel |
+| UCI Gravel Chile | gravel-chile | 3 | 54 | 62.1 mi | 2,182 ft | Lago Ranco, Los Ríos Region, Chile | October | gravel |
 | Karukinka | karukinka | 3 | 54 | 120 mi | 10,000 ft | Tierra del Fuego, Chile | February | gravel |
-| Oregon Coast Gravel Epic | oregon-coast-gravel-epic | 3 | 54 | 62 mi | 6,733 ft | Waldport, Oregon | May | gravel |
+| Oregon Coast Gravel Epic | oregon-coast-gravel-epic | 3 | 54 | 62 mi | 6,733 ft | Waldport, Oregon | April | gravel |
 | River City Gravel Fondo | river-city-gravel-fondo | 3 | 54 | 71 mi | 4,000 ft | Campbell River, British Columbia | April | gravel |
 | Ruby Roubaix | ruby-roubaix | 3 | 54 | 62 mi | 4,365 ft | Lamoille, Nevada | June | gravel |
 | The InSayner | the-insayner | 3 | 54 | 25 mi | — | Sayner, Wisconsin | June | mtb |
@@ -1246,7 +1255,7 @@ Each race's Markdown mirror is at https://gravelgodcycling.com/race/{slug}.md �
 | Gravel One Fifty | gravel-one-fifty | 3 | 47 | 93 mi | 800 ft | Roden, Drenthe, Netherlands | April | gravel |
 | Gravelista | gravelista | 3 | 47 | 86 mi | 5,740 ft | Victoria, Australia | October | gravel |
 | Hegau Gravel Race | hegau-gravel-race | 3 | 47 | 65 mi | 3,500 ft | Singen, Germany | July | gravel |
-| KowTown Gravel | kowtown-gravel | 3 | 47 | 60 mi | 4,500 ft | Kremmling, CO | June | gravel |
+| KowTown Gravel | kowtown-gravel | 3 | 47 | 88 mi | — | Kremmling, Colorado | June | gravel |
 | Lone Wolf Gravel | lone-wolf-gravel | 3 | 47 | 62 mi | 4,000 ft | Iron Mountain, Michigan | September | gravel |
 | Montana Gravel Challenge | montana-gravel-challenge | 3 | 47 | 65 mi | 4,800 ft | Huson, MT | October | gravel |
 | Opelika Okey Dokey | opelika-okey-dokey | 3 | 47 | 75 mi | 3,000 ft | Opelika, Alabama | May | gravel |
@@ -1281,7 +1290,6 @@ Each race's Markdown mirror is at https://gravelgodcycling.com/race/{slug}.md �
 | Dirty Pecan | dirty-pecan | 4 | 44 | 40 mi | 800 ft | Florida | March | gravel |
 | Fairfield Harvest Rush | fairfield-harvest-rush | 4 | 44 | 62 mi | 3,000 ft | Fairfield, Iowa | October | gravel |
 | Glenwood Gravel | glenwood-gravel | 4 | 44 | 60 mi | 2,400 ft | Glenwood, Iowa | August | gravel |
-| Gravel and Granite | gravel-and-granite | 4 | 44 | 65 mi | 4,500 ft | Tenterfield, New South Wales, Australia | May | gravel |
 | Gravel Unravel - Bon Jon Pass Out | gravel-unravel-bon-jon-pass-out | 4 | 44 | 60 mi | 5,000 ft | Quilcene, WA | June | gravel |
 | Gray Duck Grit | gray-duck-grit | 4 | 44 | 62 mi | 3,000 ft | Cannon Falls, Minnesota | September | gravel |
 | Hart Hills | hart-hills | 4 | 44 | 55 mi | 2,500 ft | Hart, Michigan | May | gravel |
@@ -1297,7 +1305,7 @@ Each race's Markdown mirror is at https://gravelgodcycling.com/race/{slug}.md �
 | Waukon 100 | waukon-100 | 4 | 44 | 100 mi | 5,000 ft | Waukon, Iowa | June | gravel |
 | West Coast Gravel | west-coast-gravel | 4 | 44 | 53 mi | 6,690 ft | Yachats, Oregon | April | gravel |
 | Cedar Blitz | cedar-blitz | 4 | 43 | 50 mi | 3,000 ft | Cedar Springs, Michigan | July | gravel |
-| De Ronde Van Grampian | de-ronde-van-grampian | 4 | 43 | 50 mi | 2,000 ft | Oxford, Michigan | August | gravel |
+| De Ronde Van Grampian | de-ronde-van-grampian | 4 | 43 | 52 mi | 3,123 ft | Oxford, Michigan | August | gravel |
 | Fast Fitty | fast-fitty | 4 | 43 | 50 mi | 1,800 ft | Charlotte, Michigan | August | gravel |
 | Forbidden Gravel | forbidden-gravel | 4 | 43 | 68.4 mi | — | Cumberland, British Columbia, Canada | September | gravel |
 | Galactic Grinder | galactic-grinder | 4 | 43 | 60 mi | 3,500 ft | Cedar Hill, New Mexico | April | gravel |
@@ -1314,6 +1322,7 @@ Each race's Markdown mirror is at https://gravelgodcycling.com/race/{slug}.md �
 | Clarkes Gambit | clarkes-gambit | 4 | 41 | 55 mi | 4,000 ft | Nelligen, New South Wales, Australia | August | gravel |
 | Cowboy Crusher | cowboy-crusher | 4 | 41 | 60 mi | 3,500 ft | Glenrock, Wyoming | July | gravel |
 | Dirty Dino | dirty-dino | 4 | 41 | 58 mi | 3,500 ft | Vernal, Utah | June | gravel |
+| Gravel n Granite | gravel-and-granite | 4 | 41 | 56.5 mi | — | Tenterfield, New South Wales, Australia | March | gravel |
 | Hardwood Hustle | hardwood-hustle | 4 | 41 | 62 mi | 3,000 ft | Nelma, Wisconsin | September | gravel |
 | Heywood Ride | heywood-ride | 4 | 41 | 50 mi | 2,000 ft | Northfield, Minnesota | May | gravel |
 | JUST.GRAVEL | just-gravel | 4 | 41 | 50 mi | 4,000 ft | Southern Lake District, UK | October | gravel |

--- a/web/llms.txt
+++ b/web/llms.txt
@@ -1,15 +1,15 @@
 # Gravel God Race Database
 
-> The definitive gravel race database. 369 races rated on 14 base dimensions plus a Cultural Impact bonus, scored 0-100+, and tiered 1-4.
-> Last generated: 2026-08-10
+> The definitive gravel race database. 372 races rated on 14 base dimensions plus a Cultural Impact bonus, scored 0-100+, and tiered 1-4.
+> Last generated: 2026-08-13
 
 ## Overview
 
-Gravel God is a gravel cycling database covering 369 races across North America and beyond. Every race is scored on 14 base dimensions (logistics, length, technicality, elevation, climate, altitude, adventure, prestige, race quality, experience, community, field depth, value, expenses) on a 1-5 scale, plus a Cultural Impact bonus from 0-5, producing an overall score out of 100+ and a tier assignment (T1=Elite, T2=Contender, T3=Solid, T4=Roster).
+Gravel God is a gravel cycling database covering 372 races across North America and beyond. Every race is scored on 14 base dimensions (logistics, length, technicality, elevation, climate, altitude, adventure, prestige, race quality, experience, community, field depth, value, expenses) on a 1-5 scale, plus a Cultural Impact bonus from 0-5, producing an overall score out of 100+ and a tier assignment (T1=Elite, T2=Contender, T3=Solid, T4=Roster).
 
 - **Tier 1 (Elite)**: 30 races — score >= 80 or prestige override
-- **Tier 2 (Contender)**: 129 races — score >= 60
-- **Tier 3 (Solid)**: 137 races — score >= 45
+- **Tier 2 (Contender)**: 130 races — score >= 60
+- **Tier 3 (Solid)**: 139 races — score >= 45
 - **Tier 4 (Roster)**: 73 races — score < 45
 
 Disciplines: gravel, MTB, bikepacking.
@@ -18,7 +18,7 @@ Regions: Africa, Asia, Europe, Midwest, North America, Northeast, Oceania, Other
 ## Machine-Readable Resources
 
 - [Full LLM context (this database as text)](https://gravelgodcycling.com/llms-full.txt)
-- [Race index JSON (369 entries)](https://gravelgodcycling.com/race-index.json)
+- [Race index JSON (372 entries)](https://gravelgodcycling.com/race-index.json)
 - [REST API (OpenAPI)](https://gravelgodcycling.com/api/v1/docs)
 - [RSS feed](https://gravelgodcycling.com/feed/races.xml)
 - [MCP Server (GitHub)](https://github.com/wattgod/gravel-race-automation)
@@ -30,7 +30,7 @@ Regions: Africa, Asia, Europe, Midwest, North America, Northeast, Oceania, Other
 ## Training Plans
 
 - [Training Plans Hub](https://gravelgodcycling.com/products/training-plans/)
-- 352 race-specific training guides are available at `https://gravelgodcycling.com/race/{slug}/training-plan/`.
+- 351 race-specific training guides are available at `https://gravelgodcycling.com/race/{slug}/training-plan/`.
 
 ## Markdown Mirrors
 


### PR DESCRIPTION
## Summary
- regenerate the Nannup World Championships machine-readable and video derivatives from the corrected race profile
- refresh the synthesis brief and geocoding override
- add a regression contract covering the public LLM feed, date feed, geocoder, brief, and video briefs

## Verification
- `python3 -m pytest tests/test_uci_gravel_worlds_nannup_2026.py tests/test_generate_llms_txt.py -q` (51 passed)
- all four video-brief validators pass with no errors (pre-existing corpus warnings remain)
- `python3 scripts/generate_race_dates.py --check`
- `git diff --check`