### PR TITLE
fix: use exact Bend Dirt Fest distance

### DIFF
--- a/race-data/bend-dirt-fest.json
+++ b/race-data/bend-dirt-fest.json
@@ -366,7 +366,7 @@
       "tier_overrides": {},
       "marketplace_variables": {
         "race_name": "Bend Dirt Fest",
-        "race_hook": "55 miles and 4,016 feet through Bend's high-desert forest roads",
+        "race_hook": "54.7 miles and 4,016 feet through Bend's high-desert forest roads",
         "race_hook_detail": "A first-half climb to 5,608 feet, loose second-half descending, and a three-discipline festival at the finish.",
         "distance": "54.7",
         "dark_mile": "35",


### PR DESCRIPTION
## Summary
- use the verified 54.7-mile distance in Bend Dirt Fest public race hook
- retain the verified 4,016-foot course gain

## Verification
- python3 -m pytest -q tests/test_bend_dirt_fest_2027_source.py
- python3 scripts/generate_index.py --with-jsonld
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One marketing string in race JSON; no logic, auth, or runtime behavior changes.
> 
> **Overview**
> Aligns the Bend Dirt Fest **marketplace** `race_hook` with the verified long-course distance by changing **55 miles** to **54.7 miles**; **4,016 feet** of gain is unchanged.
> 
> This is a single-field copy fix in `race-data/bend-dirt-fest.json` so public/marketing text matches vitals and the 2027 route sources already used elsewhere in the profile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c56b231a0d05caca219220e96ca72fb598b3ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->