### PR TITLE
seo(sitemap): add eight UCI gravel pages

### DIFF
--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -8322,4 +8322,52 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://gravelgodcycling.com/race/gravel-arteaga-mexico/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://gravelgodcycling.com/race/og-classique/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://gravelgodcycling.com/race/grand-tour-3-cime-lavaredo/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://gravelgodcycling.com/race/gravel-tour-hlinsko/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://gravelgodcycling.com/race/gravel-weekend-tukums/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://gravelgodcycling.com/race/the-wolf-dronninglund/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://gravelgodcycling.com/race/falling-leaves-lahti/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://gravelgodcycling.com/race/tartu-rattamaraton-gravel/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add the eight newly published UCI qualifier race URLs to the existing sitemap
- preserve all 1,387 existing race, comparison, series, and site URLs
- avoid the clean-worktree generator path that would omit ignored comparison-page artifacts

## Verification
- sitemap parses as XML with 1,395 URLs
- all eight new URLs appear exactly once
- 4/4 sitemap/noindex parity tests passed
- `git diff --check` passed
- all eight public pages return HTTP 200