### PR TITLE
fix(deploy): vary race-page verification cache keys

### DIFF
--- a/.github/workflows/deploy-race-page.yml
+++ b/.github/workflows/deploy-race-page.yml
@@ -84,14 +84,15 @@ jobs:
           set -euo pipefail
           expected="/tmp/gg-race-page/$RACE_SLUG.html"
           live="/tmp/$RACE_SLUG.live.html"
-          for attempt in 1 2 3 4 5; do
+          for attempt in 1 2 3 4 5 6 7 8; do
             if curl -L --fail --silent --show-error --compressed \
-              "https://gravelgodcycling.com/race/$RACE_SLUG/?v=${GITHUB_SHA}-${GITHUB_RUN_ATTEMPT}" \
+              "https://gravelgodcycling.com/race/$RACE_SLUG/?v=${GITHUB_SHA}-${GITHUB_RUN_ATTEMPT}-${attempt}" \
               -o "$live" && cmp -s "$expected" "$live"; then
               echo "Exact race page is live (attempt $attempt)"
               exit 0
             fi
             echo "Attempt $attempt: live bytes do not yet match the deployed page"
+            sha256sum "$expected" "$live" || true
             sleep 10
           done
           echo "::error::Live race page did not match the scoped deployment"


### PR DESCRIPTION
## Summary

- gives each live race-page verification retry a distinct cache-busting URL
- extends the propagation window from 50 to 80 seconds
- logs expected and live hashes on every mismatch

## Root cause

The first Bootlegger deploy uploaded the correct artifact, but the first verification request received stale CDN content. Every retry reused the same query string and therefore reused that stale cache entry. After the run, the live page matched the deployed artifact hash exactly.

## Validation

- workflow YAML parses successfully
- current live Bootlegger hash matches the deployed workflow artifact: `f778a13f96a9534664f5b92788be8757a6c92fc52ad54fcd19845c12dc3a54a1`
- `git diff --check`
