### PR TITLE
Index the three new UCI gravel profiles

### DIFF
--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -8370,4 +8370,22 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://gravelgodcycling.com/race/hysk-gravel-classic-yakurai/</loc>
+    <lastmod>2026-08-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://gravelgodcycling.com/race/khomas100/</loc>
+    <lastmod>2026-08-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://gravelgodcycling.com/race/graean-cymru/</loc>
+    <lastmod>2026-08-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
Adds HYSK Gravel Classic Yakurai, Khomas100, and Graean Cymru to the existing full race sitemap without dropping comparison or hub URLs.\n\nValidation: xmllint --noout web/sitemap.xml; 63 sitemap/indexing tests passed.