### PR TITLE
Link Oregon Trail FULL-7 plan suite

### DIFF
--- a/data/tp-race-plan-links.json
+++ b/data/tp-race-plan-links.json
@@ -4408,6 +4408,57 @@
       "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659632/p"
     }
   ],
+  "oregon-trail-gravel": [
+    {
+      "planId": 669620,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669620/p"
+    },
+    {
+      "planId": 669621,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669621/p"
+    },
+    {
+      "planId": 669622,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669622/p"
+    },
+    {
+      "planId": 669623,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669623/p"
+    },
+    {
+      "planId": 669624,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669624/p"
+    },
+    {
+      "planId": 669625,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669625/p"
+    },
+    {
+      "planId": 669626,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669626/p"
+    }
+  ],
   "paris-to-ancaster": [
     {
       "planId": 659186,

--- a/tests/test_plan_ladder.py
+++ b/tests/test_plan_ladder.py
@@ -23,6 +23,17 @@ import generate_neo_brutalist as gnb
 from generate_neo_brutalist import build_inline_js, build_plan_ladder, get_page_css
 
 
+def test_configure_plans_db_resolves_path_and_invalidates_cache(tmp_path, monkeypatch):
+    source = tmp_path / "plans.json"
+    source.write_text('{"plans": []}\n', encoding="utf-8")
+    monkeypatch.setattr(gnb, "_PLANS_BY_SLUG_CACHE", {"stale": []})
+
+    gnb.configure_plans_db(source)
+
+    assert gnb.PLANS_DB_PATH == source.resolve()
+    assert gnb._PLANS_BY_SLUG_CACHE is None
+
+
 def _rd(slug="test-race", name="Test Race"):
     return {"slug": slug, "name": name}
 

--- a/tests/test_sync_tp_race_plan_links.py
+++ b/tests/test_sync_tp_race_plan_links.py
@@ -1,5 +1,6 @@
 """Published Gravel God TrainingPeaks link synchronization."""
 
+import json
 import sys
 from pathlib import Path
 
@@ -67,3 +68,16 @@ def test_build_links_filters_and_sorts_published_gravel_plans():
 
     assert list(links) == ["race-a"]
     assert [plan["planId"] for plan in links["race-a"]] == [1, 2, 3]
+
+
+def test_oregon_trail_publishes_the_complete_full_7_ladder():
+    links = json.loads(
+        (Path(__file__).resolve().parent.parent / "data" / "tp-race-plan-links.json")
+        .read_text(encoding="utf-8")
+    )
+    ladder = links["oregon-trail-gravel"]
+
+    assert [plan["planId"] for plan in ladder] == [
+        669620, 669621, 669622, 669623, 669624, 669625, 669626
+    ]
+    assert all(plan["url"].endswith(f"tp-{plan['planId']}/p") for plan in ladder)

--- a/wordpress/generate_neo_brutalist.py
+++ b/wordpress/generate_neo_brutalist.py
@@ -5022,6 +5022,13 @@ PLAN_SLUG_ALIASES = {
 }
 
 
+def configure_plans_db(path: Path) -> None:
+    """Select an explicit plan database and invalidate the module cache."""
+    global PLANS_DB_PATH, _PLANS_BY_SLUG_CACHE
+    PLANS_DB_PATH = Path(path).resolve()
+    _PLANS_BY_SLUG_CACHE = None
+
+
 def _load_plans_by_slug() -> dict:
     """Load ../gravel-god-training-plans/db/plans.json, grouped by race_slug.
 
@@ -6579,10 +6586,20 @@ def main():
     parser.add_argument('--all', action='store_true', help='Generate pages for all races')
     parser.add_argument('--data-dir', help='Primary data directory (default: auto-detect)')
     parser.add_argument('--output-dir', default=None, help='Output directory (default: wordpress/output/)')
+    parser.add_argument(
+        '--plans-db',
+        type=Path,
+        help='Explicit gravel-god-training-plans db/plans.json path',
+    )
     args = parser.parse_args()
 
     if not args.slug and not args.all:
         parser.error("Provide a race slug or use --all")
+
+    if args.plans_db:
+        if not args.plans_db.is_file():
+            parser.error(f"Plan database not found: {args.plans_db}")
+        configure_plans_db(args.plans_db)
 
     # Resolve data directories
     script_dir = Path(__file__).parent


### PR DESCRIPTION
## Summary
- sync the 7 newly published Oregon Trail Gravel Grinder TrainingPeaks links
- add an explicit plan-database input to isolated page generation
- pin the exact FULL-7 plan IDs in a source test

## Verification
- python3 -m pytest -q tests/test_sync_tp_race_plan_links.py tests/test_plan_ladder.py
- generated the Oregon Trail page against /tmp/plan-2027-wave.bi09Wh/db/plans.json
- all 7 public marketplace URLs returned HTTP 200