### PR TITLE
feat(plans): link 2027 Grasshopper suites

### DIFF
--- a/data/tp-race-plan-links.json
+++ b/data/tp-race-plan-links.json
@@ -3237,6 +3237,57 @@
       "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659968/p"
     }
   ],
+  "huffmaster-grasshopper": [
+    {
+      "planId": 669649,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669649/p"
+    },
+    {
+      "planId": 669650,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669650/p"
+    },
+    {
+      "planId": 669651,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669651/p"
+    },
+    {
+      "planId": 669652,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669652/p"
+    },
+    {
+      "planId": 669653,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669653/p"
+    },
+    {
+      "planId": 669654,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669654/p"
+    },
+    {
+      "planId": 669655,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669655/p"
+    }
+  ],
   "hungry-bear-100": [
     {
       "planId": 659829,
@@ -3337,6 +3388,57 @@
       "weeks": 6,
       "price": 69,
       "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-668059/p"
+    }
+  ],
+  "jackson-forest-grasshopper": [
+    {
+      "planId": 669656,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669656/p"
+    },
+    {
+      "planId": 669657,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669657/p"
+    },
+    {
+      "planId": 669658,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669658/p"
+    },
+    {
+      "planId": 669659,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669659/p"
+    },
+    {
+      "planId": 669660,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669660/p"
+    },
+    {
+      "planId": 669661,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669661/p"
+    },
+    {
+      "planId": 669662,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669662/p"
     }
   ],
   "jeroboam": [
@@ -3758,6 +3860,57 @@
       "weeks": 6,
       "price": 69,
       "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-659747/p"
+    }
+  ],
+  "low-gap-grasshopper": [
+    {
+      "planId": 669642,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669642/p"
+    },
+    {
+      "planId": 669643,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669643/p"
+    },
+    {
+      "planId": 669644,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669644/p"
+    },
+    {
+      "planId": 669645,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669645/p"
+    },
+    {
+      "planId": 669646,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669646/p"
+    },
+    {
+      "planId": 669647,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669647/p"
+    },
+    {
+      "planId": 669648,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669648/p"
     }
   ],
   "lowell-classic": [
@@ -6184,6 +6337,57 @@
       "weeks": 6,
       "price": 69,
       "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669260/p"
+    }
+  ],
+  "ukiah-mendo-gravel-epic": [
+    {
+      "planId": 669663,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669663/p"
+    },
+    {
+      "planId": 669664,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669664/p"
+    },
+    {
+      "planId": 669665,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669665/p"
+    },
+    {
+      "planId": 669666,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669666/p"
+    },
+    {
+      "planId": 669667,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669667/p"
+    },
+    {
+      "planId": 669668,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669668/p"
+    },
+    {
+      "planId": 669669,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669669/p"
     }
   ],
   "unbound-100": [

--- a/tests/test_sync_tp_race_plan_links.py
+++ b/tests/test_sync_tp_race_plan_links.py
@@ -94,3 +94,24 @@ def test_rule_of_three_publishes_the_complete_full_7_ladder():
         669630, 669631, 669632, 669633, 669634, 669635, 669636
     ]
     assert all(plan["url"].endswith(f"tp-{plan['planId']}/p") for plan in ladder)
+
+
+def test_2027_grasshoppers_publish_their_complete_full_7_ladders():
+    links = json.loads(
+        (Path(__file__).resolve().parent.parent / "data" / "tp-race-plan-links.json")
+        .read_text(encoding="utf-8")
+    )
+    expected = {
+        "low-gap-grasshopper": list(range(669642, 669649)),
+        "huffmaster-grasshopper": list(range(669649, 669656)),
+        "jackson-forest-grasshopper": list(range(669656, 669663)),
+        "ukiah-mendo-gravel-epic": list(range(669663, 669670)),
+    }
+
+    for slug, plan_ids in expected.items():
+        ladder = links[slug]
+        assert [plan["planId"] for plan in ladder] == plan_ids
+        assert all(
+            plan["url"].endswith(f"tp-{plan['planId']}/p")
+            for plan in ladder
+        )


### PR DESCRIPTION
## Summary
- sync the four newly published 2027 Grasshopper FULL-7 suites into the Gravel God plan-link catalog
- pin exact TrainingPeaks IDs for Low Gap, Huffmaster, Jackson Forest, and Ukiah Mendo
- add regression coverage for all 28 marketplace URLs

## Verification
- `python3 -m pytest -q tests/test_grasshopper_2027_source.py tests/test_sync_tp_race_plan_links.py` (8 passed)
- `python3 scripts/preflight_quality.py` (passes; existing optional-dependency warnings only)
- `git diff --check`