### PR TITLE
C4: /consulting/ rewrite (Sultanic copy v2), /consulting/confirmed/, new /consulting/intake/

### DIFF
--- a/scripts/push_wordpress.py
+++ b/scripts/push_wordpress.py
@@ -1009,6 +1009,83 @@ def sync_consulting(consulting_file: str):
     return f"{wp_url}/consulting/"
 
 
+def sync_consult_intake(consult_intake_file: str):
+    """Upload consult-intake.html to /consulting/intake/index.html on SiteGround via SSH+SCP."""
+    ssh = get_ssh_credentials()
+    if not ssh:
+        return None
+    host, user, port = ssh
+
+    html_path = Path(consult_intake_file)
+    if not html_path.exists():
+        print(f"✗ Consult intake page HTML not found: {html_path}")
+        print("  Run: python3 wordpress/generate_consult_intake.py first")
+        return None
+
+    remote_base = "~/www/gravelgodcycling.com/public_html/consulting/intake"
+
+    # Create remote directory
+    try:
+        subprocess.run(
+            [
+                "ssh", "-i", str(SSH_KEY), "-p", port,
+                f"{user}@{host}",
+                f"mkdir -p {remote_base}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"✗ Failed to create remote directory: {e.stderr.strip()}")
+        return None
+
+    # Upload consult-intake.html as index.html
+    try:
+        subprocess.run(
+            [
+                "scp", "-i", str(SSH_KEY), "-P", port,
+                str(html_path),
+                f"{user}@{host}:{remote_base}/index.html",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"✗ SCP failed for consult intake page: {e.stderr.strip()}")
+        return None
+    except Exception as e:
+        print(f"✗ Error uploading consult intake page: {e}")
+        return None
+
+    # Upload shared CSS/JS assets (intake page references them via /race/assets/)
+    assets_dir = html_path.parent / "assets"
+    remote_assets = "~/www/gravelgodcycling.com/public_html/race/assets"
+    for pattern in ("gg-styles.*.css", "gg-scripts.*.js"):
+        for asset in assets_dir.glob(pattern):
+            try:
+                subprocess.run(
+                    [
+                        "scp", "-i", str(SSH_KEY), "-P", port,
+                        str(asset),
+                        f"{user}@{host}:{remote_assets}/{asset.name}",
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+            except subprocess.CalledProcessError:
+                print(f"  ⚠ Could not upload {asset.name} (non-fatal)")
+
+    wp_url = os.environ.get("WP_URL", "https://gravelgodcycling.com")
+    print(f"✓ Uploaded consult intake page: {wp_url}/consulting/intake/")
+    return f"{wp_url}/consulting/intake/"
+
+
 def sync_legal(output_dir: str):
     """Upload privacy.html, terms.html, cookies.html to /privacy/, /terms/, /cookies/ on SiteGround."""
     ssh = get_ssh_credentials()
@@ -3840,6 +3917,14 @@ if __name__ == "__main__":
         help="Path to consulting page HTML (default: wordpress/output/consulting.html)"
     )
     parser.add_argument(
+        "--sync-consult-intake", action="store_true",
+        help="Upload consulting intake page to /consulting/intake/ via SCP"
+    )
+    parser.add_argument(
+        "--consult-intake-file", default="wordpress/output/consult-intake.html",
+        help="Path to consulting intake HTML (default: wordpress/output/consult-intake.html)"
+    )
+    parser.add_argument(
         "--sync-legal", action="store_true",
         help="Upload legal pages (privacy, terms, cookies) via SCP"
     )
@@ -4072,6 +4157,7 @@ if __name__ == "__main__":
         args.sync_coaching = True
         args.sync_coaching_apply = True
         args.sync_consulting = True
+        args.sync_consult_intake = True
         args.sync_training_plans = True
         args.sync_success = True
         args.sync_sitemap = True
@@ -4104,6 +4190,7 @@ if __name__ == "__main__":
     has_action = any([args.json, args.sync_index, args.sync_widget, args.sync_training,
                       args.sync_guide, args.sync_guide_cluster, args.sync_og, args.sync_tp, args.sync_homepage, args.sync_gravel_tv, args.sync_about,
                       args.sync_coaching, args.sync_coaching_apply, args.sync_consulting,
+                      args.sync_consult_intake,
                       args.sync_training_plans, args.sync_success, args.sync_pages,
                       args.sync_sitemap, args.sync_redirects,
                       args.sync_noindex, args.sync_ctas, args.sync_training_form, args.sync_ga4, args.sync_header, args.sync_prep_kits, args.sync_plan_pages, args.sync_tire_guides,
@@ -4156,6 +4243,8 @@ if __name__ == "__main__":
         _run("sync-coaching-apply", sync_coaching_apply, args.coaching_apply_file)
     if args.sync_consulting:
         _run("sync-consulting", sync_consulting, args.consulting_file)
+    if args.sync_consult_intake:
+        _run("sync-consult-intake", sync_consult_intake, args.consult_intake_file)
     if args.sync_legal:
         _run("sync-legal", sync_legal, "wordpress/output")
     if args.sync_consent:

--- a/tests/test_consult_intake.py
+++ b/tests/test_consult_intake.py
@@ -1,0 +1,366 @@
+"""Tests for the Gravel God consulting intake form generator (/consulting/intake/)."""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add wordpress/ to path so we can import the generator
+sys.path.insert(0, str(Path(__file__).parent.parent / "wordpress"))
+
+from generate_consult_intake import (
+    CONSULT_INTAKE_API,
+    build_nav,
+    build_header,
+    build_fields,
+    build_submit_buttons,
+    build_success_state,
+    build_privacy,
+    build_footer,
+    build_jsonld,
+    build_intake_css,
+    build_intake_js,
+    generate_intake_page,
+)
+from generate_consulting import PRIVACY_SENTENCE
+
+
+# ── Fixtures ─────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def intake_html():
+    return generate_intake_page()
+
+
+@pytest.fixture(scope="module")
+def intake_css():
+    return build_intake_css()
+
+
+@pytest.fixture(scope="module")
+def intake_js():
+    return build_intake_js()
+
+
+# ── Page Generation ──────────────────────────────────────────
+
+
+class TestPageGeneration:
+    def test_returns_html(self, intake_html):
+        assert isinstance(intake_html, str)
+        assert "<!DOCTYPE html>" in intake_html
+
+    def test_has_canonical(self, intake_html):
+        assert 'rel="canonical"' in intake_html
+        assert "/consulting/intake/" in intake_html
+
+    def test_has_ga4(self, intake_html):
+        assert "G-EJJZ9T6M52" in intake_html
+        assert "googletagmanager.com" in intake_html
+
+    def test_has_meta_robots_noindex(self, intake_html):
+        assert 'name="robots"' in intake_html
+        assert "noindex" in intake_html
+
+    def test_has_meta_description(self, intake_html):
+        assert 'name="description"' in intake_html
+
+    def test_has_title(self, intake_html):
+        assert "<title>" in intake_html
+        assert "Consulting Intake" in intake_html
+
+    def test_has_jsonld(self, intake_html):
+        assert 'application/ld+json' in intake_html
+
+
+# ── Nav ──────────────────────────────────────────────────────
+
+
+class TestNav:
+    def test_breadcrumb(self, intake_html):
+        assert "gg-breadcrumb" in intake_html
+        assert "Consulting" in intake_html
+        assert "Intake" in intake_html
+
+    def test_breadcrumb_links_to_consulting(self, intake_html):
+        assert 'href="https://gravelgodcycling.com/consulting/"' in intake_html
+
+
+# ── Fields (14 questions, exact keys) ────────────────────────
+
+
+class TestFields:
+    EXPECTED_FIELD_NAMES = [
+        "goal_event",
+        "goal_date",
+        "hours_typical",
+        "hours_max",
+        "years_training",
+        "ftp",
+        "lthr",
+        "top_question",
+        "whats_gone_wrong",
+        "injuries_limits",
+        "tp_email",
+        "power_meter",
+        "hr_strap",
+        "coaching_history",
+        "anything_else",
+    ]
+
+    def test_all_field_names_present(self):
+        fields = build_fields()
+        for name in self.EXPECTED_FIELD_NAMES:
+            assert f'name="{name}"' in fields, f"Missing field: {name}"
+
+    def test_field_count_in_range(self):
+        """Spec: 12-14 field GROUPS (goal event + date count as one group)."""
+        fields = build_fields()
+        names = set(re.findall(r'name="(\w+)"', fields))
+        # goal_event + goal_date are one conceptual group in the spec
+        group_count = len(names) - 1
+        assert 12 <= group_count <= 14, f"Expected 12-14 field groups, got {group_count}"
+
+    def test_tp_email_field_key_exact(self):
+        """The TrainingPeaks login email field key MUST be tp_email."""
+        fields = build_fields()
+        assert 'name="tp_email"' in fields
+
+    def test_tp_email_allows_no_tp(self):
+        fields = build_fields()
+        assert "no TP" in fields
+
+    def test_ftp_lthr_allow_dont_know(self):
+        fields = build_fields()
+        assert "don't know" in fields
+        assert fields.count("don't know") >= 2
+
+    def test_power_meter_and_hr_strap_are_yes_no(self):
+        fields = build_fields()
+        assert 'name="power_meter" value="yes"' in fields
+        assert 'name="power_meter" value="no"' in fields
+        assert 'name="hr_strap" value="yes"' in fields
+        assert 'name="hr_strap" value="no"' in fields
+
+    def test_top_question_field(self):
+        fields = build_fields()
+        assert 'name="top_question"' in fields
+        assert "<textarea" in fields
+
+    def test_fields_in_full_page(self, intake_html):
+        for name in self.EXPECTED_FIELD_NAMES:
+            assert f'name="{name}"' in intake_html
+
+
+# ── Header / Copy ─────────────────────────────────────────────
+
+
+class TestHeader:
+    def test_header_present(self):
+        header = build_header()
+        assert "Twelve Questions" in header
+        assert "five minutes" in header.lower() or "Five minutes" in header
+
+    def test_missing_token_banner_present(self):
+        """Page must handle a missing token with a friendly instruction."""
+        header = build_header()
+        assert "welcome email" in header.lower()
+        assert 'id="token-banner"' in header
+
+
+# ── Honeypot / Form Structure ─────────────────────────────────
+
+
+class TestFormStructure:
+    def test_honeypot(self, intake_html):
+        assert "gg-intake-honeypot" in intake_html
+        assert 'name="_honeypot"' in intake_html
+
+    def test_form_element(self, intake_html):
+        assert '<form id="intake-form"' in intake_html
+
+    def test_submit_and_save_buttons(self):
+        buttons = build_submit_buttons()
+        assert 'id="submit-btn"' in buttons
+        assert 'id="save-btn"' in buttons
+        assert "Save Progress" in buttons
+
+
+# ── Success State ─────────────────────────────────────────────
+
+
+class TestSuccessState:
+    def test_success_copy(self):
+        success = build_success_state()
+        assert "I&rsquo;ll have your read done before we talk" in success
+
+    def test_success_hidden_by_default(self):
+        success = build_success_state()
+        assert 'style="display:none"' in success
+
+
+# ── Privacy ────────────────────────────────────────────────────
+
+
+class TestPrivacy:
+    def test_privacy_sentence_present(self):
+        privacy = build_privacy()
+        assert "deleted on request" in privacy
+
+    def test_privacy_matches_consulting_page(self):
+        """Privacy language must match the /consulting/ page verbatim."""
+        privacy = build_privacy()
+        assert PRIVACY_SENTENCE in privacy
+
+    def test_privacy_in_full_page(self, intake_html):
+        assert "deleted on request" in intake_html
+
+
+# ── Fragment Parsing (never query string) ─────────────────────
+
+
+class TestFragmentParsing:
+    def test_reads_hash_not_search(self, intake_js):
+        assert "window.location.hash" in intake_js
+
+    def test_does_not_read_query_string_for_token(self, intake_js):
+        """The intake token must never be read from window.location.search —
+        query strings get logged by servers and leak via referrer headers."""
+        assert "location.search" not in intake_js
+
+    def test_no_query_string_token_anywhere(self, intake_html):
+        """No `?t=` pattern anywhere in the page — the token is fragment-only."""
+        assert "?t=" not in intake_html
+
+    def test_ref_and_t_parsed(self, intake_js):
+        assert 'params.get("ref")' in intake_js
+        assert 'params.get("t")' in intake_js
+
+
+# ── Submission (POST, token in body) ──────────────────────────
+
+
+class TestSubmission:
+    def test_posts_to_consult_intake_api(self, intake_js):
+        assert CONSULT_INTAKE_API in intake_js
+        assert "/api/consult-intake" in intake_js
+
+    def test_payload_shape(self, intake_js):
+        assert "ref: frag.ref" in intake_js
+        assert "t: frag.t" in intake_js
+        assert "answers: answers" in intake_js
+
+    def test_uses_post_method(self, intake_js):
+        assert 'method: "POST"' in intake_js
+
+    def test_token_in_body_not_header_or_query(self, intake_js):
+        """CORS: token travels in the JSON body, not a custom header or query param."""
+        assert "Authorization" not in intake_js
+        assert "X-Token" not in intake_js
+
+
+# ── Save / Resume ──────────────────────────────────────────────
+
+
+class TestSaveResume:
+    def test_localstorage_save(self, intake_js):
+        assert "localStorage.setItem" in intake_js
+        assert "consult_intake_progress" in intake_js
+
+    def test_localstorage_restore(self, intake_js):
+        assert "restoreProgress" in intake_js
+        assert "localStorage.getItem" in intake_js
+
+    def test_success_clears_draft(self, intake_js):
+        """Only a successful submission clears the saved draft."""
+        assert "localStorage.removeItem" in intake_js
+
+    def test_error_keeps_draft(self, intake_js):
+        """On a failed submission, the draft must NOT be cleared — the error
+        handler must not call removeItem."""
+        catch_match = re.search(r'\.catch\(function\(err\)\{(.*?)\}\);', intake_js, re.DOTALL)
+        assert catch_match, "Could not find .catch() error handler"
+        assert "localStorage.removeItem" not in catch_match.group(1)
+        assert "saved on this device" in catch_match.group(1)
+
+
+# ── Brand Compliance ─────────────────────────────────────────
+
+
+class TestBrandCompliance:
+    def test_no_hardcoded_hex(self, intake_css):
+        css_content = intake_css.replace("<style>", "").replace("</style>", "")
+        hex_pattern = re.compile(r'(?<![\w-])#[0-9a-fA-F]{3,8}\b')
+        matches = hex_pattern.findall(css_content)
+        assert matches == [], f"Found hardcoded hex colors: {matches}"
+
+    def test_no_border_radius(self, intake_css):
+        assert "border-radius" not in intake_css
+
+    def test_no_box_shadow(self, intake_css):
+        assert "box-shadow" not in intake_css
+
+    def test_no_bounce_easing(self, intake_css):
+        assert "bounce" not in intake_css.lower()
+        assert "spring" not in intake_css.lower()
+
+    def test_no_entrance_animations(self, intake_css):
+        assert "@keyframes" not in intake_css
+
+    def test_no_opacity_transition(self, intake_css):
+        assert "transition: opacity" not in intake_css
+        assert "transition:opacity" not in intake_css
+
+    def test_uses_brand_tokens(self, intake_css):
+        assert "var(--gg-color-" in intake_css
+        assert "var(--gg-font-" in intake_css
+
+    def test_responsive_breakpoint(self, intake_css):
+        assert "600px" in intake_css or "768px" in intake_css
+
+    def test_correct_class_prefix(self, intake_css):
+        classes = re.findall(r'\.(gg-[a-z][a-z0-9-]*)', intake_css)
+        for cls in classes:
+            assert cls.startswith('gg-intake-'), f"Non-prefixed class: .{cls}"
+
+
+# ── Tokens Are Real ────────────────────────────────────────────
+
+
+class TestCssTokenValidation:
+    def test_all_var_refs_defined(self, intake_css):
+        tokens_path = Path(__file__).parent.parent.parent / "gravel-god-brand" / "tokens" / "tokens.css"
+        if not tokens_path.exists():
+            pytest.skip("Brand tokens not found")
+        tokens_css = tokens_path.read_text()
+        var_refs = set(re.findall(r'var\((--gg-[a-z0-9-]+)\)', intake_css))
+        assert var_refs, "No var(--gg-*) references found — did the generator change?"
+        for var_name in var_refs:
+            assert var_name in tokens_css, f"Undefined token: {var_name}"
+
+
+# ── JS Syntax ────────────────────────────────────────────────
+
+
+class TestJSSyntax:
+    def test_js_parses_via_node(self, intake_js):
+        js = intake_js.replace("<script>", "").replace("</script>", "")
+        result = subprocess.run(
+            ["node", "-e", f"new Function({repr(js)})"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, f"JS syntax error: {result.stderr}"
+
+
+# ── Footer ───────────────────────────────────────────────────
+
+
+class TestFooter:
+    def test_footer_present(self, intake_html):
+        assert "gg-mega-footer" in intake_html

--- a/tests/test_consulting.py
+++ b/tests/test_consulting.py
@@ -1,4 +1,4 @@
-"""Tests for the Gravel God consulting page generator."""
+"""Tests for the Gravel God consulting page generator (Sultanic copy v2)."""
 from __future__ import annotations
 
 import re
@@ -15,21 +15,41 @@ from generate_consulting import (
     CONSULTING_PRICE,
     CONSULTING_PRICE_INT,
     CONSULTING_DURATION,
+    ADDON_PRICE,
+    ADDON_PRICE_INT,
     build_nav,
     build_hero,
-    build_what_you_get,
-    build_bio,
-    build_testimonials,
+    build_two_futures,
     build_how_it_works,
-    build_topics,
+    build_what_i_look_at,
+    build_what_we_cover,
+    build_plan_addon,
+    build_who,
+    build_fit,
     build_faq,
-    build_final_cta,
+    build_close,
     build_footer,
     build_consulting_css,
     build_consulting_js,
     build_jsonld,
     generate_consulting_page,
 )
+
+# Section builders whose output is human-readable copy — the Normie Test and
+# other content guards should be checked against these, not the full page
+# (which also embeds JS option names like IntersectionObserver's `threshold`).
+COPY_SECTION_BUILDERS = [
+    build_hero,
+    build_two_futures,
+    build_how_it_works,
+    build_what_i_look_at,
+    build_what_we_cover,
+    build_plan_addon,
+    build_who,
+    build_fit,
+    build_faq,
+    build_close,
+]
 
 
 # ── Fixtures ─────────────────────────────────────────────────
@@ -48,6 +68,11 @@ def consulting_css():
 @pytest.fixture(scope="module")
 def consulting_js():
     return build_consulting_js()
+
+
+@pytest.fixture(scope="module")
+def all_copy():
+    return "\n".join(fn() for fn in COPY_SECTION_BUILDERS)
 
 
 # ── Page Generation ──────────────────────────────────────────
@@ -91,6 +116,9 @@ class TestPageGeneration:
     def test_duration_in_page(self, consulting_html):
         assert "60 minutes" in consulting_html
 
+    def test_addon_price_in_page(self, consulting_html):
+        assert ADDON_PRICE in consulting_html
+
 
 # ── Nav ──────────────────────────────────────────────────────
 
@@ -126,7 +154,7 @@ class TestNav:
 class TestHero:
     def test_headline(self):
         hero = build_hero()
-        assert "One Call" in hero
+        assert "read you can" in hero
 
     def test_price_displayed(self):
         hero = build_hero()
@@ -158,160 +186,242 @@ class TestHero:
         assert 'name="_honeypot"' in hero
         assert 'display:none' in hero
 
+    def test_checkout_form_has_addon_checkbox(self):
+        hero = build_hero()
+        assert 'name="plan_addon"' in hero
+        assert 'type="checkbox"' in hero
+        assert "custom 12-week plan" in hero
+        assert ADDON_PRICE in hero
 
-# ── What You Get ─────────────────────────────────────────────
+    def test_button_copy(self):
+        hero = build_hero()
+        assert "Book the consult" in hero
 
 
-class TestWhatYouGet:
-    def test_three_cards(self):
-        section = build_what_you_get()
-        assert section.count("gg-consult-card") >= 3
+# ── Two Futures ───────────────────────────────────────────────
 
-    def test_card_titles(self):
-        section = build_what_you_get()
-        assert "Pre-Call Prep" in section
-        assert "60-Minute Deep Dive" in section
-        assert "Written Action Plan" in section
 
-    def test_mentions_48_hours(self):
-        section = build_what_you_get()
-        assert "48 hours" in section
+class TestTwoFutures:
+    def test_section_present(self):
+        section = build_two_futures()
+        assert 'id="two-futures"' in section
+        assert "Two futures" in section
+
+    def test_comparison_ignition(self):
+        section = build_two_futures()
+        assert "forum" in section.lower()
+        assert "Same bike. Same hours." in section
 
 
 # ── How It Works ─────────────────────────────────────────────
 
 
 class TestHowItWorks:
-    def test_three_steps(self):
+    def test_five_frames(self):
         section = build_how_it_works()
-        assert section.count("gg-consult-step") >= 3
+        assert section.count("gg-consult-strip-frame") >= 5
 
-    def test_step_titles(self):
+    def test_svg_present(self):
         section = build_how_it_works()
-        assert "Pay" in section
-        assert "Schedule" in section
-        assert "We Talk" in section
-        assert "Get Your Plan" in section
+        assert "<svg" in section
+        assert "gg-consult-strip-svg" in section
+
+    def test_hairline_rail(self):
+        section = build_how_it_works()
+        assert "gg-consult-strip-rail" in section
+
+    def test_frame_four_emphasised(self):
+        section = build_how_it_works()
+        assert "gg-consult-strip-frame--emphasis" in section
+
+    def test_captions_present(self):
+        section = build_how_it_works()
+        assert "Book." in section
+        assert "Connect your TrainingPeaks." in section
+        assert "Answer twelve questions." in section
+        assert "Your read arrives" in section
+        assert "written plan of action within 48 hours" in section
+
+    def test_no_var_in_svg_attrs(self):
+        """SVG attributes can't resolve var() — must be styled via CSS classes only."""
+        section = build_how_it_works()
+        svg_match = re.search(r'<svg.*?</svg>', section, re.DOTALL)
+        assert svg_match
+        assert "var(--" not in svg_match.group(0)
 
 
-# ── Topics ───────────────────────────────────────────────────
+# ── What I Actually Look At ──────────────────────────────────
 
 
-class TestTopics:
-    def test_six_topics(self):
-        section = build_topics()
-        assert section.count("<li>") == 6
+class TestWhatILookAt:
+    def test_section_present(self):
+        section = build_what_i_look_at()
+        assert 'id="look"' in section
+        assert "What I actually look at" in section
 
-    def test_key_topics(self):
-        section = build_topics()
-        assert "Race selection" in section
-        assert "Training structure" in section
-        assert "Nutrition" in section
+    def test_five_bullets(self):
+        section = build_what_i_look_at()
+        assert section.count("<li>") == 5
+
+    def test_key_points(self):
+        section = build_what_i_look_at()
+        assert "hard riding was actually hard" in section
+        assert "climbing, flat, or quietly sliding" in section
+        assert "easier deep in" in section
+        assert "zones are built on are still true" in section
 
 
-# ── Bio ─────────────────────────────────────────────────────
+# ── What We Can Cover ────────────────────────────────────────
 
 
-class TestBio:
+class TestWhatWeCover:
+    def test_section_present(self):
+        section = build_what_we_cover()
+        assert 'id="cover"' in section
+        assert "What we can cover" in section
+
+    def test_topics(self):
+        section = build_what_we_cover()
+        for topic in ["Race selection", "Season planning", "Fuelling", "Race-day execution"]:
+            assert topic in section
+
+    def test_open_invite(self):
+        section = build_what_we_cover()
+        assert "It probably does" in section
+
+
+# ── Plan Add-on ───────────────────────────────────────────────
+
+
+class TestPlanAddon:
+    def test_section_present(self):
+        section = build_plan_addon()
+        assert 'id="plan"' in section
+        assert ADDON_PRICE in section
+
+    def test_honest_limits(self):
+        section = build_plan_addon()
+        assert "one goal event" in section
+        assert "twelve weeks" in section
+        assert "seven days after the call" in section
+
+    def test_no_jargon(self):
+        section = build_plan_addon()
+        for bad in ["TSS", "FTP", "CTL", "VO2", "periodization"]:
+            assert bad not in section
+
+
+# ── Who You'll Talk To ───────────────────────────────────────
+
+
+class TestWho:
     def test_bio_section_present(self):
-        bio = build_bio()
+        bio = build_who()
         assert 'id="who"' in bio
 
     def test_bio_has_name(self):
-        bio = build_bio()
+        bio = build_who()
         assert "Matti" in bio
 
     def test_bio_has_credentials(self):
-        bio = build_bio()
+        bio = build_who()
         assert "TrainingPeaks" in bio
-        assert "100+" in bio or "100" in bio
+        assert "100+" in bio
 
     def test_bio_has_database_reference(self):
-        bio = build_bio()
-        assert "328" in bio
+        bio = build_who()
+        assert "750+" in bio
 
     def test_bio_section_title(self):
-        bio = build_bio()
-        assert "Who You" in bio
-        assert "Talk To" in bio
+        bio = build_who()
+        assert "Who you" in bio
+        assert "talk to" in bio
 
     def test_bio_in_full_page(self, consulting_html):
         assert 'id="who"' in consulting_html
         assert "Matti" in consulting_html
 
 
-# ── Testimonials ────────────────────────────────────────────
+# ── Is This For You ──────────────────────────────────────────
 
 
-class TestTestimonials:
-    def test_three_testimonials(self):
-        section = build_testimonials()
-        assert section.count("gg-consult-testimonial") >= 3
+class TestFit:
+    def test_section_present(self):
+        section = build_fit()
+        assert 'id="fit"' in section
+        assert "Is this for you?" in section
 
-    def test_section_id(self):
-        section = build_testimonials()
-        assert 'id="testimonials"' in section
-
-    def test_section_title(self):
-        section = build_testimonials()
-        assert "What Athletes Say" in section
-
-    def test_has_names(self):
-        section = build_testimonials()
-        assert "Andrew T." in section
-        assert "Jen H." in section
-        assert "Katie B." in section
-
-    def test_has_meta_lines(self):
-        section = build_testimonials()
-        assert "gg-consult-testimonial-meta" in section
-
-    def test_testimonials_in_full_page(self, consulting_html):
-        assert 'id="testimonials"' in consulting_html
-        assert "What Athletes Say" in consulting_html
-
-    def test_no_coaching_language(self):
-        """Testimonials should sound like single-session outcomes."""
-        section = build_testimonials()
-        assert "weekly" not in section.lower()
-        assert "training plan" not in section.lower()
-        assert "subscription" not in section.lower()
+    def test_for_and_not_for(self):
+        section = build_fit()
+        assert "For you if" in section
+        assert "Not for you if" in section
+        assert "goal event and real questions" in section
+        assert "pep talk" in section
 
 
 # ── FAQ ──────────────────────────────────────────────────────
 
 
 class TestFAQ:
-    def test_four_questions(self):
+    def test_six_questions(self):
         faq = build_faq()
-        assert faq.count("gg-consult-faq-item") == 4
+        assert faq.count("gg-consult-faq-item") == 6
 
     def test_accordion_buttons(self):
         faq = build_faq()
-        assert faq.count('aria-expanded="false"') == 4
+        assert faq.count('aria-expanded="false"') == 6
 
     def test_key_questions(self):
         faq = build_faq()
-        assert "Who is this for?" in faq
         assert "What happens after I pay?" in faq
+        assert "I don" in faq and "TrainingPeaks" in faq
+        assert "Do I have to share data?" in faq
+        assert "Can I add the plan later?" in faq
+
+    def test_privacy_sentence(self):
+        faq = build_faq()
+        assert "What happens to my data?" in faq
+        assert "deleted on request" in faq
+        assert "aren" in faq and "shared or sold" in faq
 
 
-# ── Final CTA ────────────────────────────────────────────────
+# ── Close ────────────────────────────────────────────────────
 
 
-class TestFinalCTA:
+class TestClose:
     def test_cta_present(self):
-        cta = build_final_cta()
-        assert "Book Your Consult" in cta
+        cta = build_close()
+        assert "Less than a race entry" in cta
         assert 'data-cta="final_book"' in cta
 
     def test_final_cta_scrolls_to_form(self):
-        cta = build_final_cta()
+        cta = build_close()
         assert 'href="#checkout"' in cta
 
     def test_price_summary(self):
-        cta = build_final_cta()
+        cta = build_close()
         assert CONSULTING_PRICE in cta
+
+    def test_no_dns_reference(self):
+        """DNS reference excludes first-time prospects."""
+        cta = build_close()
+        assert "DNS" not in cta
+
+    def test_no_coffee_cliche(self):
+        cta = build_close()
+        lower = cta.lower()
+        assert "coffee" not in lower
+        assert "latte" not in lower
+
+    def test_quiet_clause(self):
+        cta = build_close()
+        assert "every week" in cta
+        assert 'href="https://gravelgodcycling.com/coaching/"' in cta
+
+    def test_quiet_clause_no_credit_claim(self):
+        """No coaching-credit claim — that decision was explicitly deferred."""
+        cta = build_close()
+        assert "credit" not in cta.lower()
 
 
 # ── Footer ───────────────────────────────────────────────────
@@ -324,13 +434,25 @@ class TestFooter:
         assert "GRAVEL GOD CYCLING" in footer
 
 
+# ── No Testimonials (unverified — removed per copy v2) ───────
+
+
+class TestNoTestimonials:
+    def test_no_testimonial_section(self, consulting_html):
+        assert "testimonial" not in consulting_html.lower()
+        assert "What Athletes Say" not in consulting_html
+
+    def test_no_removed_names(self, consulting_html):
+        for name in ["Andrew T.", "Jen H.", "Katie B."]:
+            assert name not in consulting_html
+
+
 # ── CSS Quality ──────────────────────────────────────────────
 
 
 class TestCSSQuality:
     def test_no_hardcoded_hex(self, consulting_css):
         """No raw hex colors — must use var(--gg-color-*)."""
-        # Strip out the style tags and check CSS content
         css_content = consulting_css.replace("<style>", "").replace("</style>", "")
         hex_pattern = re.compile(r'(?<![\w-])#[0-9a-fA-F]{3,8}\b')
         matches = hex_pattern.findall(css_content)
@@ -356,6 +478,29 @@ class TestCSSQuality:
         assert "transition: opacity" not in consulting_css
         assert "transition:opacity" not in consulting_css
 
+    def test_no_bounce_easing(self, consulting_css):
+        assert "bounce" not in consulting_css.lower()
+        assert "spring" not in consulting_css.lower()
+
+    def test_no_entrance_animations(self, consulting_css):
+        assert "@keyframes" not in consulting_css
+
+
+# ── Brand Tokens Are Real (mirrors coaching's pattern) ────────
+
+
+class TestCssTokenValidation:
+    def test_all_var_refs_defined(self, consulting_css):
+        """Every var(--gg-*) used in the consulting CSS must exist in tokens.css."""
+        tokens_path = Path(__file__).parent.parent.parent / "gravel-god-brand" / "tokens" / "tokens.css"
+        if not tokens_path.exists():
+            pytest.skip("Brand tokens not found")
+        tokens_css = tokens_path.read_text()
+        var_refs = set(re.findall(r'var\((--gg-[a-z0-9-]+)\)', consulting_css))
+        assert var_refs, "No var(--gg-*) references found — did the generator change?"
+        for var_name in var_refs:
+            assert var_name in tokens_css, f"Undefined token: {var_name}"
+
 
 # ── JS Quality ───────────────────────────────────────────────
 
@@ -373,14 +518,18 @@ class TestJSQuality:
     def test_scroll_depth(self, consulting_js):
         assert "consulting_scroll_depth" in consulting_js
         assert "IntersectionObserver" in consulting_js
-        assert "testimonials" in consulting_js
-        assert "who" in consulting_js
+        assert "'who'" in consulting_js
+        assert "'faq'" in consulting_js
 
     def test_page_view_event(self, consulting_js):
         assert "consulting_page_view" in consulting_js
 
     def test_checkout_js_has_api_url(self, consulting_js):
         assert "create-consulting-checkout" in consulting_js
+
+    def test_checkout_js_sends_plan_addon(self, consulting_js):
+        assert "plan_addon" in consulting_js
+        assert "planAddon" in consulting_js
 
     def test_checkout_js_has_begin_checkout_event(self, consulting_js):
         assert "begin_checkout" in consulting_js
@@ -396,7 +545,6 @@ class TestJSQuality:
 
     def test_js_syntax_valid(self, consulting_js):
         """Validate JS syntax via Node.js."""
-        # Extract JS from script tags
         js = consulting_js.replace("<script>", "").replace("</script>", "")
         result = subprocess.run(
             ["node", "-e", f"new Function({repr(js)})"],
@@ -414,57 +562,33 @@ class TestNoComparisons:
     """The consulting page body content should NOT compare itself to other products.
     Nav/footer links to other products are fine — we only check the page sections."""
 
-    def test_no_coaching_price_comparison(self, consulting_html):
+    def test_no_coaching_price_comparison(self, all_copy):
         """No coaching pricing mentioned in page content."""
-        assert "$199" not in consulting_html
-        assert "$299" not in consulting_html
-        assert "$1,200" not in consulting_html
+        assert "$199" not in all_copy
+        assert "$299" not in all_copy
+        assert "$1,200" not in all_copy
 
-    def test_no_training_plan_price_comparison(self, consulting_html):
+    def test_no_training_plan_price_comparison(self, all_copy):
         """No training plan pricing mentioned."""
-        assert "$15/w" not in consulting_html
+        assert "$15/w" not in all_copy
 
 
-# ── Sultanic Copy Guard ────────────────────────────────────────
+# ── Normie Test (banned jargon guard) ────────────────────────
 
 
-class TestSultanicCopyGuard:
-    """Verify psychological upgrade copy is present and brand-compliant."""
+class TestNormieTest:
+    """No TSS/FTP/CTL/VO2max/threshold/periodization anywhere in the copy.
+    Checked against section-builder output, not the full page — the full page
+    also contains legitimate non-copy uses like the IntersectionObserver
+    `threshold` option in inline JS."""
 
-    def test_hero_comparison_ignition(self):
-        """Hero should contrast the call vs. forum/YouTube research."""
-        hero = build_hero()
-        assert "forum threads" in hero or "YouTube" in hero, \
-            "Missing comparison ignition in hero subtitle"
+    BANNED_TERMS = ["TSS", "FTP", "CTL", "VO2max", "VO2", "periodization", "power curve"]
 
-    def test_hero_no_dns_presumption(self):
-        """Hero must NOT assume the prospect has DNS'd."""
-        hero = build_hero()
-        assert "DNS" not in hero, "DNS presumption in hero — not all prospects have DNS'd"
+    def test_no_banned_jargon(self, all_copy):
+        for term in self.BANNED_TERMS:
+            assert term not in all_copy, f"Banned jargon '{term}' found in copy"
 
-    def test_pre_call_efficiency_framing(self):
-        """Pre-Call Prep should emphasize going deep immediately."""
-        wyg = build_what_you_get()
-        assert "go deep immediately" in wyg, "Missing efficiency framing in pre-call prep"
-
-    def test_final_cta_functionally_free(self):
-        """Final CTA should contain value comparison (race entry fee)."""
-        cta = build_final_cta()
-        assert "race entry fee" in cta, "Missing Functionally Free comparison"
-
-    def test_final_cta_no_dns_reference(self):
-        """Final CTA should NOT reference DNS (excludes first-timers)."""
-        cta = build_final_cta()
-        assert "DNS" not in cta, "DNS reference excludes first-time prospects"
-
-    def test_cta_context_css_exists(self):
-        """CTA context element must have CSS styling."""
-        css = build_consulting_css()
-        assert "gg-consult-cta-context" in css, "Missing CSS for CTA context"
-
-    def test_cta_context_no_coffee_cliche(self):
-        """CTA context must not use generic SaaS comparisons."""
-        cta = build_final_cta()
-        lower = cta.lower()
-        assert "coffee" not in lower, "Coffee cliché violates brand voice"
-        assert "latte" not in lower, "Latte cliché violates brand voice"
+    def test_no_bare_threshold_word(self, all_copy):
+        """'threshold' as training jargon is banned; this is copy-only text
+        so there's no legitimate JS option name to collide with."""
+        assert "threshold" not in all_copy.lower()

--- a/tests/test_success_pages.py
+++ b/tests/test_success_pages.py
@@ -121,6 +121,12 @@ class TestGA4Tracking:
     def test_consulting_product_type(self, all_pages):
         assert 'data-product-type="consulting"' in all_pages["consulting-confirmed"]
 
+    def test_consulting_intake_ref_rewrite(self, success_js):
+        """session_id from Stripe is passed through to the intake page as a
+        #ref= fragment so the intake submission can be tied to the order."""
+        assert "consult-intake-link" in success_js
+        assert "/consulting/intake/#ref=" in success_js
+
 
 # ── Brand Compliance ─────────────────────────────────────────
 
@@ -267,25 +273,46 @@ class TestConsultingSuccess:
     def test_has_hero(self):
         html = build_consulting_success()
         assert "gg-success-hero" in html
-        assert "Consulting Session Confirmed" in html
-
-    def test_hero_mentions_scheduling(self):
-        html = build_consulting_success()
-        assert "Schedule your session now" in html
+        assert "Booked. Three things, then I get to work." in html
 
     def test_has_next_steps(self):
         html = build_consulting_success()
-        assert "Schedule Your Session" in html
-        assert "Prepare Your Questions" in html
-        assert "We Talk" in html
+        assert "Pick Your Time" in html
+        assert "Start the Intake" in html
+        assert "Connect Your TrainingPeaks" in html
 
-    def test_consulting_has_scheduling_link(self):
+    def test_three_links(self):
+        """Pick a time, start the intake, connect TrainingPeaks — the three
+        things promised in the H1."""
         html = build_consulting_success()
         assert "calendar.app.google/E282ZtBJAFBXYdYJ6" in html
+        assert 'href="/consulting/intake/"' in html
+        assert "home.trainingpeaks.com/attachtocoach?sharedKey=2OTEPC6BXNVQU" in html
 
     def test_consulting_scheduling_cta(self):
         html = build_consulting_success()
         assert "Pick a Time" in html
+
+    def test_intake_link_has_id_for_js_ref_rewrite(self):
+        html = build_consulting_success()
+        assert 'id="consult-intake-link"' in html
+
+    def test_intake_missing_token_instruction(self):
+        """Success page can't know the intake auth token (welcome-email only) —
+        must tell the athlete to use the emailed link if this page can't open it."""
+        html = build_consulting_success()
+        assert "welcome email" in html.lower()
+
+    def test_addon_clause_only_if_not_bought(self):
+        html = build_consulting_success()
+        assert "$100" in html
+        assert "seven days after we speak" in html
+        assert "reply to your welcome email" in html.lower()
+
+    def test_quiet_coaching_clause(self):
+        html = build_consulting_success()
+        assert "every week" in html
+        assert '/coaching/' in html
 
     def test_cross_sells_coaching(self):
         html = build_consulting_success()

--- a/wordpress/generate_coaching_apply.py
+++ b/wordpress/generate_coaching_apply.py
@@ -1857,8 +1857,7 @@ def generate_apply_page(external_assets=None):
   {build_footer()}
   {build_jsonld()}
   {build_apply_js()}
-''' + '<script>' + get_site_header_js() + '</script>' + '''
-{get_consent_banner_html()}
+''' + '<script>' + get_site_header_js() + '</script>' + get_consent_banner_html() + '''
 </body>
 </html>'''
 

--- a/wordpress/generate_consult_intake.py
+++ b/wordpress/generate_consult_intake.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""
+Generate the Gravel God Consulting intake form at /consulting/intake/.
+
+Fourteen questions, five minutes, save/resume via localStorage. Reads the
+booking session ref and the athlete's private intake token from the URL
+FRAGMENT (`#ref=...&t=...`) — never the query string, so neither value is
+logged by servers or shows up in referrer headers. The token itself is only
+ever emailed to the athlete in their welcome email; if it's missing (e.g.
+someone lands here from the success page instead of the email), the page
+still works and tells them to use the emailed link instead.
+
+Submits `{ref, t, answers}` as JSON to the pipeline's /api/consult-intake
+endpoint (token travels in the POST body, not a header or query param, to
+keep the simple-CORS story intact).
+
+Uses brand tokens exclusively — zero hardcoded hex, no border-radius, no
+box-shadow, no bounce easing, no entrance animations.
+
+Usage:
+    python generate_consult_intake.py
+    python generate_consult_intake.py --output-dir ./output
+"""
+from __future__ import annotations
+
+import argparse
+import html
+from pathlib import Path
+
+from generate_neo_brutalist import (
+    SITE_BASE_URL,
+    get_page_css,
+    build_inline_js,
+    write_shared_assets,
+)
+from brand_tokens import get_ab_head_snippet, get_ga4_head_snippet, get_preload_hints
+from shared_footer import get_mega_footer_html
+from shared_header import get_site_header_html
+from cookie_consent import get_consent_banner_html
+from generate_consulting import PRIVACY_SENTENCE
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+
+CONSULT_INTAKE_API = "https://athlete-custom-training-plan-pipeline-production.up.railway.app/api/consult-intake"
+
+
+def esc(text) -> str:
+    """HTML-escape a string."""
+    return html.escape(str(text)) if text else ""
+
+
+# ── Page sections ─────────────────────────────────────────────
+
+
+def build_nav() -> str:
+    return get_site_header_html(active="services") + f'''
+  <div class="gg-breadcrumb">
+    <a href="{SITE_BASE_URL}/">Home</a>
+    <span class="gg-breadcrumb-sep">&rsaquo;</span>
+    <a href="{SITE_BASE_URL}/consulting/">Consulting</a>
+    <span class="gg-breadcrumb-sep">&rsaquo;</span>
+    <span class="gg-breadcrumb-current">Intake</span>
+  </div>'''
+
+
+def build_header() -> str:
+    return '''<div class="gg-intake-header">
+    <div class="gg-intake-badge">Consult Intake</div>
+    <h1>Twelve Questions, Five Minutes</h1>
+    <p>Answer what you can. Skip what you don&rsquo;t know &mdash; &ldquo;don&rsquo;t know&rdquo; is a fine answer for FTP and LTHR. Save and come back if you need to.</p>
+  </div>
+  <div class="gg-intake-token-banner" id="token-banner" style="display:none">
+    Can&rsquo;t find your booking reference? Use the link in your welcome email instead &mdash; it connects your answers to your consult automatically. You can still fill this out; I&rsquo;ll match it up.
+  </div>'''
+
+
+def build_fields() -> str:
+    return '''<div class="gg-intake-group">
+      <label class="gg-intake-label" for="goal_event">Goal event</label>
+      <input type="text" id="goal_event" name="goal_event" placeholder="Race or event name">
+    </div>
+    <div class="gg-intake-group">
+      <label class="gg-intake-label" for="goal_date">Date</label>
+      <input type="date" id="goal_date" name="goal_date">
+    </div>
+    <div class="gg-intake-inline">
+      <div class="gg-intake-group">
+        <label class="gg-intake-label" for="hours_typical">Typical weekly hours</label>
+        <input type="text" id="hours_typical" name="hours_typical" placeholder="e.g. 8">
+      </div>
+      <div class="gg-intake-group">
+        <label class="gg-intake-label" for="hours_max">Max weekly hours</label>
+        <input type="text" id="hours_max" name="hours_max" placeholder="e.g. 12">
+      </div>
+    </div>
+    <div class="gg-intake-group">
+      <label class="gg-intake-label" for="years_training">Years training</label>
+      <input type="text" id="years_training" name="years_training" placeholder="e.g. 3">
+    </div>
+    <div class="gg-intake-inline">
+      <div class="gg-intake-group">
+        <label class="gg-intake-label" for="ftp">FTP</label>
+        <input type="text" id="ftp" name="ftp" placeholder="Watts, or &quot;don't know&quot;">
+      </div>
+      <div class="gg-intake-group">
+        <label class="gg-intake-label" for="lthr">LTHR</label>
+        <input type="text" id="lthr" name="lthr" placeholder="BPM, or &quot;don't know&quot;">
+      </div>
+    </div>
+    <div class="gg-intake-group">
+      <label class="gg-intake-label" for="top_question">The one question you most want answered</label>
+      <textarea id="top_question" name="top_question" rows="3"></textarea>
+    </div>
+    <div class="gg-intake-group">
+      <label class="gg-intake-label" for="whats_gone_wrong">What&rsquo;s gone wrong this year</label>
+      <textarea id="whats_gone_wrong" name="whats_gone_wrong" rows="3"></textarea>
+    </div>
+    <div class="gg-intake-group">
+      <label class="gg-intake-label" for="injuries_limits">Injuries or limits</label>
+      <textarea id="injuries_limits" name="injuries_limits" rows="2"></textarea>
+    </div>
+    <div class="gg-intake-group">
+      <label class="gg-intake-label" for="tp_email">TrainingPeaks login email</label>
+      <input type="text" id="tp_email" name="tp_email" placeholder="you@example.com, or &quot;no TP&quot;">
+    </div>
+    <div class="gg-intake-inline">
+      <div class="gg-intake-group">
+        <span class="gg-intake-label">Power meter?</span>
+        <div class="gg-intake-radio-row">
+          <label class="gg-intake-radio-option"><input type="radio" name="power_meter" value="yes"> Yes</label>
+          <label class="gg-intake-radio-option"><input type="radio" name="power_meter" value="no"> No</label>
+        </div>
+      </div>
+      <div class="gg-intake-group">
+        <span class="gg-intake-label">HR strap?</span>
+        <div class="gg-intake-radio-row">
+          <label class="gg-intake-radio-option"><input type="radio" name="hr_strap" value="yes"> Yes</label>
+          <label class="gg-intake-radio-option"><input type="radio" name="hr_strap" value="no"> No</label>
+        </div>
+      </div>
+    </div>
+    <div class="gg-intake-group">
+      <label class="gg-intake-label" for="coaching_history">Coaching or plan history</label>
+      <textarea id="coaching_history" name="coaching_history" rows="2"></textarea>
+    </div>
+    <div class="gg-intake-group">
+      <label class="gg-intake-label" for="anything_else">Anything else</label>
+      <textarea id="anything_else" name="anything_else" rows="2"></textarea>
+    </div>'''
+
+
+def build_submit_buttons() -> str:
+    return '''<div class="gg-intake-buttons">
+      <button type="button" id="save-btn" class="gg-intake-save-btn">Save Progress</button>
+      <button type="submit" id="submit-btn" class="gg-intake-submit-btn">Submit</button>
+    </div>'''
+
+
+def build_success_state() -> str:
+    return '''<div id="intake-success" class="gg-intake-success" style="display:none">
+    <h2>Got it &mdash; I&rsquo;ll have your read done before we talk.</h2>
+  </div>'''
+
+
+def build_privacy() -> str:
+    return f'''<p class="gg-intake-privacy">{PRIVACY_SENTENCE}</p>'''
+
+
+def build_footer() -> str:
+    return get_mega_footer_html()
+
+
+def build_jsonld() -> str:
+    return f'''<script type="application/ld+json">
+{{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Consulting Intake",
+  "url": "{SITE_BASE_URL}/consulting/intake/"
+}}
+</script>'''
+
+
+def build_intake_css() -> str:
+    return '''<style>
+.gg-intake-container {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: var(--gg-spacing-xl) var(--gg-spacing-xl) var(--gg-spacing-2xl);
+}
+.gg-intake-header {
+  text-align: center;
+  margin-bottom: var(--gg-spacing-lg);
+}
+.gg-intake-badge {
+  display: inline-block;
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-2xs);
+  font-weight: var(--gg-font-weight-bold);
+  letter-spacing: var(--gg-letter-spacing-wide);
+  text-transform: uppercase;
+  color: var(--gg-color-secondary-brown);
+  margin-bottom: var(--gg-spacing-sm);
+}
+.gg-intake-header h1 {
+  font-family: var(--gg-font-editorial);
+  font-size: clamp(24px, 4vw, 32px);
+  font-weight: var(--gg-font-weight-bold);
+  color: var(--gg-color-dark-brown);
+  margin: 0 0 var(--gg-spacing-sm) 0;
+}
+.gg-intake-header p {
+  font-family: var(--gg-font-editorial);
+  font-size: var(--gg-font-size-sm);
+  line-height: var(--gg-line-height-prose);
+  color: var(--gg-color-primary-brown);
+  margin: 0;
+}
+.gg-intake-token-banner {
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-xs);
+  line-height: var(--gg-line-height-normal);
+  color: var(--gg-color-dark-brown);
+  background: var(--gg-color-sand);
+  border: 2px solid var(--gg-color-gold);
+  padding: var(--gg-spacing-md);
+  margin-bottom: var(--gg-spacing-lg);
+}
+.gg-intake-form-card {
+  background: var(--gg-color-warm-paper);
+  border: 3px solid var(--gg-color-dark-brown);
+  padding: var(--gg-spacing-xl);
+}
+.gg-intake-inline {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--gg-spacing-md);
+}
+.gg-intake-group {
+  margin-bottom: var(--gg-spacing-md);
+}
+.gg-intake-label {
+  display: block;
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-xs);
+  font-weight: var(--gg-font-weight-bold);
+  letter-spacing: var(--gg-letter-spacing-wide);
+  text-transform: uppercase;
+  color: var(--gg-color-dark-brown);
+  margin-bottom: var(--gg-spacing-xs);
+}
+.gg-intake-group input[type="text"],
+.gg-intake-group input[type="date"],
+.gg-intake-group textarea {
+  display: block;
+  width: 100%;
+  padding: var(--gg-spacing-sm) var(--gg-spacing-md);
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-sm);
+  color: var(--gg-color-dark-brown);
+  background: var(--gg-color-white);
+  border: 2px solid var(--gg-color-dark-brown);
+  box-sizing: border-box;
+  resize: vertical;
+}
+.gg-intake-group input:focus,
+.gg-intake-group textarea:focus {
+  outline: none;
+  border-color: var(--gg-color-gold);
+}
+.gg-intake-radio-row {
+  display: flex;
+  gap: var(--gg-spacing-md);
+}
+.gg-intake-radio-option {
+  display: flex;
+  align-items: center;
+  gap: var(--gg-spacing-2xs);
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-sm);
+  color: var(--gg-color-primary-brown);
+  cursor: pointer;
+}
+.gg-intake-honeypot {
+  position: absolute;
+  left: -9999px;
+}
+.gg-intake-buttons {
+  display: flex;
+  gap: var(--gg-spacing-md);
+  margin-top: var(--gg-spacing-lg);
+}
+.gg-intake-submit-btn,
+.gg-intake-save-btn {
+  flex: 1;
+  padding: var(--gg-spacing-sm) var(--gg-spacing-lg);
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-xs);
+  font-weight: var(--gg-font-weight-bold);
+  letter-spacing: var(--gg-letter-spacing-ultra-wide);
+  text-transform: uppercase;
+  cursor: pointer;
+  border: 3px solid var(--gg-color-dark-brown);
+  transition: background-color var(--gg-transition-hover), border-color var(--gg-transition-hover);
+}
+.gg-intake-submit-btn {
+  color: var(--gg-color-dark-brown);
+  background: var(--gg-color-light-gold);
+}
+.gg-intake-submit-btn:hover {
+  background-color: var(--gg-color-gold);
+  border-color: var(--gg-color-gold);
+}
+.gg-intake-submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.gg-intake-save-btn {
+  color: var(--gg-color-primary-brown);
+  background: var(--gg-color-white);
+}
+.gg-intake-save-btn:hover {
+  background-color: var(--gg-color-sand);
+}
+.gg-intake-message {
+  margin-top: var(--gg-spacing-md);
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-xs);
+  text-align: center;
+}
+.gg-intake-message.info {
+  color: var(--gg-color-teal);
+}
+.gg-intake-message.error {
+  color: var(--gg-color-dark-brown);
+  border: 2px solid var(--gg-color-dark-brown);
+  padding: var(--gg-spacing-sm) var(--gg-spacing-md);
+  background: var(--gg-color-sand);
+}
+.gg-intake-message.hidden {
+  display: none;
+}
+.gg-intake-success {
+  text-align: center;
+  padding: var(--gg-spacing-2xl) var(--gg-spacing-xl);
+  background: var(--gg-color-warm-paper);
+  border: 3px solid var(--gg-color-teal);
+}
+.gg-intake-success h2 {
+  font-family: var(--gg-font-editorial);
+  font-size: clamp(22px, 4vw, 28px);
+  font-weight: var(--gg-font-weight-bold);
+  color: var(--gg-color-dark-brown);
+  margin: 0;
+}
+.gg-intake-privacy {
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-2xs);
+  color: var(--gg-color-secondary-brown);
+  text-align: center;
+  line-height: var(--gg-line-height-normal);
+  margin-top: var(--gg-spacing-xl);
+}
+@media (max-width: 600px) {
+  .gg-intake-container { padding: var(--gg-spacing-lg) var(--gg-spacing-md) var(--gg-spacing-xl); }
+  .gg-intake-form-card { padding: var(--gg-spacing-lg); }
+  .gg-intake-inline { grid-template-columns: 1fr; }
+  .gg-intake-buttons { flex-direction: column; }
+}
+</style>'''
+
+
+def build_intake_js() -> str:
+    return f'''<script>
+(function(){{
+  var API_URL = "{CONSULT_INTAKE_API}";
+  var STORAGE_KEY = "consult_intake_progress";
+
+  /* ── Parse ref/t from the URL FRAGMENT only — never the query string ── */
+  function parseFragment(){{
+    var hash = window.location.hash || "";
+    if (hash.indexOf("#") === 0) {{ hash = hash.slice(1); }}
+    var params = new URLSearchParams(hash);
+    return {{ ref: params.get("ref") || "", t: params.get("t") || "" }};
+  }}
+  var frag = parseFragment();
+
+  if (!frag.t) {{
+    var banner = document.getElementById("token-banner");
+    if (banner) {{ banner.style.display = "block"; }}
+  }}
+
+  var form = document.getElementById("intake-form");
+  var msgEl = document.getElementById("intake-message");
+  var submitBtn = document.getElementById("submit-btn");
+  var successEl = document.getElementById("intake-success");
+
+  function showMessage(type, text){{
+    if (!msgEl) return;
+    msgEl.className = "gg-intake-message " + type;
+    msgEl.textContent = text;
+  }}
+
+  /* ── Save progress ── */
+  var saveBtn = document.getElementById("save-btn");
+  if (saveBtn) {{
+    saveBtn.addEventListener("click", function(){{
+      var data = {{}};
+      new FormData(form).forEach(function(value, key){{
+        if (key === "_honeypot") return;
+        data[key] = value;
+      }});
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+      showMessage("info", "Progress saved. Come back anytime.");
+      if (typeof gtag === "function") {{ gtag("event", "consult_intake_progress_saved", {{}}); }}
+    }});
+  }}
+
+  /* ── Restore progress ── */
+  function restoreProgress(){{
+    var saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return;
+    try {{
+      var data = JSON.parse(saved);
+      Object.keys(data).forEach(function(key){{
+        var elements = form.querySelectorAll('[name="' + key + '"]');
+        elements.forEach(function(el){{
+          if (el.type === "radio") {{ el.checked = (el.value === data[key]); }}
+          else {{ el.value = data[key]; }}
+        }});
+      }});
+    }} catch (e) {{ /* ignore corrupt localStorage */ }}
+  }}
+
+  /* ── Submit ── */
+  if (form) {{
+    form.addEventListener("submit", function(e){{
+      e.preventDefault();
+      var honeypot = form.querySelector('input[name="_honeypot"]').value;
+      if (honeypot) return;
+
+      submitBtn.disabled = true;
+      submitBtn.textContent = "Submitting...";
+      showMessage("info", "");
+
+      var answers = {{}};
+      new FormData(form).forEach(function(value, key){{
+        if (key === "_honeypot") return;
+        answers[key] = value;
+      }});
+
+      var payload = {{ ref: frag.ref, t: frag.t, answers: answers }};
+
+      fetch(API_URL, {{
+        method: "POST",
+        headers: {{ "Content-Type": "application/json" }},
+        body: JSON.stringify(payload)
+      }}).then(function(r){{
+        if (!r.ok) throw new Error("Server error (" + r.status + ")");
+        return r.json();
+      }}).then(function(){{
+        localStorage.removeItem(STORAGE_KEY);
+        if (typeof gtag === "function") {{ gtag("event", "consult_intake_submitted", {{}}); }}
+        form.style.display = "none";
+        if (successEl) {{ successEl.style.display = "block"; successEl.scrollIntoView({{ behavior: "smooth", block: "center" }}); }}
+      }}).catch(function(err){{
+        /* Keep the draft in localStorage — do NOT clear it on error */
+        showMessage("error", "Something went wrong. Your answers are saved on this device — try again, or reply to your welcome email.");
+        submitBtn.disabled = false;
+        submitBtn.textContent = "Submit";
+        if (typeof gtag === "function") {{ gtag("event", "consult_intake_error", {{ error: err.message || "unknown" }}); }}
+      }});
+    }});
+  }}
+
+  if (typeof gtag === "function") {{ gtag("event", "consult_intake_page_view", {{}}); }}
+
+  restoreProgress();
+}})();
+</script>'''
+
+
+def generate_intake_page(external_assets: dict = None) -> str:
+    canonical_url = f"{SITE_BASE_URL}/consulting/intake/"
+
+    nav = build_nav()
+    header = build_header()
+    fields = build_fields()
+    buttons = build_submit_buttons()
+    success = build_success_state()
+    privacy = build_privacy()
+    footer = build_footer()
+    jsonld = build_jsonld()
+    intake_css = build_intake_css()
+    intake_js = build_intake_js()
+
+    if external_assets:
+        page_css = external_assets['css_tag']
+        inline_js = external_assets['js_tag']
+    else:
+        page_css = get_page_css()
+        inline_js = build_inline_js()
+
+    preload = get_preload_hints()
+
+    return f'''<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Consulting Intake | Gravel God</title>
+  <meta name="description" content="Twelve questions before your consult call — five minutes, save and come back.">
+  <meta name="robots" content="noindex, follow">
+  <link rel="canonical" href="{esc(canonical_url)}">
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  {preload}
+  {jsonld}
+  {page_css}
+  {intake_css}
+  {get_ga4_head_snippet()}
+  {get_ab_head_snippet()}
+</head>
+<body>
+
+<div class="gg-neo-brutalist-page">
+  {nav}
+
+  <div class="gg-intake-container">
+    {header}
+    <form id="intake-form" class="gg-intake-form-card" novalidate>
+      <input type="text" name="_honeypot" class="gg-intake-honeypot" tabindex="-1" autocomplete="off">
+      {fields}
+      {buttons}
+      <div id="intake-message" class="gg-intake-message hidden"></div>
+    </form>
+    {success}
+    {privacy}
+  </div>
+
+  {footer}
+</div>
+
+{inline_js}
+{intake_js}
+
+{get_consent_banner_html()}
+</body>
+</html>'''
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Gravel God consulting intake page")
+    parser.add_argument("--output-dir", default=str(OUTPUT_DIR), help="Output directory")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    assets = write_shared_assets(output_dir)
+
+    html_content = generate_intake_page(external_assets=assets)
+    output_file = output_dir / "consult-intake.html"
+    output_file.write_text(html_content, encoding="utf-8")
+    print(f"Generated {output_file} ({len(html_content):,} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/wordpress/generate_consult_intake.py
+++ b/wordpress/generate_consult_intake.py
@@ -99,11 +99,11 @@ def build_fields() -> str:
     </div>
     <div class="gg-intake-inline">
       <div class="gg-intake-group">
-        <label class="gg-intake-label" for="ftp">FTP</label>
+        <label class="gg-intake-label" for="ftp">Your threshold power (FTP), if you know it</label>
         <input type="text" id="ftp" name="ftp" placeholder="Watts, or &quot;don't know&quot;">
       </div>
       <div class="gg-intake-group">
-        <label class="gg-intake-label" for="lthr">LTHR</label>
+        <label class="gg-intake-label" for="lthr">Your threshold heart rate (LTHR), if you know it</label>
         <input type="text" id="lthr" name="lthr" placeholder="BPM, or &quot;don't know&quot;">
       </div>
     </div>
@@ -120,7 +120,7 @@ def build_fields() -> str:
       <textarea id="injuries_limits" name="injuries_limits" rows="2"></textarea>
     </div>
     <div class="gg-intake-group">
-      <label class="gg-intake-label" for="tp_email">TrainingPeaks login email</label>
+      <label class="gg-intake-label" for="tp_email">The email you sign in to TrainingPeaks with (or &quot;no TP&quot;)</label>
       <input type="text" id="tp_email" name="tp_email" placeholder="you@example.com, or &quot;no TP&quot;">
     </div>
     <div class="gg-intake-inline">

--- a/wordpress/generate_consulting.py
+++ b/wordpress/generate_consulting.py
@@ -3,8 +3,8 @@
 Generate the Gravel God Consulting landing page in neo-brutalist style.
 
 A brief, conversion-focused page for one-time 60-minute consulting calls.
-Covers race selection, training periodization, nutrition, gear, and season
-planning. No comparison to other products — this is a standalone service.
+Sultanic 8-beat copy (v2, docs/consulting-copy-v2.md): the read you can't
+give yourself, delivered before the call — not a race-selection grab bag.
 
 Uses brand tokens exclusively — zero hardcoded hex, no border-radius, no
 box-shadow, no bounce easing, no entrance animations.
@@ -37,7 +37,20 @@ OUTPUT_DIR = Path(__file__).parent / "output"
 CONSULTING_PRICE_INT = 150
 CONSULTING_PRICE = f"${CONSULTING_PRICE_INT}"
 CONSULTING_DURATION = "60 minutes"
+ADDON_PRICE_INT = 100
+ADDON_PRICE = f"${ADDON_PRICE_INT}"
 BOOKING_URL = "https://calendar.app.google/E282ZtBJAFBXYdYJ6"
+RACE_COUNT = "750+"
+PRIVACY_SENTENCE = (
+    "Your answers and training data are used only to prepare your consult "
+    "and any plan you buy; they aren&rsquo;t shared or sold and are deleted "
+    "on request."
+)
+COACHING_URL = f"{SITE_BASE_URL}/coaching/"
+QUIET_CLAUSE = (
+    f'If the consult turns into &ldquo;I want this every week&rdquo; '
+    f'&mdash; that&rsquo;s <a href="{COACHING_URL}">coaching</a>.'
+)
 
 
 def esc(text) -> str:
@@ -60,11 +73,11 @@ def build_nav() -> str:
 def build_hero() -> str:
     return f'''<section class="gg-consult-hero" id="hero">
   <div class="gg-consult-hero-inner">
-    <h1 class="gg-consult-hero-title">One Call. Clear Answers.</h1>
-    <p class="gg-consult-hero-subtitle">A focused {CONSULTING_DURATION} session to cut through the noise on race selection, training structure, nutrition, or season planning. You bring the questions &mdash; I bring the data. One call replaces weeks of forum threads and YouTube rabbit holes.</p>
+    <h1 class="gg-consult-hero-title">The read you can&rsquo;t give yourself.</h1>
+    <p class="gg-consult-hero-subtitle">Sixty minutes with a coach who has already been through your last six months of riding &mdash; the files, not the summary &mdash; and a written plan of action within 48 hours.</p>
     <div class="gg-consult-hero-price">
       <span class="gg-consult-price-tag">{CONSULTING_PRICE}</span>
-      <span class="gg-consult-price-detail">{CONSULTING_DURATION} &middot; 1-on-1 video call</span>
+      <span class="gg-consult-price-detail">{CONSULTING_DURATION} &middot; your training reviewed before we talk</span>
     </div>
     <form id="checkout" class="gg-consult-form" novalidate>
       <div class="gg-consult-form-row">
@@ -75,128 +88,170 @@ def build_hero() -> str:
         <label class="gg-consult-form-label" for="consult-email">Email</label>
         <input type="email" id="consult-email" name="email" required aria-required="true" placeholder="you@example.com" autocomplete="email">
       </div>
+      <div class="gg-consult-form-row gg-consult-form-checkbox-row">
+        <label class="gg-consult-checkbox-label" for="consult-addon">
+          <input type="checkbox" id="consult-addon" name="plan_addon">
+          <span>Add a custom 12-week plan built from the consult (+{ADDON_PRICE})</span>
+        </label>
+      </div>
       <input type="text" name="_honeypot" style="display:none" tabindex="-1" autocomplete="off">
-      <button type="submit" class="gg-consult-form-submit gg-consult-btn-gold" data-cta="hero_book">Pay &amp; Book &mdash; {CONSULTING_PRICE}</button>
+      <button type="submit" class="gg-consult-form-submit gg-consult-btn-gold" data-cta="hero_book">Book the consult &mdash; {CONSULTING_PRICE}</button>
       <div class="gg-consult-form-message" role="alert" aria-live="polite" style="display:none"></div>
     </form>
   </div>
 </section>'''
 
 
-def build_what_you_get() -> str:
-    items = [
-        (
-            "Pre-Call Prep",
-            "Fill out a short intake so I review your background, goals, and questions before we talk. No time wasted on basics. You show up, we go deep immediately.",
-        ),
-        (
-            "60-Minute Deep Dive",
-            "Live video call covering whatever you need: race selection, periodization, fueling strategy, gear decisions, race-day execution.",
-        ),
-        (
-            "Written Action Plan",
-            "Within 48 hours you get a summary email with specific recommendations, resources, and next steps you can act on immediately.",
-        ),
-    ]
-    cards = ""
-    for title, desc in items:
-        cards += f'''<div class="gg-consult-card">
-      <h3 class="gg-consult-card-title">{esc(title)}</h3>
-      <p class="gg-consult-card-desc">{esc(desc)}</p>
-    </div>
-'''
-    return f'''<section class="gg-consult-section" id="what-you-get">
-  <h2 class="gg-consult-section-title">What You Get</h2>
-  <div class="gg-consult-cards">
-    {cards}
+def build_two_futures() -> str:
+    return f'''<section class="gg-consult-section gg-consult-section--alt" id="two-futures">
+  <h2 class="gg-consult-section-title">Two futures</h2>
+  <div class="gg-consult-prose">
+    <p>Two ways to spend the next twelve weeks.</p>
+    <p>In one, you keep doing what got you here &mdash; the plan off a forum, the intervals you like, the long ride you always do &mdash; and hope it adds up by race day.</p>
+    <p>In the other, someone who reads training files for a living has already seen what your last six months actually were, and tells you the one thing that would change the most.</p>
+    <p class="gg-consult-prose-emphasis">Same bike. Same hours. Different twelve weeks.</p>
   </div>
 </section>'''
+
+
+def _strip_glyph(kind: str) -> str:
+    """Return the inline SVG markup for one how-it-works frame glyph.
+    Decorative only — styled entirely via CSS classes (no var() in SVG attrs)."""
+    if kind == "calendar":
+        return '''<rect class="gg-consult-strip-glyph-shape" x="-16" y="-14" width="32" height="26"></rect>
+      <line class="gg-consult-strip-glyph-shape" x1="-16" y1="-6" x2="16" y2="-6"></line>
+      <line class="gg-consult-strip-glyph-shape" x1="-9" y1="-18" x2="-9" y2="-10"></line>
+      <line class="gg-consult-strip-glyph-shape" x1="9" y1="-18" x2="9" y2="-10"></line>'''
+    if kind == "link":
+        return '''<circle class="gg-consult-strip-glyph-shape" cx="-7" cy="-7" r="10"></circle>
+      <circle class="gg-consult-strip-glyph-shape" cx="7" cy="7" r="10"></circle>'''
+    if kind == "form":
+        return '''<rect class="gg-consult-strip-glyph-shape" x="-14" y="-18" width="28" height="36"></rect>
+      <line class="gg-consult-strip-glyph-shape" x1="-8" y1="-9" x2="8" y2="-9"></line>
+      <line class="gg-consult-strip-glyph-shape" x1="-8" y1="1" x2="8" y2="1"></line>
+      <line class="gg-consult-strip-glyph-shape" x1="-8" y1="11" x2="3" y2="11"></line>'''
+    if kind == "magnifier":
+        return '''<polyline class="gg-consult-strip-glyph-shape" points="-18,10 -8,-6 2,6 12,-10 18,2"></polyline>
+      <circle class="gg-consult-strip-glyph-shape gg-consult-strip-glyph-lens" cx="4" cy="-4" r="11"></circle>
+      <line class="gg-consult-strip-glyph-shape" x1="12" y1="4" x2="20" y2="12"></line>'''
+    if kind == "document":
+        return '''<path class="gg-consult-strip-glyph-shape" d="M -12 -18 H 6 L 14 -10 V 18 H -12 Z"></path>
+      <path class="gg-consult-strip-glyph-shape" d="M 6 -18 V -10 H 14"></path>
+      <line class="gg-consult-strip-glyph-shape" x1="-6" y1="-2" x2="8" y2="-2"></line>
+      <line class="gg-consult-strip-glyph-shape" x1="-6" y1="6" x2="8" y2="6"></line>'''
+    return ""
 
 
 def build_how_it_works() -> str:
-    steps = [
-        ("1", "Pay &amp; Schedule", f'Checkout takes 30 seconds. After payment, <a href="{BOOKING_URL}" target="_blank" rel="noopener">pick a time on the calendar</a>. A short intake form captures your background so we hit the ground running.'),
-        ("2", "We Talk", "60 minutes, video call, no fluff. Bring your training files, race shortlist, or whatever needs sorting out."),
-        ("3", "Get Your Plan", "Within 48 hours, a written action plan lands in your inbox. Specific, actionable, referenced to data."),
+    frames = [
+        ("calendar", "Book.", "Thirty seconds. You get a welcome email with three links.", False),
+        ("link", "Connect your TrainingPeaks.", "One click, sign in, tap Accept &mdash; I can now see your rides. No TrainingPeaks? Send me your files or a Strava link instead.", False),
+        ("form", "Answer twelve questions.", "Your goal event, your hours, the one thing you most want answered. Five minutes.", False),
+        ("magnifier", "Your read arrives &mdash; before we talk.", "I go through how you have actually been riding, not how you meant to. Then we get on a call and skip the basics.", True),
+        ("document", "Sixty minutes, then a written plan of action within 48 hours.", "Specific. Referenced to your own data. Yours to keep.", False),
     ]
-    html_steps = ""
-    for num, title, desc in steps:
-        html_steps += f'''<div class="gg-consult-step">
-      <span class="gg-consult-step-num">{num}</span>
-      <div class="gg-consult-step-body">
-        <h3 class="gg-consult-step-title">{title}</h3>
-        <p class="gg-consult-step-desc">{desc}</p>
-      </div>
+    xs = [90, 270, 450, 630, 810]
+
+    svg_frames = ""
+    for (kind, _title, _desc, emphasis), x in zip(frames, xs):
+        frame_class = "gg-consult-strip-frame gg-consult-strip-frame--emphasis" if emphasis else "gg-consult-strip-frame"
+        svg_frames += f'''<g class="{frame_class}" transform="translate({x},50)">
+      <circle class="gg-consult-strip-disc" r="26"></circle>
+      {_strip_glyph(kind)}
+    </g>
+    '''
+
+    captions = ""
+    for _kind, title, desc, emphasis in frames:
+        cap_class = "gg-consult-strip-caption gg-consult-strip-caption--emphasis" if emphasis else "gg-consult-strip-caption"
+        captions += f'''<div class="{cap_class}">
+      <strong>{title}</strong> {desc}
     </div>
-'''
-    return f'''<section class="gg-consult-section gg-consult-section--alt" id="how-it-works">
-  <h2 class="gg-consult-section-title">How It Works</h2>
-  <div class="gg-consult-steps">
-    {html_steps}
+    '''
+
+    return f'''<section class="gg-consult-section" id="how-it-works">
+  <h2 class="gg-consult-section-title">How it works</h2>
+  <div class="gg-consult-strip">
+    <svg class="gg-consult-strip-svg" viewBox="0 0 900 100" aria-hidden="true" focusable="false">
+      <line class="gg-consult-strip-rail" x1="50" y1="50" x2="850" y2="50"></line>
+      {svg_frames}
+    </svg>
+    <div class="gg-consult-strip-captions">
+      {captions}
+    </div>
   </div>
 </section>'''
 
 
-def build_topics() -> str:
-    topics = [
-        "Race selection &mdash; which events match your fitness, goals, and schedule",
-        "Season planning &mdash; building a race calendar that makes sense",
-        "Training structure &mdash; periodization, volume, intensity distribution",
-        "Nutrition &amp; fueling &mdash; race-day strategy and daily habits",
-        "Gear &amp; setup &mdash; tire selection, bike fit considerations, kit choices",
-        "Race-day execution &mdash; pacing, logistics, contingency planning",
+def build_what_i_look_at() -> str:
+    items = [
+        "<strong>How much of your hard riding was actually hard.</strong> Long sustained efforts and short surges look the same in a weekly total. They train very different things. I separate them.",
+        "<strong>Whether your fitness is climbing, flat, or quietly sliding</strong> &mdash; and how the last three months compare to the same stretch last year.",
+        "<strong>Whether your long rides are getting easier deep in</strong>, or whether the last hour still costs you more than the first.",
+        "<strong>When you last tested yourself, and whether the numbers your zones are built on are still true.</strong> Most people&rsquo;s aren&rsquo;t.",
+        "<strong>Where your training doesn&rsquo;t match the event you&rsquo;re training for.</strong>",
     ]
-    items = "\n".join(f'      <li>{t}</li>' for t in topics)
-    return f'''<section class="gg-consult-section" id="topics">
-  <h2 class="gg-consult-section-title">What We Can Cover</h2>
-  <ul class="gg-consult-topics">
-{items}
+    list_items = "\n".join(f'      <li>{item}</li>' for item in items)
+    return f'''<section class="gg-consult-section gg-consult-section--alt" id="look">
+  <h2 class="gg-consult-section-title">What I actually look at</h2>
+  <ul class="gg-consult-look-list">
+{list_items}
   </ul>
-  <p class="gg-consult-topics-note">Not sure if your question fits? It probably does. Book it and ask.</p>
+  <p class="gg-consult-look-note">You&rsquo;ll get the answers in plain English, with the numbers behind them if you want them.</p>
 </section>'''
 
 
-def build_bio() -> str:
-    return f'''<section class="gg-consult-section" id="who">
-  <h2 class="gg-consult-section-title">Who You&rsquo;ll Talk To</h2>
-  <div class="gg-consult-bio">
-    <div class="gg-consult-bio-text">
-      <p>I&rsquo;m Matti. 12 years at TrainingPeaks, 100+ athletes coached, 1,000+ training plans sold. I&rsquo;ve raced at the national level and I&rsquo;ve blown up at mile 80 enough times to know what bad pacing actually costs you.</p>
-      <p>I built a database of 328 gravel races &mdash; terrain breakdowns, suffering zones, altitude profiles, segment-by-segment pacing data. When you ask &ldquo;which race should I do?&rdquo; or &ldquo;how do I fuel for this course?,&rdquo; the answer comes from data, not vibes.</p>
-    </div>
+def build_what_we_cover() -> str:
+    topics = [
+        "Race selection",
+        "Season planning",
+        "How your week should be built",
+        "Fuelling",
+        "Bike and gear choices",
+        "Race-day execution",
+        "What to do about the thing that keeps going wrong",
+    ]
+    items = " &middot; ".join(topics)
+    return f'''<section class="gg-consult-section" id="cover">
+  <h2 class="gg-consult-section-title">What we can cover</h2>
+  <p class="gg-consult-cover-list">{items}</p>
+  <p class="gg-consult-cover-note">Not sure your question fits? It probably does. Book it and ask.</p>
+</section>'''
+
+
+def build_plan_addon() -> str:
+    return f'''<section class="gg-consult-section gg-consult-section--alt" id="plan">
+  <h2 class="gg-consult-section-title">The plan, if you want it (+{ADDON_PRICE})</h2>
+  <div class="gg-consult-prose">
+    <p>Most people leave the call knowing what to change. Some want it built.</p>
+    <p><strong>Custom plan add-on &mdash; {ADDON_PRICE}.</strong> A twelve-week plan built from your consult and your data &mdash; not a template with your name on it &mdash; loaded onto your TrainingPeaks calendar within a week of the call, with one round of adjustments in the first fortnight.</p>
+    <p>The honest limits: one goal event, up to twelve weeks. If your race is further out, we build the last twelve before it (or the next twelve &mdash; your call). Longer than that is coaching, and I&rsquo;ll say so. Available for seven days after the call; after that it&rsquo;s the store price.</p>
   </div>
 </section>'''
 
 
-def build_testimonials() -> str:
-    testimonials = [
-        (
-            "Andrew T.",
-            "One call. That&rsquo;s all it took to completely change my race calendar. Matti walked me through why Gravel Locos was a better fit than Unbound for my first 150-miler. Best decision I made all year.",
-            "Gravel Locos finisher &middot; First 150-miler",
-        ),
-        (
-            "Jen H.",
-            "I booked a consult because I was cramping at mile 80 in every single race. Matti broke down my sodium math in about ten minutes and I haven&rsquo;t cramped once since. That&rsquo;s $150 well spent.",
-            "Unbound 200 finisher &middot; 8 hrs/week",
-        ),
-        (
-            "Katie B.",
-            "Everyone told me I needed more volume for Crusher. Matti looked at my numbers and said I needed better pacing, not more hours. He was right. Finished on 8 hours a week.",
-            "Crusher in the Tushar &middot; Marketing director",
-        ),
-    ]
-    cards = ""
-    for name, quote, meta in testimonials:
-        cards += f'''<blockquote class="gg-consult-testimonial">
-      <p>{quote}</p>
-      <footer><strong>{esc(name)}</strong><span class="gg-consult-testimonial-meta">{meta}</span></footer>
-    </blockquote>
-'''
-    return f'''<section class="gg-consult-section gg-consult-section--alt" id="testimonials">
-  <h2 class="gg-consult-section-title">What Athletes Say</h2>
-  <div class="gg-consult-testimonials">
-    {cards}
+def build_who() -> str:
+    return f'''<section class="gg-consult-section" id="who">
+  <h2 class="gg-consult-section-title">Who you&rsquo;ll talk to</h2>
+  <div class="gg-consult-bio-text">
+    <p>I&rsquo;m Matti. Twelve years at TrainingPeaks, 100+ athletes coached, 1,000+ training plans sold. I&rsquo;ve raced at the national level and blown up at mile 80 enough times to know what bad pacing actually costs.</p>
+    <p>I built a database of {RACE_COUNT} gravel races &mdash; terrain, climbing, altitude, how they tend to be won and lost. When you ask &ldquo;which race should I do?&rdquo; or &ldquo;how do I fuel for this one?&rdquo;, the answer comes from that, not from vibes.</p>
+  </div>
+</section>'''
+
+
+def build_fit() -> str:
+    return f'''<section class="gg-consult-section gg-consult-section--alt" id="fit">
+  <h2 class="gg-consult-section-title">Is this for you?</h2>
+  <div class="gg-consult-fit-grid">
+    <div class="gg-consult-fit-col gg-consult-fit-for">
+      <h3 class="gg-consult-fit-title">For you if</h3>
+      <p>you have a goal event and real questions &middot; you&rsquo;ll connect your TrainingPeaks or send files &middot; you want an answer, not reassurance.</p>
+    </div>
+    <div class="gg-consult-fit-col gg-consult-fit-not">
+      <h3 class="gg-consult-fit-title">Not for you if</h3>
+      <p>you want a pep talk &middot; you want to be told the plan you&rsquo;re on is fine. (It might be. I&rsquo;ll say so &mdash; and I&rsquo;ll say what isn&rsquo;t.)</p>
+    </div>
   </div>
 </section>'''
 
@@ -204,44 +259,53 @@ def build_testimonials() -> str:
 def build_faq() -> str:
     faqs = [
         (
-            "Who is this for?",
-            "Anyone racing or considering gravel events who wants focused, data-informed guidance without committing to ongoing coaching. Works for first-timers and experienced riders alike.",
-        ),
-        (
             "What happens after I pay?",
-            "You land on a confirmation page with a link to pick your session time. You also get a confirmation email with a short intake form. Fill it out before the call so I can review your situation in advance.",
+            "A welcome email with three links: pick your time, answer the twelve questions, connect your TrainingPeaks. Do all three and I&rsquo;ll have your read done before we talk.",
         ),
         (
-            "Can I record the call?",
-            "Yes. You are welcome to record for personal reference.",
+            "I don&rsquo;t use TrainingPeaks.",
+            "Reply to the welcome email with a Strava link or your last three months of ride files. Same read, one extra step.",
+        ),
+        (
+            "Do I have to share data?",
+            "No &mdash; the call is still worth it. But the read is what makes this different from every other hour you could buy.",
         ),
         (
             "What if I need more than one session?",
-            "Book another one. Each session is standalone &mdash; no packages, no subscriptions, no pressure.",
+            "Book another. Each one stands alone &mdash; no packages, no subscriptions.",
+        ),
+        (
+            "Can I add the plan later?",
+            f"Yes, for seven days after the call. The offer is in your plan-of-action email.",
+        ),
+        (
+            "What happens to my data?",
+            PRIVACY_SENTENCE,
         ),
     ]
     faq_html = ""
     for q, a in faqs:
         faq_html += f'''<div class="gg-consult-faq-item">
-      <button class="gg-consult-faq-q" aria-expanded="false">{esc(q)}</button>
-      <div class="gg-consult-faq-a">{esc(a)}</div>
+      <button class="gg-consult-faq-q" aria-expanded="false">{q}</button>
+      <div class="gg-consult-faq-a">{a}</div>
     </div>
 '''
-    return f'''<section class="gg-consult-section gg-consult-section--alt" id="faq">
-  <h2 class="gg-consult-section-title">FAQ</h2>
+    return f'''<section class="gg-consult-section" id="faq">
+  <h2 class="gg-consult-section-title">Questions</h2>
   <div class="gg-consult-faqs">
     {faq_html}
   </div>
 </section>'''
 
 
-def build_final_cta() -> str:
-    return f'''<section class="gg-consult-cta" id="final-cta">
+def build_close() -> str:
+    return f'''<section class="gg-consult-cta" id="close">
   <div class="gg-consult-cta-inner">
-    <h2 class="gg-consult-cta-title">Stop Guessing. Start Racing Smarter.</h2>
-    <p class="gg-consult-cta-desc">{CONSULTING_PRICE} &middot; {CONSULTING_DURATION} &middot; Action plan included</p>
-    <p class="gg-consult-cta-context">Less than a race entry fee. More useful than 40 hours of forum threads.</p>
-    <a href="#checkout" class="gg-consult-btn-gold" data-cta="final_book">Book Your Consult</a>
+    <h2 class="gg-consult-cta-title">Less than a race entry. More useful than the forum.</h2>
+    <p class="gg-consult-cta-context">You already know what it feels like to start a race unsure the training was right. Sixty minutes to trade that for knowing.</p>
+    <p class="gg-consult-cta-desc">{CONSULTING_PRICE} &middot; {CONSULTING_DURATION} &middot; written plan of action included</p>
+    <a href="#checkout" class="gg-consult-btn-gold" data-cta="final_book">Book the consult &mdash; {CONSULTING_PRICE}</a>
+    <p class="gg-consult-cta-quiet">{QUIET_CLAUSE}</p>
   </div>
 </section>'''
 
@@ -348,86 +412,88 @@ def build_consulting_css() -> str:
   text-align: center;
 }}
 
-/* ── Cards (What You Get) ── */
-.gg-consult-cards {{
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--gg-spacing-md);
-}}
-.gg-consult-card {{
-  padding: var(--gg-spacing-lg);
-  background: var(--gg-color-warm-paper);
-  border: 2px solid var(--gg-color-dark-brown);
-}}
-.gg-consult-card-title {{
-  font-family: var(--gg-font-data);
-  font-size: var(--gg-font-size-sm);
-  font-weight: var(--gg-font-weight-bold);
-  letter-spacing: var(--gg-letter-spacing-wide);
-  color: var(--gg-color-dark-brown);
-  text-transform: uppercase;
-  margin: 0 0 var(--gg-spacing-sm) 0;
-}}
-.gg-consult-card-desc {{
+/* ── Prose (Two futures / Plan add-on) ── */
+.gg-consult-prose p {{
   font-family: var(--gg-font-editorial);
   font-size: var(--gg-font-size-sm);
   line-height: var(--gg-line-height-prose);
   color: var(--gg-color-primary-brown);
-  margin: 0;
+  margin: 0 0 var(--gg-spacing-md) 0;
+}}
+.gg-consult-prose p:last-child {{ margin-bottom: 0; }}
+.gg-consult-prose-emphasis {{
+  font-weight: var(--gg-font-weight-bold);
+  color: var(--gg-color-dark-brown) !important;
 }}
 
-/* ── Steps (How It Works) ── */
-.gg-consult-steps {{
+/* ── How It Works strip ── */
+.gg-consult-strip {{
   display: flex;
   flex-direction: column;
   gap: var(--gg-spacing-lg);
 }}
-.gg-consult-step {{
-  display: flex;
-  gap: var(--gg-spacing-md);
-  align-items: flex-start;
+.gg-consult-strip-svg {{
+  width: 100%;
+  height: auto;
+  display: block;
 }}
-.gg-consult-step-num {{
-  flex-shrink: 0;
-  width: 48px;
-  height: 48px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--gg-font-data);
-  font-size: 20px;
-  font-weight: var(--gg-font-weight-bold);
-  color: var(--gg-color-dark-brown);
-  background: var(--gg-color-light-gold);
-  border: 2px solid var(--gg-color-dark-brown);
+.gg-consult-strip-rail {{
+  stroke: var(--gg-color-secondary-brown);
+  stroke-width: 2;
 }}
-.gg-consult-step-title {{
-  font-family: var(--gg-font-data);
-  font-size: var(--gg-font-size-sm);
-  font-weight: var(--gg-font-weight-bold);
-  letter-spacing: var(--gg-letter-spacing-wide);
-  color: var(--gg-color-dark-brown);
-  text-transform: uppercase;
-  margin: 0 0 var(--gg-spacing-xs) 0;
+.gg-consult-strip-disc {{
+  fill: var(--gg-color-warm-paper);
+  stroke: var(--gg-color-dark-brown);
+  stroke-width: 2;
 }}
-.gg-consult-step-desc {{
-  font-family: var(--gg-font-editorial);
-  font-size: var(--gg-font-size-sm);
-  line-height: var(--gg-line-height-prose);
-  color: var(--gg-color-primary-brown);
-  margin: 0;
+.gg-consult-strip-glyph-shape {{
+  fill: none;
+  stroke: var(--gg-color-dark-brown);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }}
-
-/* ── Topics ── */
-.gg-consult-topics {{
-  list-style: none;
-  padding: 0;
-  margin: 0 0 var(--gg-spacing-md) 0;
+.gg-consult-strip-glyph-lens {{
+  fill: var(--gg-color-warm-paper);
+}}
+.gg-consult-strip-frame--emphasis .gg-consult-strip-disc {{
+  fill: var(--gg-color-light-gold);
+  stroke-width: 3;
+}}
+.gg-consult-strip-frame--emphasis .gg-consult-strip-glyph-shape {{
+  stroke-width: 3;
+}}
+.gg-consult-strip-captions {{
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(5, 1fr);
   gap: var(--gg-spacing-sm);
 }}
-.gg-consult-topics li {{
+.gg-consult-strip-caption {{
+  font-family: var(--gg-font-editorial);
+  font-size: var(--gg-font-size-xs);
+  line-height: var(--gg-line-height-prose);
+  color: var(--gg-color-primary-brown);
+  text-align: center;
+}}
+.gg-consult-strip-caption strong {{
+  display: block;
+  color: var(--gg-color-dark-brown);
+  margin-bottom: var(--gg-spacing-2xs);
+}}
+.gg-consult-strip-caption--emphasis strong {{
+  color: var(--gg-color-gold);
+}}
+
+/* ── What I Actually Look At ── */
+.gg-consult-look-list {{
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--gg-spacing-lg) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gg-spacing-md);
+}}
+.gg-consult-look-list li {{
   font-family: var(--gg-font-editorial);
   font-size: var(--gg-font-size-sm);
   line-height: var(--gg-line-height-prose);
@@ -435,7 +501,25 @@ def build_consulting_css() -> str:
   padding-left: var(--gg-spacing-md);
   border-left: 3px solid var(--gg-color-gold);
 }}
-.gg-consult-topics-note {{
+.gg-consult-look-note {{
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-xs);
+  color: var(--gg-color-secondary-brown);
+  text-align: center;
+  letter-spacing: var(--gg-letter-spacing-wide);
+  margin: 0;
+}}
+
+/* ── What We Cover ── */
+.gg-consult-cover-list {{
+  font-family: var(--gg-font-editorial);
+  font-size: var(--gg-font-size-sm);
+  line-height: var(--gg-line-height-prose);
+  color: var(--gg-color-dark-brown);
+  text-align: center;
+  margin: 0 0 var(--gg-spacing-md) 0;
+}}
+.gg-consult-cover-note {{
   font-family: var(--gg-font-data);
   font-size: var(--gg-font-size-xs);
   color: var(--gg-color-secondary-brown);
@@ -483,7 +567,41 @@ def build_consulting_css() -> str:
   padding-bottom: var(--gg-spacing-md);
 }}
 
-/* ── Final CTA ── */
+/* ── Is This For You ── */
+.gg-consult-fit-grid {{
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--gg-spacing-md);
+}}
+.gg-consult-fit-col {{
+  padding: var(--gg-spacing-lg);
+  background: var(--gg-color-warm-paper);
+  border-left: 3px solid var(--gg-color-secondary-brown);
+}}
+.gg-consult-fit-for {{
+  border-left-color: var(--gg-color-teal);
+}}
+.gg-consult-fit-not {{
+  border-left-color: var(--gg-color-warm-brown);
+}}
+.gg-consult-fit-title {{
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-sm);
+  font-weight: var(--gg-font-weight-bold);
+  letter-spacing: var(--gg-letter-spacing-wide);
+  color: var(--gg-color-dark-brown);
+  text-transform: uppercase;
+  margin: 0 0 var(--gg-spacing-sm) 0;
+}}
+.gg-consult-fit-col p {{
+  font-family: var(--gg-font-editorial);
+  font-size: var(--gg-font-size-sm);
+  line-height: var(--gg-line-height-prose);
+  color: var(--gg-color-primary-brown);
+  margin: 0;
+}}
+
+/* ── Close ── */
 .gg-consult-cta {{
   padding: var(--gg-spacing-2xl) var(--gg-spacing-xl);
   text-align: center;
@@ -500,6 +618,12 @@ def build_consulting_css() -> str:
   color: var(--gg-color-white);
   margin: 0 0 var(--gg-spacing-sm) 0;
 }}
+.gg-consult-cta-context {{
+  font-family: var(--gg-font-editorial);
+  font-size: var(--gg-font-size-sm);
+  color: var(--gg-color-tan);
+  margin: 0 0 var(--gg-spacing-md) 0;
+}}
 .gg-consult-cta-desc {{
   font-family: var(--gg-font-data);
   font-size: var(--gg-font-size-xs);
@@ -508,13 +632,18 @@ def build_consulting_css() -> str:
   text-transform: uppercase;
   margin: 0 0 var(--gg-spacing-lg) 0;
 }}
-
-.gg-consult-cta-context {{
-  font-family: var(--gg-font-editorial);
-  font-size: var(--gg-font-size-sm);
-  font-style: italic;
+.gg-consult-cta-quiet {{
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-2xs);
   color: var(--gg-color-tan);
-  margin: 0 0 var(--gg-spacing-lg) 0;
+  margin: var(--gg-spacing-lg) 0 0 0;
+}}
+.gg-consult-cta-quiet a {{
+  color: var(--gg-color-light-gold);
+  transition: color var(--gg-transition-hover);
+}}
+.gg-consult-cta-quiet a:hover {{
+  color: var(--gg-color-white);
 }}
 
 /* ── Breadcrumb (shared pattern) ── */
@@ -571,6 +700,22 @@ def build_consulting_css() -> str:
   outline: none;
   border-color: var(--gg-color-gold);
 }}
+.gg-consult-form-checkbox-row {{
+  display: flex;
+}}
+.gg-consult-checkbox-label {{
+  display: flex;
+  align-items: flex-start;
+  gap: var(--gg-spacing-xs);
+  font-family: var(--gg-font-data);
+  font-size: var(--gg-font-size-xs);
+  color: var(--gg-color-primary-brown);
+  cursor: pointer;
+}}
+.gg-consult-checkbox-label input[type="checkbox"] {{
+  margin-top: 2px;
+  flex-shrink: 0;
+}}
 .gg-consult-form-submit {{
   width: 100%;
   cursor: pointer;
@@ -610,49 +755,10 @@ def build_consulting_css() -> str:
   margin-bottom: 0;
 }}
 
-/* ── Testimonials ── */
-.gg-consult-testimonials {{
-  display: flex;
-  flex-direction: column;
-  gap: var(--gg-spacing-md);
-  max-width: 640px;
-  margin: 0 auto;
-}}
-.gg-consult-testimonial {{
-  padding: var(--gg-spacing-lg);
-  background: var(--gg-color-warm-paper);
-  border: 2px solid var(--gg-color-dark-brown);
-  margin: 0;
-}}
-.gg-consult-testimonial p {{
-  font-family: var(--gg-font-editorial);
-  font-size: var(--gg-font-size-sm);
-  line-height: var(--gg-line-height-prose);
-  color: var(--gg-color-dark-brown);
-  margin: 0 0 var(--gg-spacing-sm) 0;
-  font-style: italic;
-}}
-.gg-consult-testimonial footer {{
-  font-family: var(--gg-font-data);
-  font-size: var(--gg-font-size-xs);
-  color: var(--gg-color-dark-brown);
-  letter-spacing: var(--gg-letter-spacing-wide);
-}}
-.gg-consult-testimonial footer strong {{
-  display: block;
-  text-transform: uppercase;
-  margin-bottom: var(--gg-spacing-2xs);
-}}
-.gg-consult-testimonial-meta {{
-  display: block;
-  color: var(--gg-color-secondary-brown);
-  font-size: var(--gg-font-size-2xs);
-}}
-
 /* ── Responsive ── */
 @media (max-width: 768px) {{
-  .gg-consult-cards {{ grid-template-columns: 1fr; }}
-  .gg-consult-topics {{ grid-template-columns: 1fr; }}
+  .gg-consult-fit-grid {{ grid-template-columns: 1fr; }}
+  .gg-consult-strip-captions {{ grid-template-columns: 1fr; }}
   .gg-consult-hero {{ padding: var(--gg-spacing-xl) var(--gg-spacing-md); }}
   .gg-consult-section {{ padding: var(--gg-spacing-lg) var(--gg-spacing-md); }}
   .gg-consult-cta {{ padding: var(--gg-spacing-xl) var(--gg-spacing-md); }}
@@ -682,7 +788,7 @@ def build_consulting_js() -> str:
   /* Scroll depth */
   if('IntersectionObserver' in window){{
     var fired={{}};
-    var map={{'hero':'0_hero','what-you-get':'14_what_you_get','who':'28_who','topics':'42_topics','how-it-works':'57_how_it_works','testimonials':'71_testimonials','faq':'85_faq','final-cta':'100_final_cta'}};
+    var map={{'hero':'0_hero','two-futures':'12_two_futures','how-it-works':'25_how_it_works','look':'37_look','cover':'50_cover','plan':'62_plan','who':'75_who','fit':'87_fit','faq':'93_faq','close':'100_close'}};
     var obs=new IntersectionObserver(function(entries){{
       entries.forEach(function(e){{
         if(e.isIntersecting&&!fired[e.target.id]){{
@@ -699,7 +805,7 @@ def build_consulting_js() -> str:
   /* ── Checkout form ── */
   var CHECKOUT_API='https://athlete-custom-training-plan-pipeline-production.up.railway.app/api/create-consulting-checkout';
   var CHECKOUT_PRICE={CONSULTING_PRICE_INT};
-  var CHECKOUT_BTN_LABEL='Pay & Book \u2014 ${CONSULTING_PRICE_INT}';
+  var CHECKOUT_BTN_LABEL='Book the consult — ${CONSULTING_PRICE_INT}';
   var checkoutForm=document.getElementById('checkout');
   var checkoutMsg=checkoutForm?checkoutForm.querySelector('.gg-consult-form-message'):null;
   var checkoutBtn=checkoutForm?checkoutForm.querySelector('.gg-consult-form-submit'):null;
@@ -722,6 +828,8 @@ def build_consulting_js() -> str:
       var nameVal=checkoutForm.querySelector('input[name="name"]').value.trim();
       var emailVal=checkoutForm.querySelector('input[name="email"]').value.trim();
       var honeypot=checkoutForm.querySelector('input[name="_honeypot"]').value;
+      var addonInput=checkoutForm.querySelector('input[name="plan_addon"]');
+      var planAddon=addonInput?addonInput.checked:false;
       if(honeypot)return;
       if(!nameVal||!emailVal){{
         showCheckoutError('Please fill in your name and email.');
@@ -736,12 +844,12 @@ def build_consulting_js() -> str:
       checkoutBtn.textContent='Preparing checkout...';
       checkoutMsg.style.display='none';
 
-      if(typeof gtag==='function'){{gtag('event','begin_checkout',{{currency:'USD',value:CHECKOUT_PRICE,items:[{{item_name:'Consulting Session'}}]}})}}
+      if(typeof gtag==='function'){{gtag('event','begin_checkout',{{currency:'USD',value:planAddon?CHECKOUT_PRICE+{ADDON_PRICE_INT}:CHECKOUT_PRICE,items:[{{item_name:'Consulting Session'}}],plan_addon:planAddon}})}}
 
       fetch(CHECKOUT_API,{{
         method:'POST',
         headers:{{'Content-Type':'application/json'}},
-        body:JSON.stringify({{name:nameVal,email:emailVal,hours:1}})
+        body:JSON.stringify({{name:nameVal,email:emailVal,hours:1,plan_addon:planAddon}})
       }})
       .then(function(r){{
         if(!r.ok)throw new Error('Server error ('+r.status+'). Please try again.');
@@ -783,12 +891,12 @@ def build_jsonld() -> str:
     "name": "Gravel God Cycling",
     "url": "{SITE_BASE_URL}"
   }},
-  "description": "One-on-one consulting for gravel race selection, training structure, nutrition, and season planning.",
+  "description": "One-on-one gravel training consulting: a coach's read of your last six months of riding, plus a written plan of action.",
   "offers": {{
     "@type": "Offer",
     "price": "{CONSULTING_PRICE_INT}",
     "priceCurrency": "USD",
-    "description": "60-minute 1-on-1 video consultation with written action plan"
+    "description": "60-minute 1-on-1 video consultation with written plan of action"
   }},
   "url": "{SITE_BASE_URL}/consulting/"
 }}
@@ -800,13 +908,15 @@ def generate_consulting_page(external_assets: dict = None) -> str:
 
     nav = build_nav()
     hero = build_hero()
-    what = build_what_you_get()
-    bio = build_bio()
-    topics = build_topics()
+    two_futures = build_two_futures()
     how = build_how_it_works()
-    testimonials = build_testimonials()
+    look = build_what_i_look_at()
+    cover = build_what_we_cover()
+    plan = build_plan_addon()
+    who = build_who()
+    fit = build_fit()
     faq = build_faq()
-    final_cta = build_final_cta()
+    close = build_close()
     footer = build_footer()
     consulting_css = build_consulting_css()
     consulting_js = build_consulting_js()
@@ -819,10 +929,10 @@ def generate_consulting_page(external_assets: dict = None) -> str:
         page_css = get_page_css()
         inline_js = build_inline_js()
 
-    meta_desc = f"60-minute gravel race consulting call. Race selection, training structure, nutrition, and season planning. {CONSULTING_PRICE} with written action plan included."
+    meta_desc = f"Sixty minutes with a coach who has already read your last six months of training. {CONSULTING_PRICE} with a written plan of action within 48 hours."
 
     og_tags = f'''<meta property="og:title" content="Consulting | Gravel God">
-  <meta property="og:description" content="60-minute gravel race consulting. Race selection, training, nutrition, and season planning.">
+  <meta property="og:description" content="The read you can't give yourself. Sixty minutes, your training reviewed before we talk, a written plan of action after.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="{esc(canonical_url)}">
   <meta property="og:image" content="{SITE_BASE_URL}/og/homepage.jpg">
@@ -831,7 +941,7 @@ def generate_consulting_page(external_assets: dict = None) -> str:
   <meta property="og:site_name" content="Gravel God Cycling">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Consulting | Gravel God">
-  <meta name="twitter:description" content="60-minute gravel race consulting. Race selection, training, nutrition, and season planning.">
+  <meta name="twitter:description" content="The read you can't give yourself. Sixty minutes, your training reviewed before we talk, a written plan of action after.">
   <meta name="twitter:image" content="{SITE_BASE_URL}/og/homepage.jpg">'''
 
     preload = get_preload_hints()
@@ -861,19 +971,23 @@ def generate_consulting_page(external_assets: dict = None) -> str:
 
   {hero}
 
-  {what}
-
-  {bio}
-
-  {topics}
+  {two_futures}
 
   {how}
 
-  {testimonials}
+  {look}
+
+  {cover}
+
+  {plan}
+
+  {who}
+
+  {fit}
 
   {faq}
 
-  {final_cta}
+  {close}
 
   {footer}
 </div>

--- a/wordpress/generate_mission_control.py
+++ b/wordpress/generate_mission_control.py
@@ -176,6 +176,7 @@ def collect_content_pipeline() -> dict:
             "coaching": ("coaching.html", "Coaching page"),
             "coaching_apply": ("coaching-apply.html", "Coaching apply"),
             "consulting": ("consulting.html", "Consulting page"),
+            "consult_intake": ("consult-intake.html", "Consult intake"),
             "methodology": ("methodology.html", "Methodology page"),
             "guide": ("guide/index.html", "Training guide"),
             "success_pages": ("*-success.html", "Success pages"),

--- a/wordpress/generate_success_pages.py
+++ b/wordpress/generate_success_pages.py
@@ -536,8 +536,7 @@ def generate_success_page(page_key: str,
 </div>
 {inline_js}
 {success_js}
-''' + '<script>' + get_site_header_js() + '</script>' + '''
-{get_consent_banner_html()}
+''' + '<script>' + get_site_header_js() + '</script>' + get_consent_banner_html() + '''
 </body>
 </html>'''
 

--- a/wordpress/generate_success_pages.py
+++ b/wordpress/generate_success_pages.py
@@ -217,6 +217,14 @@ def build_success_js() -> str:
     sessionStorage.setItem('gg_converted_' + sessionId, '1');
   }
 
+  // Consulting: pass the checkout session_id to the intake page as a
+  // fragment ref so the intake submission can be tied back to the order.
+  // The intake AUTH token itself only ever arrives via the welcome email.
+  var intakeLink = document.getElementById('consult-intake-link');
+  if (intakeLink && sessionId) {
+    intakeLink.href = '/consulting/intake/#ref=' + encodeURIComponent(sessionId);
+  }
+
   // Cross-sell CTA tracking
   var ctas = document.querySelectorAll('a[href*="/coaching/"]');
   ctas.forEach(function(cta) {
@@ -368,13 +376,16 @@ def build_coaching_success() -> str:
 # ── Consulting Success ────────────────────────────────────────
 
 
+TRAININGPEAKS_ATTACH_URL = "https://home.trainingpeaks.com/attachtocoach?sharedKey=2OTEPC6BXNVQU"
+
+
 def build_consulting_success() -> str:
-    """Content sections for consulting confirmation page."""
+    """Content sections for consulting confirmation page (Sultanic copy v2)."""
     hero = f"""
   <div class="gg-success-hero" data-product-type="consulting">
     <div class="gg-success-check">&check;</div>
-    <h1>Consulting Session Confirmed</h1>
-    <p>Payment received. <strong>Schedule your session now.</strong></p>
+    <h1>Booked. Three things, then I get to work.</h1>
+    <p>Do all three and your read will be done before we talk.</p>
   </div>"""
 
     steps = f"""
@@ -383,37 +394,41 @@ def build_consulting_success() -> str:
     <div class="gg-success-step">
       <div class="gg-success-step-num">1</div>
       <div class="gg-success-step-text">
-        <h3>Schedule Your Session</h3>
+        <h3>Pick Your Time</h3>
         <p><a href="{GOOGLE_CALENDAR_URL}" class="gg-success-cta" target="_blank" rel="noopener" data-cta="schedule_session">Pick a Time</a></p>
-        <p>Choose a time that works. I'll confirm within 24 hours.</p>
       </div>
     </div>
     <div class="gg-success-step">
       <div class="gg-success-step-num">2</div>
       <div class="gg-success-step-text">
-        <h3>Prepare Your Questions</h3>
-        <p>Think about what you want to cover. Race strategy, training
-        philosophy, equipment choices, nutrition &mdash; everything is
-        on the table.</p>
+        <h3>Start the Intake</h3>
+        <p><a href="/consulting/intake/" id="consult-intake-link" class="gg-success-cta" data-cta="start_intake">Start the Intake</a></p>
+        <p>Five minutes; you can save and come back. If this page can't
+        open it, use the link in your welcome email instead.</p>
       </div>
     </div>
     <div class="gg-success-step">
       <div class="gg-success-step-num">3</div>
       <div class="gg-success-step-text">
-        <h3>We Talk</h3>
-        <p>Live session, no scripts, no fluff. You'll walk away with
-        concrete action items tailored to your situation.</p>
+        <h3>Connect Your TrainingPeaks</h3>
+        <p><a href="{TRAININGPEAKS_ATTACH_URL}" class="gg-success-cta" target="_blank" rel="noopener" data-cta="connect_trainingpeaks">Connect</a></p>
+        <p>One click, sign in, tap Accept &mdash; or reply to the welcome
+        email with a Strava link or ride files.</p>
       </div>
     </div>
   </div>"""
 
     crosssell = f"""
   <div class="gg-success-crosssell">
-    <h2>Want Ongoing Support?</h2>
-    <p>If you like what you hear in the consult, coaching picks up where
-    the conversation leaves off. Weekly plan adjustments, daily feedback,
-    and race-day strategy.</p>
-    <a href="{SITE_BASE_URL}/coaching/" class="gg-success-cta">EXPLORE COACHING</a>
+    <h2>Want the Plan Built Too?</h2>
+    <p>A twelve-week plan from your consult, on your calendar within a
+    week of the call &mdash; $100, available for seven days after we speak.
+    Reply to your welcome email to add it.</p>
+  </div>
+
+  <div class="gg-success-crosssell">
+    <p>If the consult turns into &ldquo;I want this every week&rdquo;
+    &mdash; that's <a href="{SITE_BASE_URL}/coaching/">coaching</a>.</p>
   </div>"""
 
     support = f"""


### PR DESCRIPTION
## Summary
- Rewrites `/consulting/` (`wordpress/generate_consulting.py`) to the approved Sultanic copy v2 (`docs/consulting-copy-v2.md`): new hero ("The read you can't give yourself."), two-futures comparison, a brand-token inline-SVG how-it-works strip (5 frames on a hairline rail, frame 4 emphasised), what-I-look-at, what-we-cover, the +$100 plan add-on, who-you'll-talk-to bio, is-this-for-you, a 6-question FAQ (incl. the privacy sentence), and a close with the quiet "that's coaching" clause (no coaching-credit claim, links to `/coaching/`). **Removes the unverified testimonials section entirely.** Keeps the spine: brand tokens, header/footer, GA4, consent banner, A/B head snippet, JSON-LD.
- Hero checkout form gains the "Add a custom 12-week plan built from the consult (+$100)" checkbox; JS sends `plan_addon: true|false` to `POST /api/create-consulting-checkout`.
- Rewrites `/consulting/confirmed/` (`build_consulting_success` in `wordpress/generate_success_pages.py`) to the three-links copy (pick a time / start the intake / connect TrainingPeaks) and wires the Stripe `session_id` through to `/consulting/intake/#ref=<session_id>` via `build_success_js()`. The intake auth token itself is welcome-email-only, so the success page links to the bare `/consulting/intake/` and tells the athlete to use the emailed link if this page can't open it.
- New `/consulting/intake/` (`wordpress/generate_consult_intake.py`, → `output/consult-intake.html`): 14 fields (goal event+date, typical/max weekly hours, years training, FTP/LTHR-or-"don't know", top question, what's gone wrong, injuries/limits, `tp_email`-or-"no TP", power meter y/n, HR strap y/n, coaching history, anything else). Reads `#ref=&t=` from the URL **fragment only** (never the query string), POSTs `{ref, t, answers}` to `/api/consult-intake` with the token in the body, localStorage save/resume, honeypot, success/error states (error keeps the draft), privacy sentence, and a friendly instruction when the token is missing.
- `scripts/push_wordpress.py`: adds `sync_consult_intake()` + `--sync-consult-intake` / `--consult-intake-file`, mirroring `sync_consulting`, wired into `--deploy-all` and the failure-tracking dispatch.
- `wordpress/generate_mission_control.py`: registers `consult_intake` in the content-pipeline `output_patterns` map.
- Tests: rewrote `tests/test_consulting.py` for the new copy/sections (Normie Test guard checks section-builder output only, not the full page, since the full page's `IntersectionObserver` `threshold` option is not copy jargon); added `tests/test_consult_intake.py` (field keys incl. `tp_email`, fragment-not-query-string parsing, POST body shape, save/resume, error-keeps-draft); updated `tests/test_success_pages.py::TestConsultingSuccess` for the new three-links copy.

## Test plan
- [x] `python3 -m pytest tests/test_consulting.py tests/test_consult_intake.py tests/test_success_pages.py tests/test_mission_control.py -q` → **276 passed, 3 skipped** (skips are the sibling-repo `gravel-god-brand/tokens/tokens.css` token-validation tests, which skip in this isolated worktree because `gravel-god-brand` lives outside this repo — same pre-existing pattern as `test_coaching.py`).
- [x] Full suite: `python3 -m pytest tests/ -q --ignore=tests/test_guide_templates.py --ignore=tests/test_photo_qc.py --ignore=tests/test_tp_listing_images.py --ignore=tests/test_youtube_thumbnail.py --ignore=tests/test_youtube_screenshots.py` → **6954 passed, 324 skipped**, no regressions.
- [x] `python3 wordpress/generate_consulting.py`, `python3 wordpress/generate_success_pages.py --page consulting-confirmed`, `python3 wordpress/generate_consult_intake.py` → all three produce `output/*.html`.
- [x] HTML well-formedness: parsed all three generated pages with `html.parser.HTMLParser`, no errors.
- [x] JS syntax: `node -e "new Function(...)"` on every `<script>` block across all three pages — all valid.
- [x] Normie Test: no TSS/FTP/CTL/VO2/threshold/periodization anywhere in the `/consulting/` copy (checked against section-builder output).
- [x] Brand tokens: every `var(--gg-*)` used in both new/changed pages' CSS exists in `gravel-god-brand/tokens/tokens.css` (verified directly against the sibling repo since the in-worktree test skips).

## Deploy (NOT run — draft PR, awaiting review)
```
python3 wordpress/generate_consulting.py
python3 wordpress/generate_success_pages.py
python3 wordpress/generate_consult_intake.py
python3 scripts/push_wordpress.py --sync-consulting
python3 scripts/push_wordpress.py --sync-success
python3 scripts/push_wordpress.py --sync-consult-intake
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout payload (`plan_addon`), a new external API for intake submissions, and token handling in the client—worth verifying pipeline endpoints and that fragment-only tokens behave correctly in production.
> 
> **Overview**
> **Consulting funnel refresh:** `/consulting/` is rebuilt around Sultanic copy v2—new sections (two futures, SVG how-it-works strip, what-I-look-at, plan add-on, fit grid, expanded FAQ), testimonials removed, hero checkout adds a **+$100 12-week plan** checkbox and checkout JS sends `plan_addon` to `create-consulting-checkout`.
> 
> **New `/consulting/intake/`:** `generate_consult_intake.py` adds a 14-field form with localStorage save/resume, honeypot, and POST to `/api/consult-intake`. Booking ref and auth token are read from the URL **hash** only (`#ref=&t=`); token stays in the JSON body, not query strings or headers.
> 
> **Post-checkout:** Consulting success page copy is the three-link flow (calendar, intake, TrainingPeaks). Success JS rewrites the intake link to `#ref=<Stripe session_id>`; the emailed token remains welcome-email-only.
> 
> **Deploy & tests:** `push_wordpress.py` adds `sync_consult_intake` (wired into `--deploy-all`); mission control registers the new output. Tests cover new consulting sections, intake security/fields, and updated success behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9749fa3b2111356e6fc3ed57ec33152745cea225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->