### PR TITLE
feat(plans): link Rule of Three FULL-7 suite

### DIFF
--- a/data/tp-race-plan-links.json
+++ b/data/tp-race-plan-links.json
@@ -5075,6 +5075,57 @@
       "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659639/p"
     }
   ],
+  "rule-of-three": [
+    {
+      "planId": 669630,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669630/p"
+    },
+    {
+      "planId": 669631,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669631/p"
+    },
+    {
+      "planId": 669632,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669632/p"
+    },
+    {
+      "planId": 669633,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669633/p"
+    },
+    {
+      "planId": 669634,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669634/p"
+    },
+    {
+      "planId": 669635,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669635/p"
+    },
+    {
+      "planId": 669636,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669636/p"
+    }
+  ],
   "safari-gravel-race": [
     {
       "planId": 659837,

--- a/tests/test_sync_tp_race_plan_links.py
+++ b/tests/test_sync_tp_race_plan_links.py
@@ -81,3 +81,16 @@ def test_oregon_trail_publishes_the_complete_full_7_ladder():
         669620, 669621, 669622, 669623, 669624, 669625, 669626
     ]
     assert all(plan["url"].endswith(f"tp-{plan['planId']}/p") for plan in ladder)
+
+
+def test_rule_of_three_publishes_the_complete_full_7_ladder():
+    links = json.loads(
+        (Path(__file__).resolve().parent.parent / "data" / "tp-race-plan-links.json")
+        .read_text(encoding="utf-8")
+    )
+    ladder = links["rule-of-three"]
+
+    assert [plan["planId"] for plan in ladder] == [
+        669630, 669631, 669632, 669633, 669634, 669635, 669636
+    ]
+    assert all(plan["url"].endswith(f"tp-{plan['planId']}/p") for plan in ladder)


### PR DESCRIPTION
Adds the seven live TrainingPeaks Cycling listings for Rule of Three and locks the exact FULL-7 plan IDs in tests.