### PR TITLE
feat(plans): expose Gravel God race suites

### DIFF
--- a/data/tp-race-plan-links.json
+++ b/data/tp-race-plan-links.json
@@ -1,0 +1,6805 @@
+{
+  "114-gravel-race": [
+    {
+      "planId": 666658,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666658/p"
+    },
+    {
+      "planId": 666659,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666659/p"
+    },
+    {
+      "planId": 666660,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666660/p"
+    },
+    {
+      "planId": 666661,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666661/p"
+    },
+    {
+      "planId": 666662,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666662/p"
+    },
+    {
+      "planId": 666663,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666663/p"
+    },
+    {
+      "planId": 666664,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666664/p"
+    }
+  ],
+  "66-south-pyrenees": [
+    {
+      "planId": 659714,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659714/p"
+    },
+    {
+      "planId": 659715,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659715/p"
+    },
+    {
+      "planId": 659716,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659716/p"
+    }
+  ],
+  "alentejo-gravel": [
+    {
+      "planId": 659919,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659919/p"
+    },
+    {
+      "planId": 659920,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659920/p"
+    },
+    {
+      "planId": 659924,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659924/p"
+    },
+    {
+      "planId": 659925,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659925/p"
+    },
+    {
+      "planId": 659921,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659921/p"
+    },
+    {
+      "planId": 659923,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659923/p"
+    },
+    {
+      "planId": 659927,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659927/p"
+    }
+  ],
+  "atlas-mountain-race": [
+    {
+      "planId": 667965,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667965/p"
+    },
+    {
+      "planId": 667966,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667966/p"
+    },
+    {
+      "planId": 667967,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667967/p"
+    },
+    {
+      "planId": 667968,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667968/p"
+    },
+    {
+      "planId": 667969,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667969/p"
+    },
+    {
+      "planId": 667970,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667970/p"
+    },
+    {
+      "planId": 667971,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667971/p"
+    }
+  ],
+  "barry-roubaix": [
+    {
+      "planId": 659268,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659268/barry-roubaix-finisher-12wk"
+    },
+    {
+      "planId": 659269,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659269/barry-roubaix-finisher-8wk"
+    },
+    {
+      "planId": 659272,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659272/barry-roubaix-time-crunched-12wk"
+    },
+    {
+      "planId": 659273,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659273/barry-roubaix-time-crunched-8wk"
+    },
+    {
+      "planId": 659270,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659270/barry-roubaix-compete-12wk"
+    },
+    {
+      "planId": 659271,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659271/barry-roubaix-masters-50-12wk"
+    },
+    {
+      "planId": 659274,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659274/barry-roubaix-save-my-race-6wk"
+    }
+  ],
+  "battenkill": [
+    {
+      "planId": 659550,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659550/battenkill-finisher-12wk"
+    },
+    {
+      "planId": 659552,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659552/battenkill-finisher-8wk"
+    },
+    {
+      "planId": 659556,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659556/battenkill-time-crunched-12wk"
+    },
+    {
+      "planId": 659557,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659557/battenkill-time-crunched-8wk"
+    },
+    {
+      "planId": 659553,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659553/battenkill-compete-12wk"
+    },
+    {
+      "planId": 659554,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659554/battenkill-masters-50-12wk"
+    },
+    {
+      "planId": 659558,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659558/battenkill-save-my-race-6wk"
+    }
+  ],
+  "belgian-waffle-ride-kansas": [
+    {
+      "planId": 659485,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659485/belgian-waffle-ride-kansas-finisher-12wk"
+    },
+    {
+      "planId": 659487,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659487/belgian-waffle-ride-kansas-finisher-8wk"
+    },
+    {
+      "planId": 659491,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659491/belgian-waffle-ride-kansas-time-crunched-12wk"
+    },
+    {
+      "planId": 659492,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659492/belgian-waffle-ride-kansas-time-crunched-8wk"
+    },
+    {
+      "planId": 659488,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659488/belgian-waffle-ride-kansas-compete-12wk"
+    },
+    {
+      "planId": 659489,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659489/belgian-waffle-ride-kansas-masters-50-12wk"
+    },
+    {
+      "planId": 659493,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659493/belgian-waffle-ride-kansas-save-my-race-6wk"
+    }
+  ],
+  "bend-dirt-fest": [
+    {
+      "planId": 659261,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659261/bend-dirt-fest-finisher-12wk"
+    },
+    {
+      "planId": 659262,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659262/bend-dirt-fest-finisher-8wk"
+    },
+    {
+      "planId": 659265,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659265/bend-dirt-fest-time-crunched-12wk"
+    },
+    {
+      "planId": 659266,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659266/bend-dirt-fest-time-crunched-8wk"
+    },
+    {
+      "planId": 659263,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659263/bend-dirt-fest-compete-12wk"
+    },
+    {
+      "planId": 659264,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659264/bend-dirt-fest-masters-50-12wk"
+    },
+    {
+      "planId": 659267,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659267/bend-dirt-fest-save-my-race-6wk"
+    }
+  ],
+  "big-horn-gravel": [
+    {
+      "planId": 659147,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659147/bighorn-gravel-finisher-12wk"
+    },
+    {
+      "planId": 659148,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659148/bighorn-gravel-finisher-8wk"
+    },
+    {
+      "planId": 659151,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659151/bighorn-gravel-time-crunched-12wk"
+    },
+    {
+      "planId": 659152,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659152/bighorn-gravel-time-crunched-8wk"
+    },
+    {
+      "planId": 659149,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659149/bighorn-gravel-compete-12wk"
+    },
+    {
+      "planId": 659150,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659150/bighorn-gravel-masters-50-12wk"
+    },
+    {
+      "planId": 659153,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659153/bighorn-gravel-save-my-race-6wk"
+    }
+  ],
+  "big-sugar": [
+    {
+      "planId": 658462,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658462/big-sugar-gravel-finisher-12wk"
+    },
+    {
+      "planId": 658463,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658463/big-sugar-gravel-finisher-8wk"
+    },
+    {
+      "planId": 658466,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658466/big-sugar-gravel-time-crunched-12wk"
+    },
+    {
+      "planId": 658467,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658467/big-sugar-gravel-time-crunched-8wk"
+    },
+    {
+      "planId": 658464,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658464/big-sugar-gravel-compete-12wk"
+    },
+    {
+      "planId": 658465,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658465/big-sugar-gravel-masters-50-12wk"
+    },
+    {
+      "planId": 658461,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658461/big-sugar-gravel-save-my-race-6wk"
+    }
+  ],
+  "bikingman-corsica": [
+    {
+      "planId": 667987,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667987/p"
+    },
+    {
+      "planId": 667988,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667988/p"
+    },
+    {
+      "planId": 667989,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667989/p"
+    },
+    {
+      "planId": 667990,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667990/p"
+    },
+    {
+      "planId": 667991,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667991/p"
+    },
+    {
+      "planId": 667992,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667992/p"
+    },
+    {
+      "planId": 667993,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667993/p"
+    }
+  ],
+  "bwr-arizona": [
+    {
+      "planId": 659190,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659190/bwr-arizona-finisher-12wk"
+    },
+    {
+      "planId": 659194,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659194/bwr-arizona-finisher-8wk"
+    },
+    {
+      "planId": 659200,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659200/bwr-arizona-time-crunched-12wk"
+    },
+    {
+      "planId": 659203,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659203/bwr-arizona-time-crunched-8wk"
+    },
+    {
+      "planId": 659195,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659195/bwr-arizona-compete-12wk"
+    },
+    {
+      "planId": 659197,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659197/bwr-arizona-masters-50-12wk"
+    },
+    {
+      "planId": 659206,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659206/bwr-arizona-save-my-race-6wk"
+    }
+  ],
+  "bwr-california": [
+    {
+      "planId": 658857,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658857/belgian-waffle-ride-ca-finisher-12wk"
+    },
+    {
+      "planId": 658858,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658858/belgian-waffle-ride-ca-finisher-8wk"
+    },
+    {
+      "planId": 658861,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658861/belgian-waffle-ride-ca-time-crunched-12wk"
+    },
+    {
+      "planId": 658862,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658862/belgian-waffle-ride-ca-time-crunched-8wk"
+    },
+    {
+      "planId": 658859,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658859/belgian-waffle-ride-ca-compete-12wk"
+    },
+    {
+      "planId": 658860,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658860/belgian-waffle-ride-ca-masters-50-12wk"
+    },
+    {
+      "planId": 658863,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658863/belgian-waffle-ride-ca-save-my-race-6wk"
+    }
+  ],
+  "bwr-cedar-city": [
+    {
+      "planId": 658874,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658874/belgian-waffle-ride-cedar-city-finisher-12wk"
+    },
+    {
+      "planId": 658875,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658875/belgian-waffle-ride-cedar-city-finisher-8wk"
+    },
+    {
+      "planId": 658878,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658878/belgian-waffle-ride-cedar-city-time-crunched-12wk"
+    },
+    {
+      "planId": 658879,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658879/belgian-waffle-ride-cedar-city-time-crunched-8wk"
+    },
+    {
+      "planId": 658876,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658876/belgian-waffle-ride-cedar-city-compete-12wk"
+    },
+    {
+      "planId": 658877,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658877/belgian-waffle-ride-cedar-city-masters-50-12wk"
+    },
+    {
+      "planId": 658880,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658880/belgian-waffle-ride-cedar-city-save-my-race-6wk"
+    }
+  ],
+  "bwr-montana": [
+    {
+      "planId": 658968,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658968/bwr-montana-finisher-12wk"
+    },
+    {
+      "planId": 658956,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658956/bwr-montana-finisher-8wk"
+    },
+    {
+      "planId": 658959,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658959/bwr-montana-time-crunched-12wk"
+    },
+    {
+      "planId": 658961,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658961/bwr-montana-time-crunched-8wk"
+    },
+    {
+      "planId": 658957,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658957/bwr-montana-compete-12wk"
+    },
+    {
+      "planId": 658958,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658958/bwr-montana-masters-50-12wk"
+    },
+    {
+      "planId": 658963,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658963/bwr-montana-save-my-race-6wk"
+    }
+  ],
+  "bwr-north-carolina": [
+    {
+      "planId": 658647,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658647/belgian-waffle-ride-nc-finisher-12wk"
+    },
+    {
+      "planId": 658648,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658648/belgian-waffle-ride-nc-finisher-8wk"
+    },
+    {
+      "planId": 658651,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658651/belgian-waffle-ride-nc-time-crunched-12wk"
+    },
+    {
+      "planId": 658652,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658652/belgian-waffle-ride-nc-time-crunched-8wk"
+    },
+    {
+      "planId": 658649,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658649/belgian-waffle-ride-nc-compete-12wk"
+    },
+    {
+      "planId": 658650,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658650/belgian-waffle-ride-nc-masters-50-12wk"
+    },
+    {
+      "planId": 658646,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658646/belgian-waffle-ride-nc-save-my-race-6wk"
+    }
+  ],
+  "bwr-san-diego": [
+    {
+      "planId": 658864,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658864/belgian-waffle-ride-san-diego-finisher-12wk"
+    },
+    {
+      "planId": 658865,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658865/belgian-waffle-ride-san-diego-finisher-8wk"
+    },
+    {
+      "planId": 658868,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658868/belgian-waffle-ride-san-diego-time-crunched-12wk"
+    },
+    {
+      "planId": 658869,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658869/belgian-waffle-ride-san-diego-time-crunched-8wk"
+    },
+    {
+      "planId": 658866,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658866/belgian-waffle-ride-san-diego-compete-12wk"
+    },
+    {
+      "planId": 658867,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658867/belgian-waffle-ride-san-diego-masters-50-12wk"
+    },
+    {
+      "planId": 658870,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658870/belgian-waffle-ride-san-diego-save-my-race-6wk"
+    }
+  ],
+  "bwr-utah": [
+    {
+      "planId": 658885,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658885/bwr-utah-finisher-12wk"
+    },
+    {
+      "planId": 658886,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658886/bwr-utah-finisher-8wk"
+    },
+    {
+      "planId": 658889,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658889/bwr-utah-time-crunched-12wk"
+    },
+    {
+      "planId": 658890,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658890/bwr-utah-time-crunched-8wk"
+    },
+    {
+      "planId": 658887,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658887/bwr-utah-compete-12wk"
+    },
+    {
+      "planId": 658888,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658888/bwr-utah-masters-50-12wk"
+    },
+    {
+      "planId": 658891,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658891/bwr-utah-save-my-race-6wk"
+    }
+  ],
+  "chequamegon-mtb": [
+    {
+      "planId": 667358,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667358/p"
+    },
+    {
+      "planId": 667359,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667359/p"
+    },
+    {
+      "planId": 667360,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667360/p"
+    },
+    {
+      "planId": 667361,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667361/p"
+    },
+    {
+      "planId": 667362,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667362/p"
+    },
+    {
+      "planId": 667363,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667363/p"
+    },
+    {
+      "planId": 667364,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667364/p"
+    }
+  ],
+  "chino-grinder": [
+    {
+      "planId": 666490,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666490/p"
+    },
+    {
+      "planId": 666491,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666491/p"
+    },
+    {
+      "planId": 666492,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666492/p"
+    }
+  ],
+  "coast-to-coast": [
+    {
+      "planId": 669335,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669335/p"
+    },
+    {
+      "planId": 669336,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669336/p"
+    },
+    {
+      "planId": 669337,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669337/p"
+    },
+    {
+      "planId": 669338,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669338/p"
+    },
+    {
+      "planId": 669339,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669339/p"
+    },
+    {
+      "planId": 669340,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669340/p"
+    },
+    {
+      "planId": 669341,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669341/p"
+    }
+  ],
+  "cowichan-crusher-gravel-fondo": [
+    {
+      "planId": 659598,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659598/cowichan-crusher-finisher-12wk"
+    },
+    {
+      "planId": 659599,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659599/cowichan-crusher-finisher-8wk"
+    },
+    {
+      "planId": 659602,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659602/cowichan-crusher-time-crunched-12wk"
+    },
+    {
+      "planId": 659603,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659603/cowichan-crusher-time-crunched-8wk"
+    },
+    {
+      "planId": 659600,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659600/cowichan-crusher-compete-12wk"
+    },
+    {
+      "planId": 659601,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659601/cowichan-crusher-masters-50-12wk"
+    },
+    {
+      "planId": 659604,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659604/cowichan-crusher-save-my-race-6wk"
+    }
+  ],
+  "croatan-buck-fifty": [
+    {
+      "planId": 668068,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668068/p"
+    },
+    {
+      "planId": 668069,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668069/p"
+    },
+    {
+      "planId": 668070,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668070/p"
+    },
+    {
+      "planId": 668071,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668071/p"
+    },
+    {
+      "planId": 668072,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668072/p"
+    },
+    {
+      "planId": 668073,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668073/p"
+    },
+    {
+      "planId": 668074,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668074/p"
+    }
+  ],
+  "crooked-gravel": [
+    {
+      "planId": 659494,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659494/crooked-gravel-finisher-12wk"
+    },
+    {
+      "planId": 659495,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659495/crooked-gravel-finisher-8wk"
+    },
+    {
+      "planId": 659498,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659498/crooked-gravel-time-crunched-12wk"
+    },
+    {
+      "planId": 659499,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659499/crooked-gravel-time-crunched-8wk"
+    },
+    {
+      "planId": 659496,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659496/crooked-gravel-compete-12wk"
+    },
+    {
+      "planId": 659497,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659497/crooked-gravel-masters-50-12wk"
+    },
+    {
+      "planId": 659500,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659500/crooked-gravel-save-my-race-6wk"
+    }
+  ],
+  "crusher-in-the-tushar": [
+    {
+      "planId": 658871,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658871/crusher-in-the-tushar-finisher-12wk"
+    },
+    {
+      "planId": 658872,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658872/crusher-in-the-tushar-finisher-8wk"
+    },
+    {
+      "planId": 658882,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658882/crusher-in-the-tushar-time-crunched-12wk"
+    },
+    {
+      "planId": 658883,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658883/crusher-in-the-tushar-time-crunched-8wk"
+    },
+    {
+      "planId": 658873,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658873/crusher-in-the-tushar-compete-12wk"
+    },
+    {
+      "planId": 658881,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658881/crusher-in-the-tushar-masters-50-12wk"
+    },
+    {
+      "planId": 658884,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658884/crusher-in-the-tushar-save-my-race-6wk"
+    }
+  ],
+  "d2r2": [
+    {
+      "planId": 659479,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659479/p"
+    },
+    {
+      "planId": 659480,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659480/p"
+    },
+    {
+      "planId": 659483,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659483/p"
+    },
+    {
+      "planId": 659484,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659484/p"
+    },
+    {
+      "planId": 659481,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659481/p"
+    },
+    {
+      "planId": 659482,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659482/p"
+    },
+    {
+      "planId": 659486,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659486/p"
+    }
+  ],
+  "de-ronde-van-grampian": [
+    {
+      "planId": 669223,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669223/p"
+    },
+    {
+      "planId": 669224,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669224/p"
+    },
+    {
+      "planId": 669225,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669225/p"
+    },
+    {
+      "planId": 669226,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669226/p"
+    },
+    {
+      "planId": 669227,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669227/p"
+    },
+    {
+      "planId": 669228,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669228/p"
+    },
+    {
+      "planId": 669229,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669229/p"
+    }
+  ],
+  "dead-swede-gravel": [
+    {
+      "planId": 659979,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659979/p"
+    },
+    {
+      "planId": 659980,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659980/p"
+    },
+    {
+      "planId": 659983,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659983/p"
+    },
+    {
+      "planId": 659984,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659984/p"
+    },
+    {
+      "planId": 659981,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659981/p"
+    },
+    {
+      "planId": 659982,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659982/p"
+    },
+    {
+      "planId": 659985,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659985/p"
+    }
+  ],
+  "devils-cardigan": [
+    {
+      "planId": 659571,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659571/the-devils-cardigan-finisher-12wk"
+    },
+    {
+      "planId": 659572,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659572/the-devils-cardigan-finisher-8wk"
+    },
+    {
+      "planId": 659575,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659575/the-devils-cardigan-time-crunched-12wk"
+    },
+    {
+      "planId": 659576,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659576/the-devils-cardigan-time-crunched-8wk"
+    },
+    {
+      "planId": 659573,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659573/the-devils-cardigan-compete-12wk"
+    },
+    {
+      "planId": 659574,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659574/the-devils-cardigan-masters-50-12wk"
+    },
+    {
+      "planId": 659577,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659577/the-devils-cardigan-save-my-race-6wk"
+    }
+  ],
+  "dirty-30": [
+    {
+      "planId": 666497,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666497/p"
+    },
+    {
+      "planId": 666498,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666498/p"
+    },
+    {
+      "planId": 666531,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666531/p"
+    },
+    {
+      "planId": 666524,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666524/p"
+    },
+    {
+      "planId": 666494,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666494/p"
+    },
+    {
+      "planId": 666509,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666509/p"
+    },
+    {
+      "planId": 666512,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666512/p"
+    }
+  ],
+  "dirty-hector": [
+    {
+      "planId": 659675,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659675/p"
+    },
+    {
+      "planId": 659676,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659676/p"
+    },
+    {
+      "planId": 659679,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659679/p"
+    },
+    {
+      "planId": 659680,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659680/p"
+    },
+    {
+      "planId": 659677,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659677/p"
+    },
+    {
+      "planId": 659678,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659678/p"
+    },
+    {
+      "planId": 659681,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659681/p"
+    }
+  ],
+  "dirty-reiver": [
+    {
+      "planId": 658991,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658991/dirty-reiver-finisher-12wk"
+    },
+    {
+      "planId": 658992,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658992/dirty-reiver-finisher-8wk"
+    },
+    {
+      "planId": 658995,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658995/dirty-reiver-time-crunched-12wk"
+    },
+    {
+      "planId": 658996,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658996/dirty-reiver-time-crunched-8wk"
+    },
+    {
+      "planId": 658993,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658993/dirty-reiver-compete-12wk"
+    },
+    {
+      "planId": 658994,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658994/dirty-reiver-masters-50-12wk"
+    },
+    {
+      "planId": 658997,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658997/dirty-reiver-save-my-race-6wk"
+    }
+  ],
+  "dirty-sheets-gravel-grind": [
+    {
+      "planId": 667365,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667365/p"
+    },
+    {
+      "planId": 667366,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667366/p"
+    },
+    {
+      "planId": 667367,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667367/p"
+    }
+  ],
+  "dusty-bandita": [
+    {
+      "planId": 666798,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666798/p"
+    },
+    {
+      "planId": 666799,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666799/p"
+    },
+    {
+      "planId": 666800,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666800/p"
+    },
+    {
+      "planId": 666801,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666801/p"
+    },
+    {
+      "planId": 666802,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666802/p"
+    },
+    {
+      "planId": 666803,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666803/p"
+    },
+    {
+      "planId": 666804,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666804/p"
+    }
+  ],
+  "edition-zero": [
+    {
+      "planId": 659537,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659537/edition-zero-finisher-12wk"
+    },
+    {
+      "planId": 659538,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659538/edition-zero-finisher-8wk"
+    },
+    {
+      "planId": 659541,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659541/edition-zero-time-crunched-12wk"
+    },
+    {
+      "planId": 659542,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659542/edition-zero-time-crunched-8wk"
+    },
+    {
+      "planId": 659539,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659539/edition-zero-compete-12wk"
+    },
+    {
+      "planId": 659540,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659540/edition-zero-masters-50-12wk"
+    },
+    {
+      "planId": 659543,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659543/edition-zero-save-my-race-6wk"
+    }
+  ],
+  "eislek-gravel": [
+    {
+      "planId": 659989,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659989/p"
+    },
+    {
+      "planId": 659990,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659990/p"
+    },
+    {
+      "planId": 659993,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659993/p"
+    },
+    {
+      "planId": 659994,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659994/p"
+    },
+    {
+      "planId": 659991,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659991/p"
+    },
+    {
+      "planId": 659992,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659992/p"
+    },
+    {
+      "planId": 659995,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659995/p"
+    }
+  ],
+  "fairfield-harvest-rush": [
+    {
+      "planId": 666679,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666679/p"
+    }
+  ],
+  "fast-fitty": [
+    {
+      "planId": 666791,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666791/p"
+    },
+    {
+      "planId": 666792,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666792/p"
+    },
+    {
+      "planId": 666793,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666793/p"
+    },
+    {
+      "planId": 666794,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666794/p"
+    },
+    {
+      "planId": 666795,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666795/p"
+    },
+    {
+      "planId": 666796,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666796/p"
+    },
+    {
+      "planId": 666797,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666797/p"
+    }
+  ],
+  "filthy-50": [
+    {
+      "planId": 659527,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659527/the-filthy-50-finisher-12wk"
+    },
+    {
+      "planId": 659528,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659528/the-filthy-50-finisher-8wk"
+    },
+    {
+      "planId": 659532,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659532/the-filthy-50-time-crunched-12wk"
+    },
+    {
+      "planId": 659533,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659533/the-filthy-50-time-crunched-8wk"
+    },
+    {
+      "planId": 659529,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659529/the-filthy-50-compete-12wk"
+    },
+    {
+      "planId": 659530,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659530/the-filthy-50-masters-50-12wk"
+    },
+    {
+      "planId": 659536,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659536/the-filthy-50-save-my-race-6wk"
+    }
+  ],
+  "finnish-gravel": [
+    {
+      "planId": 659389,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659389/p"
+    },
+    {
+      "planId": 659390,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659390/p"
+    },
+    {
+      "planId": 659393,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659393/p"
+    },
+    {
+      "planId": 659398,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659398/p"
+    },
+    {
+      "planId": 659391,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659391/p"
+    },
+    {
+      "planId": 659392,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659392/p"
+    },
+    {
+      "planId": 659399,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659399/p"
+    }
+  ],
+  "flanders-legacy-gravel": [
+    {
+      "planId": 659953,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659953/p"
+    },
+    {
+      "planId": 659954,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659954/p"
+    },
+    {
+      "planId": 659957,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659957/p"
+    },
+    {
+      "planId": 659958,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659958/p"
+    },
+    {
+      "planId": 659955,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659955/p"
+    },
+    {
+      "planId": 659956,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659956/p"
+    },
+    {
+      "planId": 659959,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659959/p"
+    }
+  ],
+  "forbidden-gravel": [
+    {
+      "planId": 667246,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667246/p"
+    }
+  ],
+  "giro-sardegna-gravel": [
+    {
+      "planId": 659016,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659016/giro-sardegna-gravel-finisher-12wk"
+    },
+    {
+      "planId": 659017,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659017/giro-sardegna-gravel-finisher-8wk"
+    },
+    {
+      "planId": 659020,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659020/giro-sardegna-gravel-time-crunched-12wk"
+    },
+    {
+      "planId": 659021,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659021/giro-sardegna-gravel-time-crunched-8wk"
+    },
+    {
+      "planId": 659018,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659018/giro-sardegna-gravel-compete-12wk"
+    },
+    {
+      "planId": 659019,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659019/giro-sardegna-gravel-masters-50-12wk"
+    },
+    {
+      "planId": 659022,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659022/giro-sardegna-gravel-save-my-race-6wk"
+    }
+  ],
+  "grassroots-gravel": [
+    {
+      "planId": 666680,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666680/p"
+    },
+    {
+      "planId": 666681,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666681/p"
+    },
+    {
+      "planId": 666682,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666682/p"
+    }
+  ],
+  "gravel-and-granite": [
+    {
+      "planId": 669230,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669230/p"
+    },
+    {
+      "planId": 669231,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669231/p"
+    },
+    {
+      "planId": 669232,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669232/p"
+    },
+    {
+      "planId": 669233,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669233/p"
+    },
+    {
+      "planId": 669234,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669234/p"
+    },
+    {
+      "planId": 669235,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669235/p"
+    },
+    {
+      "planId": 669236,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669236/p"
+    }
+  ],
+  "gravel-and-tar-classic": [
+    {
+      "planId": 659233,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659233/gravel-and-tar-finisher-12wk"
+    },
+    {
+      "planId": 659234,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659234/gravel-and-tar-finisher-8wk"
+    },
+    {
+      "planId": 659237,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659237/gravel-and-tar-time-crunched-12wk"
+    },
+    {
+      "planId": 659238,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659238/gravel-and-tar-time-crunched-8wk"
+    },
+    {
+      "planId": 659235,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659235/gravel-and-tar-compete-12wk"
+    },
+    {
+      "planId": 659236,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659236/gravel-and-tar-masters-50-12wk"
+    },
+    {
+      "planId": 659239,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659239/gravel-and-tar-save-my-race-6wk"
+    }
+  ],
+  "gravel-battle-of-sumter-forest": [
+    {
+      "planId": 659805,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659805/p"
+    },
+    {
+      "planId": 659806,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659806/p"
+    },
+    {
+      "planId": 659809,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659809/p"
+    },
+    {
+      "planId": 659810,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659810/p"
+    },
+    {
+      "planId": 659807,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659807/p"
+    },
+    {
+      "planId": 659808,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659808/p"
+    },
+    {
+      "planId": 659811,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659811/p"
+    }
+  ],
+  "gravel-brazil": [
+    {
+      "planId": 659165,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659165/p"
+    },
+    {
+      "planId": 659166,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659166/p"
+    },
+    {
+      "planId": 659169,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659169/p"
+    },
+    {
+      "planId": 659170,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659170/p"
+    },
+    {
+      "planId": 659167,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659167/p"
+    },
+    {
+      "planId": 659168,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659168/p"
+    },
+    {
+      "planId": 659171,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659171/p"
+    }
+  ],
+  "gravel-burn": [
+    {
+      "planId": 669435,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669435/p"
+    },
+    {
+      "planId": 669436,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669436/p"
+    },
+    {
+      "planId": 669437,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669437/p"
+    },
+    {
+      "planId": 669438,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669438/p"
+    },
+    {
+      "planId": 669439,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669439/p"
+    },
+    {
+      "planId": 669440,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669440/p"
+    },
+    {
+      "planId": 669442,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669442/p"
+    }
+  ],
+  "gravel-chile": [
+    {
+      "planId": 669242,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669242/p"
+    }
+  ],
+  "gravel-del-fuego": [
+    {
+      "planId": 667972,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667972/p"
+    },
+    {
+      "planId": 667973,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667973/p"
+    },
+    {
+      "planId": 667974,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667974/p"
+    },
+    {
+      "planId": 667975,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667975/p"
+    },
+    {
+      "planId": 667976,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667976/p"
+    },
+    {
+      "planId": 667977,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667977/p"
+    },
+    {
+      "planId": 667978,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667978/p"
+    }
+  ],
+  "gravel-grit-n-grind": [
+    {
+      "planId": 659969,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659969/p"
+    },
+    {
+      "planId": 659970,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659970/p"
+    },
+    {
+      "planId": 659971,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659971/p"
+    }
+  ],
+  "gravel-locos": [
+    {
+      "planId": 658892,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658892/gravel-locos-finisher-12wk"
+    },
+    {
+      "planId": 658893,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658893/gravel-locos-finisher-8wk"
+    },
+    {
+      "planId": 658896,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658896/gravel-locos-time-crunched-12wk"
+    },
+    {
+      "planId": 658897,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658897/gravel-locos-time-crunched-8wk"
+    },
+    {
+      "planId": 658894,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658894/gravel-locos-compete-12wk"
+    },
+    {
+      "planId": 658895,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658895/gravel-locos-masters-50-12wk"
+    },
+    {
+      "planId": 658898,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658898/gravel-locos-save-my-race-6wk"
+    }
+  ],
+  "gravel-of-marathon": [
+    {
+      "planId": 669243,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669243/p"
+    },
+    {
+      "planId": 669244,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669244/p"
+    },
+    {
+      "planId": 669245,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669245/p"
+    },
+    {
+      "planId": 669246,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669246/p"
+    },
+    {
+      "planId": 669247,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669247/p"
+    },
+    {
+      "planId": 669248,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669248/p"
+    },
+    {
+      "planId": 669249,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669249/p"
+    }
+  ],
+  "gravel-revival": [
+    {
+      "planId": 666499,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666499/p"
+    },
+    {
+      "planId": 666525,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666525/p"
+    },
+    {
+      "planId": 666513,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666513/p"
+    }
+  ],
+  "gravel-worlds": [
+    {
+      "planId": 659005,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659005/gravel-worlds-finisher-12wk"
+    },
+    {
+      "planId": 659006,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659006/gravel-worlds-finisher-8wk"
+    },
+    {
+      "planId": 659009,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659009/gravel-worlds-time-crunched-12wk"
+    },
+    {
+      "planId": 659010,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659010/gravel-worlds-time-crunched-8wk"
+    },
+    {
+      "planId": 659007,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659007/gravel-worlds-compete-12wk"
+    },
+    {
+      "planId": 659008,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659008/gravel-worlds-masters-50-12wk"
+    },
+    {
+      "planId": 659011,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659011/gravel-worlds-save-my-race-6wk"
+    }
+  ],
+  "gravelista": [
+    {
+      "planId": 666500,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666500/p"
+    },
+    {
+      "planId": 666526,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666526/p"
+    },
+    {
+      "planId": 666514,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666514/p"
+    }
+  ],
+  "great-otway-gravel-grind": [
+    {
+      "planId": 666729,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666729/p"
+    },
+    {
+      "planId": 666730,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666730/p"
+    },
+    {
+      "planId": 666731,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666731/p"
+    },
+    {
+      "planId": 666732,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666732/p"
+    },
+    {
+      "planId": 666734,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666734/p"
+    },
+    {
+      "planId": 666735,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666735/p"
+    },
+    {
+      "planId": 666736,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666736/p"
+    }
+  ],
+  "grinduro-california": [
+    {
+      "planId": 659013,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659013/grinduro-california-finisher-8wk"
+    },
+    {
+      "planId": 659014,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659014/grinduro-california-time-crunched-8wk"
+    },
+    {
+      "planId": 659015,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659015/grinduro-california-save-my-race-6wk"
+    }
+  ],
+  "grinduro-france": [
+    {
+      "planId": 659097,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659097/grinduro-france-finisher-12wk"
+    },
+    {
+      "planId": 659098,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659098/grinduro-france-finisher-8wk"
+    },
+    {
+      "planId": 659101,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659101/grinduro-france-time-crunched-12wk"
+    },
+    {
+      "planId": 659102,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659102/grinduro-france-time-crunched-8wk"
+    },
+    {
+      "planId": 659099,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659099/grinduro-france-compete-12wk"
+    },
+    {
+      "planId": 659100,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659100/grinduro-france-masters-50-12wk"
+    },
+    {
+      "planId": 659103,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659103/grinduro-france-save-my-race-6wk"
+    }
+  ],
+  "grinduro-germany": [
+    {
+      "planId": 659104,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659104/grinduro-germany-finisher-12wk"
+    },
+    {
+      "planId": 659105,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659105/grinduro-germany-finisher-8wk"
+    },
+    {
+      "planId": 659108,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659108/grinduro-germany-time-crunched-12wk"
+    },
+    {
+      "planId": 659109,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659109/grinduro-germany-time-crunched-8wk"
+    },
+    {
+      "planId": 659106,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659106/grinduro-germany-compete-12wk"
+    },
+    {
+      "planId": 659107,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659107/grinduro-germany-masters-50-12wk"
+    },
+    {
+      "planId": 659110,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659110/grinduro-germany-save-my-race-6wk"
+    }
+  ],
+  "grinduro-italy": [
+    {
+      "planId": 659682,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659682/p"
+    },
+    {
+      "planId": 659683,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659683/p"
+    },
+    {
+      "planId": 659684,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659684/p"
+    }
+  ],
+  "grusk": [
+    {
+      "planId": 666505,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666505/p"
+    },
+    {
+      "planId": 666507,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666507/p"
+    },
+    {
+      "planId": 666532,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666532/p"
+    },
+    {
+      "planId": 666534,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666534/p"
+    },
+    {
+      "planId": 666495,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666495/p"
+    },
+    {
+      "planId": 666510,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666510/p"
+    },
+    {
+      "planId": 666520,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666520/p"
+    }
+  ],
+  "gunni-grinder": [
+    {
+      "planId": 658757,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658757/gunni-grinder-finisher-8wk"
+    },
+    {
+      "planId": 658758,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658758/gunni-grinder-time-crunched-8wk"
+    },
+    {
+      "planId": 658759,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658759/gunni-grinder-save-my-race-6wk"
+    }
+  ],
+  "hazel-valley-rally": [
+    {
+      "planId": 668257,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668257/p"
+    },
+    {
+      "planId": 668258,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668258/p"
+    },
+    {
+      "planId": 668259,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668259/p"
+    },
+    {
+      "planId": 668260,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668260/p"
+    },
+    {
+      "planId": 668261,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668261/p"
+    },
+    {
+      "planId": 668262,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668262/p"
+    },
+    {
+      "planId": 668263,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668263/p"
+    }
+  ],
+  "heathland-gravel": [
+    {
+      "planId": 666813,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666813/p"
+    },
+    {
+      "planId": 666814,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666814/p"
+    },
+    {
+      "planId": 666815,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666815/p"
+    },
+    {
+      "planId": 666816,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666816/p"
+    },
+    {
+      "planId": 666817,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666817/p"
+    },
+    {
+      "planId": 666818,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666818/p"
+    },
+    {
+      "planId": 666819,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666819/p"
+    }
+  ],
+  "heck-of-the-north": [
+    {
+      "planId": 659160,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659160/heck-of-the-north-finisher-8wk"
+    },
+    {
+      "planId": 659161,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659161/heck-of-the-north-time-crunched-8wk"
+    },
+    {
+      "planId": 659162,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659162/heck-of-the-north-save-my-race-6wk"
+    }
+  ],
+  "hegau-gravel-race": [
+    {
+      "planId": 666805,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666805/p"
+    },
+    {
+      "planId": 666806,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666806/p"
+    },
+    {
+      "planId": 666807,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666807/p"
+    },
+    {
+      "planId": 666808,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666808/p"
+    },
+    {
+      "planId": 666809,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666809/p"
+    },
+    {
+      "planId": 666810,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666810/p"
+    },
+    {
+      "planId": 666811,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666811/p"
+    }
+  ],
+  "highlands-gravel-classic": [
+    {
+      "planId": 659196,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659196/highlands-gravel-classic-finisher-12wk"
+    },
+    {
+      "planId": 659198,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659198/highlands-gravel-classic-finisher-8wk"
+    },
+    {
+      "planId": 659202,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659202/highlands-gravel-classic-time-crunched-12wk"
+    },
+    {
+      "planId": 659204,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659204/highlands-gravel-classic-time-crunched-8wk"
+    },
+    {
+      "planId": 659199,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659199/highlands-gravel-classic-compete-12wk"
+    },
+    {
+      "planId": 659201,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659201/highlands-gravel-classic-masters-50-12wk"
+    },
+    {
+      "planId": 659205,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659205/highlands-gravel-classic-save-my-race-6wk"
+    }
+  ],
+  "homegrown-gravel-adventure": [
+    {
+      "planId": 668444,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668444/p"
+    },
+    {
+      "planId": 668446,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668446/p"
+    },
+    {
+      "planId": 668447,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668447/p"
+    },
+    {
+      "planId": 668448,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668448/p"
+    },
+    {
+      "planId": 668449,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668449/p"
+    },
+    {
+      "planId": 668450,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668450/p"
+    },
+    {
+      "planId": 668451,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668451/p"
+    }
+  ],
+  "hot-springs-gravel-gauntlet": [
+    {
+      "planId": 659748,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659748/p"
+    },
+    {
+      "planId": 659749,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659749/p"
+    },
+    {
+      "planId": 659752,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659752/p"
+    },
+    {
+      "planId": 659753,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659753/p"
+    },
+    {
+      "planId": 659750,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659750/p"
+    },
+    {
+      "planId": 659751,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659751/p"
+    },
+    {
+      "planId": 659754,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659754/p"
+    }
+  ],
+  "houffa-gravel": [
+    {
+      "planId": 659962,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659962/p"
+    },
+    {
+      "planId": 659963,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659963/p"
+    },
+    {
+      "planId": 659966,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659966/p"
+    },
+    {
+      "planId": 659967,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659967/p"
+    },
+    {
+      "planId": 659964,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659964/p"
+    },
+    {
+      "planId": 659965,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659965/p"
+    },
+    {
+      "planId": 659968,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659968/p"
+    }
+  ],
+  "hungry-bear-100": [
+    {
+      "planId": 659829,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659829/p"
+    },
+    {
+      "planId": 659830,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659830/p"
+    },
+    {
+      "planId": 659833,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659833/p"
+    },
+    {
+      "planId": 659834,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659834/p"
+    },
+    {
+      "planId": 659831,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659831/p"
+    },
+    {
+      "planId": 659832,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659832/p"
+    },
+    {
+      "planId": 659835,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659835/p"
+    }
+  ],
+  "iceman-cometh": [
+    {
+      "planId": 668053,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668053/p"
+    },
+    {
+      "planId": 668054,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668054/p"
+    },
+    {
+      "planId": 668055,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668055/p"
+    },
+    {
+      "planId": 668056,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668056/p"
+    },
+    {
+      "planId": 668057,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668057/p"
+    },
+    {
+      "planId": 668058,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668058/p"
+    },
+    {
+      "planId": 668059,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668059/p"
+    }
+  ],
+  "jeroboam": [
+    {
+      "planId": 666523,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666523/p"
+    }
+  ],
+  "kettle-mettle": [
+    {
+      "planId": 659707,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659707/p"
+    },
+    {
+      "planId": 659708,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659708/p"
+    },
+    {
+      "planId": 659711,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659711/p"
+    },
+    {
+      "planId": 659712,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659712/p"
+    },
+    {
+      "planId": 659709,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659709/p"
+    },
+    {
+      "planId": 659710,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659710/p"
+    },
+    {
+      "planId": 659713,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659713/p"
+    }
+  ],
+  "kindling": [
+    {
+      "planId": 668292,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668292/p"
+    },
+    {
+      "planId": 668293,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668293/p"
+    },
+    {
+      "planId": 668294,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668294/p"
+    },
+    {
+      "planId": 668295,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668295/p"
+    },
+    {
+      "planId": 668296,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668296/p"
+    },
+    {
+      "planId": 668297,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668297/p"
+    },
+    {
+      "planId": 668298,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668298/p"
+    }
+  ],
+  "kowtown-gravel": [
+    {
+      "planId": 669214,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669214/p"
+    },
+    {
+      "planId": 669215,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669215/p"
+    },
+    {
+      "planId": 669216,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669216/p"
+    },
+    {
+      "planId": 669217,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669217/p"
+    },
+    {
+      "planId": 669218,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669218/p"
+    },
+    {
+      "planId": 669219,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669219/p"
+    },
+    {
+      "planId": 669220,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669220/p"
+    }
+  ],
+  "la-dromoise-gravel": [
+    {
+      "planId": 660063,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-660063/p"
+    },
+    {
+      "planId": 660064,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-660064/p"
+    },
+    {
+      "planId": 660065,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-660065/p"
+    }
+  ],
+  "la-resistance": [
+    {
+      "planId": 659531,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659531/p"
+    },
+    {
+      "planId": 659534,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659534/p"
+    },
+    {
+      "planId": 659535,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659535/p"
+    }
+  ],
+  "lauf-true-grit": [
+    {
+      "planId": 659135,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659135/lauf-true-grit-finisher-12wk"
+    },
+    {
+      "planId": 659134,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659134/lauf-true-grit-finisher-8wk"
+    },
+    {
+      "planId": 659138,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659138/lauf-true-grit-time-crunched-12wk"
+    },
+    {
+      "planId": 659139,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659139/lauf-true-grit-time-crunched-8wk"
+    },
+    {
+      "planId": 659133,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659133/lauf-true-grit-compete-12wk"
+    },
+    {
+      "planId": 659136,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659136/lauf-true-grit-masters-50-12wk"
+    },
+    {
+      "planId": 659137,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659137/lauf-true-grit-save-my-race-6wk"
+    }
+  ],
+  "le-grand-du-nord": [
+    {
+      "planId": 659141,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659141/le-grand-du-nord-finisher-12wk"
+    },
+    {
+      "planId": 659142,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659142/le-grand-du-nord-finisher-8wk"
+    },
+    {
+      "planId": 659146,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659146/le-grand-du-nord-time-crunched-12wk"
+    },
+    {
+      "planId": 659145,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659145/le-grand-du-nord-time-crunched-8wk"
+    },
+    {
+      "planId": 659140,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659140/le-grand-du-nord-compete-12wk"
+    },
+    {
+      "planId": 659143,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659143/le-grand-du-nord-masters-50-12wk"
+    },
+    {
+      "planId": 659144,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659144/le-grand-du-nord-save-my-race-6wk"
+    }
+  ],
+  "little-apple-100": [
+    {
+      "planId": 659735,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659735/p"
+    },
+    {
+      "planId": 659736,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659736/p"
+    },
+    {
+      "planId": 659740,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659740/p"
+    },
+    {
+      "planId": 659739,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659739/p"
+    },
+    {
+      "planId": 659734,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659734/p"
+    },
+    {
+      "planId": 659737,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659737/p"
+    },
+    {
+      "planId": 659738,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659738/p"
+    }
+  ],
+  "lone-wolf-gravel": [
+    {
+      "planId": 666665,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666665/p"
+    }
+  ],
+  "lost-and-found-gravel": [
+    {
+      "planId": 659741,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659741/p"
+    },
+    {
+      "planId": 659742,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659742/p"
+    },
+    {
+      "planId": 659745,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659745/p"
+    },
+    {
+      "planId": 659746,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659746/p"
+    },
+    {
+      "planId": 659743,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659743/p"
+    },
+    {
+      "planId": 659744,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659744/p"
+    },
+    {
+      "planId": 659747,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659747/p"
+    }
+  ],
+  "lowell-classic": [
+    {
+      "planId": 666503,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666503/p"
+    },
+    {
+      "planId": 666529,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666529/p"
+    },
+    {
+      "planId": 666517,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666517/p"
+    }
+  ],
+  "maap-beechworth-granite-classic": [
+    {
+      "planId": 659546,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659546/maap-beechworth-granite-classic-finisher-12wk"
+    },
+    {
+      "planId": 659547,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659547/maap-beechworth-granite-classic-finisher-8wk"
+    },
+    {
+      "planId": 659551,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659551/maap-beechworth-granite-classic-time-crunched-12wk"
+    },
+    {
+      "planId": 659555,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659555/maap-beechworth-granite-classic-time-crunched-8wk"
+    },
+    {
+      "planId": 659548,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659548/maap-beechworth-granite-classic-compete-12wk"
+    },
+    {
+      "planId": 659549,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659549/maap-beechworth-granite-classic-masters-50-12wk"
+    },
+    {
+      "planId": 659559,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659559/maap-beechworth-granite-classic-save-my-race-6wk"
+    }
+  ],
+  "mammoth-tuff": [
+    {
+      "planId": 659084,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659084/mammoth-tuff-finisher-8wk"
+    },
+    {
+      "planId": 659085,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659085/mammoth-tuff-time-crunched-8wk"
+    },
+    {
+      "planId": 659086,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659086/mammoth-tuff-save-my-race-6wk"
+    }
+  ],
+  "marly-grav": [
+    {
+      "planId": 666700,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666700/p"
+    },
+    {
+      "planId": 666701,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666701/p"
+    },
+    {
+      "planId": 666702,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666702/p"
+    },
+    {
+      "planId": 666703,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666703/p"
+    },
+    {
+      "planId": 666704,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666704/p"
+    },
+    {
+      "planId": 666705,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666705/p"
+    },
+    {
+      "planId": 666706,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666706/p"
+    }
+  ],
+  "marys-mayhem": [
+    {
+      "planId": 666502,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666502/p"
+    },
+    {
+      "planId": 666528,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666528/p"
+    },
+    {
+      "planId": 666516,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666516/p"
+    }
+  ],
+  "melting-mann": [
+    {
+      "planId": 666826,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666826/p"
+    },
+    {
+      "planId": 666827,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666827/p"
+    },
+    {
+      "planId": 666828,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666828/p"
+    },
+    {
+      "planId": 666829,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666829/p"
+    },
+    {
+      "planId": 666830,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666830/p"
+    },
+    {
+      "planId": 666831,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666831/p"
+    },
+    {
+      "planId": 666832,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666832/p"
+    }
+  ],
+  "mid-south": [
+    {
+      "planId": 668061,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668061/p"
+    },
+    {
+      "planId": 668062,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668062/p"
+    },
+    {
+      "planId": 668063,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668063/p"
+    },
+    {
+      "planId": 668064,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668064/p"
+    },
+    {
+      "planId": 668065,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668065/p"
+    },
+    {
+      "planId": 668066,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668066/p"
+    },
+    {
+      "planId": 668067,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668067/p"
+    }
+  ],
+  "monaco-gravel-race": [
+    {
+      "planId": 659089,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659089/monaco-gravel-race-finisher-12wk"
+    },
+    {
+      "planId": 659090,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659090/monaco-gravel-race-finisher-8wk"
+    },
+    {
+      "planId": 659093,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659093/monaco-gravel-race-time-crunched-12wk"
+    },
+    {
+      "planId": 659094,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659094/monaco-gravel-race-time-crunched-8wk"
+    },
+    {
+      "planId": 659091,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659091/monaco-gravel-race-compete-12wk"
+    },
+    {
+      "planId": 659092,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659092/monaco-gravel-race-masters-50-12wk"
+    },
+    {
+      "planId": 659095,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659095/monaco-gravel-race-save-my-race-6wk"
+    }
+  ],
+  "muck-n-mac-fest": [
+    {
+      "planId": 668304,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668304/p"
+    },
+    {
+      "planId": 668305,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668305/p"
+    },
+    {
+      "planId": 668306,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668306/p"
+    },
+    {
+      "planId": 668307,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668307/p"
+    },
+    {
+      "planId": 668308,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668308/p"
+    },
+    {
+      "planId": 668309,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668309/p"
+    },
+    {
+      "planId": 668310,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668310/p"
+    }
+  ],
+  "ned-gravel": [
+    {
+      "planId": 659400,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659400/ned-gravel-finisher-12wk"
+    },
+    {
+      "planId": 659401,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659401/ned-gravel-finisher-8wk"
+    },
+    {
+      "planId": 659404,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659404/ned-gravel-time-crunched-12wk"
+    },
+    {
+      "planId": 659405,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659405/ned-gravel-time-crunched-8wk"
+    },
+    {
+      "planId": 659402,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659402/ned-gravel-compete-12wk"
+    },
+    {
+      "planId": 659403,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659403/ned-gravel-masters-50-12wk"
+    },
+    {
+      "planId": 659406,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659406/ned-gravel-save-my-race-6wk"
+    }
+  ],
+  "niseko-gravel": [
+    {
+      "planId": 666522,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666522/p"
+    }
+  ],
+  "noosa-gravel-enduro": [
+    {
+      "planId": 659590,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659590/noosa-gravel-enduro-finisher-12wk"
+    },
+    {
+      "planId": 659591,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659591/noosa-gravel-enduro-finisher-8wk"
+    },
+    {
+      "planId": 659594,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659594/noosa-gravel-enduro-time-crunched-12wk"
+    },
+    {
+      "planId": 659595,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659595/noosa-gravel-enduro-time-crunched-8wk"
+    },
+    {
+      "planId": 659592,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659592/noosa-gravel-enduro-compete-12wk"
+    },
+    {
+      "planId": 659593,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659593/noosa-gravel-enduro-masters-50-12wk"
+    },
+    {
+      "planId": 659596,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659596/noosa-gravel-enduro-save-my-race-6wk"
+    }
+  ],
+  "nova-eroica": [
+    {
+      "planId": 659118,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659118/nova-eroica-finisher-12wk"
+    },
+    {
+      "planId": 659119,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659119/nova-eroica-finisher-8wk"
+    },
+    {
+      "planId": 659122,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659122/nova-eroica-time-crunched-12wk"
+    },
+    {
+      "planId": 659123,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659123/nova-eroica-time-crunched-8wk"
+    },
+    {
+      "planId": 659120,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659120/nova-eroica-compete-12wk"
+    },
+    {
+      "planId": 659121,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659121/nova-eroica-masters-50-12wk"
+    },
+    {
+      "planId": 659124,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659124/nova-eroica-save-my-race-6wk"
+    }
+  ],
+  "okanagan-graveller": [
+    {
+      "planId": 668176,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668176/p"
+    },
+    {
+      "planId": 668177,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668177/p"
+    },
+    {
+      "planId": 668178,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668178/p"
+    },
+    {
+      "planId": 668179,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668179/p"
+    },
+    {
+      "planId": 668180,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668180/p"
+    },
+    {
+      "planId": 668181,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668181/p"
+    },
+    {
+      "planId": 668182,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668182/p"
+    }
+  ],
+  "old-fashioned-gravel": [
+    {
+      "planId": 666685,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666685/p"
+    }
+  ],
+  "oregon-coast-gravel-epic": [
+    {
+      "planId": 659626,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659626/p"
+    },
+    {
+      "planId": 659627,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659627/p"
+    },
+    {
+      "planId": 659630,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659630/p"
+    },
+    {
+      "planId": 659631,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659631/p"
+    },
+    {
+      "planId": 659628,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659628/p"
+    },
+    {
+      "planId": 659629,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659629/p"
+    },
+    {
+      "planId": 659632,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659632/p"
+    }
+  ],
+  "paris-to-ancaster": [
+    {
+      "planId": 659186,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659186/paris-to-ancaster-finisher-12wk"
+    },
+    {
+      "planId": 659187,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659187/paris-to-ancaster-finisher-8wk"
+    },
+    {
+      "planId": 659191,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659191/paris-to-ancaster-time-crunched-12wk"
+    },
+    {
+      "planId": 659192,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659192/paris-to-ancaster-time-crunched-8wk"
+    },
+    {
+      "planId": 659188,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659188/paris-to-ancaster-compete-12wk"
+    },
+    {
+      "planId": 659189,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659189/paris-to-ancaster-masters-50-12wk"
+    },
+    {
+      "planId": 659193,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659193/paris-to-ancaster-save-my-race-6wk"
+    }
+  ],
+  "pisgah-monster-cross": [
+    {
+      "planId": 659157,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659157/pisgah-monster-cross-finisher-8wk"
+    },
+    {
+      "planId": 659158,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659158/pisgah-monster-cross-time-crunched-8wk"
+    },
+    {
+      "planId": 659159,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659159/pisgah-monster-cross-save-my-race-6wk"
+    }
+  ],
+  "pony-express-120": [
+    {
+      "planId": 666651,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666651/p"
+    },
+    {
+      "planId": 666652,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666652/p"
+    },
+    {
+      "planId": 666653,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666653/p"
+    },
+    {
+      "planId": 666654,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666654/p"
+    },
+    {
+      "planId": 666655,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666655/p"
+    },
+    {
+      "planId": 666656,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666656/p"
+    },
+    {
+      "planId": 666657,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666657/p"
+    }
+  ],
+  "pyrenees-catalanes-gravel-tour": [
+    {
+      "planId": 669241,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669241/p"
+    }
+  ],
+  "race-around-rwanda": [
+    {
+      "planId": 668392,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668392/p"
+    },
+    {
+      "planId": 668393,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668393/p"
+    },
+    {
+      "planId": 668394,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668394/p"
+    },
+    {
+      "planId": 668395,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668395/p"
+    },
+    {
+      "planId": 668396,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668396/p"
+    },
+    {
+      "planId": 668397,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668397/p"
+    },
+    {
+      "planId": 668398,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668398/p"
+    }
+  ],
+  "race-to-valhalla": [
+    {
+      "planId": 659762,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659762/p"
+    },
+    {
+      "planId": 659764,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659764/p"
+    },
+    {
+      "planId": 659767,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659767/p"
+    },
+    {
+      "planId": 659768,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659768/p"
+    },
+    {
+      "planId": 659765,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659765/p"
+    },
+    {
+      "planId": 659766,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659766/p"
+    },
+    {
+      "planId": 659769,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659769/p"
+    }
+  ],
+  "rad-am-ring-gravel": [
+    {
+      "planId": 668198,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668198/p"
+    },
+    {
+      "planId": 668199,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668199/p"
+    },
+    {
+      "planId": 668200,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668200/p"
+    },
+    {
+      "planId": 668201,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668201/p"
+    },
+    {
+      "planId": 668202,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668202/p"
+    },
+    {
+      "planId": 668203,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668203/p"
+    },
+    {
+      "planId": 668204,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668204/p"
+    }
+  ],
+  "radl-grvl": [
+    {
+      "planId": 659254,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659254/radl-grvl-finisher-12wk"
+    },
+    {
+      "planId": 659255,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659255/radl-grvl-finisher-8wk"
+    },
+    {
+      "planId": 659258,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659258/radl-grvl-time-crunched-12wk"
+    },
+    {
+      "planId": 659259,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659259/radl-grvl-time-crunched-8wk"
+    },
+    {
+      "planId": 659256,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659256/radl-grvl-compete-12wk"
+    },
+    {
+      "planId": 659257,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659257/radl-grvl-masters-50-12wk"
+    },
+    {
+      "planId": 659260,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659260/radl-grvl-save-my-race-6wk"
+    }
+  ],
+  "real-west-gravel": [
+    {
+      "planId": 666718,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666718/p"
+    },
+    {
+      "planId": 666720,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666720/p"
+    },
+    {
+      "planId": 666721,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666721/p"
+    },
+    {
+      "planId": 666722,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666722/p"
+    },
+    {
+      "planId": 666723,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666723/p"
+    },
+    {
+      "planId": 666724,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666724/p"
+    },
+    {
+      "planId": 666725,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666725/p"
+    }
+  ],
+  "rebeccas-private-idaho": [
+    {
+      "planId": 658668,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658668/rebecca-s-private-idaho-finisher-8wk"
+    },
+    {
+      "planId": 658669,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658669/rebecca-s-private-idaho-time-crunched-8wk"
+    },
+    {
+      "planId": 658670,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658670/rebecca-s-private-idaho-save-my-race-6wk"
+    }
+  ],
+  "reliance-deep-woods": [
+    {
+      "planId": 666506,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666506/p"
+    },
+    {
+      "planId": 666508,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666508/p"
+    },
+    {
+      "planId": 666533,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666533/p"
+    },
+    {
+      "planId": 666535,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666535/p"
+    },
+    {
+      "planId": 666496,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666496/p"
+    },
+    {
+      "planId": 666511,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666511/p"
+    },
+    {
+      "planId": 666521,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666521/p"
+    }
+  ],
+  "river-city-gravel-fondo": [
+    {
+      "planId": 659645,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659645/p"
+    },
+    {
+      "planId": 659653,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659653/p"
+    },
+    {
+      "planId": 659656,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659656/p"
+    },
+    {
+      "planId": 659657,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659657/p"
+    },
+    {
+      "planId": 659654,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659654/p"
+    },
+    {
+      "planId": 659655,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659655/p"
+    },
+    {
+      "planId": 659658,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659658/p"
+    }
+  ],
+  "rock-cobbler": [
+    {
+      "planId": 659240,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659240/rock-cobbler-finisher-12wk"
+    },
+    {
+      "planId": 659241,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659241/rock-cobbler-finisher-8wk"
+    },
+    {
+      "planId": 659244,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659244/rock-cobbler-time-crunched-12wk"
+    },
+    {
+      "planId": 659245,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659245/rock-cobbler-time-crunched-8wk"
+    },
+    {
+      "planId": 659242,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659242/rock-cobbler-compete-12wk"
+    },
+    {
+      "planId": 659243,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659243/rock-cobbler-masters-50-12wk"
+    },
+    {
+      "planId": 659246,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659246/rock-cobbler-save-my-race-6wk"
+    }
+  ],
+  "ruby-roubaix": [
+    {
+      "planId": 659633,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659633/p"
+    },
+    {
+      "planId": 659634,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659634/p"
+    },
+    {
+      "planId": 659637,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659637/p"
+    },
+    {
+      "planId": 659638,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659638/p"
+    },
+    {
+      "planId": 659635,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659635/p"
+    },
+    {
+      "planId": 659636,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659636/p"
+    },
+    {
+      "planId": 659639,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659639/p"
+    }
+  ],
+  "safari-gravel-race": [
+    {
+      "planId": 659837,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659837/p"
+    },
+    {
+      "planId": 659838,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659838/p"
+    },
+    {
+      "planId": 659841,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659841/p"
+    },
+    {
+      "planId": 659842,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659842/p"
+    },
+    {
+      "planId": 659839,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659839/p"
+    },
+    {
+      "planId": 659840,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659840/p"
+    },
+    {
+      "planId": 659843,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659843/p"
+    }
+  ],
+  "salida-76": [
+    {
+      "planId": 659850,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659850/p"
+    },
+    {
+      "planId": 659851,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659851/p"
+    },
+    {
+      "planId": 659852,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659852/p"
+    }
+  ],
+  "santa-fe-century-gravelon": [
+    {
+      "planId": 659819,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659819/p"
+    },
+    {
+      "planId": 659820,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659820/p"
+    },
+    {
+      "planId": 659823,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659823/p"
+    },
+    {
+      "planId": 659824,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659824/p"
+    },
+    {
+      "planId": 659821,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659821/p"
+    },
+    {
+      "planId": 659822,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659822/p"
+    },
+    {
+      "planId": 659825,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659825/p"
+    }
+  ],
+  "sasquatch-duro": [
+    {
+      "planId": 659564,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659564/sasquatch-duro-finisher-12wk"
+    },
+    {
+      "planId": 659565,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659565/sasquatch-duro-finisher-8wk"
+    },
+    {
+      "planId": 659568,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659568/sasquatch-duro-time-crunched-12wk"
+    },
+    {
+      "planId": 659569,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659569/sasquatch-duro-time-crunched-8wk"
+    },
+    {
+      "planId": 659566,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659566/sasquatch-duro-compete-12wk"
+    },
+    {
+      "planId": 659567,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659567/sasquatch-duro-masters-50-12wk"
+    },
+    {
+      "planId": 659570,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659570/sasquatch-duro-save-my-race-6wk"
+    }
+  ],
+  "sea-otter-europe-gravel": [
+    {
+      "planId": 659780,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659780/p"
+    },
+    {
+      "planId": 659781,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659781/p"
+    },
+    {
+      "planId": 659782,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659782/p"
+    }
+  ],
+  "sea-otter-gravel": [
+    {
+      "planId": 658850,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658850/sea-otter-gravel-finisher-12wk"
+    },
+    {
+      "planId": 658851,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658851/sea-otter-gravel-finisher-8wk"
+    },
+    {
+      "planId": 658854,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658854/sea-otter-gravel-time-crunched-12wk"
+    },
+    {
+      "planId": 658855,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658855/sea-otter-gravel-time-crunched-8wk"
+    },
+    {
+      "planId": 658852,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658852/sea-otter-gravel-compete-12wk"
+    },
+    {
+      "planId": 658853,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658853/sea-otter-gravel-masters-50-12wk"
+    },
+    {
+      "planId": 658856,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658856/sea-otter-gravel-save-my-race-6wk"
+    }
+  ],
+  "serenissima-gravel": [
+    {
+      "planId": 666504,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666504/p"
+    },
+    {
+      "planId": 666530,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666530/p"
+    },
+    {
+      "planId": 666518,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666518/p"
+    }
+  ],
+  "seven": [
+    {
+      "planId": 658998,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658998/seven-finisher-12wk"
+    },
+    {
+      "planId": 658999,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658999/seven-finisher-8wk"
+    },
+    {
+      "planId": 659002,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659002/seven-time-crunched-12wk"
+    },
+    {
+      "planId": 659003,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659003/seven-time-crunched-8wk"
+    },
+    {
+      "planId": 659000,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659000/seven-compete-12wk"
+    },
+    {
+      "planId": 659001,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659001/seven-masters-50-12wk"
+    },
+    {
+      "planId": 659004,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659004/seven-save-my-race-6wk"
+    }
+  ],
+  "soldier-cutoff-hillduro": [
+    {
+      "planId": 666683,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666683/p"
+    }
+  ],
+  "southern-cross-gravel": [
+    {
+      "planId": 659172,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659172/southern-cross-finisher-12wk"
+    },
+    {
+      "planId": 659173,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659173/southern-cross-finisher-8wk"
+    },
+    {
+      "planId": 659176,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659176/southern-cross-time-crunched-12wk"
+    },
+    {
+      "planId": 659177,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659177/southern-cross-time-crunched-8wk"
+    },
+    {
+      "planId": 659174,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659174/southern-cross-compete-12wk"
+    },
+    {
+      "planId": 659175,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659175/southern-cross-masters-50-12wk"
+    },
+    {
+      "planId": 659178,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659178/southern-cross-save-my-race-6wk"
+    }
+  ],
+  "spirit-world-100": [
+    {
+      "planId": 659861,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659861/p"
+    },
+    {
+      "planId": 659860,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659860/p"
+    },
+    {
+      "planId": 659858,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659858/p"
+    },
+    {
+      "planId": 659859,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659859/p"
+    },
+    {
+      "planId": 659856,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659856/p"
+    },
+    {
+      "planId": 659855,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659855/p"
+    },
+    {
+      "planId": 659857,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659857/p"
+    }
+  ],
+  "steamboat-gravel": [
+    {
+      "planId": 658907,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658907/sbt-grvl-finisher-12wk"
+    },
+    {
+      "planId": 658908,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658908/sbt-grvl-finisher-8wk"
+    },
+    {
+      "planId": 658911,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658911/sbt-grvl-time-crunched-12wk"
+    },
+    {
+      "planId": 658912,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658912/sbt-grvl-time-crunched-8wk"
+    },
+    {
+      "planId": 658909,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658909/sbt-grvl-compete-12wk"
+    },
+    {
+      "planId": 658910,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658910/sbt-grvl-masters-50-12wk"
+    },
+    {
+      "planId": 658913,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658913/sbt-grvl-save-my-race-6wk"
+    }
+  ],
+  "takelma-gravel-grinder": [
+    {
+      "planId": 666931,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666931/p"
+    },
+    {
+      "planId": 666932,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666932/p"
+    },
+    {
+      "planId": 666933,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666933/p"
+    },
+    {
+      "planId": 666934,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666934/p"
+    },
+    {
+      "planId": 666935,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666935/p"
+    },
+    {
+      "planId": 666936,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666936/p"
+    },
+    {
+      "planId": 666937,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666937/p"
+    }
+  ],
+  "the-equalizer": [
+    {
+      "planId": 659438,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659438/the-equalizer-finisher-12wk"
+    },
+    {
+      "planId": 659439,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659439/the-equalizer-finisher-8wk"
+    },
+    {
+      "planId": 659443,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659443/the-equalizer-time-crunched-12wk"
+    },
+    {
+      "planId": 659444,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659444/the-equalizer-time-crunched-8wk"
+    },
+    {
+      "planId": 659441,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659441/the-equalizer-compete-12wk"
+    },
+    {
+      "planId": 659442,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659442/the-equalizer-masters-50-12wk"
+    },
+    {
+      "planId": 659445,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659445/the-equalizer-save-my-race-6wk"
+    }
+  ],
+  "the-gralloch": [
+    {
+      "planId": 667980,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667980/p"
+    },
+    {
+      "planId": 667981,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667981/p"
+    },
+    {
+      "planId": 667982,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667982/p"
+    },
+    {
+      "planId": 667983,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667983/p"
+    },
+    {
+      "planId": 667984,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667984/p"
+    },
+    {
+      "planId": 667985,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667985/p"
+    },
+    {
+      "planId": 667986,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667986/p"
+    }
+  ],
+  "the-majestics": [
+    {
+      "planId": 659126,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659126/uci-gravel-suisse-finisher-12wk"
+    },
+    {
+      "planId": 659127,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659127/uci-gravel-suisse-finisher-8wk"
+    },
+    {
+      "planId": 659130,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659130/uci-gravel-suisse-time-crunched-12wk"
+    },
+    {
+      "planId": 659131,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659131/uci-gravel-suisse-time-crunched-8wk"
+    },
+    {
+      "planId": 659128,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659128/uci-gravel-suisse-compete-12wk"
+    },
+    {
+      "planId": 659129,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659129/uci-gravel-suisse-masters-50-12wk"
+    },
+    {
+      "planId": 659132,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659132/uci-gravel-suisse-save-my-race-6wk"
+    }
+  ],
+  "the-mane-event-gravel": [
+    {
+      "planId": 666678,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666678/p"
+    }
+  ],
+  "the-rad": [
+    {
+      "planId": 658746,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658746/the-rad-dirt-fest-finisher-8wk"
+    },
+    {
+      "planId": 658747,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658747/the-rad-dirt-fest-time-crunched-8wk"
+    },
+    {
+      "planId": 658748,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658748/the-rad-dirt-fest-save-my-race-6wk"
+    }
+  ],
+  "the-range": [
+    {
+      "planId": 659646,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659646/p"
+    },
+    {
+      "planId": 659647,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659647/p"
+    },
+    {
+      "planId": 659650,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659650/p"
+    },
+    {
+      "planId": 659651,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659651/p"
+    },
+    {
+      "planId": 659648,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659648/p"
+    },
+    {
+      "planId": 659649,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659649/p"
+    },
+    {
+      "planId": 659652,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659652/p"
+    }
+  ],
+  "the-rift": [
+    {
+      "planId": 658984,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658984/the-rift-finisher-12wk"
+    },
+    {
+      "planId": 658985,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658985/the-rift-finisher-8wk"
+    },
+    {
+      "planId": 658988,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658988/the-rift-time-crunched-12wk"
+    },
+    {
+      "planId": 658989,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658989/the-rift-time-crunched-8wk"
+    },
+    {
+      "planId": 658986,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658986/the-rift-compete-12wk"
+    },
+    {
+      "planId": 658987,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658987/the-rift-masters-50-12wk"
+    },
+    {
+      "planId": 658990,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658990/the-rift-save-my-race-6wk"
+    }
+  ],
+  "the-traka": [
+    {
+      "planId": 660066,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-660066/p"
+    },
+    {
+      "planId": 660068,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-660068/p"
+    },
+    {
+      "planId": 660071,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-660071/p"
+    },
+    {
+      "planId": 660072,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-660072/p"
+    },
+    {
+      "planId": 660069,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-660069/p"
+    },
+    {
+      "planId": 660070,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-660070/p"
+    },
+    {
+      "planId": 660073,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-660073/p"
+    }
+  ],
+  "tour-divide": [
+    {
+      "planId": 668376,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668376/p"
+    },
+    {
+      "planId": 668377,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668377/p"
+    },
+    {
+      "planId": 668378,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668378/p"
+    },
+    {
+      "planId": 668379,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668379/p"
+    },
+    {
+      "planId": 668381,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668381/p"
+    },
+    {
+      "planId": 668382,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668382/p"
+    },
+    {
+      "planId": 668383,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668383/p"
+    }
+  ],
+  "trough-creek-gravel-grinder": [
+    {
+      "planId": 666684,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666684/p"
+    }
+  ],
+  "truckee-tahoe-gravel": [
+    {
+      "planId": 659460,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659460/sagan-fondo-finisher-12wk"
+    },
+    {
+      "planId": 659461,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659461/sagan-fondo-finisher-8wk"
+    },
+    {
+      "planId": 659464,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659464/sagan-fondo-time-crunched-12wk"
+    },
+    {
+      "planId": 659465,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659465/sagan-fondo-time-crunched-8wk"
+    },
+    {
+      "planId": 659462,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659462/sagan-fondo-compete-12wk"
+    },
+    {
+      "planId": 659463,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659463/sagan-fondo-masters-50-12wk"
+    },
+    {
+      "planId": 659466,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659466/sagan-fondo-save-my-race-6wk"
+    }
+  ],
+  "uci-gravel-dustman": [
+    {
+      "planId": 659854,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659854/p"
+    },
+    {
+      "planId": 659862,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659862/p"
+    },
+    {
+      "planId": 659865,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659865/p"
+    },
+    {
+      "planId": 659866,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659866/p"
+    },
+    {
+      "planId": 659863,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659863/p"
+    },
+    {
+      "planId": 659864,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659864/p"
+    },
+    {
+      "planId": 659867,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659867/p"
+    }
+  ],
+  "uci-gravel-worlds": [
+    {
+      "planId": 669258,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669258/p"
+    },
+    {
+      "planId": 669259,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669259/p"
+    },
+    {
+      "planId": 669260,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669260/p"
+    }
+  ],
+  "unbound-100": [
+    {
+      "planId": 658900,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658900/unbound-gravel-100-finisher-12wk"
+    },
+    {
+      "planId": 658901,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658901/unbound-gravel-100-finisher-8wk"
+    },
+    {
+      "planId": 658904,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658904/unbound-gravel-100-time-crunched-12wk"
+    },
+    {
+      "planId": 658905,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658905/unbound-gravel-100-time-crunched-8wk"
+    },
+    {
+      "planId": 658902,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658902/unbound-gravel-100-compete-12wk"
+    },
+    {
+      "planId": 658903,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658903/unbound-gravel-100-masters-50-12wk"
+    },
+    {
+      "planId": 658906,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-658906/unbound-gravel-100-save-my-race-6wk"
+    }
+  ],
+  "unbound-200": [
+    {
+      "planId": 668219,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668219/p"
+    },
+    {
+      "planId": 668220,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668220/p"
+    },
+    {
+      "planId": 668221,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668221/p"
+    },
+    {
+      "planId": 668222,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668222/p"
+    },
+    {
+      "planId": 668223,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668223/p"
+    },
+    {
+      "planId": 668224,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668224/p"
+    },
+    {
+      "planId": 668225,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668225/p"
+    }
+  ],
+  "unbound-xl": [
+    {
+      "planId": 668226,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668226/p"
+    },
+    {
+      "planId": 668227,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668227/p"
+    },
+    {
+      "planId": 668228,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668228/p"
+    },
+    {
+      "planId": 668229,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668229/p"
+    },
+    {
+      "planId": 668230,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668230/p"
+    },
+    {
+      "planId": 668231,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668231/p"
+    },
+    {
+      "planId": 668232,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668232/p"
+    }
+  ],
+  "usa-cycling-gravel-nationals": [
+    {
+      "planId": 659394,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659394/usa-cycling-gravel-nationals-finisher-8wk"
+    },
+    {
+      "planId": 659395,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659395/usa-cycling-gravel-nationals-time-crunched-8wk"
+    },
+    {
+      "planId": 659396,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659396/usa-cycling-gravel-nationals-save-my-race-6wk"
+    }
+  ],
+  "uwharrie-forest-gravel-grinder": [
+    {
+      "planId": 659814,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659814/p"
+    },
+    {
+      "planId": 659813,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659813/p"
+    },
+    {
+      "planId": 659817,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659817/p"
+    },
+    {
+      "planId": 659818,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659818/p"
+    },
+    {
+      "planId": 659812,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659812/p"
+    },
+    {
+      "planId": 659815,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659815/p"
+    },
+    {
+      "planId": 659816,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659816/p"
+    }
+  ],
+  "vermont-overland": [
+    {
+      "planId": 659179,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659179/vermont-overland-finisher-12wk"
+    },
+    {
+      "planId": 659180,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659180/vermont-overland-finisher-8wk"
+    },
+    {
+      "planId": 659183,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659183/vermont-overland-time-crunched-12wk"
+    },
+    {
+      "planId": 659184,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659184/vermont-overland-time-crunched-8wk"
+    },
+    {
+      "planId": 659181,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659181/vermont-overland-compete-12wk"
+    },
+    {
+      "planId": 659182,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659182/vermont-overland-masters-50-12wk"
+    },
+    {
+      "planId": 659185,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659185/vermont-overland-save-my-race-6wk"
+    }
+  ],
+  "vuelta-altas-cumbres": [
+    {
+      "planId": 659452,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659452/vuelta-altas-cumbres-finisher-12wk"
+    },
+    {
+      "planId": 659453,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659453/vuelta-altas-cumbres-finisher-8wk"
+    },
+    {
+      "planId": 659456,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659456/vuelta-altas-cumbres-time-crunched-12wk"
+    },
+    {
+      "planId": 659457,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659457/vuelta-altas-cumbres-time-crunched-8wk"
+    },
+    {
+      "planId": 659454,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659454/vuelta-altas-cumbres-compete-12wk"
+    },
+    {
+      "planId": 659455,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659455/vuelta-altas-cumbres-masters-50-12wk"
+    },
+    {
+      "planId": 659458,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659458/vuelta-altas-cumbres-save-my-race-6wk"
+    }
+  ],
+  "wasatch-all-road": [
+    {
+      "planId": 659431,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659431/wasatch-all-road-finisher-12wk"
+    },
+    {
+      "planId": 659432,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659432/wasatch-all-road-finisher-8wk"
+    },
+    {
+      "planId": 659435,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659435/wasatch-all-road-time-crunched-12wk"
+    },
+    {
+      "planId": 659436,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659436/wasatch-all-road-time-crunched-8wk"
+    },
+    {
+      "planId": 659433,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659433/wasatch-all-road-compete-12wk"
+    },
+    {
+      "planId": 659434,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659434/wasatch-all-road-masters-50-12wk"
+    },
+    {
+      "planId": 659437,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/gran-fondo-century/tp-659437/wasatch-all-road-save-my-race-6wk"
+    }
+  ],
+  "waucheesi-bike-race": [
+    {
+      "planId": 659771,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659771/p"
+    },
+    {
+      "planId": 659772,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659772/p"
+    },
+    {
+      "planId": 659775,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659775/p"
+    },
+    {
+      "planId": 659776,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659776/p"
+    },
+    {
+      "planId": 659773,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659773/p"
+    },
+    {
+      "planId": 659774,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659774/p"
+    },
+    {
+      "planId": 659777,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659777/p"
+    }
+  ],
+  "west-coast-gravel": [
+    {
+      "planId": 666834,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666834/p"
+    },
+    {
+      "planId": 666835,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666835/p"
+    },
+    {
+      "planId": 666836,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666836/p"
+    },
+    {
+      "planId": 666837,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666837/p"
+    },
+    {
+      "planId": 666838,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666838/p"
+    },
+    {
+      "planId": 666839,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666839/p"
+    },
+    {
+      "planId": 666840,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666840/p"
+    }
+  ],
+  "whiskey-off-road": [
+    {
+      "planId": 668235,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668235/p"
+    },
+    {
+      "planId": 668237,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668237/p"
+    },
+    {
+      "planId": 668245,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668245/p"
+    },
+    {
+      "planId": 668246,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668246/p"
+    },
+    {
+      "planId": 668247,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668247/p"
+    },
+    {
+      "planId": 668248,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668248/p"
+    },
+    {
+      "planId": 668249,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668249/p"
+    }
+  ],
+  "wild-gravel": [
+    {
+      "planId": 666501,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666501/p"
+    },
+    {
+      "planId": 666527,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666527/p"
+    },
+    {
+      "planId": 666515,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-666515/p"
+    }
+  ],
+  "wild-horse-gravel": [
+    {
+      "planId": 659922,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659922/p"
+    },
+    {
+      "planId": 659926,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659926/p"
+    },
+    {
+      "planId": 659930,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659930/p"
+    },
+    {
+      "planId": 659931,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659931/p"
+    },
+    {
+      "planId": 659928,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659928/p"
+    },
+    {
+      "planId": 659929,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659929/p"
+    },
+    {
+      "planId": 659932,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659932/p"
+    }
+  ],
+  "wish-one-millau": [
+    {
+      "planId": 659912,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659912/p"
+    },
+    {
+      "planId": 659913,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659913/p"
+    },
+    {
+      "planId": 659916,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659916/p"
+    },
+    {
+      "planId": 659917,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659917/p"
+    },
+    {
+      "planId": 659914,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659914/p"
+    },
+    {
+      "planId": 659915,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659915/p"
+    },
+    {
+      "planId": 659918,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659918/p"
+    }
+  ],
+  "worthersee-gravel-race": [
+    {
+      "planId": 659718,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659718/p"
+    },
+    {
+      "planId": 659720,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659720/p"
+    },
+    {
+      "planId": 659723,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659723/p"
+    },
+    {
+      "planId": 659724,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659724/p"
+    },
+    {
+      "planId": 659721,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659721/p"
+    },
+    {
+      "planId": 659722,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659722/p"
+    },
+    {
+      "planId": 659725,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659725/p"
+    }
+  ],
+  "wyscig-niepolomice": [
+    {
+      "planId": 667368,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667368/p"
+    }
+  ]
+}

--- a/scripts/sync_tp_race_plan_links.py
+++ b/scripts/sync_tp_race_plan_links.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Sync published Gravel God race-plan links from the TP plan database."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SOURCE = PROJECT_ROOT.parent / "gravel-god-training-plans" / "db" / "plans.json"
+DEFAULT_OUTPUT = PROJECT_ROOT / "data" / "tp-race-plan-links.json"
+TIER_ORDER = {
+    "Finisher": 0,
+    "Time-Crunched": 1,
+    "Compete": 2,
+    "Masters 50+": 3,
+    "Save My Race": 4,
+}
+
+
+def load_rows(path: Path) -> list[dict]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    rows = payload.get("plans", []) if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        raise SystemExit(f"{path} does not contain a plan list")
+    return rows
+
+
+def build_links(rows: list[dict]) -> dict[str, list[dict]]:
+    result: dict[str, list[dict]] = {}
+    for plan in rows:
+        slug = plan.get("race_slug")
+        url = plan.get("marketplace_url")
+        if (
+            plan.get("discipline") != "gravel"
+            or plan.get("status") != "published"
+            or not slug
+            or not url
+        ):
+            continue
+        result.setdefault(slug, []).append(
+            {
+                "planId": plan["planId"],
+                "tier": plan["tier"],
+                "weeks": plan["length_wk"],
+                "price": plan["price"],
+                "url": url,
+            }
+        )
+
+    for plans in result.values():
+        plans.sort(
+            key=lambda plan: (
+                TIER_ORDER.get(plan["tier"], 99),
+                -int(plan["weeks"]),
+                int(plan["planId"]),
+            )
+        )
+    return dict(sorted(result.items()))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    links = build_links(load_rows(args.source))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(links, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        f"synced {sum(len(plans) for plans in links.values())} published plans "
+        f"across {len(links)} Gravel God races to {args.output}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_plan_ladder.py
+++ b/tests/test_plan_ladder.py
@@ -88,6 +88,16 @@ class TestPublishedLinkCase:
         assert "12 wk" in html
         assert "$99" in html
 
+    def test_plan_slug_alias_renders_published_suite(self, monkeypatch):
+        _set_plans(monkeypatch, "the-majestics", [
+            _plan(
+                status="published",
+                marketplace_url="https://www.trainingpeaks.com/plan/659126",
+            ),
+        ])
+        html = build_plan_ladder(_rd(slug="gravel-suisse", name="Gravel Suisse"))
+        assert 'href="https://www.trainingpeaks.com/plan/659126"' in html
+
 
 class TestEmailGateCase:
     def test_private_plan_renders_notify_form(self, monkeypatch):

--- a/tests/test_sync_tp_race_plan_links.py
+++ b/tests/test_sync_tp_race_plan_links.py
@@ -1,0 +1,69 @@
+"""Published Gravel God TrainingPeaks link synchronization."""
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from sync_tp_race_plan_links import build_links
+
+
+def test_build_links_filters_and_sorts_published_gravel_plans():
+    rows = [
+        {
+            "planId": 3,
+            "race_slug": "race-a",
+            "discipline": "gravel",
+            "status": "published",
+            "marketplace_url": "https://tp.example/3",
+            "tier": "Save My Race",
+            "length_wk": 6,
+            "price": 69,
+        },
+        {
+            "planId": 2,
+            "race_slug": "race-a",
+            "discipline": "gravel",
+            "status": "published",
+            "marketplace_url": "https://tp.example/2",
+            "tier": "Finisher",
+            "length_wk": 8,
+            "price": 79,
+        },
+        {
+            "planId": 1,
+            "race_slug": "race-a",
+            "discipline": "gravel",
+            "status": "published",
+            "marketplace_url": "https://tp.example/1",
+            "tier": "Finisher",
+            "length_wk": 12,
+            "price": 99,
+        },
+        {
+            "planId": 4,
+            "race_slug": "race-a",
+            "discipline": "road",
+            "status": "published",
+            "marketplace_url": "https://tp.example/4",
+            "tier": "Finisher",
+            "length_wk": 12,
+            "price": 99,
+        },
+        {
+            "planId": 5,
+            "race_slug": "race-a",
+            "discipline": "gravel",
+            "status": "private-ready",
+            "marketplace_url": "https://tp.example/5",
+            "tier": "Finisher",
+            "length_wk": 12,
+            "price": 99,
+        },
+    ]
+
+    links = build_links(rows)
+
+    assert list(links) == ["race-a"]
+    assert [plan["planId"] for plan in links["race-a"]] == [1, 2, 3]

--- a/tests/test_training_plan_pages.py
+++ b/tests/test_training_plan_pages.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "wordpress"))
 
 from generate_training_plan_pages import (
     generate_page, load_pack, est_hours, fueling_numbers, build_faq,
+    load_sku_link,
 )
 
 RACE_DATA = Path(__file__).resolve().parent.parent / "race-data"
@@ -110,6 +111,13 @@ class TestSafety:
 
     def test_no_pack_returns_skip(self):
         assert load_pack("no-such-slug-xyz") == {}
+
+    def test_plan_slug_alias_uses_exact_race_suite(self):
+        sku = load_sku_link("gravel-suisse")
+        assert sku["mode"] == "race"
+        assert [plan["planId"] for plan in sku["links"]] == [
+            659126, 659127, 659130, 659131, 659128, 659129, 659132,
+        ]
 
 
 if __name__ == "__main__":

--- a/web/race-packs/gravel-chile.json
+++ b/web/race-packs/gravel-chile.json
@@ -1,0 +1,136 @@
+{
+  "slug": "gravel-chile",
+  "race_name": "UCI Gravel Chile",
+  "distance_mi": 62.1,
+  "demands": {
+    "durability": 2,
+    "climbing": 3,
+    "vo2_power": 6,
+    "threshold": 5,
+    "technical": 4,
+    "heat_resilience": 0,
+    "altitude": 2,
+    "race_specificity": 7
+  },
+  "top_categories": [
+    {
+      "category": "Race_Simulation",
+      "score": 100,
+      "workouts": [
+        "Breakaway Simulation",
+        "Variable Pace Chaos",
+        "Sector Simulation"
+      ],
+      "workout_context": "Race-pace efforts that mimic UCI Gravel Chile's demands. Pacing, fueling, and tactical decisions under fatigue. Practice the race before October."
+    },
+    {
+      "category": "Gravel_Specific",
+      "score": 96,
+      "workouts": [
+        "Surge and Settle",
+        "Terrain Microbursts"
+      ],
+      "workout_context": "UCI Gravel Chile's Lakeside gravel, Northern Patagonia forces constant power changes. Surge over the rough stuff, settle on the smooth, repeat for 62 miles."
+    },
+    {
+      "category": "VO2max",
+      "score": 85,
+      "workouts": [
+        "5x3 VO2 Classic",
+        "Descending VO2 Pyramid",
+        "Norwegian 4x8"
+      ],
+      "workout_context": "When someone attacks on fast lakeside and rural gravel around Lago Ranco, you have 10 seconds to respond or you're off the back. This builds that response."
+    },
+    {
+      "category": "TT_Threshold",
+      "score": 72,
+      "workouts": [
+        "Single Sustained Threshold",
+        "Threshold Ramps",
+        "Descending Threshold"
+      ],
+      "workout_context": "UCI Gravel Chile's fast lakeside and rural gravel around Lago Ranco rewards steady threshold power. Surging and recovering costs more watts than just holding."
+    },
+    {
+      "category": "Critical_Power",
+      "score": 63,
+      "workouts": [
+        "Above CP Repeats",
+        "W-Prime Depletion"
+      ],
+      "workout_context": "How long can you hold 105% FTP before you blow? At UCI Gravel Chile, that number decides whether you bridge or get dropped."
+    },
+    {
+      "category": "Durability",
+      "score": 61,
+      "workouts": [
+        "Tired VO2max",
+        "Double Day Simulation",
+        "Progressive Fatigue"
+      ],
+      "workout_context": "62 miles on fast lakeside and rural gravel around Lago Ranco burns energy faster than the distance suggests. Train the fade resistance now."
+    },
+    {
+      "category": "Anaerobic_Capacity",
+      "score": 59,
+      "workouts": [
+        "2min Killers",
+        "90sec Repeats"
+      ],
+      "workout_context": "2-minute all-out efforts on fast lakeside and rural gravel around Lago Ranco. Closing gaps, responding to attacks, sprinting for position. Train the burn."
+    },
+    {
+      "category": "G_Spot",
+      "score": 57,
+      "workouts": [
+        "G-Spot Standard",
+        "G-Spot Extended",
+        "Criss-Cross"
+      ],
+      "workout_context": "88\u201392% FTP is where you'll spend the hardest sustained miles of UCI Gravel Chile. Train it until it feels boring."
+    },
+    {
+      "category": "Over_Under",
+      "score": 56,
+      "workouts": [
+        "Classic Over-Unders",
+        "Ladder Over-Unders"
+      ],
+      "workout_context": "At UCI Gravel Chile, surges push you above threshold and you have to recover while still riding. Over-unders train exactly that."
+    },
+    {
+      "category": "Blended",
+      "score": 37,
+      "workouts": [
+        "Z2 + VO2 Combo",
+        "Endurance with Spikes"
+      ],
+      "workout_context": "Long rides with hard efforts mixed in. Simulates what UCI Gravel Chile's fast lakeside and rural gravel around Lago Ranco actually does to you."
+    },
+    {
+      "category": "Norwegian_Double",
+      "score": 37,
+      "workouts": [
+        "Norwegian 4x8 Classic",
+        "Double Threshold"
+      ],
+      "workout_context": "Double-threshold training builds sustained power with less fatigue. More FTP per hour of training."
+    },
+    {
+      "category": "Mixed_Climbing",
+      "score": 33,
+      "workouts": [
+        "Seated/Standing Climbs",
+        "Variable Grade Simulation"
+      ],
+      "workout_context": "Varied gradients on fast lakeside and rural gravel around Lago Ranco demand climbing versatility. Sit the shallow stuff, stand the steep stuff, switch without thinking."
+    }
+  ],
+  "race_overlay": {
+    "nutrition": "Target 40\u201360g carbs/hour for UCI Gravel Chile\u2019s 62 miles. Front-load calories in the first half. One bottle per hour minimum, more in heat.",
+    "terrain": "Mixed terrain at UCI Gravel Chile requires surface adaptability. Include weekly rides on fast lakeside and rural gravel around lago ranco to build confidence. Expect: lakeside gravel, northern patagonia, fast rolling loop."
+  },
+  "pack_summary": "This 10-workout pack focuses on Race Simulation, Gravel Specific, and VO2max to prepare you for 62 miles of fast lakeside and rural gravel around lago ranco in Lago Ranco, Los R\u00edos Region, Chile.",
+  "generated_at": "2026-08-14"
+}

--- a/web/race-packs/gravel-of-marathon.json
+++ b/web/race-packs/gravel-of-marathon.json
@@ -1,0 +1,136 @@
+{
+  "slug": "gravel-of-marathon",
+  "race_name": "The Gravel of Marathon",
+  "distance_mi": 75.2,
+  "demands": {
+    "durability": 4,
+    "climbing": 7,
+    "vo2_power": 6,
+    "threshold": 8,
+    "technical": 6,
+    "heat_resilience": 0,
+    "altitude": 2,
+    "race_specificity": 7
+  },
+  "top_categories": [
+    {
+      "category": "TT_Threshold",
+      "score": 100,
+      "workouts": [
+        "Single Sustained Threshold",
+        "Threshold Ramps",
+        "Descending Threshold"
+      ],
+      "workout_context": "88ft/mi means long efforts at or near FTP on every climb. If your threshold cracks at minute 15, you'll walk the rest."
+    },
+    {
+      "category": "Gravel_Specific",
+      "score": 93,
+      "workouts": [
+        "Surge and Settle",
+        "Terrain Microbursts"
+      ],
+      "workout_context": "The Gravel of Marathon's Lake Marathon gravel, Farm roads forces constant power changes. Surge over the rough stuff, settle on the smooth, repeat for 75 miles."
+    },
+    {
+      "category": "Race_Simulation",
+      "score": 87,
+      "workouts": [
+        "Breakaway Simulation",
+        "Variable Pace Chaos",
+        "Sector Simulation"
+      ],
+      "workout_context": "Race-pace efforts that mimic The Gravel of Marathon's demands. Pacing, fueling, and tactical decisions under fatigue. Practice the race before November."
+    },
+    {
+      "category": "Over_Under",
+      "score": 86,
+      "workouts": [
+        "Classic Over-Unders",
+        "Ladder Over-Unders"
+      ],
+      "workout_context": "At The Gravel of Marathon, surges push you above threshold and you have to recover while still riding. Over-unders train exactly that."
+    },
+    {
+      "category": "G_Spot",
+      "score": 78,
+      "workouts": [
+        "G-Spot Standard",
+        "G-Spot Extended",
+        "Criss-Cross"
+      ],
+      "workout_context": "88\u201392% FTP is where you'll spend the hardest sustained miles of The Gravel of Marathon. Train it until it feels boring."
+    },
+    {
+      "category": "VO2max",
+      "score": 67,
+      "workouts": [
+        "5x3 VO2 Classic",
+        "Descending VO2 Pyramid",
+        "Norwegian 4x8"
+      ],
+      "workout_context": "6,627ft of climbing means repeated surges above threshold. VO2max work is how you survive the fifth climb, not just the first."
+    },
+    {
+      "category": "Durability",
+      "score": 65,
+      "workouts": [
+        "Tired VO2max",
+        "Double Day Simulation",
+        "Progressive Fatigue"
+      ],
+      "workout_context": "75 miles on repeated lake, farm-road, stream, and dam gravel burns energy faster than the distance suggests. Train the fade resistance now."
+    },
+    {
+      "category": "Mixed_Climbing",
+      "score": 61,
+      "workouts": [
+        "Seated/Standing Climbs",
+        "Variable Grade Simulation"
+      ],
+      "workout_context": "6,627ft of climbing on grades that change every minute. You need to switch from seated to standing without losing rhythm."
+    },
+    {
+      "category": "Critical_Power",
+      "score": 61,
+      "workouts": [
+        "Above CP Repeats",
+        "W-Prime Depletion"
+      ],
+      "workout_context": "How long can you hold 105% FTP before you blow? At The Gravel of Marathon, that number decides whether you bridge or get dropped."
+    },
+    {
+      "category": "Anaerobic_Capacity",
+      "score": 52,
+      "workouts": [
+        "2min Killers",
+        "90sec Repeats"
+      ],
+      "workout_context": "Short, max efforts are unavoidable. Punchy climbs, gap closures, attacks on repeated lake, farm-road, stream, and dam gravel. If you haven't trained them, you'll crack."
+    },
+    {
+      "category": "Norwegian_Double",
+      "score": 46,
+      "workouts": [
+        "Norwegian 4x8 Classic",
+        "Double Threshold"
+      ],
+      "workout_context": "Double-threshold training builds sustained power with less fatigue. More FTP per hour of training."
+    },
+    {
+      "category": "SFR_Muscle_Force",
+      "score": 41,
+      "workouts": [
+        "SFR Low Cadence",
+        "Force Repeats"
+      ],
+      "workout_context": "Low-cadence force work for 6,627ft of climbing. The slow, grinding ascents where you can't spin\u2014you push."
+    }
+  ],
+  "race_overlay": {
+    "nutrition": "Target 40\u201360g carbs/hour for The Gravel of Marathon\u2019s 75 miles. Front-load calories in the first half. One bottle per hour minimum, more in heat.",
+    "terrain": "Mixed terrain at The Gravel of Marathon requires surface adaptability. Include weekly rides on repeated lake, farm-road, stream, and dam gravel loops to build confidence. Expect: lake marathon gravel, farm roads, concrete climbing wall."
+  },
+  "pack_summary": "This 10-workout pack focuses on TT Threshold, Gravel Specific, and Race Simulation to prepare you for 75 miles of repeated lake, farm-road, stream, and dam gravel loops in Marathon, Attica, Greece.",
+  "generated_at": "2026-08-14"
+}

--- a/web/race-packs/hazel-valley-rally.json
+++ b/web/race-packs/hazel-valley-rally.json
@@ -1,0 +1,136 @@
+{
+  "slug": "hazel-valley-rally",
+  "race_name": "Hazel Valley Rally",
+  "distance_mi": 62.5,
+  "demands": {
+    "durability": 2,
+    "climbing": 7,
+    "vo2_power": 4,
+    "threshold": 6,
+    "technical": 6,
+    "heat_resilience": 0,
+    "altitude": 2,
+    "race_specificity": 6
+  },
+  "top_categories": [
+    {
+      "category": "Gravel_Specific",
+      "score": 100,
+      "workouts": [
+        "Surge and Settle",
+        "Terrain Microbursts"
+      ],
+      "workout_context": "Hazel Valley Rally's Rugged gravel roads, Ozark National Forest roads forces constant power changes. Surge over the rough stuff, settle on the smooth, repeat for 62 miles."
+    },
+    {
+      "category": "TT_Threshold",
+      "score": 95,
+      "workouts": [
+        "Single Sustained Threshold",
+        "Threshold Ramps",
+        "Descending Threshold"
+      ],
+      "workout_context": "95ft/mi means long efforts at or near FTP on every climb. If your threshold cracks at minute 15, you'll walk the rest."
+    },
+    {
+      "category": "Race_Simulation",
+      "score": 90,
+      "workouts": [
+        "Breakaway Simulation",
+        "Variable Pace Chaos",
+        "Sector Simulation"
+      ],
+      "workout_context": "Race-pace efforts that mimic Hazel Valley Rally's demands. Pacing, fueling, and tactical decisions under fatigue. Practice the race before April."
+    },
+    {
+      "category": "Over_Under",
+      "score": 88,
+      "workouts": [
+        "Classic Over-Unders",
+        "Ladder Over-Unders"
+      ],
+      "workout_context": "At Hazel Valley Rally, surges push you above threshold and you have to recover while still riding. Over-unders train exactly that."
+    },
+    {
+      "category": "G_Spot",
+      "score": 73,
+      "workouts": [
+        "G-Spot Standard",
+        "G-Spot Extended",
+        "Criss-Cross"
+      ],
+      "workout_context": "88\u201392% FTP is where you'll spend the hardest sustained miles of Hazel Valley Rally. Train it until it feels boring."
+    },
+    {
+      "category": "Mixed_Climbing",
+      "score": 70,
+      "workouts": [
+        "Seated/Standing Climbs",
+        "Variable Grade Simulation"
+      ],
+      "workout_context": "5,933ft of climbing on grades that change every minute. You need to switch from seated to standing without losing rhythm."
+    },
+    {
+      "category": "Critical_Power",
+      "score": 60,
+      "workouts": [
+        "Above CP Repeats",
+        "W-Prime Depletion"
+      ],
+      "workout_context": "How long can you hold 105% FTP before you blow? At Hazel Valley Rally, that number decides whether you bridge or get dropped."
+    },
+    {
+      "category": "VO2max",
+      "score": 57,
+      "workouts": [
+        "5x3 VO2 Classic",
+        "Descending VO2 Pyramid",
+        "Norwegian 4x8"
+      ],
+      "workout_context": "5,933ft of climbing means repeated surges above threshold. VO2max work is how you survive the fifth climb, not just the first."
+    },
+    {
+      "category": "Durability",
+      "score": 50,
+      "workouts": [
+        "Tired VO2max",
+        "Double Day Simulation",
+        "Progressive Fatigue"
+      ],
+      "workout_context": "62 miles on rugged Ozark National Forest gravel burns energy faster than the distance suggests. Train the fade resistance now."
+    },
+    {
+      "category": "SFR_Muscle_Force",
+      "score": 47,
+      "workouts": [
+        "SFR Low Cadence",
+        "Force Repeats"
+      ],
+      "workout_context": "Low-cadence force work for 5,933ft of climbing. The slow, grinding ascents where you can't spin\u2014you push."
+    },
+    {
+      "category": "Anaerobic_Capacity",
+      "score": 47,
+      "workouts": [
+        "2min Killers",
+        "90sec Repeats"
+      ],
+      "workout_context": "Short, max efforts are unavoidable. Punchy climbs, gap closures, attacks on rugged Ozark National Forest gravel. If you haven't trained them, you'll crack."
+    },
+    {
+      "category": "Norwegian_Double",
+      "score": 40,
+      "workouts": [
+        "Norwegian 4x8 Classic",
+        "Double Threshold"
+      ],
+      "workout_context": "Double-threshold training builds sustained power with less fatigue. More FTP per hour of training."
+    }
+  ],
+  "race_overlay": {
+    "nutrition": "Target 40\u201360g carbs/hour for Hazel Valley Rally\u2019s 62 miles. Front-load calories in the first half. One bottle per hour minimum, more in heat.",
+    "terrain": "Mixed terrain at Hazel Valley Rally requires surface adaptability. Include weekly rides on rugged ozark national forest gravel to build confidence. Expect: rugged gravel roads, ozark national forest roads, sustained rolling climbs."
+  },
+  "pack_summary": "This 10-workout pack focuses on Gravel Specific, TT Threshold, and Race Simulation to prepare you for 62 miles of rugged ozark national forest gravel in Washington County, Arkansas.",
+  "generated_at": "2026-08-14"
+}

--- a/web/race-packs/kindling.json
+++ b/web/race-packs/kindling.json
@@ -1,0 +1,138 @@
+{
+  "slug": "kindling",
+  "race_name": "Kindling",
+  "distance_mi": 188.3,
+  "demands": {
+    "durability": 8,
+    "climbing": 8,
+    "vo2_power": 4,
+    "threshold": 5,
+    "technical": 6,
+    "heat_resilience": 6,
+    "altitude": 4,
+    "race_specificity": 8
+  },
+  "top_categories": [
+    {
+      "category": "Durability",
+      "score": 100,
+      "workouts": [
+        "Tired VO2max",
+        "Double Day Simulation",
+        "Progressive Fatigue"
+      ],
+      "workout_context": "188 miles across 3 consecutive days. Train the repeatable power that still exists after yesterday's ride is in your legs."
+    },
+    {
+      "category": "Gravel_Specific",
+      "score": 71,
+      "workouts": [
+        "Surge and Settle",
+        "Terrain Microbursts"
+      ],
+      "workout_context": "Kindling's changing Scottish gravel rewards traction, cadence, and power control that stay reliable across 3 days."
+    },
+    {
+      "category": "Race_Simulation",
+      "score": 69,
+      "workouts": [
+        "Breakaway Simulation",
+        "Variable Pace Chaos",
+        "Sector Simulation"
+      ],
+      "workout_context": "Back-to-back race simulations rehearse Kindling's real problem: perform, recover overnight, then perform again."
+    },
+    {
+      "category": "Endurance",
+      "score": 65,
+      "workouts": [
+        "Pre-Race Openers",
+        "Terrain Simulation Z2"
+      ],
+      "workout_context": "Aerobic efficiency covers the untimed transfers without stealing the power reserved for timed stages across 3 days."
+    },
+    {
+      "category": "Over_Under",
+      "score": 57,
+      "workouts": [
+        "Classic Over-Unders",
+        "Ladder Over-Unders"
+      ],
+      "workout_context": "Timed stages surge above threshold, then demand recovery while you keep moving. Over-unders train that pattern for both Kindling's days."
+    },
+    {
+      "category": "TT_Threshold",
+      "score": 56,
+      "workouts": [
+        "Single Sustained Threshold",
+        "Threshold Ramps",
+        "Descending Threshold"
+      ],
+      "workout_context": "The clock runs on selected stages at Kindling. Build repeatable threshold power without racing the transfers between them."
+    },
+    {
+      "category": "HVLI_Extended",
+      "score": 54,
+      "workouts": [
+        "HVLI Extended Z2",
+        "Multi-Hour Z2",
+        "Back-to-Back Long"
+      ],
+      "workout_context": "Multi-day volume builds the aerobic base to cover 188 total miles without turning every transfer into recovery debt."
+    },
+    {
+      "category": "Mixed_Climbing",
+      "score": 50,
+      "workouts": [
+        "Seated/Standing Climbs",
+        "Variable Grade Simulation"
+      ],
+      "workout_context": "Climbing must be repeatable across 3 days. Switch cadence and position without burning matches you need tomorrow."
+    },
+    {
+      "category": "VO2max",
+      "score": 46,
+      "workouts": [
+        "5x3 VO2 Classic",
+        "Descending VO2 Pyramid",
+        "Norwegian 4x8"
+      ],
+      "workout_context": "Timed stages reward repeated high power, including on day 3. VO2 work keeps the final hard segment from becoming damage control."
+    },
+    {
+      "category": "G_Spot",
+      "score": 43,
+      "workouts": [
+        "G-Spot Standard",
+        "G-Spot Extended",
+        "Criss-Cross"
+      ],
+      "workout_context": "Sustainable 88\u201392% FTP gives you hard, controlled speed on timed segments without emptying day 3's legs on day one."
+    },
+    {
+      "category": "Blended",
+      "score": 42,
+      "workouts": [
+        "Z2 + VO2 Combo",
+        "Endurance with Spikes"
+      ],
+      "workout_context": "Endurance with controlled intensity spikes matches a stage event: ride the transfers, race the segments, repeat for 3 days."
+    },
+    {
+      "category": "Critical_Power",
+      "score": 38,
+      "workouts": [
+        "Above CP Repeats",
+        "W-Prime Depletion"
+      ],
+      "workout_context": "Decisive timed segments live just above sustainable power. Train how long you can stay there and how quickly you can reset for the next one."
+    }
+  ],
+  "race_overlay": {
+    "heat": "April in Graaff-Reinet, Eastern Cape, South Africa can bring heat. Complete 3\u20134 heat exposure sessions in the final 2 weeks before Kindling. Increase sodium intake 48 hours before race day.",
+    "nutrition": "Target 40\u201370g carbs/hour on each of Kindling's 3 event days. Begin recovery fueling within 30 minutes of every finish, replace fluid and sodium, then eat a full carbohydrate-forward meal. Tomorrow's legs are built the night before.",
+    "terrain": "Mixed terrain at Kindling requires surface adaptability. Include weekly rides on karoo stage-race gravel to build confidence. Expect: great karoo gravel roads, long open climbs, remote farm tracks."
+  },
+  "pack_summary": "This 10-workout pack focuses on Durability, Gravel Specific, and Race Simulation to prepare you for 188 miles of karoo stage-race gravel across 3 consecutive days in Graaff-Reinet, Eastern Cape, South Africa.",
+  "generated_at": "2026-08-14"
+}

--- a/web/race-packs/pyrenees-catalanes-gravel-tour.json
+++ b/web/race-packs/pyrenees-catalanes-gravel-tour.json
@@ -1,0 +1,137 @@
+{
+  "slug": "pyrenees-catalanes-gravel-tour",
+  "race_name": "Pyr\u00e9n\u00e9es Catalanes Gravel Tour",
+  "distance_mi": 62.1,
+  "demands": {
+    "durability": 2,
+    "climbing": 8,
+    "vo2_power": 7,
+    "threshold": 6,
+    "technical": 6,
+    "heat_resilience": 0,
+    "altitude": 8,
+    "race_specificity": 9
+  },
+  "top_categories": [
+    {
+      "category": "VO2max",
+      "score": 100,
+      "workouts": [
+        "5x3 VO2 Classic",
+        "Descending VO2 Pyramid",
+        "Norwegian 4x8"
+      ],
+      "workout_context": "7,500ft of climbing means repeated surges above threshold. VO2max work is how you survive the fifth climb, not just the first."
+    },
+    {
+      "category": "Gravel_Specific",
+      "score": 88,
+      "workouts": [
+        "Surge and Settle",
+        "Terrain Microbursts"
+      ],
+      "workout_context": "Pyr\u00e9n\u00e9es Catalanes Gravel Tour's High-altitude Pyrenean gravel, Cerdagne plateau forces constant power changes. Surge over the rough stuff, settle on the smooth, repeat for 62 miles."
+    },
+    {
+      "category": "Race_Simulation",
+      "score": 88,
+      "workouts": [
+        "Breakaway Simulation",
+        "Variable Pace Chaos",
+        "Sector Simulation"
+      ],
+      "workout_context": "Race-pace efforts that mimic Pyr\u00e9n\u00e9es Catalanes Gravel Tour's demands. Pacing, fueling, and tactical decisions under fatigue. Practice the race before September."
+    },
+    {
+      "category": "TT_Threshold",
+      "score": 73,
+      "workouts": [
+        "Single Sustained Threshold",
+        "Threshold Ramps",
+        "Descending Threshold"
+      ],
+      "workout_context": "121ft/mi means long efforts at or near FTP on every climb. If your threshold cracks at minute 15, you'll walk the rest."
+    },
+    {
+      "category": "Over_Under",
+      "score": 71,
+      "workouts": [
+        "Classic Over-Unders",
+        "Ladder Over-Unders"
+      ],
+      "workout_context": "At Pyr\u00e9n\u00e9es Catalanes Gravel Tour, surges push you above threshold and you have to recover while still riding. Over-unders train exactly that."
+    },
+    {
+      "category": "Mixed_Climbing",
+      "score": 59,
+      "workouts": [
+        "Seated/Standing Climbs",
+        "Variable Grade Simulation"
+      ],
+      "workout_context": "7,500ft of climbing on grades that change every minute. You need to switch from seated to standing without losing rhythm."
+    },
+    {
+      "category": "G_Spot",
+      "score": 56,
+      "workouts": [
+        "G-Spot Standard",
+        "G-Spot Extended",
+        "Criss-Cross"
+      ],
+      "workout_context": "88\u201392% FTP is where you'll spend the hardest sustained miles of Pyr\u00e9n\u00e9es Catalanes Gravel Tour. Train it until it feels boring."
+    },
+    {
+      "category": "Critical_Power",
+      "score": 55,
+      "workouts": [
+        "Above CP Repeats",
+        "W-Prime Depletion"
+      ],
+      "workout_context": "How long can you hold 105% FTP before you blow? At Pyr\u00e9n\u00e9es Catalanes Gravel Tour, that number decides whether you bridge or get dropped."
+    },
+    {
+      "category": "Anaerobic_Capacity",
+      "score": 49,
+      "workouts": [
+        "2min Killers",
+        "90sec Repeats"
+      ],
+      "workout_context": "Short, max efforts are unavoidable. Punchy climbs, gap closures, attacks on high-altitude gravel loops across the Cerdagne. If you haven't trained them, you'll crack."
+    },
+    {
+      "category": "Durability",
+      "score": 48,
+      "workouts": [
+        "Tired VO2max",
+        "Double Day Simulation",
+        "Progressive Fatigue"
+      ],
+      "workout_context": "62 miles on high-altitude gravel loops across the Cerdagne burns energy faster than the distance suggests. Train the fade resistance now."
+    },
+    {
+      "category": "Endurance",
+      "score": 39,
+      "workouts": [
+        "Pre-Race Openers",
+        "Terrain Simulation Z2"
+      ],
+      "workout_context": "Base fitness for Pyr\u00e9n\u00e9es Catalanes Gravel Tour. Without this, the hard workouts break you down instead of building you up."
+    },
+    {
+      "category": "SFR_Muscle_Force",
+      "score": 39,
+      "workouts": [
+        "SFR Low Cadence",
+        "Force Repeats"
+      ],
+      "workout_context": "Low-cadence force work for 7,500ft of climbing. The slow, grinding ascents where you can't spin\u2014you push."
+    }
+  ],
+  "race_overlay": {
+    "nutrition": "Target 40\u201360g carbs/hour for Pyr\u00e9n\u00e9es Catalanes Gravel Tour\u2019s 62 miles. Front-load calories in the first half. One bottle per hour minimum, more in heat.",
+    "altitude": "Pyr\u00e9n\u00e9es Catalanes Gravel Tour with 7,500ft of climbing, much of it above 8,000ft demands altitude preparation. Arrive 5\u20137 days early for acclimatization. Expect 5\u201315% power reduction at altitude. Increase iron intake 4 weeks out. Hydrate aggressively \u2014 altitude increases fluid loss by 20\u201340%. Fast temperature changes at mountain elevation.",
+    "terrain": "Mixed terrain at Pyr\u00e9n\u00e9es Catalanes Gravel Tour requires surface adaptability. Include weekly rides on high-altitude gravel loops across the cerdagne plateau to build confidence. Expect: high-altitude pyrenean gravel, cerdagne plateau, three-loop uci qualifier."
+  },
+  "pack_summary": "This 10-workout pack focuses on VO2max, Gravel Specific, and Race Simulation to prepare you for 62 miles of high-altitude gravel loops across the cerdagne plateau in Font-Romeu, Pyr\u00e9n\u00e9es-Orientales, France.",
+  "generated_at": "2026-08-14"
+}

--- a/wordpress/generate_neo_brutalist.py
+++ b/wordpress/generate_neo_brutalist.py
@@ -5018,6 +5018,7 @@ _PLANS_BY_SLUG_CACHE: Optional[dict] = None
 # so the page side aliases to it rather than the other way around.
 PLAN_SLUG_ALIASES = {
     "bighorn-gravel": "big-horn-gravel",  # dedup kept bighorn-gravel.json (a0b85bdf)
+    "gravel-suisse": "the-majestics",  # original TP suite predates the current page slug
 }
 
 

--- a/wordpress/generate_training_plan_pages.py
+++ b/wordpress/generate_training_plan_pages.py
@@ -39,6 +39,7 @@ from generate_neo_brutalist import (
     parse_event_dates,
     _safe_json_for_script,
     WORKOUT_SHOWCASE,
+    PLAN_SLUG_ALIASES,
 )
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -296,13 +297,24 @@ def build_fueling(rd: dict) -> str:
 
 
 def load_sku_link(slug: str) -> dict:
-    """TP static-plan links for this race's SKU family (northstar P3.1).
+    """Published TP plans for this race, with family links as a fallback.
 
-    Reads data/tp-sku-map.json (race → family, from assign_tp_skus.py) and
-    data/tp-sku-links.json (family → {weeks: TP url}, filled as the TP
-    marketplace plans get published). Returns {} until links exist, so the
-    section renders nothing — safe to ship ahead of the TP builds.
+    Exact race-plan links are synced from the canonical TP database by
+    scripts/sync_tp_race_plan_links.py. The older family mapping remains as a
+    fallback for races whose dedicated suite has not been published yet.
     """
+    try:
+        race_links = json.loads(
+            (PROJECT_ROOT / "data" / "tp-race-plan-links.json").read_text()
+        )
+    except (OSError, json.JSONDecodeError):
+        race_links = {}
+    exact = race_links.get(slug, [])
+    if not exact:
+        exact = race_links.get(PLAN_SLUG_ALIASES.get(slug, ""), [])
+    if exact:
+        return {"mode": "race", "links": exact}
+
     try:
         sku_map = json.loads((PROJECT_ROOT / "data" / "tp-sku-map.json").read_text())
         links = json.loads((PROJECT_ROOT / "data" / "tp-sku-links.json").read_text())
@@ -312,13 +324,32 @@ def load_sku_link(slug: str) -> dict:
     if not family:
         return {}
     fam_links = {w: u for w, u in links.get(family, {}).items() if u}
-    return {"family": family, "links": fam_links} if fam_links else {}
+    return {"mode": "family", "family": family, "links": fam_links} if fam_links else {}
 
 
 def build_static_plan(rd: dict) -> str:
     sku = load_sku_link(rd["slug"])
     if not sku:
         return ""
+    if sku["mode"] == "race":
+        links = "\n    ".join(
+            f'<a href="{esc(plan["url"])}" class="gg-btn gg-btn--outline" '
+            f'data-cta="tpp_race_sku" data-plan-id="{int(plan["planId"])}" '
+            f'rel="noopener" target="_blank">{esc(plan["tier"])} &middot; '
+            f'{int(plan["weeks"])}WK &middot; ${int(plan["price"])} &rarr;</a>'
+            for plan in sku["links"]
+        )
+        return f"""<section class="gg-tpp-section" id="ready-made">
+  <h2>Choose Your {esc(rd["name"])} Plan</h2>
+  <p>These are the published, race-specific TrainingPeaks plans for
+  <strong>{esc(rd["name"])}</strong>. Pick the tier and runway that match your
+  goal; each uses this race&rsquo;s date, terrain, race-week layout, guide, and
+  pacing context.</p>
+  <div class="gg-tpp-cta-row gg-tpp-plan-grid">
+    {links}
+  </div>
+</section>"""
+
     fam_label = sku["family"].replace("-", " ").title()
     links = "\n    ".join(
         f'<a href="{esc(u)}" class="gg-btn gg-btn--outline" data-cta="tpp_static_sku" rel="noopener" target="_blank">{w}-WEEK PLAN &rarr;</a>'


### PR DESCRIPTION
## Summary
- sync all 927 published Gravel God TrainingPeaks plans across 157 race suites into a deterministic site link map
- render exact race-specific tier, runway, price, and TrainingPeaks links on every eligible training-plan guide, with family plans retained only as fallback
- resolve legacy plan slugs for Bighorn Gravel and Gravel Suisse / The Majestics
- add the five missing race demand packs required to generate every published suite guide

## Verification
- `pytest -q tests/test_sync_tp_race_plan_links.py tests/test_training_plan_pages.py tests/test_plan_ladder.py` — 36 passed
- `python3 scripts/preflight_quality.py` — all checks passed (warnings are existing environment/output warnings)
- fleet reconciliation — 157/157 guides generated; all 927 unique published plan IDs present; zero missing profiles, packs, or IDs
- full suite excluding two unavailable optional dependencies — 7,334 passed, 326 skipped, 78 failed; all 78 failures are existing Mission Control environment/auth failures (`resend` absent and `/triage` test client receives 401)
- unfiltered suite also cannot collect `test_mcp_server.py` / `test_scrape_date_fallback.py` locally because `fastmcp` and `ddgs`/`duckduckgo_search` are absent
