### PR TITLE
feat(catalog): link and deploy The Bootlegger plans

### DIFF
--- a/.github/workflows/deploy-race-page.yml
+++ b/.github/workflows/deploy-race-page.yml
@@ -1,0 +1,99 @@
+name: Deploy Race Page
+
+on:
+  workflow_dispatch:
+    inputs:
+      slug:
+        description: "Canonical race slug (for example, bootlegger-100)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout Gravel God source
+        uses: actions/checkout@v4
+
+      - name: Checkout published TrainingPeaks catalog
+        uses: actions/checkout@v4
+        with:
+          repository: wattgod/gravel-god-training-plans
+          ref: builtfor-publish
+          token: ${{ secrets.GH_PAT }}
+          path: gravel-god-training-plans
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build and validate scoped payload
+        env:
+          RACE_SLUG: ${{ inputs.slug }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$RACE_SLUG" | grep -Eq '^[a-z0-9]+(-[a-z0-9]+)*$'; then
+            echo "::error::Invalid race slug: $RACE_SLUG"
+            exit 1
+          fi
+          test -f "race-data/$RACE_SLUG.json"
+          mkdir -p /tmp/gg-race-page
+          python wordpress/generate_neo_brutalist.py "$RACE_SLUG" \
+            --data-dir race-data \
+            --output-dir /tmp/gg-race-page \
+            --plans-db gravel-god-training-plans/db/plans.json
+          test -s "/tmp/gg-race-page/$RACE_SLUG.html"
+          test -d /tmp/gg-race-page/assets
+          grep -Eq 'trainingpeaks\.com/training-plans/cycling/tp-[0-9]+' \
+            "/tmp/gg-race-page/$RACE_SLUG.html"
+
+      - name: Setup SSH
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/siteground_key
+          chmod 600 ~/.ssh/siteground_key
+          ssh-keyscan -p "${{ secrets.SSH_PORT }}" "${{ secrets.SSH_HOST }}" \
+            >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy page and shared assets
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ secrets.SSH_PORT }}
+        run: |
+          python scripts/push_wordpress.py \
+            --sync-pages \
+            --pages-dir /tmp/gg-race-page \
+            --purge-cache
+
+      - name: Verify exact live page
+        env:
+          RACE_SLUG: ${{ inputs.slug }}
+        run: |
+          set -euo pipefail
+          expected="/tmp/gg-race-page/$RACE_SLUG.html"
+          live="/tmp/$RACE_SLUG.live.html"
+          for attempt in 1 2 3 4 5; do
+            if curl -L --fail --silent --show-error --compressed \
+              "https://gravelgodcycling.com/race/$RACE_SLUG/?v=${GITHUB_SHA}-${GITHUB_RUN_ATTEMPT}" \
+              -o "$live" && cmp -s "$expected" "$live"; then
+              echo "Exact race page is live (attempt $attempt)"
+              exit 0
+            fi
+            echo "Attempt $attempt: live bytes do not yet match the deployed page"
+            sleep 10
+          done
+          echo "::error::Live race page did not match the scoped deployment"
+          sha256sum "$expected" "$live" || true
+          exit 1

--- a/data/tp-race-plan-links.json
+++ b/data/tp-race-plan-links.json
@@ -532,6 +532,57 @@
       "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-667993/p"
     }
   ],
+  "bootlegger-100": [
+    {
+      "planId": 669681,
+      "tier": "Finisher",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669681/p"
+    },
+    {
+      "planId": 669682,
+      "tier": "Finisher",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669682/p"
+    },
+    {
+      "planId": 669683,
+      "tier": "Time-Crunched",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669683/p"
+    },
+    {
+      "planId": 669684,
+      "tier": "Time-Crunched",
+      "weeks": 8,
+      "price": 79,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669684/p"
+    },
+    {
+      "planId": 669685,
+      "tier": "Compete",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669685/p"
+    },
+    {
+      "planId": 669686,
+      "tier": "Masters 50+",
+      "weeks": 12,
+      "price": 99,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669686/p"
+    },
+    {
+      "planId": 669687,
+      "tier": "Save My Race",
+      "weeks": 6,
+      "price": 69,
+      "url": "https://www.trainingpeaks.com/training-plans/cycling/tp-669687/p"
+    }
+  ],
   "bwr-arizona": [
     {
       "planId": 659190,

--- a/tests/test_bootlegger_2027_source.py
+++ b/tests/test_bootlegger_2027_source.py
@@ -81,3 +81,22 @@ def test_bootlegger_index_uses_corrected_date_location_and_grade():
     assert indexed["location"] == "Lenoir, North Carolina"
     assert indexed["overall_score"] == 71
     assert indexed["tier"] == 2
+
+
+def test_bootlegger_workout_pack_stays_fact_bounded_and_customer_ready():
+    pack = json.loads(
+        (ROOT / "web" / "race-packs" / f"{SLUG}.json").read_text(encoding="utf-8")
+    )
+    rendered = json.dumps(pack)
+
+    assert pack["distance_mi"] == 85
+    assert "Wilson Creek Gorge" in pack["pack_summary"]
+    assert "Maple Sally Road" in pack["pack_summary"]
+    for rejected in (
+        "glycogen is gone",
+        "Bonking at mile 60",
+        "5 PSI wrong costs you 15+ minutes",
+        "western North Carolina mountain gravel with.",
+        "you'll walk the rest",
+    ):
+        assert rejected not in rendered

--- a/tests/test_sync_tp_race_plan_links.py
+++ b/tests/test_sync_tp_race_plan_links.py
@@ -96,6 +96,17 @@ def test_rule_of_three_publishes_the_complete_full_7_ladder():
     assert all(plan["url"].endswith(f"tp-{plan['planId']}/p") for plan in ladder)
 
 
+def test_bootlegger_publishes_the_complete_full_7_ladder():
+    links = json.loads(
+        (Path(__file__).resolve().parent.parent / "data" / "tp-race-plan-links.json")
+        .read_text(encoding="utf-8")
+    )
+    ladder = links["bootlegger-100"]
+
+    assert [plan["planId"] for plan in ladder] == list(range(669681, 669688))
+    assert all(plan["url"].endswith(f"tp-{plan['planId']}/p") for plan in ladder)
+
+
 def test_2027_grasshoppers_publish_their_complete_full_7_ladders():
     links = json.loads(
         (Path(__file__).resolve().parent.parent / "data" / "tp-race-plan-links.json")

--- a/web/race-packs/bootlegger-100.json
+++ b/web/race-packs/bootlegger-100.json
@@ -20,7 +20,7 @@
         "Surge and Settle",
         "Terrain Microbursts"
       ],
-      "workout_context": "The Bootlegger's Gravel and paved country roads, Wilson Creek Gorge forces constant power changes. Surge over the rough stuff, settle on the smooth, repeat for 85 miles."
+      "workout_context": "The Bootlegger moves between paved country roads and mountain gravel through Wilson Creek Gorge and the Grandfather Ranger District. Practice controlled power changes without turning every surface transition into a surge."
     },
     {
       "category": "Race_Simulation",
@@ -30,7 +30,7 @@
         "Variable Pace Chaos",
         "Sector Simulation"
       ],
-      "workout_context": "Race-pace efforts that mimic The Bootlegger's demands. Pacing, fueling, and tactical decisions under fatigue. Practice the race before April."
+      "workout_context": "Use long race simulations to join climbing restraint, open-road descending, fueling, navigation, and repair decisions under fatigue before April 17."
     },
     {
       "category": "TT_Threshold",
@@ -40,7 +40,7 @@
         "Threshold Ramps",
         "Descending Threshold"
       ],
-      "workout_context": "85ft/mi means long efforts at or near FTP on every climb. If your threshold cracks at minute 15, you'll walk the rest."
+      "workout_context": "The 85-mile course accumulates approximately 7,250 feet of climbing. Sustained threshold work raises climbing capacity, while race simulations teach you to stay below that ceiling early."
     },
     {
       "category": "Over_Under",
@@ -49,7 +49,7 @@
         "Classic Over-Unders",
         "Ladder Over-Unders"
       ],
-      "workout_context": "At The Bootlegger, surges push you above threshold and you have to recover while still riding. Over-unders train exactly that."
+      "workout_context": "Over-unders rehearse recovering while still climbing after a brief rise above threshold, a useful skill when grades or group pace change."
     },
     {
       "category": "G_Spot",
@@ -59,7 +59,7 @@
         "G-Spot Extended",
         "Criss-Cross"
       ],
-      "workout_context": "88\u201392% FTP is where you'll spend the hardest sustained miles of The Bootlegger. Train it until it feels boring."
+      "workout_context": "Subthreshold work builds the durable climbing pressure needed for a long mountain day without prescribing threshold as the default race pace."
     },
     {
       "category": "Durability",
@@ -69,7 +69,7 @@
         "Double Day Simulation",
         "Progressive Fatigue"
       ],
-      "workout_context": "At mile 60 of 85, glycogen is gone. This workout teaches your body to produce watts on fumes."
+      "workout_context": "Late in an 85-mile mountain day, accumulated climbing and descending fatigue can erode power and attention. Durability work rehearses steady output and sound decisions after a long aerobic lead-in."
     },
     {
       "category": "Critical_Power",
@@ -78,7 +78,7 @@
         "Above CP Repeats",
         "W-Prime Depletion"
       ],
-      "workout_context": "How long can you hold 105% FTP before you blow? At The Bootlegger, that number decides whether you bridge or get dropped."
+      "workout_context": "Short work above critical power can support a deliberate gap closure or steep pitch, but it should remain a limited tactical tool rather than the day's pacing plan."
     },
     {
       "category": "VO2max",
@@ -88,7 +88,7 @@
         "Descending VO2 Pyramid",
         "Norwegian 4x8"
       ],
-      "workout_context": "7,250ft of climbing means repeated surges above threshold. VO2max work is how you survive the fifth climb, not just the first."
+      "workout_context": "VO2max work creates headroom for short steep pitches and changes in group pace. The race-specific goal is to absorb those moments without compromising the long-course effort."
     },
     {
       "category": "Mixed_Climbing",
@@ -97,7 +97,7 @@
         "Seated/Standing Climbs",
         "Variable Grade Simulation"
       ],
-      "workout_context": "7,250ft of climbing on grades that change every minute. You need to switch from seated to standing without losing rhythm."
+      "workout_context": "Mixed-climbing sessions build seated efficiency and controlled standing transitions for the sustained climbing through Wilson Creek and Maple Sally."
     },
     {
       "category": "Anaerobic_Capacity",
@@ -106,7 +106,7 @@
         "2min Killers",
         "90sec Repeats"
       ],
-      "workout_context": "Short, max efforts are unavoidable. Punchy climbs, gap closures, attacks on western North Carolina mountain gravel with. If you haven't trained them, you'll crack."
+      "workout_context": "Brief high-force moments may come from steep pitches, a deliberate pass, or a gap closure. Train them selectively so they do not dictate the rest of an 85-mile day."
     },
     {
       "category": "Norwegian_Double",
@@ -115,7 +115,7 @@
         "Norwegian 4x8 Classic",
         "Double Threshold"
       ],
-      "workout_context": "Two threshold sessions per week without the recovery cost of VO2max work. For 85 miles, sustainable FTP gains matter more than peak power."
+      "workout_context": "For athletes already prepared to absorb two controlled threshold sessions, this format can build sustainable climbing power while keeping each effort submaximal."
     },
     {
       "category": "Cadence_Work",
@@ -124,13 +124,13 @@
         "High Cadence Drills",
         "Cadence Pyramids"
       ],
-      "workout_context": "Smooth pedaling at 85 miles saves muscle. Bad technique at mile 10 is invisible. At mile 80 it's a cramp."
+      "workout_context": "Cadence flexibility lets you respond to changing grades and traction without defaulting to one costly gear or posture late in the course."
     }
   ],
   "race_overlay": {
-    "nutrition": "Target 60\u201380g carbs/hour for The Bootlegger\u2019s 85 miles. Start fueling within the first 30 minutes \u2014 early fueling prevents late-race collapse. Bonking at mile 60 is a nutrition failure, not a fitness failure.",
-    "terrain": "Highly technical terrain at The Bootlegger demands practice on similar surfaces. Ride western north carolina mountain gravel with sustained climbing and technical descents at race-day cadence weekly. Expect: gravel and paved country roads, wilson creek gorge, grandfather ranger district. Practice cornering, descending, and power delivery on unstable surfaces. Dial in tire pressure before race week \u2014 5 PSI wrong costs you 15+ minutes over 85 miles."
+    "nutrition": "Use training to prove a tolerable hourly carbohydrate target, then pair it with fluid and sodium choices matched to the final forecast. Start intake early and rehearse eating immediately after rough descents, when attention often returns to the pedals before it returns to fueling.",
+    "terrain": "Practice sustained mountain-gravel climbing and long open-road descents on the race bike. Test braking, sight-line discipline, tires, pressure, sealant, plugs, a tube, and navigation before race week; final 2027 rider communications and route files remain authoritative."
   },
-  "pack_summary": "This 10-workout pack focuses on Gravel Specific, Race Simulation, and TT Threshold to prepare you for 85 miles of western north carolina mountain gravel with sustained climbing and technical descents in Lenoir, North Carolina.",
+  "pack_summary": "This 10-workout pack focuses on gravel-specific power, race simulation, and threshold capacity for the 85-mile course through Wilson Creek Gorge, the Grandfather Ranger District, Maple Sally Road, and the return to Lenoir.",
   "generated_at": "2026-08-14"
 }


### PR DESCRIPTION
## Summary

- links the public The Bootlegger 2027 FULL-7 ladder (TrainingPeaks 669681–669687) into the race page
- repairs generated race-pack copy that made fabricated or unsupported performance claims
- adds regression coverage for the exact ladder and fact-bounded customer copy
- adds a scoped manual race-page deployment workflow that builds against the published plan catalog and requires an exact live byte match

## Validation

- `python3 -m pytest -q tests/test_bootlegger_2027_source.py tests/test_sync_tp_race_plan_links.py` — 10 passed
- generated Bootlegger page contains the correct 2027 date, 85 miles, 7,250 feet, score 71, and each TrainingPeaks ID exactly once
- current Rule of Three local/live static page hashes match, proving the workflow's byte-exact verification method
- `git diff --check`

## Dependencies

- source facts merged in #91
- athlete guides merged in wattgod/gravel-god-guides#15
- plan catalog merged in wattgod/gravel-god-training-plans#13
