### PR TITLE
feat: add approval-gated Gmail lead reply loop

### DIFF
--- a/.claude/skills/email-sequences/SKILL.md
+++ b/.claude/skills/email-sequences/SKILL.md
@@ -76,3 +76,14 @@ is offered inside Matti's reply when it fits).
 Replies (primary KPI) + GA4 purchase events + unsub/spam rates.
 `sequence_report.py` purchase numbers are broken (gg_athletes is never
 written by the purchase path) — do not cite them.
+
+For the Gmail/Mission Control reply loop, use
+`scripts/lead_nurture_report.py`: it joins attributed replies to `gg_deals`,
+tracks substantive and second replies, reply latency, active-after-reply leaks,
+coach response time, draft acceptance/edit rate, draft conflicts, unsubscribes,
+and spam complaints. It measures Matti's actual sent questions as well as
+sequence questions and avoids double-crediting a lead reply after a manual
+follow-up. Require at least 30
+attributed sends per question type before reviewing a copy direction. Reports
+may recommend an approval-gated test; they never rewrite live copy or change
+variant weights automatically.

--- a/.claude/skills/email-sequences/SKILL.md
+++ b/.claude/skills/email-sequences/SKILL.md
@@ -25,6 +25,11 @@ is offered inside Matti's reply when it fits).
    site, the database, or the emails themselves. No meta, ever.
 3. **Interested?** End on a real question we genuinely want answered.
 
+Replies continue the actual thread: professional, human, sometimes lightly
+deadpan, never a performance of “brand voice.” Do not ask a person to repeat
+context they already gave. By the third lead turn, give a useful observation or
+practical suggestion before asking for more.
+
 ## Hard constraints (non-negotiable)
 
 - **Product facts only** (when facts appear at all — mostly in replies):

--- a/docs/email-voice-model.md
+++ b/docs/email-voice-model.md
@@ -49,6 +49,12 @@ way?”, “what workout do you look forward to?”). Invite a longer story only
 the person is engaged. Measurement and examples:
 `docs/specs/gmail-lead-reply-loop-2026.md`.
 
+Professional and human beats polished. Dry understatement is part of Matti's
+voice when the moment gives him an opening; a joke in every reply is a bot doing
+an impression of Matti. Continue the thread instead of resetting to “what are
+your challenges?” after the person has already answered it. By the third lead
+turn, give something useful before asking for more context.
+
 ## Brand skins (same register, different accents)
 
 | | Gravel God | Roadie Labs | XC Ski Labs (proposed) |

--- a/docs/email-voice-model.md
+++ b/docs/email-voice-model.md
@@ -32,6 +32,23 @@ voice is not a device kit, it is a register. Canonical copy:
 - **No links unless the link serves them concretely.** The reply is the click.
 - Sign-off: — Matti. Lowercase subjects, tiny, about them.
 
+## Reply register — Reflect → Give → Ask
+
+Broadcasts open the conversation; replies prove the relationship. A Matti reply
+uses the lightest structure that is still useful:
+
+1. Reflect one specific detail so the person knows they were read.
+2. Give one answer, connection, or practical implication when it is grounded.
+3. Ask one easy question. One question mark is the default.
+
+Do not stack three questions, turn a short answer into a coaching monologue, or
+add a pitch when the person did not ask about help. Clever metaphors are rare:
+if the line draws more attention than the person, cut it. Early questions should
+be easy to answer (“still deciding or registered?”, “what keeps getting in the
+way?”, “what workout do you look forward to?”). Invite a longer story only after
+the person is engaged. Measurement and examples:
+`docs/specs/gmail-lead-reply-loop-2026.md`.
+
 ## Brand skins (same register, different accents)
 
 | | Gravel God | Roadie Labs | XC Ski Labs (proposed) |

--- a/docs/specs/gmail-lead-reply-loop-2026.md
+++ b/docs/specs/gmail-lead-reply-loop-2026.md
@@ -132,6 +132,9 @@ sound like engagement bait.
 ## Improvement loop
 
 - Compare actual sent questions, not merely suggested questions.
+- Use the tagged Reply-To to recognize Gmail's copy of an automated sequence
+  send. Count the sequence ledger once; do not count that mirrored message as
+  a second send or as a manual Matti question.
 - Attribute a lead's next reply to Matti's manual question when he has replied
   since the sequence email; do not double-credit the older automation.
 - Require at least 30 attributed sends per question type before review. Larger

--- a/docs/specs/gmail-lead-reply-loop-2026.md
+++ b/docs/specs/gmail-lead-reply-loop-2026.md
@@ -1,0 +1,164 @@
+# Gmail Lead Reply Loop — implementation and voice audit
+
+**Status:** built on `codex/gmail-lead-reply-loop`; not deployed.
+**Date:** 2026-08-21
+**System of record:** Mission Control/Supabase for operational state; Gmail for
+the original communication; Endure receives the relationship only after a lead
+becomes an athlete.
+
+## Goal
+
+Know which Gravel God or Roadie message created a conversation, stop automated
+follow-ups when a person answers, give Matti one clean draft to edit, and learn
+which questions create useful conversations and customers without spending
+trust.
+
+## Evidence audit
+
+A read-only sample of recent Gmail threads tied to the canonical sequence
+subjects showed:
+
+- The simplest questions produced the richest context. “How's training going?”
+  elicited weekly volume, climbing work, vacation disruption, confidence, and
+  race concerns in one reply.
+- One plain follow-up — asking what got in the way — surfaced injury treatment,
+  insufficient preparation, a deferred goal, and a positive result at another
+  event.
+- Asking about the practical reason behind an overnight concern surfaced the
+  real constraint: cost. That is more useful than guessing an objection.
+- “How'd it go?” produced detailed race stories without needing a clever frame.
+- Operational failures (“never received it”, missing guide/attachment) also
+  appeared as replies. These are service incidents first and sales leads second.
+- Several threads accumulated multiple alternative Gmail drafts. Some were
+  later trashed, but the active thread could still contain a stale version.
+- The weakest suggested replies were not wrong; they were over-authored. Long
+  metaphors, verdict-like language, and two or three coaching assertions made
+  the response sound more eager to perform a voice than to hear the person.
+
+Conclusion: the current friend-register strategy is correct. The improvement is
+less stylistic voltage, better operational memory, and disciplined follow-up.
+
+## Matti reply register: Reflect → Give → Ask
+
+1. **Reflect one specific thing.** Prove the reply was read. Do not restate the
+   whole message or produce therapy language.
+2. **Give one useful thing when grounded.** Answer the question, make one
+   connection, or name one practical implication. If evidence is missing, do
+   not manufacture expertise to fill the space.
+3. **Ask one easy question.** One question mark is the default. The answer
+   should fit in one line, although the person may choose to say more.
+
+Do not pitch unless the person asks about a plan, coaching, price, or what to do
+next and the offer genuinely answers that question.
+
+### Question ladder
+
+Use the lowest-effort question that can reveal the next useful fact.
+
+| Stage | Purpose | Good shapes |
+|---|---|---|
+| First reply | Establish context | “Still deciding, or registered?” “How's training going?” |
+| Context known | Find the constraint | “What's been hardest to get right?” “What keeps getting in the way?” |
+| Training conversation | Learn motivation/preferences | “What workout do you actually look forward to?” |
+| Race conversation | Find failure mode | “Where does the race usually start going wrong?” |
+| Engaged relationship | Invite a story | “What went well, and what would you change?” |
+
+Avoid a three-question stack. Avoid “why?” as the first response when “what” or
+a simple choice will feel less interrogative. Favorite-workout questions are
+useful after a person has shown interest in training; dropped cold, they can
+sound like engagement bait.
+
+## Runtime
+
+1. Sequence emails receive a unique Gmail plus-address reply token.
+2. The account-local Apps Script runs every five minutes, scans a rolling
+   30-day overlap, and asks Mission Control which correspondents are known
+   leads. A one-time 180-day backfill reconciles older active drafts and
+   replies; Gmail message IDs keep repeated scans idempotent.
+3. It syncs only those Gmail threads. Mission Control verifies identity again
+   before storing any body.
+4. An inbound reply is attributed to the exact sequence send when the token is
+   present, otherwise to the nearest eligible send by email and time with lower
+   confidence.
+5. Active marketing enrollments pause immediately. Post-purchase service
+   sequences remain active.
+6. Mission Control records a conservative suggestion and an easy question.
+   Explicit questions, buying signals, or service problems are marked
+   `needs_coach_answer`.
+7. Matti edits and approves in `/lead-replies`.
+8. Apps Script creates one unsent Gmail draft. If any draft already exists in
+   the thread, it records `draft_conflict` and creates nothing.
+9. The next sync observes a sent reply and supersedes remaining suggestions.
+
+## What success means
+
+### Safety first
+
+- Marketing sends after a reply: **0**.
+- Duplicate drafts created by the bridge: **0**.
+- Unmatched lead replies: trend toward **0**.
+- Spam complaints and unsubscribe rate: non-increasing.
+- Service incidents answered before any sales treatment.
+
+### Conversation quality
+
+- Reply rate by source, brand, sequence, variant, step, and question type.
+- Median reply latency.
+- Median coach response time from an inbound reply to Matti's next sent reply.
+- Substantive reply rate (20+ newly authored words; descriptive, not a value
+  judgment).
+- Second-reply rate: did a question start a conversation rather than collect a
+  single answer?
+- Editor correction rate: how often Matti substantially changes a suggestion.
+  This is the main signal for improving the drafter.
+- Suggestion acceptance rate and median edit percentage. These measure whether
+  the queue is actually saving Matti work, not whether text was generated.
+
+### Business outcomes
+
+- Movement to qualified/proposal.
+- Consultation booked.
+- Closed won and revenue, joined through `gg_deals`/`gg_payments` rather than
+  the known-broken `gg_athletes` purchase proxy.
+- Time from first capture and first reply to conversion.
+
+## Improvement loop
+
+- Compare actual sent questions, not merely suggested questions.
+- Attribute a lead's next reply to Matti's manual question when he has replied
+  since the sequence email; do not double-credit the older automation.
+- Require at least 30 attributed sends per question type before review. Larger
+  conversion claims need more volume.
+- Change one premise or question at a time. Do not “optimize” the whole sequence
+  from a handful of colorful replies.
+- Treat replies and substantive replies as primary conversation signals;
+  opens are diagnostic only.
+- Keep the sober control intact.
+- Mission Control recommends; Matti approves. No automatic copy rewrites or
+  weight changes.
+- Review false positives and edited drafts weekly. Add the language Matti kept,
+  not the language an LLM merely generated.
+
+## Deployment order
+
+1. Apply `20260822000001_gmail_lead_reply_loop.sql`.
+2. Deploy Mission Control code with the new tables already present.
+3. Subscribe the signed Resend webhook to `email.complained` in addition to the
+   existing open/click/bounce events.
+4. Install and authorize `integrations/gmail-lead-bridge` in the coaching Gmail
+   account.
+5. Run `backfillLeadThreads()` once to surface older replies and active Gmail
+   drafts. Resolve conflicts manually; nothing is deleted automatically.
+6. Run a dry sync and confirm known leads only, exact token attribution, and
+   pause-on-reply.
+7. Approve one test suggestion and verify one unsent Gmail draft appears.
+8. Run `scripts/lead_nurture_report.py`; verify no active-after-reply leaks.
+9. Only then enable the five-minute trigger for normal operation.
+
+## Privacy and retention
+
+Lead message bodies are private operational data, excluded from Git, and
+stored in service-role-only tables. The bridge never syncs an address unless
+Mission Control already knows it as a sequence enrollment or open deal. Add a
+documented retention/deletion policy before using message bodies for model
+training or exporting them to any additional provider.

--- a/docs/specs/gmail-lead-reply-loop-2026.md
+++ b/docs/specs/gmail-lead-reply-loop-2026.md
@@ -48,6 +48,13 @@ less stylistic voltage, better operational memory, and disciplined follow-up.
 3. **Ask one easy question.** One question mark is the default. The answer
    should fit in one line, although the person may choose to say more.
 
+The tone is professionally useful, recognizably human, and occasionally
+deadpan. Dry understatement is seasoning, not a compulsory brand device. The
+system carries forward the recent thread and advances the question ladder
+instead of restarting an intake interview on every reply. By the third lead
+turn, the editor must add a useful observation or practical suggestion before
+asking for anything else.
+
 Do not pitch unless the person asks about a plan, coaching, price, or what to do
 next and the offer genuinely answers that question.
 

--- a/integrations/gmail-lead-bridge/Code.gs
+++ b/integrations/gmail-lead-bridge/Code.gs
@@ -152,6 +152,7 @@ function messagePayload_(message) {
     from: message.getFrom(),
     to: splitAddresses_(message.getTo()),
     cc: splitAddresses_(message.getCc()),
+    reply_to: message.getReplyTo(),
     subject: message.getSubject(),
     date: message.getDate().toISOString(),
     body: String(message.getPlainBody() || '').slice(0, MAX_MESSAGE_BODY_CHARS),

--- a/integrations/gmail-lead-bridge/Code.gs
+++ b/integrations/gmail-lead-bridge/Code.gs
@@ -1,0 +1,242 @@
+/**
+ * Gmail Lead Bridge for Gravel God Mission Control.
+ *
+ * Runs as the owner of gravelgodcoaching@gmail.com. It reads only known lead
+ * correspondents returned by Mission Control, syncs their threads, and turns
+ * explicitly approved suggestions into Gmail drafts. It never sends email.
+ */
+
+const BRIDGE_TRIGGER_FUNCTION = 'runLeadBridge';
+const SEARCH_OVERLAP_DAYS = 30;
+const BACKFILL_DAYS = 180;
+const CANDIDATE_BATCH_SIZE = 20;
+const MAX_THREADS_PER_QUERY = 100;
+const NORMAL_SYNC_THREADS_PER_RUN = 100;
+const MAX_SYNC_THREADS_PER_RUN = 500;
+const SYNC_POST_BATCH_SIZE = 20;
+const MAX_MESSAGES_PER_THREAD = 50;
+const MAX_MESSAGE_BODY_CHARS = 12000;
+const MAX_DRAFTS_PER_RUN = 15;
+
+
+function installLeadBridge() {
+  const props = PropertiesService.getScriptProperties();
+  const required = ['MISSION_CONTROL_URL', 'WEBHOOK_SECRET', 'ACCOUNT_EMAIL'];
+  const missing = required.filter((key) => !props.getProperty(key));
+  if (missing.length) {
+    throw new Error(`Set Script Properties first: ${missing.join(', ')}`);
+  }
+  assertCorrectAccount_();
+
+  ScriptApp.getProjectTriggers()
+    .filter((trigger) => trigger.getHandlerFunction() === BRIDGE_TRIGGER_FUNCTION)
+    .forEach((trigger) => ScriptApp.deleteTrigger(trigger));
+
+  ScriptApp.newTrigger(BRIDGE_TRIGGER_FUNCTION)
+    .timeBased()
+    .everyMinutes(5)
+    .create();
+
+  runLeadBridge();
+}
+
+
+function runLeadBridge() {
+  const lock = LockService.getScriptLock();
+  if (!lock.tryLock(1000)) return;
+  try {
+    assertCorrectAccount_();
+    syncKnownLeadThreads_(SEARCH_OVERLAP_DAYS, NORMAL_SYNC_THREADS_PER_RUN);
+    createApprovedDrafts_();
+    PropertiesService.getScriptProperties().setProperty(
+      'LAST_SUCCESS_AT', new Date().toISOString(),
+    );
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+
+/** Run manually after installation to reconcile older replies and drafts. */
+function backfillLeadThreads() {
+  assertCorrectAccount_();
+  syncKnownLeadThreads_(BACKFILL_DAYS, MAX_SYNC_THREADS_PER_RUN);
+}
+
+
+function syncKnownLeadThreads_(lookbackDays, maxSyncThreads) {
+  const response = missionControlGet_('/webhooks/gmail-sync/candidates');
+  const candidates = (response.candidates || [])
+    .map((row) => String(row.email || '').trim().toLowerCase())
+    .filter(Boolean);
+  if (!candidates.length) return;
+
+  const uniqueThreads = {};
+  chunk_(candidates, CANDIDATE_BATCH_SIZE).forEach((emails) => {
+    const addressTerms = [];
+    emails.forEach((email) => {
+      addressTerms.push(`from:${quoteGmail_(email)}`);
+      addressTerms.push(`to:${quoteGmail_(email)}`);
+    });
+    const query = [
+      'in:anywhere', '-in:spam', '-in:trash',
+      `newer_than:${lookbackDays || SEARCH_OVERLAP_DAYS}d`,
+      `{${addressTerms.join(' ')}}`,
+    ].join(' ');
+    GmailApp.search(query, 0, MAX_THREADS_PER_QUERY).forEach((thread) => {
+      uniqueThreads[thread.getId()] = thread;
+    });
+  });
+
+  const candidateSet = {};
+  candidates.forEach((email) => { candidateSet[email] = true; });
+  const threads = Object.keys(uniqueThreads).slice(
+    0, maxSyncThreads || NORMAL_SYNC_THREADS_PER_RUN,
+  ).map((threadId) => {
+    const thread = uniqueThreads[threadId];
+    return {
+      id: threadId,
+      messages: thread.getMessages()
+        .filter((message) => messageTouchesLead_(message, candidateSet))
+        .slice(-MAX_MESSAGES_PER_THREAD)
+        .map(messagePayload_),
+    };
+  }).filter((thread) => thread.messages.length);
+
+  chunk_(threads, SYNC_POST_BATCH_SIZE).forEach((threadBatch) => {
+    missionControlPost_('/webhooks/gmail-sync', {threads: threadBatch});
+  });
+}
+
+
+function createApprovedDrafts_() {
+  const response = missionControlGet_('/webhooks/gmail-sync/drafts/ready');
+  const drafts = (response.drafts || []).slice(0, MAX_DRAFTS_PER_RUN);
+  drafts.forEach((item) => {
+    let receipt;
+    try {
+      const inbound = GmailApp.getMessageById(item.inbound_message_id);
+      if (!inbound) throw new Error('Inbound Gmail message not found');
+      const thread = inbound.getThread();
+      const existingDraft = thread.getMessages().find((message) => message.isDraft());
+      if (existingDraft) {
+        receipt = {
+          status: 'draft_conflict',
+          gmail_draft_message_id: existingDraft.getId(),
+        };
+      } else {
+        const body = String(item.draft_text || '').trim();
+        if (!body) throw new Error('Approved suggestion has an empty draft');
+        const draft = inbound.createDraftReply(body, {htmlBody: plainTextToHtml_(body)});
+        receipt = {
+          status: 'gmail_drafted',
+          gmail_draft_id: draft.getId(),
+          gmail_draft_message_id: draft.getMessageId(),
+        };
+      }
+    } catch (error) {
+      console.error(`Draft ${item.suggestion_id} failed: ${error.message}`);
+      return;
+    }
+    missionControlPost_(
+      `/webhooks/gmail-sync/drafts/${encodeURIComponent(item.suggestion_id)}/receipt`,
+      receipt,
+    );
+  });
+}
+
+
+function messagePayload_(message) {
+  return {
+    id: message.getId(),
+    from: message.getFrom(),
+    to: splitAddresses_(message.getTo()),
+    cc: splitAddresses_(message.getCc()),
+    subject: message.getSubject(),
+    date: message.getDate().toISOString(),
+    body: String(message.getPlainBody() || '').slice(0, MAX_MESSAGE_BODY_CHARS),
+    is_draft: message.isDraft(),
+    is_trash: message.isInTrash(),
+  };
+}
+
+
+function assertCorrectAccount_() {
+  const props = PropertiesService.getScriptProperties();
+  const expected = String(props.getProperty('ACCOUNT_EMAIL') || '').trim().toLowerCase();
+  const actual = String(Session.getEffectiveUser().getEmail() || '').trim().toLowerCase();
+  if (!expected || actual !== expected) {
+    throw new Error(`Gmail Lead Bridge account mismatch: expected ${expected}, got ${actual || '(unknown)'}`);
+  }
+}
+
+
+function messageTouchesLead_(message, candidateSet) {
+  const addresses = [message.getFrom(), message.getTo(), message.getCc()]
+    .join(',')
+    .toLowerCase();
+  return Object.keys(candidateSet).some((email) => addresses.indexOf(email) !== -1);
+}
+
+
+function splitAddresses_(raw) {
+  if (!raw) return [];
+  return String(raw).split(',').map((value) => value.trim()).filter(Boolean);
+}
+
+
+function missionControlGet_(path) {
+  return missionControlRequest_(path, 'get');
+}
+
+
+function missionControlPost_(path, payload) {
+  return missionControlRequest_(path, 'post', payload);
+}
+
+
+function missionControlRequest_(path, method, payload) {
+  const props = PropertiesService.getScriptProperties();
+  const base = String(props.getProperty('MISSION_CONTROL_URL') || '').replace(/\/$/, '');
+  const secret = props.getProperty('WEBHOOK_SECRET');
+  const options = {
+    method,
+    muteHttpExceptions: true,
+    headers: {Authorization: `Bearer ${secret}`},
+  };
+  if (payload !== undefined) {
+    options.contentType = 'application/json';
+    options.payload = JSON.stringify(payload);
+  }
+  const response = UrlFetchApp.fetch(`${base}${path}`, options);
+  const code = response.getResponseCode();
+  const text = response.getContentText();
+  if (code < 200 || code >= 300) {
+    throw new Error(`Mission Control ${method.toUpperCase()} ${path}: ${code} ${text}`);
+  }
+  return text ? JSON.parse(text) : {};
+}
+
+
+function quoteGmail_(value) {
+  return `"${String(value).replace(/"/g, '')}"`;
+}
+
+
+function plainTextToHtml_(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/\n/g, '<br>');
+}
+
+
+function chunk_(values, size) {
+  const chunks = [];
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size));
+  }
+  return chunks;
+}

--- a/integrations/gmail-lead-bridge/README.md
+++ b/integrations/gmail-lead-bridge/README.md
@@ -1,0 +1,44 @@
+# Gmail Lead Bridge
+
+Account-local relay between `gravelgodcoaching@gmail.com` and Mission Control.
+It runs every five minutes, reads only correspondents Mission Control identifies
+as open leads, and syncs their Gmail threads. It can create a Gmail reply draft
+only after a suggestion is explicitly marked `approved_for_gmail`. It never
+sends, archives, trashes, labels, or marks messages read.
+
+## Install
+
+1. Apply `supabase/migrations/20260822000001_gmail_lead_reply_loop.sql` before
+   deploying the matching Mission Control code.
+2. Create a standalone Apps Script project while signed into
+   `gravelgodcoaching@gmail.com`.
+3. Copy `Code.gs` and `appsscript.json` into the project.
+4. Set Script Properties:
+   - `MISSION_CONTROL_URL`: production Mission Control origin, no trailing slash.
+   - `WEBHOOK_SECRET`: the existing Mission Control webhook secret.
+   - `ACCOUNT_EMAIL`: `gravelgodcoaching@gmail.com`.
+5. Run `installLeadBridge()` once and approve the Gmail, external-request, and
+   trigger scopes. This creates one five-minute installable trigger and performs
+   the first sync.
+6. Run `backfillLeadThreads()` once. It scans 180 days for known lead threads so
+   Mission Control can surface older replies and active drafts. It remains
+   read-only in Gmail and may be rerun safely.
+
+## Safety invariants
+
+- No call to `sendEmail`, `reply`, `send`, Trash, Archive, labels, or read-state APIs.
+- The script refuses to run unless the effective Google account exactly matches
+  the configured coaching account.
+- Existing draft in a thread produces `draft_conflict`; it is never overwritten.
+- Message IDs make overlapping 30-day scans and the 180-day backfill idempotent.
+- Each message body is capped at 12,000 characters before transfer; Mission
+  Control then strips quoted history and caps stored authored text again.
+- The server ignores correspondents with no sequence enrollment or open deal,
+  and stops lead sync after a deal is closed won so athlete communication moves
+  to the coaching system.
+- A real inbound reply pauses marketing enrollments; post-purchase service
+  sequences remain active.
+- Copy recommendations and Gmail draft creation are separate approval states.
+
+Google supports `GmailMessage.createDraftReply()` and installable time-driven
+triggers; see the official Gmail Service and Installable Triggers documentation.

--- a/integrations/gmail-lead-bridge/appsscript.json
+++ b/integrations/gmail-lead-bridge/appsscript.json
@@ -1,0 +1,12 @@
+{
+  "timeZone": "America/Denver",
+  "dependencies": {},
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://mail.google.com/",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/script.scriptapp"
+  ]
+}

--- a/mission_control/app.py
+++ b/mission_control/app.py
@@ -14,6 +14,7 @@ from mission_control.routers import (
 from mission_control.routers import sequences, deals_router, analytics, unsubscribe
 from mission_control.routers import races_api, nutrition_api
 from mission_control.routers import auth_routes
+from mission_control.routers import lead_replies
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +94,7 @@ def create_app() -> FastAPI:
     app.include_router(webhooks.router, include_in_schema=False)
 
     # Routers — v2 admin-protected (internal — hidden from API docs)
-    for r in [sequences, deals_router, analytics]:
+    for r in [sequences, deals_router, analytics, lead_replies]:
         app.include_router(r.router, include_in_schema=False, dependencies=_admin)
 
     # Unsubscribe — public, no auth (CAN-SPAM compliance)

--- a/mission_control/routers/lead_replies.py
+++ b/mission_control/routers/lead_replies.py
@@ -1,0 +1,60 @@
+"""Mobile-friendly editor queue for lead replies and learning metrics."""
+
+import re
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from mission_control.config import WEB_TEMPLATES_DIR
+from mission_control.services.lead_nurture import (
+    approve_reply_suggestion,
+    dismiss_reply_suggestion,
+    get_learning_metrics,
+    get_reply_queue,
+)
+
+
+router = APIRouter(prefix="/lead-replies")
+templates = Jinja2Templates(directory=str(WEB_TEMPLATES_DIR))
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+@router.get("")
+async def lead_reply_queue(request: Request):
+    return templates.TemplateResponse(request, "lead_replies/index.html", {
+        "request": request,
+        "active_page": "lead_replies",
+        "queue": get_reply_queue(),
+        "metrics": get_learning_metrics(),
+    })
+
+
+@router.post("/{suggestion_id}/approve")
+async def approve_lead_reply(
+    suggestion_id: str,
+    draft_text: str = Form(...),
+):
+    if not _UUID_RE.match(suggestion_id):
+        raise HTTPException(status_code=400, detail="Invalid suggestion ID")
+    result = approve_reply_suggestion(suggestion_id, draft_text)
+    if not result:
+        raise HTTPException(status_code=409, detail="Suggestion cannot be approved")
+    return HTMLResponse(
+        '<div class="gg-alert gg-alert--success">'
+        '<span class="gg-alert__label">Approved</span>'
+        '<span class="gg-alert__message">The Gmail relay will create an unsent draft. Nothing was sent.</span>'
+        '</div>'
+    )
+
+
+@router.post("/{suggestion_id}/dismiss")
+async def dismiss_lead_reply(suggestion_id: str):
+    if not _UUID_RE.match(suggestion_id):
+        raise HTTPException(status_code=400, detail="Invalid suggestion ID")
+    if not dismiss_reply_suggestion(suggestion_id):
+        raise HTTPException(status_code=409, detail="Suggestion cannot be dismissed")
+    return HTMLResponse("")

--- a/mission_control/routers/webhooks.py
+++ b/mission_control/routers/webhooks.py
@@ -22,6 +22,10 @@ _EMAIL_RE = re.compile(r"^[^@\s]{1,64}@[^@\s]{1,255}$")
 _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,80}$")
 _MAX_NAME_LEN = 200
 _MAX_SOURCE_LEN = 100
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
 
 # Gravel guide chapter title -> URL slug. Mirrors the "id" field of each chapter
 # in guide/gravel-guide-content.json, which generate_guide_cluster.py uses as the
@@ -69,6 +73,11 @@ def _validate_email(email: str) -> str:
 def _truncate(value: str, max_len: int) -> str:
     """Truncate string to max length."""
     return value[:max_len] if value else ""
+
+
+def _require_webhook_secret(authorization: str) -> None:
+    if not WEBHOOK_SECRET or authorization != f"Bearer {WEBHOOK_SECRET}":
+        raise HTTPException(status_code=401, detail="Invalid webhook secret")
 
 
 @router.post("/intake")
@@ -388,7 +397,7 @@ async def resend_webhook(
     if not resend_id:
         return {"status": "ignored", "reason": "no email_id"}
 
-    if event_type in ("email.opened", "email.clicked", "email.bounced"):
+    if event_type in ("email.opened", "email.clicked", "email.bounced", "email.complained"):
         success = record_event(resend_id, event_type)
         return {"status": "recorded" if success else "not_found"}
 
@@ -437,3 +446,65 @@ async def resend_inbound_webhook(
     # Log even if no matching athlete
     db.log_action("inbound_email", "contact", from_email, f"Reply (no athlete match): {subject}")
     return {"status": "recorded", "athlete_slug": None}
+
+
+# ---------------------------------------------------------------------------
+# Gmail lead bridge — Apps Script relay, approval-only drafts, never sends
+# ---------------------------------------------------------------------------
+
+@router.get("/gmail-sync/candidates")
+async def gmail_sync_candidates(
+    request: Request,
+    authorization: str = Header(""),
+):
+    _check_rate_limit(request)
+    _require_webhook_secret(authorization)
+    from mission_control.services.lead_nurture import get_sync_candidates
+
+    return {"candidates": get_sync_candidates()}
+
+
+@router.post("/gmail-sync")
+async def gmail_sync(
+    request: Request,
+    authorization: str = Header(""),
+):
+    _check_rate_limit(request)
+    _require_webhook_secret(authorization)
+    payload = await request.json()
+    if not isinstance(payload, dict) or not isinstance(payload.get("threads", []), list):
+        raise HTTPException(status_code=400, detail="threads must be a list")
+    from mission_control.services.lead_nurture import ingest_gmail_sync
+
+    return ingest_gmail_sync(payload)
+
+
+@router.get("/gmail-sync/drafts/ready")
+async def gmail_sync_ready_drafts(
+    request: Request,
+    authorization: str = Header(""),
+):
+    _check_rate_limit(request)
+    _require_webhook_secret(authorization)
+    from mission_control.services.lead_nurture import get_approved_drafts
+
+    return {"drafts": get_approved_drafts()}
+
+
+@router.post("/gmail-sync/drafts/{suggestion_id}/receipt")
+async def gmail_sync_draft_receipt(
+    suggestion_id: str,
+    request: Request,
+    authorization: str = Header(""),
+):
+    _check_rate_limit(request)
+    _require_webhook_secret(authorization)
+    if not _UUID_RE.match(suggestion_id):
+        raise HTTPException(status_code=400, detail="Invalid suggestion ID")
+    payload = await request.json()
+    from mission_control.services.lead_nurture import record_draft_receipt
+
+    result = record_draft_receipt(suggestion_id, payload if isinstance(payload, dict) else {})
+    if not result:
+        raise HTTPException(status_code=409, detail="Suggestion is not ready for a Gmail draft")
+    return result

--- a/mission_control/services/lead_nurture.py
+++ b/mission_control/services/lead_nurture.py
@@ -350,19 +350,32 @@ def _parse_message_at(value: str) -> datetime:
 
 
 def _reply_token(message: dict) -> str:
-    for value in (message.get("to", []) or []) + (message.get("cc", []) or []):
+    values = (message.get("to", []) or []) + (message.get("cc", []) or [])
+    # Inbound replies carry the tagged address in To. The original sequence
+    # send carries it in Reply-To. Reading both lets a Gmail backfill identify
+    # the automated outbound copy instead of misclassifying it as a manual
+    # Matti reply in the learning report.
+    values.append(message.get("reply_to", ""))
+    for value in values:
         match = _REPLY_TOKEN_RE.search(value or "")
         if match:
             return match.group(1).lower()
     return ""
 
 
-def _sequence_attribution(contact: dict, message: dict) -> tuple[dict | None, str]:
+def _exact_sequence_attribution(message: dict) -> tuple[dict | None, str]:
     token = _reply_token(message)
     if token:
         exact = db.select_one("gg_sequence_sends", match={"reply_token": token})
         if exact:
             return exact, "exact"
+    return None, "none"
+
+
+def _sequence_attribution(contact: dict, message: dict) -> tuple[dict | None, str]:
+    exact, confidence = _exact_sequence_attribution(message)
+    if exact:
+        return exact, confidence
 
     inbound_at = _parse_message_at(message.get("date", "")).isoformat()
     candidates: list[dict] = []
@@ -536,6 +549,11 @@ def _ingest_thread(thread: dict, candidate_map: dict[str, dict]) -> dict:
             # must never leave the marketing sequence free to send again.
             paused += _pause_marketing_sequences(contact)
             sequence_send, confidence = _sequence_attribution(contact, message)
+        elif direction == "outbound":
+            # Only exact Reply-To token attribution is safe for an outbound
+            # Gmail message. A nearest-send guess could mistake Matti's real
+            # reply for automation and erase it from the learning loop.
+            sequence_send, confidence = _exact_sequence_attribution(message)
         question_type = classify_question(body) if direction in {"outbound", "draft"} else "other"
 
         db.insert("gg_lead_messages", {
@@ -882,6 +900,11 @@ def get_learning_metrics(days: int = 90) -> dict:
     for conversation_messages in messages_by_conversation.values():
         for index, message in enumerate(conversation_messages):
             if message.get("direction") != "outbound":
+                continue
+            # The sequence ledger already counted this automated send. Gmail
+            # mirrors it for thread context, but it is not a second experiment
+            # and it is not a manual Matti question.
+            if message.get("sequence_send_id"):
                 continue
             question_type = message.get("question_type") or "other"
             bucket = bucket_for(question_type)

--- a/mission_control/services/lead_nurture.py
+++ b/mission_control/services/lead_nurture.py
@@ -58,7 +58,7 @@ _RACE_DECISION_TERMS = (
 )
 _POSITIVE_TRAINING_TERMS = (
     "training is going well", "training was great", "feeling good",
-    "going well", "back training", "back!", "on track",
+    "going well", "going pretty well", "back training", "back!", "on track",
 )
 _DEFERRED_TERMS = ("deferred", "defer", "dns", "didn't race", "did not race")
 
@@ -70,6 +70,7 @@ _QUESTION_RULES = (
     ("frustration", ("frustrat", "most annoying", "bothering you")),
     ("challenge", ("challenge", "hardest", "get right", "holding you back")),
     ("race_decision", ("which race", "still deciding", "what matters most", "registered")),
+    ("race_goal", ("training toward", "training for", "main goal", "a race")),
     ("race_outcome", ("how did it go", "how'd it go", "what went well", "what went badly")),
     ("training_status", ("how's training", "how is training", "where is the training")),
     ("schedule", ("weekly hours", "schedule", "your week", "time do you have")),
@@ -138,8 +139,57 @@ def _stable_choice(seed: str, choices: tuple[tuple[str, str], ...]) -> tuple[str
     return choices[index]
 
 
+def _conversation_next_move(
+    text: str, *, prior_question_type: str = "", seed: str = "",
+) -> tuple[str, str, str]:
+    """Choose a grounded next move without trying to perform a persona."""
+    folded = (text or "").casefold()
+    hours = re.search(r"\b(\d+(?:\.\d+)?)\s*(?:hours?|hrs?)\b", folded)
+    mentions_climbing = any(term in folded for term in ("climb", "climbing", "uphill"))
+    mentions_fueling = any(term in folded for term in ("fuel", "carb", "eat", "nutrition"))
+
+    if mentions_climbing and mentions_fueling:
+        return (
+            "That makes sense. Long climbs are pretty honest about late fueling.",
+            "fueling",
+            "When the climbs come apart, what goes first — legs, breathing, or fueling?",
+        )
+    if mentions_fueling:
+        return (
+            "Yep. Fueling can turn a good day sideways pretty quietly.",
+            "fueling",
+            "Where does fueling usually start to get away from you?",
+        )
+    if mentions_climbing:
+        return (
+            "Got it. Climbs are not especially subtle about the weak link.",
+            "challenge",
+            "When a climb goes bad, what goes first — legs, breathing, or pacing?",
+        )
+
+    acknowledgement = "Good to hear."
+    if hours:
+        acknowledgement = f"Good to hear. {hours.group(1)} hours is a real week."
+    ladder = {
+        "challenge": ("favorite_workout", "What kind of workout do you actually look forward to?"),
+        "frustration": ("favorite_workout", "What kind of workout has been feeling best lately?"),
+        "favorite_workout": ("race_goal", "What are you training toward right now?"),
+        "race_goal": ("schedule", "How much training time can you actually protect most weeks?"),
+        "schedule": ("workout_feedback", "What kind of session has been clicking lately?"),
+    }
+    question_type, question = ladder.get(
+        prior_question_type,
+        _stable_choice(seed or text, (
+            ("challenge", "What part of training feels hardest to get right right now?"),
+            ("favorite_workout", "What kind of workout do you actually look forward to?"),
+        )),
+    )
+    return acknowledgement, question_type, question
+
+
 def build_reply_suggestion(
     *, text: str, first_name: str = "", seed: str = "",
+    prior_question_type: str = "", lead_turn: int = 1,
 ) -> dict:
     """Build a deliberately plain Reflect → Ask starting point.
 
@@ -173,18 +223,29 @@ def build_reply_suggestion(
         question_type = "challenge"
         question = "What ended up getting in the way?"
     elif intent == "training_positive":
-        acknowledgement = "Good to hear."
-        question_type, question = _stable_choice(seed or text, (
-            ("challenge", "What part of training feels hardest to get right right now?"),
-            ("favorite_workout", "What kind of workout do you actually look forward to doing?"),
-        ))
+        acknowledgement, question_type, question = _conversation_next_move(
+            text, prior_question_type=prior_question_type, seed=seed,
+        )
     else:
         acknowledgement = "Got it."
-        question_type = "challenge"
-        question = "What's the biggest training challenge you're trying to sort out right now?"
+        ladder = {
+            "challenge": ("favorite_workout", "What kind of workout has been feeling best lately?"),
+            "favorite_workout": ("race_goal", "What are you training toward right now?"),
+            "race_goal": ("schedule", "How much training time can you actually protect most weeks?"),
+            "schedule": ("challenge", "What keeps getting in the way most often?"),
+        }
+        question_type, question = ladder.get(
+            prior_question_type,
+            ("challenge", "What's the biggest training challenge you're trying to sort out right now?"),
+        )
 
     if needs_answer and not answer_placeholder:
         answer_placeholder = "[Answer their question directly first.]"
+    elif lead_turn >= 3 and not answer_placeholder:
+        # Do not turn the relationship into an intake form. By the third lead
+        # turn, Matti should add value before asking for more context.
+        answer_placeholder = "[Add one useful observation or practical suggestion from this thread.]"
+        needs_answer = True
 
     greeting = f"{first_name}," if first_name else "Hey —"
     parts = [greeting, acknowledgement]
@@ -350,11 +411,34 @@ def _record_suggestion(conversation: dict, message: dict, body: str) -> dict:
     )
     if existing:
         return existing
+    prior_messages = db.select(
+        "gg_lead_messages", match={"conversation_id": conversation["id"]},
+        order="message_at", order_desc=True, limit=12,
+    )
+    prior_outbound = next((
+        row for row in prior_messages
+        if row.get("direction") == "outbound"
+        and row.get("gmail_message_id") != message["id"]
+    ), {})
+    lead_turn = sum(1 for row in prior_messages if row.get("direction") == "inbound")
+
+    # Consecutive inbound messages are one editor job. Approved or drafted work
+    # remains visible, but older unapproved alternatives leave the queue.
+    now = datetime.now(timezone.utc).isoformat()
+    for pending in db.select(
+        "gg_lead_reply_suggestions", match={"conversation_id": conversation["id"]},
+    ):
+        if pending.get("status") in {"suggested", "needs_coach_answer"}:
+            db.update("gg_lead_reply_suggestions", {
+                "status": "superseded", "updated_at": now,
+            }, {"id": pending["id"]})
     first_name = (conversation.get("contact_name") or "").split(" ", 1)[0]
     suggestion = build_reply_suggestion(
         text=body,
         first_name=first_name,
         seed=f"{conversation.get('contact_email')}:{message['id']}",
+        prior_question_type=prior_outbound.get("question_type") or "",
+        lead_turn=lead_turn,
     )
     status = "needs_coach_answer" if suggestion["needs_coach_answer"] else "suggested"
     return db.insert("gg_lead_reply_suggestions", {
@@ -579,6 +663,18 @@ def get_approved_drafts(limit: int = 25) -> list[dict]:
         conversation = db.select_one("gg_lead_conversations", match={"id": row["conversation_id"]})
         if not inbound or not conversation:
             continue
+        newer_inbound = next((
+            message for message in db.select(
+                "gg_lead_messages", match={"conversation_id": row["conversation_id"]},
+            )
+            if message.get("direction") == "inbound"
+            and (message.get("message_at") or "") > (inbound.get("message_at") or "")
+        ), None)
+        if newer_inbound:
+            db.update("gg_lead_reply_suggestions", {
+                "status": "superseded", "updated_at": datetime.now(timezone.utc).isoformat(),
+            }, {"id": row["id"]})
+            continue
         output.append({
             "suggestion_id": row["id"],
             "gmail_thread_id": conversation["gmail_thread_id"],
@@ -638,6 +734,10 @@ def get_reply_queue(limit: int = 100) -> list[dict]:
         )
         if not inbound or not conversation:
             continue
+        thread_messages = db.select(
+            "gg_lead_messages", match={"conversation_id": row["conversation_id"]},
+            order="message_at", order_desc=True, limit=8,
+        )
         output.append({
             **row,
             "contact_email": conversation.get("contact_email", ""),
@@ -647,6 +747,7 @@ def get_reply_queue(limit: int = 100) -> list[dict]:
             "subject": inbound.get("subject", ""),
             "inbound_body": inbound.get("body_text", ""),
             "message_at": inbound.get("message_at"),
+            "thread_context": list(reversed(thread_messages)),
         })
     return output
 
@@ -660,7 +761,12 @@ def approve_reply_suggestion(suggestion_id: str, draft_text: str) -> dict | None
         return None
     if suggestion.get("needs_coach_answer"):
         initial = (suggestion.get("initial_draft_text") or "").strip()
-        if draft_text == initial or "[Answer " in draft_text or "[Say exactly " in draft_text:
+        if (
+            draft_text == initial
+            or "[Answer " in draft_text
+            or "[Say exactly " in draft_text
+            or "[Add one useful " in draft_text
+        ):
             return None
     now = datetime.now(timezone.utc).isoformat()
     updated = db.update("gg_lead_reply_suggestions", {

--- a/mission_control/services/lead_nurture.py
+++ b/mission_control/services/lead_nurture.py
@@ -1,0 +1,941 @@
+"""Gmail-to-Mission-Control lead conversation and approval loop.
+
+The bridge is intentionally conservative:
+- Gmail remains the communication record.
+- Mission Control stores a private, queryable snapshot and attribution.
+- A real reply pauses marketing sequences immediately.
+- Suggestions are editable and never send email.
+- Only suggestions explicitly approved by Matti may become Gmail drafts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import re
+import statistics
+from difflib import SequenceMatcher
+from datetime import timedelta
+from datetime import datetime, timezone
+from email.utils import parseaddr
+
+from mission_control import supabase_client as db
+from mission_control.sequences import get_sequence
+
+
+MAX_BODY_CHARS = 30_000
+MAX_SUBJECT_CHARS = 500
+MAX_THREADS_PER_SYNC = 100
+MAX_MESSAGES_PER_THREAD = 50
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+$")
+_REPLY_TOKEN_RE = re.compile(
+    r"\+lead\.([a-f0-9]{32})@", re.IGNORECASE,
+)
+_QUOTED_LINE_RE = re.compile(
+    r"^(?:On .+ wrote:|From:\s|Sent:\s|To:\s|Subject:\s|-{2,}\s*Original Message)",
+    re.IGNORECASE,
+)
+
+_POST_PURCHASE_TRIGGERS = {"plan_purchased"}
+
+_SUPPORT_TERMS = (
+    "never received", "didn't receive", "did not receive", "no guide",
+    "no attachment", "not attached", "missing attachment", "broken link",
+    "can't open", "cannot open", "refund", "charged", "unsubscribe",
+)
+_BUYING_TERMS = (
+    "how much", "price", "cost of coaching", "hire you", "work with you",
+    "coaching", "training plan", "sign up", "subscribe",
+)
+_HEALTH_TERMS = (
+    "injury", "injured", "pain", "sick", "illness", "covid", "knee",
+    "back", "neck", "physical therapy", " pt ", "injection", "doctor",
+)
+_RACE_DECISION_TERMS = (
+    "still deciding", "which race", "between", "enter", "register",
+    "shortlist", "leaning toward", "overnight", "travel", "hotel",
+)
+_POSITIVE_TRAINING_TERMS = (
+    "training is going well", "training was great", "feeling good",
+    "going well", "back training", "back!", "on track",
+)
+_DEFERRED_TERMS = ("deferred", "defer", "dns", "didn't race", "did not race")
+
+_QUESTION_RULES = (
+    ("resource_feedback", ("did it cover", "how did you like", "how'd the prep kit land", "how did the prep kit land")),
+    ("workout_feedback", ("first rides feel", "how's it feeling", "numbers feel right")),
+    ("health", ("anything hurt", "does it hurt", "pain")),
+    ("favorite_workout", ("favorite workout", "workout do you", "look forward to")),
+    ("frustration", ("frustrat", "most annoying", "bothering you")),
+    ("challenge", ("challenge", "hardest", "get right", "holding you back")),
+    ("race_decision", ("which race", "still deciding", "what matters most", "registered")),
+    ("race_outcome", ("how did it go", "how'd it go", "what went well", "what went badly")),
+    ("training_status", ("how's training", "how is training", "where is the training")),
+    ("schedule", ("weekly hours", "schedule", "your week", "time do you have")),
+    ("fueling", ("fuel", "nutrition", "carb", "eat and drink")),
+)
+
+
+def normalize_email(value: str) -> str:
+    """Extract and normalize one mailbox address."""
+    address = parseaddr(value or "")[1].strip().lower()
+    return address if _EMAIL_RE.match(address) else ""
+
+
+def strip_quoted_reply(raw: str) -> str:
+    """Keep the newly authored portion of a Gmail message."""
+    text = html.unescape(raw or "").replace("\r", "")
+    kept: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(">") or _QUOTED_LINE_RE.match(stripped):
+            break
+        if stripped:
+            kept.append(stripped)
+    cleaned = "\n".join(kept).strip()
+    return cleaned[:MAX_BODY_CHARS]
+
+
+def classify_question(text: str) -> str:
+    folded = (text or "").casefold()
+    for label, terms in _QUESTION_RULES:
+        if any(term in folded for term in terms):
+            return label
+    return "other"
+
+
+def _reply_quality(text: str) -> tuple[str, int]:
+    words = re.findall(r"\b[\w'-]+\b", text or "")
+    # Twenty words is enough to contain actionable training/race context,
+    # while one-line answers remain correctly classified as brief.
+    return ("substantive" if len(words) >= 20 else "brief", len(words))
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    folded = f" {(text or '').casefold()} "
+    return any(term in folded for term in terms)
+
+
+def classify_intent(text: str) -> str:
+    if _contains_any(text, _SUPPORT_TERMS):
+        return "support"
+    if _contains_any(text, _BUYING_TERMS):
+        return "buying"
+    if _contains_any(text, _HEALTH_TERMS):
+        return "health_constraint"
+    if _contains_any(text, _RACE_DECISION_TERMS):
+        return "race_decision"
+    if _contains_any(text, _DEFERRED_TERMS):
+        return "deferred"
+    if _contains_any(text, _POSITIVE_TRAINING_TERMS):
+        return "training_positive"
+    return "conversation"
+
+
+def _stable_choice(seed: str, choices: tuple[tuple[str, str], ...]) -> tuple[str, str]:
+    index = int(hashlib.sha256(seed.encode()).hexdigest()[:8], 16) % len(choices)
+    return choices[index]
+
+
+def build_reply_suggestion(
+    *, text: str, first_name: str = "", seed: str = "",
+) -> dict:
+    """Build a deliberately plain Reflect → Ask starting point.
+
+    No product pitch is generated. An explicit question, operational problem,
+    or buying signal requires a coach answer before the draft can be approved.
+    """
+    intent = classify_intent(text)
+    needs_answer = "?" in text or intent in {"support", "buying"}
+
+    answer_placeholder = ""
+    if intent == "support":
+        acknowledgement = "Thanks for flagging that."
+        question_type = "support_resolution"
+        question = ""
+        answer_placeholder = "[Say exactly what you did or will do next.]"
+    elif intent == "buying":
+        acknowledgement = "Yep — happy to give you a straight answer."
+        question_type = "buying_context"
+        question = "What are you hoping the plan or coaching solves for you?"
+        answer_placeholder = "[Answer their question directly first.]"
+    elif intent == "health_constraint":
+        acknowledgement = "That sounds frustrating."
+        question_type = "frustration"
+        question = "What's the biggest thing keeping you from training normally right now?"
+    elif intent == "race_decision":
+        acknowledgement = "That makes sense."
+        question_type = "race_decision"
+        question = "What matters most in the choice — the course, the travel, or how it fits your training?"
+    elif intent == "deferred":
+        acknowledgement = "Got it."
+        question_type = "challenge"
+        question = "What ended up getting in the way?"
+    elif intent == "training_positive":
+        acknowledgement = "Good to hear."
+        question_type, question = _stable_choice(seed or text, (
+            ("challenge", "What part of training feels hardest to get right right now?"),
+            ("favorite_workout", "What kind of workout do you actually look forward to doing?"),
+        ))
+    else:
+        acknowledgement = "Got it."
+        question_type = "challenge"
+        question = "What's the biggest training challenge you're trying to sort out right now?"
+
+    if needs_answer and not answer_placeholder:
+        answer_placeholder = "[Answer their question directly first.]"
+
+    greeting = f"{first_name}," if first_name else "Hey —"
+    parts = [greeting, acknowledgement]
+    if answer_placeholder:
+        parts.append(answer_placeholder)
+    if question:
+        parts.append(question)
+    parts.append("— Matti")
+    draft = "\n\n".join(parts)
+    move = (
+        f"one easy {question_type.replace('_', ' ')} question"
+        if question else "a direct service resolution before any nurture question"
+    )
+    rationale = f"Intent: {intent}. {move}; no pitch and no invented coaching claim."
+    return {
+        "intent": intent,
+        "question_type": question_type,
+        "suggested_question": question,
+        "draft_text": draft,
+        "needs_coach_answer": needs_answer,
+        "rationale": rationale,
+    }
+
+
+def get_sync_candidates(limit: int = 500) -> list[dict]:
+    """Return open lead mailboxes for the account-local Apps Script relay."""
+    contacts: dict[str, dict] = {}
+    deals = db.select("gg_deals", limit=limit)
+    converted_emails = {
+        normalize_email(row.get("contact_email", ""))
+        for row in deals if row.get("stage") == "closed_won"
+    }
+    for enrollment in db.select("gg_sequence_enrollments", limit=limit):
+        email = normalize_email(enrollment.get("contact_email", ""))
+        if not email or email in converted_emails:
+            continue
+        seq = get_sequence(enrollment.get("sequence_id", "")) or {}
+        if seq.get("trigger") in _POST_PURCHASE_TRIGGERS:
+            continue
+        contacts[email] = {
+            "email": email,
+            "name": enrollment.get("contact_name", ""),
+            "brand": seq.get("brand", "gravelgod"),
+        }
+    for deal in deals:
+        if deal.get("stage") in {"closed_won", "closed_lost"}:
+            continue
+        email = normalize_email(deal.get("contact_email", ""))
+        if not email:
+            continue
+        existing = contacts.setdefault(email, {"email": email, "name": "", "brand": "gravelgod"})
+        existing["name"] = existing.get("name") or deal.get("contact_name", "")
+    return sorted(contacts.values(), key=lambda row: row["email"])[:limit]
+
+
+def _contact_record(email: str) -> dict | None:
+    # Existing rows predate strict lower-casing; compare normalized addresses.
+    deal = next((
+        row for row in db.select("gg_deals", limit=1000)
+        if normalize_email(row.get("contact_email", "")) == email
+    ), None)
+    enrollments = [
+        row for row in db.select("gg_sequence_enrollments", limit=1000)
+        if normalize_email(row.get("contact_email", "")) == email
+    ]
+    if not deal and not enrollments:
+        return None
+    enrollment = enrollments[-1] if enrollments else {}
+    seq = get_sequence(enrollment.get("sequence_id", "")) or {}
+    return {
+        "email": email,
+        "name": (deal or {}).get("contact_name") or enrollment.get("contact_name", ""),
+        "brand": seq.get("brand", "gravelgod"),
+        "deal_id": (deal or {}).get("id"),
+        "enrollments": enrollments,
+    }
+
+
+def _message_contact(message: dict, candidate_emails: set[str]) -> str:
+    addresses = [normalize_email(message.get("from", ""))]
+    addresses.extend(normalize_email(v) for v in message.get("to", []) or [])
+    addresses.extend(normalize_email(v) for v in message.get("cc", []) or [])
+    return next((address for address in addresses if address in candidate_emails), "")
+
+
+def _direction(message: dict, contact_email: str) -> str:
+    if message.get("is_draft"):
+        return "draft"
+    if normalize_email(message.get("from", "")) == contact_email:
+        return "inbound"
+    return "outbound"
+
+
+def _parse_message_at(value: str) -> datetime:
+    if not value:
+        return datetime.now(timezone.utc)
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return datetime.now(timezone.utc)
+
+
+def _reply_token(message: dict) -> str:
+    for value in (message.get("to", []) or []) + (message.get("cc", []) or []):
+        match = _REPLY_TOKEN_RE.search(value or "")
+        if match:
+            return match.group(1).lower()
+    return ""
+
+
+def _sequence_attribution(contact: dict, message: dict) -> tuple[dict | None, str]:
+    token = _reply_token(message)
+    if token:
+        exact = db.select_one("gg_sequence_sends", match={"reply_token": token})
+        if exact:
+            return exact, "exact"
+
+    inbound_at = _parse_message_at(message.get("date", "")).isoformat()
+    candidates: list[dict] = []
+    for enrollment in contact.get("enrollments", []):
+        for send in db.select("gg_sequence_sends", match={"enrollment_id": enrollment.get("id")}):
+            sent_at = send.get("sent_at") or ""
+            if not sent_at or sent_at <= inbound_at:
+                candidates.append(send)
+    if not candidates:
+        return None, "none"
+    candidates.sort(key=lambda row: row.get("sent_at") or "")
+    return candidates[-1], "email_time"
+
+
+def _pause_marketing_sequences(contact: dict) -> int:
+    paused = 0
+    for enrollment in contact.get("enrollments", []):
+        if enrollment.get("status") != "active":
+            continue
+        seq = get_sequence(enrollment.get("sequence_id", "")) or {}
+        if seq.get("trigger") in _POST_PURCHASE_TRIGGERS:
+            continue
+        db.update("gg_sequence_enrollments", {"status": "paused_reply"}, {"id": enrollment["id"]})
+        enrollment["status"] = "paused_reply"
+        paused += 1
+    return paused
+
+
+def _conversation(thread_id: str, contact: dict) -> dict:
+    existing = db.select_one("gg_lead_conversations", match={"gmail_thread_id": thread_id})
+    if existing:
+        return existing
+    return db.insert("gg_lead_conversations", {
+        "gmail_thread_id": thread_id,
+        "contact_email": contact["email"],
+        "contact_name": contact.get("name", ""),
+        "brand": contact.get("brand", "gravelgod"),
+        "deal_id": contact.get("deal_id"),
+        "status": "needs_reply",
+    })
+
+
+def _record_suggestion(conversation: dict, message: dict, body: str) -> dict:
+    existing = db.select_one(
+        "gg_lead_reply_suggestions", match={"inbound_message_id": message["id"]},
+    )
+    if existing:
+        return existing
+    first_name = (conversation.get("contact_name") or "").split(" ", 1)[0]
+    suggestion = build_reply_suggestion(
+        text=body,
+        first_name=first_name,
+        seed=f"{conversation.get('contact_email')}:{message['id']}",
+    )
+    status = "needs_coach_answer" if suggestion["needs_coach_answer"] else "suggested"
+    return db.insert("gg_lead_reply_suggestions", {
+        "conversation_id": conversation["id"],
+        "inbound_message_id": message["id"],
+        "initial_draft_text": suggestion["draft_text"],
+        "draft_text": suggestion["draft_text"],
+        "suggested_question": suggestion["suggested_question"],
+        "question_type": suggestion["question_type"],
+        "needs_coach_answer": suggestion["needs_coach_answer"],
+        "rationale": suggestion["rationale"],
+        "status": status,
+    })
+
+
+def _record_existing_draft_conflict(
+    conversation: dict, message: dict, body: str,
+) -> dict | None:
+    """Surface an untracked Gmail draft without ever replacing or duplicating it."""
+    tracked = next((
+        row for row in db.select(
+            "gg_lead_reply_suggestions", match={"conversation_id": conversation["id"]},
+        )
+        if row.get("gmail_draft_message_id") == message["id"]
+    ), None)
+    if tracked:
+        return None
+    existing = db.select_one(
+        "gg_lead_reply_suggestions", match={"inbound_message_id": message["id"]},
+    )
+    if existing:
+        return existing
+    return db.insert("gg_lead_reply_suggestions", {
+        "conversation_id": conversation["id"],
+        # The schema uses this as the unique source-message key. For a conflict,
+        # the source is deliberately the existing Gmail draft itself.
+        "inbound_message_id": message["id"],
+        "initial_draft_text": body,
+        "draft_text": body,
+        "suggested_question": "",
+        "question_type": classify_question(body),
+        "needs_coach_answer": False,
+        "rationale": (
+            "An existing Gmail draft was found in this lead thread. Review it "
+            "in Gmail; do not approve or create another version here."
+        ),
+        "status": "draft_conflict",
+        "gmail_draft_message_id": message["id"],
+    })
+
+
+def _ingest_thread(thread: dict, candidate_map: dict[str, dict]) -> dict:
+    thread_id = str(thread.get("id", ""))[:255]
+    messages = (thread.get("messages") or [])[:MAX_MESSAGES_PER_THREAD]
+    if not thread_id or not messages:
+        return {"status": "ignored", "reason": "empty_thread"}
+
+    candidate_emails = set(candidate_map)
+    contact_email = ""
+    for message in messages:
+        contact_email = _message_contact(message, candidate_emails)
+        if contact_email:
+            break
+    if not contact_email:
+        return {"status": "ignored", "reason": "not_a_known_lead"}
+    contact = _contact_record(contact_email)
+    if not contact:
+        return {"status": "ignored", "reason": "not_a_known_lead"}
+
+    conversation = _conversation(thread_id, contact)
+    inserted = 0
+    latest_direction = None
+    latest_message_id = None
+    latest_at = None
+    latest_intent = conversation.get("intent", "unknown")
+    latest_question_type = conversation.get("latest_question_type", "other")
+    last_sequence_send_id = conversation.get("last_sequence_send_id")
+    first_reply_latency_seconds = conversation.get("first_reply_latency_seconds")
+    inbound_delta = 0
+    outbound_delta = 0
+    substantive_delta = 0
+    paused = 0
+
+    for message in sorted(messages, key=lambda row: row.get("date", "")):
+        message_id = str(message.get("id", ""))[:255]
+        if not message_id or db.select_one("gg_lead_messages", match={"gmail_message_id": message_id}):
+            continue
+        direction = _direction(message, contact_email)
+        message_at = _parse_message_at(message.get("date", ""))
+        body = strip_quoted_reply(message.get("body", ""))
+        quality, word_count = _reply_quality(body)
+        sequence_send, confidence = (None, "none")
+        if direction == "inbound":
+            # Pause before any downstream drafting work. A suggestion failure
+            # must never leave the marketing sequence free to send again.
+            paused += _pause_marketing_sequences(contact)
+            sequence_send, confidence = _sequence_attribution(contact, message)
+        question_type = classify_question(body) if direction in {"outbound", "draft"} else "other"
+
+        db.insert("gg_lead_messages", {
+            "gmail_message_id": message_id,
+            "conversation_id": conversation["id"],
+            "gmail_thread_id": thread_id,
+            "direction": direction,
+            "from_address": normalize_email(message.get("from", "")),
+            "to_addresses": [normalize_email(v) for v in message.get("to", []) or [] if normalize_email(v)],
+            "cc_addresses": [normalize_email(v) for v in message.get("cc", []) or [] if normalize_email(v)],
+            "subject": str(message.get("subject", ""))[:MAX_SUBJECT_CHARS],
+            "body_text": body,
+            "body_sha256": hashlib.sha256(body.encode()).hexdigest(),
+            "message_at": message_at.isoformat(),
+            "sequence_send_id": (sequence_send or {}).get("id"),
+            "attribution_confidence": confidence,
+            "question_type": question_type,
+            "reply_quality": quality,
+            "word_count": word_count,
+            "is_trash": bool(message.get("is_trash")),
+        })
+        inserted += 1
+        latest_direction = direction
+        latest_message_id = message_id
+        latest_at = message_at
+
+        if direction == "inbound":
+            inbound_delta += 1
+            substantive_delta += int(quality == "substantive")
+            suggestion = _record_suggestion(conversation, message, body)
+            latest_intent = classify_intent(body)
+            latest_question_type = suggestion.get("question_type", "other")
+            if sequence_send:
+                current_send = db.select_one(
+                    "gg_sequence_sends", match={"id": sequence_send["id"]},
+                ) or sequence_send
+                updates = {"reply_count": int(current_send.get("reply_count") or 0) + 1}
+                if not current_send.get("first_reply_at"):
+                    updates["first_reply_at"] = message_at.isoformat()
+                    try:
+                        sent_at = datetime.fromisoformat(
+                            (current_send.get("sent_at") or "").replace("Z", "+00:00")
+                        )
+                        first_reply_latency_seconds = max(
+                            0, int((message_at - sent_at).total_seconds()),
+                        )
+                    except (TypeError, ValueError):
+                        pass
+                db.update("gg_sequence_sends", updates, {"id": sequence_send["id"]})
+                last_sequence_send_id = sequence_send["id"]
+        elif direction == "outbound":
+            outbound_delta += 1
+            # A real sent reply supersedes every still-pending suggestion in this thread.
+            for pending in db.select("gg_lead_reply_suggestions", match={"conversation_id": conversation["id"]}):
+                if pending.get("status") in {"suggested", "needs_coach_answer", "approved_for_gmail", "gmail_drafted"}:
+                    db.update("gg_lead_reply_suggestions", {
+                        "status": "sent", "sent_at": message_at.isoformat(),
+                        "updated_at": datetime.now(timezone.utc).isoformat(),
+                    }, {"id": pending["id"]})
+        elif direction == "draft":
+            _record_existing_draft_conflict(conversation, message, body)
+
+    if inserted:
+        now = datetime.now(timezone.utc).isoformat()
+        status = conversation.get("status", "needs_reply")
+        if latest_direction == "inbound":
+            status = "suggested"
+        elif latest_direction == "draft":
+            tracked = next((
+                row for row in db.select(
+                    "gg_lead_reply_suggestions", match={"conversation_id": conversation["id"]},
+                )
+                if row.get("gmail_draft_message_id") == latest_message_id
+                and row.get("status") == "gmail_drafted"
+            ), None)
+            status = "gmail_drafted" if tracked else "draft_conflict"
+        elif latest_direction == "outbound":
+            status = "waiting_on_lead"
+        updates = {
+            "status": status,
+            "intent": latest_intent,
+            "latest_question_type": latest_question_type,
+            "last_sequence_send_id": last_sequence_send_id,
+            "first_reply_latency_seconds": first_reply_latency_seconds,
+            "inbound_count": int(conversation.get("inbound_count") or 0) + inbound_delta,
+            "outbound_count": int(conversation.get("outbound_count") or 0) + outbound_delta,
+            "substantive_reply_count": int(conversation.get("substantive_reply_count") or 0) + substantive_delta,
+            "updated_at": now,
+        }
+        if latest_at and latest_direction == "inbound":
+            updates["last_inbound_at"] = latest_at.isoformat()
+        elif latest_at and latest_direction == "outbound":
+            updates["last_outbound_at"] = latest_at.isoformat()
+        db.update("gg_lead_conversations", updates, {"id": conversation["id"]})
+        db.log_action(
+            "gmail_lead_sync", "lead_conversation", conversation["id"],
+            f"{inserted} new message(s); {paused} marketing enrollment(s) paused",
+        )
+    return {"status": "recorded", "messages": inserted, "paused": paused}
+
+
+def ingest_gmail_sync(payload: dict) -> dict:
+    threads = (payload.get("threads") or [])[:MAX_THREADS_PER_SYNC]
+    candidates = get_sync_candidates()
+    candidate_map = {row["email"]: row for row in candidates}
+    results = [_ingest_thread(thread, candidate_map) for thread in threads]
+    return {
+        "threads": len(results),
+        "recorded": sum(1 for row in results if row["status"] == "recorded"),
+        "messages": sum(row.get("messages", 0) for row in results),
+        "paused": sum(row.get("paused", 0) for row in results),
+        "ignored": sum(1 for row in results if row["status"] == "ignored"),
+    }
+
+
+def get_approved_drafts(limit: int = 25) -> list[dict]:
+    rows = db.select(
+        "gg_lead_reply_suggestions",
+        match={"status": "approved_for_gmail"},
+        order="approved_at", limit=limit,
+    )
+    output = []
+    for row in rows:
+        inbound = db.select_one("gg_lead_messages", match={"gmail_message_id": row["inbound_message_id"]})
+        conversation = db.select_one("gg_lead_conversations", match={"id": row["conversation_id"]})
+        if not inbound or not conversation:
+            continue
+        output.append({
+            "suggestion_id": row["id"],
+            "gmail_thread_id": conversation["gmail_thread_id"],
+            "inbound_message_id": row["inbound_message_id"],
+            "contact_email": conversation["contact_email"],
+            "draft_text": row["draft_text"],
+        })
+    return output
+
+
+def record_draft_receipt(suggestion_id: str, payload: dict) -> dict | None:
+    suggestion = db.select_one("gg_lead_reply_suggestions", match={"id": suggestion_id})
+    if not suggestion or suggestion.get("status") != "approved_for_gmail":
+        return None
+    receipt_status = payload.get("status")
+    if receipt_status == "draft_conflict":
+        status = "draft_conflict"
+        conversation_status = "draft_conflict"
+    elif receipt_status == "gmail_drafted":
+        status = "gmail_drafted"
+        conversation_status = "gmail_drafted"
+    else:
+        return None
+    now = datetime.now(timezone.utc).isoformat()
+    db.update("gg_lead_reply_suggestions", {
+        "status": status,
+        "gmail_draft_id": str(payload.get("gmail_draft_id", ""))[:255] or None,
+        "gmail_draft_message_id": str(payload.get("gmail_draft_message_id", ""))[:255] or None,
+        "drafted_at": now if status == "gmail_drafted" else None,
+        "updated_at": now,
+    }, {"id": suggestion_id})
+    db.update("gg_lead_conversations", {
+        "status": conversation_status, "updated_at": now,
+    }, {"id": suggestion["conversation_id"]})
+    db.log_action(status, "lead_reply_suggestion", suggestion_id)
+    return {"status": status}
+
+
+def get_reply_queue(limit: int = 100) -> list[dict]:
+    """Return the editor queue with source message and conversation context."""
+    actionable = {
+        "suggested", "needs_coach_answer", "approved_for_gmail",
+        "gmail_drafted", "draft_conflict",
+    }
+    rows = db.select(
+        "gg_lead_reply_suggestions", order="created_at", order_desc=True, limit=limit,
+    )
+    output = []
+    for row in rows:
+        if row.get("status") not in actionable:
+            continue
+        inbound = db.select_one(
+            "gg_lead_messages", match={"gmail_message_id": row["inbound_message_id"]},
+        )
+        conversation = db.select_one(
+            "gg_lead_conversations", match={"id": row["conversation_id"]},
+        )
+        if not inbound or not conversation:
+            continue
+        output.append({
+            **row,
+            "contact_email": conversation.get("contact_email", ""),
+            "contact_name": conversation.get("contact_name", ""),
+            "brand": conversation.get("brand", "gravelgod"),
+            "intent": conversation.get("intent", "unknown"),
+            "subject": inbound.get("subject", ""),
+            "inbound_body": inbound.get("body_text", ""),
+            "message_at": inbound.get("message_at"),
+        })
+    return output
+
+
+def approve_reply_suggestion(suggestion_id: str, draft_text: str) -> dict | None:
+    suggestion = db.select_one("gg_lead_reply_suggestions", match={"id": suggestion_id})
+    if not suggestion or suggestion.get("status") not in {"suggested", "needs_coach_answer"}:
+        return None
+    draft_text = (draft_text or "").strip()[:10_000]
+    if not draft_text:
+        return None
+    if suggestion.get("needs_coach_answer"):
+        initial = (suggestion.get("initial_draft_text") or "").strip()
+        if draft_text == initial or "[Answer " in draft_text or "[Say exactly " in draft_text:
+            return None
+    now = datetime.now(timezone.utc).isoformat()
+    updated = db.update("gg_lead_reply_suggestions", {
+        "draft_text": draft_text,
+        "question_type": classify_question(draft_text),
+        "status": "approved_for_gmail",
+        "approved_at": now,
+        "updated_at": now,
+    }, {"id": suggestion_id})
+    db.update("gg_lead_conversations", {
+        "status": "approved_for_gmail", "updated_at": now,
+    }, {"id": suggestion["conversation_id"]})
+    db.log_action("lead_reply_approved", "lead_reply_suggestion", suggestion_id)
+    return updated
+
+
+def dismiss_reply_suggestion(suggestion_id: str) -> dict | None:
+    suggestion = db.select_one("gg_lead_reply_suggestions", match={"id": suggestion_id})
+    if not suggestion or suggestion.get("status") in {"sent", "dismissed"}:
+        return None
+    now = datetime.now(timezone.utc).isoformat()
+    updated = db.update("gg_lead_reply_suggestions", {
+        "status": "dismissed", "updated_at": now,
+    }, {"id": suggestion_id})
+    db.update("gg_lead_conversations", {
+        "status": "closed", "updated_at": now,
+    }, {"id": suggestion["conversation_id"]})
+    db.log_action("lead_reply_dismissed", "lead_reply_suggestion", suggestion_id)
+    return updated
+
+
+def get_learning_metrics(days: int = 90) -> dict:
+    """Compute conversation outcomes without pretending tiny samples are verdicts."""
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    sends = db.select("gg_sequence_sends")
+    sends = [row for row in sends if (row.get("sent_at") or "") >= since]
+    messages = db.select("gg_lead_messages")
+    messages = [row for row in messages if (row.get("message_at") or "") >= since]
+    suggestions = db.select("gg_lead_reply_suggestions")
+    conversations = db.select("gg_lead_conversations")
+    enrollments = db.select("gg_sequence_enrollments")
+    deals = {row.get("id"): row for row in db.select("gg_deals")}
+    conversations_by_id = {row.get("id"): row for row in conversations}
+
+    sends_by_id = {row.get("id"): row for row in sends}
+    messages_by_conversation: dict[str, list[dict]] = {}
+    for message in messages:
+        messages_by_conversation.setdefault(message.get("conversation_id"), []).append(message)
+    for conversation_messages in messages_by_conversation.values():
+        conversation_messages.sort(key=lambda row: row.get("message_at") or "")
+    inbound_by_send: dict[str, list[dict]] = {}
+    for message in messages:
+        send_id = message.get("sequence_send_id")
+        if message.get("direction") == "inbound" and send_id in sends_by_id:
+            inbound_by_send.setdefault(send_id, []).append(message)
+
+    by_question: dict[str, dict] = {}
+    latencies: list[float] = []
+    coach_response_latencies: list[float] = []
+
+    def bucket_for(question_type: str) -> dict:
+        return by_question.setdefault(question_type or "other", {
+            "question_type": question_type or "other",
+            "sends": 0,
+            "replies": 0,
+            "substantive_replies": 0,
+            "assisted_wins": 0,
+            "latencies": [],
+        })
+
+    for send in sends:
+        question_type = send.get("question_type") or "other"
+        bucket = bucket_for(question_type)
+        bucket["sends"] += 1
+        replies = []
+        for reply in inbound_by_send.get(send.get("id"), []):
+            # Once Matti has replied manually, the next lead reply measures that
+            # manual question—not the older sequence email.
+            sent_at_text = send.get("sent_at") or ""
+            reply_at_text = reply.get("message_at") or ""
+            intervening_manual = any(
+                candidate.get("direction") == "outbound"
+                and sent_at_text < (candidate.get("message_at") or "") < reply_at_text
+                for candidate in messages_by_conversation.get(reply.get("conversation_id"), [])
+            )
+            if not intervening_manual:
+                replies.append(reply)
+        if replies:
+            bucket["replies"] += 1
+            bucket["substantive_replies"] += int(any(
+                row.get("reply_quality") == "substantive" for row in replies
+            ))
+            won = any(
+                deals.get(conversations_by_id.get(row.get("conversation_id"), {}).get("deal_id"), {}).get("stage")
+                == "closed_won"
+                for row in replies
+            )
+            bucket["assisted_wins"] += int(won)
+            try:
+                sent_at = datetime.fromisoformat((send.get("sent_at") or "").replace("Z", "+00:00"))
+                reply_at = min(
+                    datetime.fromisoformat(row["message_at"].replace("Z", "+00:00"))
+                    for row in replies
+                )
+                seconds = max(0.0, (reply_at - sent_at).total_seconds())
+                bucket["latencies"].append(seconds)
+                latencies.append(seconds)
+            except (KeyError, TypeError, ValueError):
+                pass
+
+    # Manual Gmail replies are experiments too. Attribute the next inbound in
+    # the same thread to the question Matti actually sent.
+    for conversation_messages in messages_by_conversation.values():
+        for index, message in enumerate(conversation_messages):
+            if message.get("direction") != "outbound":
+                continue
+            question_type = message.get("question_type") or "other"
+            bucket = bucket_for(question_type)
+            bucket["sends"] += 1
+            next_event = next((
+                candidate for candidate in conversation_messages[index + 1:]
+                if candidate.get("direction") in {"inbound", "outbound"}
+            ), None)
+            # When Matti sends twice before the lead answers, only the most
+            # recent question gets credit.
+            if not next_event or next_event.get("direction") != "inbound":
+                continue
+            reply = next_event
+            bucket["replies"] += 1
+            bucket["substantive_replies"] += int(reply.get("reply_quality") == "substantive")
+            conversation = conversations_by_id.get(reply.get("conversation_id"), {})
+            bucket["assisted_wins"] += int(
+                deals.get(conversation.get("deal_id"), {}).get("stage") == "closed_won"
+            )
+            try:
+                sent_at = datetime.fromisoformat(message["message_at"].replace("Z", "+00:00"))
+                reply_at = datetime.fromisoformat(reply["message_at"].replace("Z", "+00:00"))
+                seconds = max(0.0, (reply_at - sent_at).total_seconds())
+                bucket["latencies"].append(seconds)
+                latencies.append(seconds)
+            except (KeyError, TypeError, ValueError):
+                pass
+
+        # Responsiveness is a service KPI: time from each inbound to Matti's
+        # next sent reply, without counting drafts.
+        for index, message in enumerate(conversation_messages):
+            if message.get("direction") != "inbound":
+                continue
+            next_event = next((
+                candidate for candidate in conversation_messages[index + 1:]
+                if candidate.get("direction") in {"inbound", "outbound"}
+            ), None)
+            # Consecutive inbound messages form one lead turn; measure response
+            # time from the final message before Matti replies.
+            if not next_event or next_event.get("direction") != "outbound":
+                continue
+            outbound = next_event
+            try:
+                inbound_at = datetime.fromisoformat(message["message_at"].replace("Z", "+00:00"))
+                outbound_at = datetime.fromisoformat(outbound["message_at"].replace("Z", "+00:00"))
+                coach_response_latencies.append(max(0.0, (outbound_at - inbound_at).total_seconds()))
+            except (KeyError, TypeError, ValueError):
+                pass
+
+    question_rows = []
+    for bucket in by_question.values():
+        sends_count = bucket["sends"]
+        replies_count = bucket["replies"]
+        sample_state = "enough_to_review" if sends_count >= 30 else "keep_collecting"
+        question_rows.append({
+            "question_type": bucket["question_type"],
+            "sends": sends_count,
+            "replies": replies_count,
+            "reply_rate": round(replies_count / sends_count * 100, 1) if sends_count else 0.0,
+            "substantive_replies": bucket["substantive_replies"],
+            "assisted_wins": bucket["assisted_wins"],
+            "median_reply_hours": round(statistics.median(bucket["latencies"]) / 3600, 1)
+            if bucket["latencies"] else None,
+            "sample_state": sample_state,
+        })
+    question_rows.sort(key=lambda row: (-row["sends"], row["question_type"]))
+
+    replies = sum(row["replies"] for row in question_rows)
+    total_sends = sum(row["sends"] for row in question_rows)
+    open_after_reply = 0
+    replied_contacts = {
+        (row.get("contact_email") or "").strip().lower()
+        for row in conversations if row.get("last_inbound_at")
+    }
+    for enrollment in enrollments:
+        if enrollment.get("status") != "active":
+            continue
+        if (enrollment.get("contact_email") or "").strip().lower() not in replied_contacts:
+            continue
+        seq = get_sequence(enrollment.get("sequence_id", "")) or {}
+        if seq.get("trigger") not in _POST_PURCHASE_TRIGGERS:
+            open_after_reply += 1
+
+    enough = [row for row in question_rows if row["sample_state"] == "enough_to_review"]
+    recommendations = []
+    draft_conflicts = sum(1 for row in suggestions if row.get("status") == "draft_conflict")
+    editor_decisions = [
+        row for row in suggestions
+        if row.get("approved_at")
+        or row.get("status") in {"dismissed", "superseded"}
+    ]
+    accepted = [
+        row for row in editor_decisions if row.get("approved_at")
+    ]
+    edit_ratios = [
+        1.0 - SequenceMatcher(
+            None, row.get("initial_draft_text") or "", row.get("draft_text") or "",
+        ).ratio()
+        for row in accepted if row.get("initial_draft_text")
+    ]
+    if open_after_reply:
+        recommendations.append(
+            f"Safety: {open_after_reply} marketing enrollment(s) remain active after a reply; pause before another send."
+        )
+    if draft_conflicts:
+        recommendations.append(
+            f"Workflow: resolve {draft_conflicts} Gmail draft conflict(s); do not create another version."
+        )
+    if len(enough) >= 2:
+        best = max(enough, key=lambda row: (row["reply_rate"], row["substantive_replies"]))
+        recommendations.append(
+            f"Review {best['question_type'].replace('_', ' ')} as the current leader "
+            f"({best['reply_rate']}% replies across {best['sends']} sends). "
+            "Run one approval-gated copy test; do not change every sequence."
+        )
+    else:
+        recommendations.append(
+            "Keep collecting. No question type has enough comparative volume for a copy verdict yet."
+        )
+    if len(edit_ratios) >= 20 and statistics.median(edit_ratios) >= 0.35:
+        recommendations.append(
+            "Voice fit: approved drafts are being substantially rewritten. Review the last 20 edits "
+            "and update the suggestion rules only after Matti approves the pattern."
+        )
+
+    return {
+        "days": days,
+        "sends": total_sends,
+        "replies": replies,
+        "reply_rate": round(replies / total_sends * 100, 1) if total_sends else 0.0,
+        "median_reply_hours": round(statistics.median(latencies) / 3600, 1) if latencies else None,
+        "median_coach_response_hours": round(
+            statistics.median(coach_response_latencies) / 3600, 1,
+        ) if coach_response_latencies else None,
+        "substantive_replies": sum(row["substantive_replies"] for row in question_rows),
+        "second_reply_conversations": sum(
+            1 for rows in messages_by_conversation.values()
+            if sum(1 for row in rows if row.get("direction") == "inbound") >= 2
+        ),
+        "assisted_wins": len({
+            row.get("conversation_id") for row in messages
+            if row.get("direction") == "inbound"
+            and deals.get(
+                conversations_by_id.get(row.get("conversation_id"), {}).get("deal_id"), {},
+            ).get("stage") == "closed_won"
+        }),
+        "unsubscribes": sum(1 for row in enrollments if row.get("status") == "unsubscribed"),
+        "spam_complaints": sum(1 for row in sends if row.get("status") == "complained"),
+        "active_after_reply": open_after_reply,
+        "draft_conflicts": draft_conflicts,
+        "pending_editor": sum(1 for row in suggestions if row.get("status") in {"suggested", "needs_coach_answer"}),
+        "editor_decisions": len(editor_decisions),
+        "suggestion_acceptance_rate": round(len(accepted) / len(editor_decisions) * 100, 1)
+        if editor_decisions else None,
+        "median_edit_percent": round(statistics.median(edit_ratios) * 100, 1)
+        if edit_ratios else None,
+        "question_rows": question_rows,
+        "recommendations": recommendations,
+        "measurement_note": (
+            "Question types need at least 30 attributed sends before review. "
+            "Recommendations never change live copy automatically."
+        ),
+    }

--- a/mission_control/services/sequence_engine.py
+++ b/mission_control/services/sequence_engine.py
@@ -8,9 +8,11 @@ import hmac
 import logging
 import random
 import re
+import secrets
 import urllib.parse
 from html import escape as html_escape
 from datetime import datetime, timedelta, timezone
+from email.utils import formataddr, parseaddr
 
 from mission_control import supabase_client as db
 from mission_control.config import (
@@ -299,12 +301,14 @@ async def _send_next_step(enrollment: dict) -> bool:
         return False
 
     try:
+        reply_token = secrets.token_hex(16)
         resend_id = await asyncio.to_thread(
             _send_email_sync,
             enrollment["contact_email"],
             subject,
             html,
             brand,
+            reply_token,
         )
     except Exception as e:
         db.log_action(
@@ -316,6 +320,8 @@ async def _send_next_step(enrollment: dict) -> bool:
         return False
 
     # Record send
+    from mission_control.services.lead_nurture import classify_question
+
     db.insert("gg_sequence_sends", {
         "enrollment_id": enrollment["id"],
         "step_index": step_index,
@@ -323,6 +329,8 @@ async def _send_next_step(enrollment: dict) -> bool:
         "subject": subject,
         "resend_id": resend_id,
         "status": "sent",
+        "reply_token": reply_token,
+        "question_type": step.get("question_type") or classify_question(html),
     })
 
     # Advance to next step
@@ -476,6 +484,7 @@ def _inject_utm_params(
 
 def _send_email_sync(
     to_email: str, subject: str, html: str, brand: str = "gravelgod",
+    reply_token: str = "",
 ) -> str:
     """Send an email via Resend. Runs in a thread (called via asyncio.to_thread)."""
     import resend
@@ -487,12 +496,28 @@ def _send_email_sync(
     sender = BRAND_SEQUENCE_SENDERS.get(brand, BRAND_SEQUENCE_SENDERS["gravelgod"])
     result = resend.Emails.send({
         "from": f"{sender['from_name']} <{sender['from_email']}>",
-        "reply_to": sender["reply_to"],
+        "reply_to": _tagged_reply_to(sender["reply_to"], reply_token),
         "to": [to_email],
         "subject": subject,
         "html": html,
     })
     return result.get("id", "")
+
+
+def _tagged_reply_to(reply_to: str, token: str) -> str:
+    """Add a Gmail plus-token for exact reply-to-send attribution."""
+    if not token:
+        return reply_to
+    display_name, address = parseaddr(reply_to)
+    if "@" not in address:
+        return reply_to
+    local, domain = address.rsplit("@", 1)
+    if domain.casefold() not in {"gmail.com", "googlemail.com"}:
+        return reply_to
+    # Preserve any existing plus alias while adding our stable lead token.
+    local = local.split("+", 1)[0]
+    tagged = f"{local}+lead.{token}@{domain}"
+    return formataddr((display_name, tagged)) if display_name else tagged
 
 
 def _inject_unsubscribe(html: str, email: str) -> str:
@@ -539,6 +564,18 @@ def record_event(resend_id: str, event_type: str) -> bool:
         )
         if enrollment:
             db.update("gg_sequence_enrollments", {"status": "paused"}, {"id": enrollment["id"]})
+    elif event_type == "email.complained":
+        updates["status"] = "complained"
+        updates["complained_at"] = now
+        enrollment = db.select_one(
+            "gg_sequence_enrollments", match={"id": send["enrollment_id"]}
+        )
+        if enrollment:
+            db.update(
+                "gg_sequence_enrollments",
+                {"status": "unsubscribed"},
+                {"id": enrollment["id"]},
+            )
 
     if updates:
         db.update("gg_sequence_sends", updates, {"id": send["id"]})

--- a/mission_control/templates/base.html
+++ b/mission_control/templates/base.html
@@ -58,6 +58,10 @@
                     <svg class="mc-nav__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
                     <span>Deals</span>
                 </a>
+                <a href="/lead-replies" class="mc-nav__link {% if active_page == 'lead_replies' %}mc-nav__link--active{% endif %}">
+                    <svg class="mc-nav__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 01-4-.832L3 20l1.337-3.566A7.58 7.58 0 013 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg>
+                    <span>Lead Replies</span>
+                </a>
                 <a href="/templates" class="mc-nav__link {% if active_page == 'templates' %}mc-nav__link--active{% endif %}">
                     <svg class="mc-nav__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zm0 8a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zm10 0a1 1 0 011-1h4a1 1 0 011 1v6a1 1 0 01-1 1h-4a1 1 0 01-1-1v-6z"/></svg>
                     <span>Templates</span>

--- a/mission_control/templates/lead_replies/index.html
+++ b/mission_control/templates/lead_replies/index.html
@@ -1,0 +1,136 @@
+{% extends "base.html" %}
+
+{% block title %}Lead Replies{% endblock %}
+
+{% block head_extra %}
+<style>
+.lead-reply-grid { display:grid; grid-template-columns:minmax(0, 1.7fr) minmax(260px, .8fr); gap:var(--gg-spacing-lg); }
+.lead-reply-card { border-left:3px solid var(--gg-color-gold); }
+.lead-reply-source { white-space:pre-wrap; font-family:var(--gg-font-data); font-size:var(--gg-font-size-xs); line-height:1.55; padding:var(--gg-spacing-md); border:1px dotted var(--gg-border-color-default); background:var(--gg-color-sand); }
+.lead-reply-editor { width:100%; min-height:170px; resize:vertical; }
+.lead-reply-actions { display:flex; gap:var(--gg-spacing-sm); flex-wrap:wrap; margin-top:var(--gg-spacing-md); }
+.lead-reply-meta { display:flex; flex-wrap:wrap; gap:var(--gg-spacing-xs); margin-bottom:var(--gg-spacing-md); }
+@media (max-width: 860px) {
+  .lead-reply-grid { grid-template-columns:1fr; }
+  .mc-main { padding:var(--gg-spacing-md); }
+  .lead-reply-editor { min-height:210px; font-size:16px; }
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="mc-page-header">
+    <span class="mc-page-header__kicker">Conversion / Editor Queue</span>
+    <h1 class="mc-page-header__title">Lead Replies</h1>
+    <p class="mc-page-header__desc">Reflect one detail. Give one useful thing when grounded. Ask one easy question. Approval creates a Gmail draft; it never sends.</p>
+</div>
+
+<div class="gg-stat-grid mc-mb-lg">
+    <div class="gg-stat-card"><div class="gg-stat-card__label">90d replies</div><div class="gg-stat-card__value">{{ metrics.replies }}</div></div>
+    <div class="gg-stat-card"><div class="gg-stat-card__label">Reply rate</div><div class="gg-stat-card__value">{{ metrics.reply_rate }}%</div></div>
+    <div class="gg-stat-card"><div class="gg-stat-card__label">Substantive</div><div class="gg-stat-card__value">{{ metrics.substantive_replies }}</div></div>
+    <div class="gg-stat-card"><div class="gg-stat-card__label">Second replies</div><div class="gg-stat-card__value">{{ metrics.second_reply_conversations }}</div></div>
+    <div class="gg-stat-card"><div class="gg-stat-card__label">Assisted wins</div><div class="gg-stat-card__value">{{ metrics.assisted_wins }}</div></div>
+    <div class="gg-stat-card"><div class="gg-stat-card__label">Coach response</div><div class="gg-stat-card__value">{{ metrics.median_coach_response_hours if metrics.median_coach_response_hours is not none else '—' }}h</div></div>
+    <div class="gg-stat-card"><div class="gg-stat-card__label">Draft acceptance</div><div class="gg-stat-card__value">{{ metrics.suggestion_acceptance_rate if metrics.suggestion_acceptance_rate is not none else '—' }}{% if metrics.suggestion_acceptance_rate is not none %}%{% endif %}</div></div>
+</div>
+
+<div class="lead-reply-grid">
+    <section>
+        {% if queue %}
+        {% for item in queue %}
+        <article class="mc-card mc-mb-lg lead-reply-card" id="reply-{{ item.id }}">
+            <div class="mc-card__header">
+                <h3 class="mc-card__title">{{ item.contact_name or item.contact_email }}</h3>
+                <span class="gg-badge gg-badge--outline">{{ item.status|replace('_', ' ') }}</span>
+            </div>
+            <div class="mc-card__body">
+                <div class="lead-reply-meta">
+                    <span class="gg-badge gg-badge--default">{{ item.brand }}</span>
+                    <span class="gg-badge gg-badge--default">{{ item.intent|replace('_', ' ') }}</span>
+                    <span class="gg-badge gg-badge--default">{{ item.question_type|replace('_', ' ') }}</span>
+                    {% if item.needs_coach_answer %}<span class="gg-badge gg-badge--gold">answer needed</span>{% endif %}
+                </div>
+                <p class="mc-text-muted">{{ item.subject or '(no subject)' }} · {{ item.message_at[:16]|replace('T', ' ') if item.message_at else '—' }}</p>
+                <div class="lead-reply-source">{{ item.inbound_body }}</div>
+                <p><strong>Why this question:</strong> {{ item.rationale }}</p>
+                {% if item.needs_coach_answer %}
+                <div class="gg-alert gg-alert--warning">
+                    <span class="gg-alert__label">Answer first</span>
+                    <span class="gg-alert__message">Replace the bracketed line with the direct answer or concrete next action. The unchanged draft cannot be approved.</span>
+                </div>
+                {% endif %}
+                {% if item.status == 'draft_conflict' %}
+                <div class="gg-alert gg-alert--warning mc-mt-md">
+                    <span class="gg-alert__label">Existing Gmail draft</span>
+                    <span class="gg-alert__message">Open this thread in Gmail and decide whether to send, update, or delete that draft. Mission Control will not create a duplicate.</span>
+                </div>
+                <div class="lead-reply-actions">
+                    <button type="button" class="gg-btn gg-btn--ghost"
+                            hx-post="/lead-replies/{{ item.id }}/dismiss"
+                            hx-target="#reply-{{ item.id }}" hx-swap="outerHTML"
+                            hx-confirm="Only continue if you already resolved this draft in Gmail. Mark resolved?">I resolved it in Gmail</button>
+                </div>
+                {% else %}
+                <form hx-post="/lead-replies/{{ item.id }}/approve" hx-target="#result-{{ item.id }}" hx-swap="innerHTML">
+                    <textarea class="mc-textarea lead-reply-editor" name="draft_text">{{ item.draft_text }}</textarea>
+                    <div class="lead-reply-actions">
+                        <button type="submit" class="gg-btn gg-btn--primary">Approve Gmail Draft</button>
+                        <button type="button" class="gg-btn gg-btn--ghost"
+                                hx-post="/lead-replies/{{ item.id }}/dismiss"
+                                hx-target="#reply-{{ item.id }}" hx-swap="outerHTML"
+                                hx-confirm="Dismiss this suggestion without sending?">Dismiss</button>
+                    </div>
+                </form>
+                {% endif %}
+                <div id="result-{{ item.id }}" class="mc-mt-md"></div>
+            </div>
+        </article>
+        {% endfor %}
+        {% else %}
+        <div class="gg-empty-state">
+            <h3 class="gg-empty-state__title">No lead replies need editing</h3>
+            <p class="gg-empty-state__text">New replies appear after the Gmail relay syncs them.</p>
+        </div>
+        {% endif %}
+    </section>
+
+    <aside>
+        <div class="mc-card mc-mb-lg">
+            <div class="mc-card__header"><h3 class="mc-card__title">Question Learning</h3></div>
+            <div class="mc-card__body">
+                <p class="mc-text-muted">{{ metrics.measurement_note }}</p>
+                <table class="gg-table gg-table--compact">
+                    <thead><tr><th>Question</th><th>Sends</th><th>Replies</th><th>Rate</th></tr></thead>
+                    <tbody>
+                    {% for row in metrics.question_rows %}
+                    <tr>
+                        <td>{{ row.question_type|replace('_', ' ') }}</td>
+                        <td>{{ row.sends }}</td>
+                        <td>{{ row.replies }}</td>
+                        <td>{{ row.reply_rate }}%{% if row.sample_state == 'keep_collecting' %} · wait{% endif %}</td>
+                    </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="mc-card mc-mb-lg">
+            <div class="mc-card__header"><h3 class="mc-card__title">What to Improve</h3></div>
+            <div class="mc-card__body">
+                {% for recommendation in metrics.recommendations %}<p>{{ recommendation }}</p>{% endfor %}
+                <p class="mc-text-muted">Trust guardrails: {{ metrics.unsubscribes }} unsubscribes · {{ metrics.spam_complaints }} spam complaints · {{ metrics.active_after_reply }} active sequences after a reply · {{ metrics.draft_conflicts }} draft conflicts.</p>
+            </div>
+        </div>
+        <div class="mc-card">
+            <div class="mc-card__header"><h3 class="mc-card__title">Matti Register</h3></div>
+            <div class="mc-card__body">
+                <p>One specific acknowledgment.</p>
+                <p>One useful answer or connection, only when grounded.</p>
+                <p>One easy question.</p>
+                <p class="mc-text-muted">No pitch unless they ask. No three-question stack. No clever metaphor that competes with the person.</p>
+            </div>
+        </div>
+    </aside>
+</div>
+{% endblock %}

--- a/mission_control/templates/lead_replies/index.html
+++ b/mission_control/templates/lead_replies/index.html
@@ -53,6 +53,18 @@
                 </div>
                 <p class="mc-text-muted">{{ item.subject or '(no subject)' }} · {{ item.message_at[:16]|replace('T', ' ') if item.message_at else '—' }}</p>
                 <div class="lead-reply-source">{{ item.inbound_body }}</div>
+                {% if item.thread_context|length > 1 %}
+                <details class="mc-mt-md mc-mb-md">
+                    <summary>Thread context · {{ item.thread_context|length }} recent messages</summary>
+                    {% for message in item.thread_context %}
+                    <div class="lead-reply-source mc-mt-sm">
+                        <strong>{{ 'Lead' if message.direction == 'inbound' else ('Draft' if message.direction == 'draft' else 'Matti') }}</strong>
+                        · {{ message.message_at[:16]|replace('T', ' ') if message.message_at else '—' }}
+                        <br>{{ message.body_text }}
+                    </div>
+                    {% endfor %}
+                </details>
+                {% endif %}
                 <p><strong>Why this question:</strong> {{ item.rationale }}</p>
                 {% if item.needs_coach_answer %}
                 <div class="gg-alert gg-alert--warning">
@@ -108,7 +120,7 @@
                         <td>{{ row.question_type|replace('_', ' ') }}</td>
                         <td>{{ row.sends }}</td>
                         <td>{{ row.replies }}</td>
-                        <td>{{ row.reply_rate }}%{% if row.sample_state == 'keep_collecting' %} · wait{% endif %}</td>
+                        <td>{{ row.reply_rate }}%</td>
                     </tr>
                     {% endfor %}
                     </tbody>

--- a/mission_control/tests/test_lead_nurture.py
+++ b/mission_control/tests/test_lead_nurture.py
@@ -56,6 +56,45 @@ class TestPlainMattiSuggestions:
         assert "resend" not in result["draft_text"].lower()
         assert result["draft_text"].count("?") == 0
 
+    def test_specific_training_detail_gets_a_grounded_deadpan_move(self):
+        from mission_control.services.lead_nurture import build_reply_suggestion
+
+        result = build_reply_suggestion(
+            text=(
+                "Training is going pretty well. Long climbs still fall apart, "
+                "and I am usually behind on fueling by hour three."
+            ),
+            first_name="Jane",
+            seed="stable",
+        )
+        assert result["question_type"] == "fueling"
+        assert "Long climbs are pretty honest" in result["draft_text"]
+        assert "legs, breathing, or fueling" in result["draft_text"]
+        assert result["draft_text"].count("?") == 1
+
+    def test_question_ladder_continues_instead_of_restarting(self):
+        from mission_control.services.lead_nurture import build_reply_suggestion
+
+        result = build_reply_suggestion(
+            text="Training is going well.",
+            first_name="Jane",
+            prior_question_type="challenge",
+        )
+        assert result["question_type"] == "favorite_workout"
+        assert "look forward to" in result["draft_text"]
+
+    def test_third_lead_turn_requires_value_before_more_questions(self):
+        from mission_control.services.lead_nurture import build_reply_suggestion
+
+        result = build_reply_suggestion(
+            text="Tuesday is usually the hard day.",
+            first_name="Jane",
+            prior_question_type="schedule",
+            lead_turn=3,
+        )
+        assert result["needs_coach_answer"] is True
+        assert "[Add one useful observation" in result["draft_text"]
+
 
 class TestGmailIngestion:
     def test_closed_won_contact_is_not_offered_to_lead_bridge(self, fake_db):
@@ -176,6 +215,27 @@ class TestGmailIngestion:
         assert len(fake_db.store["gg_lead_reply_suggestions"]) == 1
         assert conversation["status"] == "gmail_drafted"
 
+    def test_consecutive_inbound_messages_supersede_older_unapproved_draft(self, fake_db):
+        from mission_control.services.lead_nurture import ingest_gmail_sync
+
+        fake_db.store["gg_sequence_enrollments"].append(
+            make_enrollment(contact_email="lead@example.com"),
+        )
+        now = datetime.now(timezone.utc)
+        payload = {"threads": [{"id": "thread-consecutive", "messages": [
+            _message(
+                message_id="in-first", body="Training is going well.",
+                date=(now - timedelta(minutes=2)).isoformat(),
+            ),
+            _message(
+                message_id="in-second", body="The climbs are the hard part.",
+                date=now.isoformat(),
+            ),
+        ]}]}
+        ingest_gmail_sync(payload)
+        suggestions = fake_db.store["gg_lead_reply_suggestions"]
+        assert [row["status"] for row in suggestions] == ["superseded", "suggested"]
+
 
 class TestDraftApproval:
     def _seed(self, fake_db):
@@ -233,6 +293,34 @@ class TestDraftApproval:
             "I’ll give you the current rate and the exact checkout link below.",
         )
         assert approve_reply_suggestion(suggestion["id"], edited)["status"] == "approved_for_gmail"
+
+    def test_newer_inbound_supersedes_approved_but_not_yet_created_draft(self, fake_db):
+        from mission_control.services.lead_nurture import get_approved_drafts
+
+        conversation_id = "conv-newer"
+        now = datetime.now(timezone.utc)
+        fake_db.store["gg_lead_conversations"].append({
+            "id": conversation_id, "gmail_thread_id": "thread-newer",
+            "contact_email": "lead@example.com",
+        })
+        fake_db.store["gg_lead_messages"].extend([
+            {
+                "gmail_message_id": "in-old", "conversation_id": conversation_id,
+                "direction": "inbound", "message_at": (now - timedelta(minutes=2)).isoformat(),
+            },
+            {
+                "gmail_message_id": "in-new", "conversation_id": conversation_id,
+                "direction": "inbound", "message_at": now.isoformat(),
+            },
+        ])
+        suggestion = {
+            "id": "suggestion-newer", "conversation_id": conversation_id,
+            "inbound_message_id": "in-old", "status": "approved_for_gmail",
+            "approved_at": now.isoformat(), "draft_text": "Old approved text",
+        }
+        fake_db.store["gg_lead_reply_suggestions"].append(suggestion)
+        assert get_approved_drafts() == []
+        assert suggestion["status"] == "superseded"
 
 
 class TestReplyToken:

--- a/mission_control/tests/test_lead_nurture.py
+++ b/mission_control/tests/test_lead_nurture.py
@@ -1,0 +1,417 @@
+"""Lead reply ingestion, approval safety, and measurement tests."""
+
+from datetime import datetime, timedelta, timezone
+
+from mission_control.tests.conftest import make_deal, make_enrollment, make_sequence_send
+
+
+def _message(
+    *, message_id="gmail-in-1", sender="Jane Lead <lead@example.com>",
+    recipients=None, body="Training is going well.", is_draft=False,
+    date=None,
+):
+    return {
+        "id": message_id,
+        "from": sender,
+        "to": recipients or ["gravelgodcoaching+lead.0123456789abcdef0123456789abcdef@gmail.com"],
+        "cc": [],
+        "subject": "Re: how's training going?",
+        "date": date or datetime.now(timezone.utc).isoformat(),
+        "body": body,
+        "is_draft": is_draft,
+        "is_trash": False,
+    }
+
+
+class TestPlainMattiSuggestions:
+    def test_positive_training_gets_one_easy_question_and_no_pitch(self):
+        from mission_control.services.lead_nurture import build_reply_suggestion
+
+        result = build_reply_suggestion(
+            text="Training is going well so far.", first_name="Jane", seed="stable",
+        )
+        assert result["question_type"] in {"challenge", "favorite_workout"}
+        assert result["draft_text"].count("?") == 1
+        assert "buy" not in result["draft_text"].lower()
+        assert "plan" not in result["draft_text"].lower()
+
+    def test_explicit_question_requires_coach_answer(self):
+        from mission_control.services.lead_nurture import build_reply_suggestion
+
+        result = build_reply_suggestion(
+            text="How much is coaching?", first_name="Jane", seed="stable",
+        )
+        assert result["needs_coach_answer"] is True
+        assert result["intent"] == "buying"
+        assert "[Answer their question directly first.]" in result["draft_text"]
+
+    def test_support_problem_never_pretends_it_is_fixed(self):
+        from mission_control.services.lead_nurture import build_reply_suggestion
+
+        result = build_reply_suggestion(
+            text="I never received the guide.", first_name="Jane", seed="stable",
+        )
+        assert result["needs_coach_answer"] is True
+        assert "i fixed" not in result["draft_text"].lower()
+        assert "resend" not in result["draft_text"].lower()
+        assert result["draft_text"].count("?") == 0
+
+
+class TestGmailIngestion:
+    def test_closed_won_contact_is_not_offered_to_lead_bridge(self, fake_db):
+        from mission_control.services.lead_nurture import get_sync_candidates
+
+        fake_db.store["gg_sequence_enrollments"].append(
+            make_enrollment(contact_email="athlete@example.com"),
+        )
+        fake_db.store["gg_deals"].append(
+            make_deal(contact_email="athlete@example.com", stage="closed_won"),
+        )
+        assert get_sync_candidates() == []
+
+    def test_known_lead_reply_is_attributed_and_pauses_marketing(self, fake_db):
+        from mission_control.services.lead_nurture import ingest_gmail_sync
+
+        enrollment = make_enrollment(contact_email="lead@example.com", contact_name="Jane Lead")
+        deal = make_deal(contact_email="lead@example.com", contact_name="Jane Lead")
+        send = make_sequence_send(
+            enrollment_id=enrollment["id"],
+            reply_token="0123456789abcdef0123456789abcdef",
+            reply_count=0,
+            first_reply_at=None,
+            question_type="training_status",
+            sent_at=(datetime.now(timezone.utc) - timedelta(hours=2)).isoformat(),
+        )
+        fake_db.store["gg_sequence_enrollments"].append(enrollment)
+        fake_db.store["gg_deals"].append(deal)
+        fake_db.store["gg_sequence_sends"].append(send)
+
+        result = ingest_gmail_sync({"threads": [{"id": "thread-1", "messages": [_message()]}]})
+
+        assert result == {"threads": 1, "recorded": 1, "messages": 1, "paused": 1, "ignored": 0}
+        assert enrollment["status"] == "paused_reply"
+        stored = fake_db.store["gg_lead_messages"][0]
+        assert stored["sequence_send_id"] == send["id"]
+        assert stored["attribution_confidence"] == "exact"
+        assert send["reply_count"] == 1
+        assert send["first_reply_at"] is not None
+        assert len(fake_db.store["gg_lead_reply_suggestions"]) == 1
+
+    def test_post_purchase_service_sequence_is_not_paused(self, fake_db):
+        from mission_control.services.lead_nurture import ingest_gmail_sync
+
+        enrollment = make_enrollment(
+            sequence_id="post_purchase_v1", contact_email="lead@example.com",
+        )
+        fake_db.store["gg_sequence_enrollments"].append(enrollment)
+        fake_db.store["gg_deals"].append(make_deal(contact_email="lead@example.com"))
+        result = ingest_gmail_sync({"threads": [{"id": "thread-2", "messages": [_message()]}]})
+        assert result["paused"] == 0
+        assert enrollment["status"] == "active"
+
+    def test_unknown_mailbox_is_ignored_without_storing_body(self, fake_db):
+        from mission_control.services.lead_nurture import ingest_gmail_sync
+
+        result = ingest_gmail_sync({
+            "threads": [{"id": "private-thread", "messages": [
+                _message(sender="Other Person <other@example.com>", body="private unrelated email"),
+            ]}],
+        })
+        assert result["ignored"] == 1
+        assert fake_db.store["gg_lead_messages"] == []
+
+    def test_overlap_is_idempotent(self, fake_db):
+        from mission_control.services.lead_nurture import ingest_gmail_sync
+
+        fake_db.store["gg_sequence_enrollments"].append(
+            make_enrollment(contact_email="lead@example.com"),
+        )
+        payload = {"threads": [{"id": "thread-3", "messages": [_message()]}]}
+        assert ingest_gmail_sync(payload)["messages"] == 1
+        assert ingest_gmail_sync(payload)["messages"] == 0
+        assert len(fake_db.store["gg_lead_messages"]) == 1
+        assert len(fake_db.store["gg_lead_reply_suggestions"]) == 1
+
+    def test_untracked_existing_draft_is_surfaced_as_conflict(self, fake_db):
+        from mission_control.services.lead_nurture import ingest_gmail_sync
+
+        fake_db.store["gg_sequence_enrollments"].append(
+            make_enrollment(contact_email="lead@example.com"),
+        )
+        draft = _message(
+            message_id="old-draft-1",
+            sender="Gravel God <gravelgodcoaching@gmail.com>",
+            recipients=["lead@example.com"],
+            body="An old draft that needs review.",
+            is_draft=True,
+        )
+        result = ingest_gmail_sync({"threads": [{"id": "thread-draft", "messages": [draft]}]})
+        assert result["messages"] == 1
+        suggestion = fake_db.store["gg_lead_reply_suggestions"][0]
+        assert suggestion["status"] == "draft_conflict"
+        assert suggestion["gmail_draft_message_id"] == "old-draft-1"
+
+    def test_tracked_bridge_draft_is_not_duplicated_as_conflict(self, fake_db):
+        from mission_control.services.lead_nurture import ingest_gmail_sync
+
+        enrollment = make_enrollment(contact_email="lead@example.com")
+        fake_db.store["gg_sequence_enrollments"].append(enrollment)
+        conversation = {
+            "id": "conv-1", "gmail_thread_id": "thread-tracked",
+            "contact_email": "lead@example.com", "contact_name": "Jane",
+            "brand": "gravelgod", "status": "gmail_drafted",
+        }
+        fake_db.store["gg_lead_conversations"].append(conversation)
+        fake_db.store["gg_lead_reply_suggestions"].append({
+            "id": "suggestion-1", "conversation_id": "conv-1",
+            "inbound_message_id": "gmail-in-prior", "status": "gmail_drafted",
+            "gmail_draft_message_id": "tracked-draft-1",
+        })
+        draft = _message(
+            message_id="tracked-draft-1",
+            sender="Gravel God <gravelgodcoaching@gmail.com>",
+            recipients=["lead@example.com"], is_draft=True,
+        )
+        ingest_gmail_sync({"threads": [{"id": "thread-tracked", "messages": [draft]}]})
+        assert len(fake_db.store["gg_lead_reply_suggestions"]) == 1
+        assert conversation["status"] == "gmail_drafted"
+
+
+class TestDraftApproval:
+    def _seed(self, fake_db):
+        from mission_control.services.lead_nurture import ingest_gmail_sync
+
+        fake_db.store["gg_sequence_enrollments"].append(
+            make_enrollment(contact_email="lead@example.com", contact_name="Jane Lead"),
+        )
+        ingest_gmail_sync({"threads": [{"id": "thread-4", "messages": [_message()]}]})
+        return fake_db.store["gg_lead_reply_suggestions"][0]
+
+    def test_approval_exposes_draft_to_relay_but_does_not_send(self, fake_db):
+        from mission_control.services.lead_nurture import (
+            approve_reply_suggestion, get_approved_drafts,
+        )
+
+        suggestion = self._seed(fake_db)
+        approved = approve_reply_suggestion(suggestion["id"], suggestion["draft_text"])
+        assert approved["status"] == "approved_for_gmail"
+        ready = get_approved_drafts()
+        assert len(ready) == 1
+        assert ready[0]["inbound_message_id"] == "gmail-in-1"
+        assert not fake_db.store["gg_lead_messages"][0].get("sent_at")
+
+    def test_existing_gmail_draft_becomes_conflict(self, fake_db):
+        from mission_control.services.lead_nurture import (
+            approve_reply_suggestion, record_draft_receipt,
+        )
+
+        suggestion = self._seed(fake_db)
+        approve_reply_suggestion(suggestion["id"], suggestion["draft_text"])
+        receipt = record_draft_receipt(suggestion["id"], {
+            "status": "draft_conflict", "gmail_draft_message_id": "existing-1",
+        })
+        assert receipt == {"status": "draft_conflict"}
+        assert suggestion["status"] == "draft_conflict"
+
+    def test_answer_required_draft_cannot_be_approved_unchanged(self, fake_db):
+        from mission_control.services.lead_nurture import (
+            approve_reply_suggestion, ingest_gmail_sync,
+        )
+
+        fake_db.store["gg_sequence_enrollments"].append(
+            make_enrollment(contact_email="lead@example.com", contact_name="Jane Lead"),
+        )
+        ingest_gmail_sync({"threads": [{"id": "thread-question", "messages": [
+            _message(body="How much is coaching?"),
+        ]}]})
+        suggestion = fake_db.store["gg_lead_reply_suggestions"][0]
+        assert suggestion["status"] == "needs_coach_answer"
+        assert approve_reply_suggestion(suggestion["id"], suggestion["draft_text"]) is None
+
+        edited = suggestion["draft_text"].replace(
+            "[Answer their question directly first.]",
+            "I’ll give you the current rate and the exact checkout link below.",
+        )
+        assert approve_reply_suggestion(suggestion["id"], edited)["status"] == "approved_for_gmail"
+
+
+class TestReplyToken:
+    def test_tagged_reply_to_preserves_normal_gmail_delivery(self):
+        from mission_control.services.sequence_engine import _tagged_reply_to
+
+        tagged = _tagged_reply_to(
+            "Gravel God <gravelgodcoaching@gmail.com>",
+            "0123456789abcdef0123456789abcdef",
+        )
+        assert tagged == (
+            "Gravel God <gravelgodcoaching+lead."
+            "0123456789abcdef0123456789abcdef@gmail.com>"
+        )
+
+    def test_non_gmail_reply_to_is_not_assumed_to_support_plus_aliases(self):
+        from mission_control.services.sequence_engine import _tagged_reply_to
+
+        assert _tagged_reply_to(
+            "Matti <coach@example.com>",
+            "0123456789abcdef0123456789abcdef",
+        ) == "Matti <coach@example.com>"
+
+    def test_spam_complaint_unsubscribes_enrollment(self, fake_db):
+        from mission_control.services.sequence_engine import record_event
+
+        enrollment = make_enrollment()
+        send = make_sequence_send(enrollment_id=enrollment["id"], resend_id="re-complaint")
+        fake_db.store["gg_sequence_enrollments"].append(enrollment)
+        fake_db.store["gg_sequence_sends"].append(send)
+        assert record_event("re-complaint", "email.complained") is True
+        assert send["status"] == "complained"
+        assert send["complained_at"] is not None
+        assert enrollment["status"] == "unsubscribed"
+
+
+class TestLearningMetrics:
+    def test_small_samples_are_explicitly_not_a_verdict(self, fake_db):
+        from mission_control.services.lead_nurture import get_learning_metrics
+
+        fake_db.store["gg_sequence_sends"].append(make_sequence_send(
+            question_type="challenge",
+            sent_at=datetime.now(timezone.utc).isoformat(),
+        ))
+        report = get_learning_metrics()
+        assert report["question_rows"][0]["sample_state"] == "keep_collecting"
+        assert "never change live copy automatically" in report["measurement_note"]
+
+    def test_manual_question_and_next_reply_feed_learning_loop(self, fake_db):
+        from mission_control.services.lead_nurture import get_learning_metrics
+
+        now = datetime.now(timezone.utc)
+        conversation = {"id": "conv-m", "deal_id": None, "inbound_count": 1}
+        fake_db.store["gg_lead_conversations"].append(conversation)
+        fake_db.store["gg_lead_messages"].extend([
+            {
+                "gmail_message_id": "out-1", "conversation_id": "conv-m",
+                "direction": "outbound", "question_type": "favorite_workout",
+                "message_at": (now - timedelta(hours=3)).isoformat(),
+            },
+            {
+                "gmail_message_id": "in-2", "conversation_id": "conv-m",
+                "direction": "inbound", "reply_quality": "substantive",
+                "message_at": (now - timedelta(hours=1)).isoformat(),
+            },
+        ])
+        report = get_learning_metrics()
+        row = next(row for row in report["question_rows"] if row["question_type"] == "favorite_workout")
+        assert row["sends"] == 1
+        assert row["replies"] == 1
+        assert row["substantive_replies"] == 1
+        assert row["median_reply_hours"] == 2.0
+
+    def test_only_latest_manual_question_gets_reply_credit(self, fake_db):
+        from mission_control.services.lead_nurture import get_learning_metrics
+
+        now = datetime.now(timezone.utc)
+        fake_db.store["gg_lead_conversations"].append({"id": "conv-latest", "deal_id": None})
+        fake_db.store["gg_lead_messages"].extend([
+            {
+                "gmail_message_id": "out-challenge", "conversation_id": "conv-latest",
+                "direction": "outbound", "question_type": "challenge",
+                "message_at": (now - timedelta(hours=4)).isoformat(),
+            },
+            {
+                "gmail_message_id": "out-favorite", "conversation_id": "conv-latest",
+                "direction": "outbound", "question_type": "favorite_workout",
+                "message_at": (now - timedelta(hours=3)).isoformat(),
+            },
+            {
+                "gmail_message_id": "in-reply", "conversation_id": "conv-latest",
+                "direction": "inbound", "reply_quality": "brief",
+                "message_at": (now - timedelta(hours=1)).isoformat(),
+            },
+        ])
+        report = get_learning_metrics()
+        rows = {row["question_type"]: row for row in report["question_rows"]}
+        assert rows["challenge"]["replies"] == 0
+        assert rows["favorite_workout"]["replies"] == 1
+
+    def test_editor_metrics_capture_acceptance_and_rewrite(self, fake_db):
+        from mission_control.services.lead_nurture import get_learning_metrics
+
+        fake_db.store["gg_lead_reply_suggestions"].append({
+            "id": "s-1", "status": "sent",
+            "approved_at": datetime.now(timezone.utc).isoformat(),
+            "initial_draft_text": "Original easy question?",
+            "draft_text": "A completely different approved reply?",
+        })
+        report = get_learning_metrics()
+        assert report["suggestion_acceptance_rate"] == 100.0
+        assert report["median_edit_percent"] > 0
+
+
+class TestGmailSyncEndpoints:
+    def test_sync_requires_auth(self, client):
+        assert client.post("/webhooks/gmail-sync", json={"threads": []}).status_code == 401
+
+    def test_sync_accepts_empty_authorized_batch(self, client):
+        response = client.post(
+            "/webhooks/gmail-sync", json={"threads": []},
+            headers={"Authorization": "Bearer test-secret-123"},
+        )
+        assert response.status_code == 200
+        assert response.json()["messages"] == 0
+
+
+class TestLeadReplyEditor:
+    def test_editor_is_admin_protected_and_renders_when_authorized(self, client):
+        assert client.get("/lead-replies").status_code == 401
+        response = client.get(
+            "/lead-replies",
+            headers={"Authorization": "Bearer test-secret-for-tests"},
+        )
+        assert response.status_code == 200
+        assert "Lead Replies" in response.text
+        assert "Nothing was sent" not in response.text
+
+    def test_existing_draft_conflict_cannot_be_approved(self, client, fake_db):
+        conversation_id = "11111111-1111-4111-8111-111111111111"
+        suggestion_id = "22222222-2222-4222-8222-222222222222"
+        fake_db.store["gg_lead_conversations"].append({
+            "id": conversation_id,
+            "gmail_thread_id": "thread-conflict",
+            "contact_email": "lead@example.com",
+            "contact_name": "Jane Lead",
+            "brand": "gravelgod",
+            "intent": "conversation",
+        })
+        fake_db.store["gg_lead_messages"].append({
+            "gmail_message_id": "draft-existing",
+            "conversation_id": conversation_id,
+            "subject": "Re: training",
+            "body_text": "Old version",
+            "message_at": datetime.now(timezone.utc).isoformat(),
+        })
+        fake_db.store["gg_lead_reply_suggestions"].append({
+            "id": suggestion_id,
+            "conversation_id": conversation_id,
+            "inbound_message_id": "draft-existing",
+            "draft_text": "Old version",
+            "question_type": "other",
+            "status": "draft_conflict",
+            "needs_coach_answer": False,
+            "rationale": "Existing Gmail draft.",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        })
+        response = client.get(
+            "/lead-replies",
+            headers={"Authorization": "Bearer test-secret-for-tests"},
+        )
+        assert response.status_code == 200
+        card = response.text.split(f'id="reply-{suggestion_id}"', 1)[1]
+        assert "Existing Gmail draft" in card
+        assert "Approve Gmail Draft" not in card.split("</article>", 1)[0]
+
+        approve = client.post(
+            f"/lead-replies/{suggestion_id}/approve",
+            data={"draft_text": "Do not allow this."},
+            headers={"Authorization": "Bearer test-secret-for-tests"},
+        )
+        assert approve.status_code == 409

--- a/mission_control/tests/test_lead_nurture.py
+++ b/mission_control/tests/test_lead_nurture.py
@@ -8,13 +8,14 @@ from mission_control.tests.conftest import make_deal, make_enrollment, make_sequ
 def _message(
     *, message_id="gmail-in-1", sender="Jane Lead <lead@example.com>",
     recipients=None, body="Training is going well.", is_draft=False,
-    date=None,
+    date=None, reply_to="",
 ):
     return {
         "id": message_id,
         "from": sender,
         "to": recipients or ["gravelgodcoaching+lead.0123456789abcdef0123456789abcdef@gmail.com"],
         "cc": [],
+        "reply_to": reply_to,
         "subject": "Re: how's training going?",
         "date": date or datetime.now(timezone.utc).isoformat(),
         "body": body,
@@ -236,6 +237,34 @@ class TestGmailIngestion:
         suggestions = fake_db.store["gg_lead_reply_suggestions"]
         assert [row["status"] for row in suggestions] == ["superseded", "suggested"]
 
+    def test_sequence_outbound_reply_to_token_is_preserved_as_automation(self, fake_db):
+        from mission_control.services.lead_nurture import ingest_gmail_sync
+
+        enrollment = make_enrollment(contact_email="lead@example.com")
+        send = make_sequence_send(
+            enrollment_id=enrollment["id"],
+            reply_token="0123456789abcdef0123456789abcdef",
+            question_type="training_status",
+        )
+        fake_db.store["gg_sequence_enrollments"].append(enrollment)
+        fake_db.store["gg_sequence_sends"].append(send)
+        outbound = _message(
+            message_id="gmail-sequence-out",
+            sender="Matti <matti@gravelgodcycling.com>",
+            recipients=["lead@example.com"],
+            reply_to=(
+                "Gravel God <gravelgodcoaching+lead."
+                "0123456789abcdef0123456789abcdef@gmail.com>"
+            ),
+        )
+
+        ingest_gmail_sync({"threads": [{"id": "thread-sequence", "messages": [outbound]}]})
+
+        stored = fake_db.store["gg_lead_messages"][0]
+        assert stored["direction"] == "outbound"
+        assert stored["sequence_send_id"] == send["id"]
+        assert stored["attribution_confidence"] == "exact"
+
 
 class TestDraftApproval:
     def _seed(self, fake_db):
@@ -393,6 +422,35 @@ class TestLearningMetrics:
         assert row["replies"] == 1
         assert row["substantive_replies"] == 1
         assert row["median_reply_hours"] == 2.0
+
+    def test_gmail_mirror_of_sequence_send_is_not_double_counted(self, fake_db):
+        from mission_control.services.lead_nurture import get_learning_metrics
+
+        now = datetime.now(timezone.utc)
+        send = make_sequence_send(
+            question_type="training_status", sent_at=(now - timedelta(hours=3)).isoformat(),
+        )
+        fake_db.store["gg_sequence_sends"].append(send)
+        fake_db.store["gg_lead_conversations"].append({"id": "conv-seq", "deal_id": None})
+        fake_db.store["gg_lead_messages"].extend([
+            {
+                "gmail_message_id": "out-seq", "conversation_id": "conv-seq",
+                "direction": "outbound", "question_type": "training_status",
+                "sequence_send_id": send["id"],
+                "message_at": (now - timedelta(hours=3)).isoformat(),
+            },
+            {
+                "gmail_message_id": "in-seq", "conversation_id": "conv-seq",
+                "direction": "inbound", "question_type": "other",
+                "sequence_send_id": send["id"], "reply_quality": "brief",
+                "message_at": (now - timedelta(hours=1)).isoformat(),
+            },
+        ])
+
+        report = get_learning_metrics()
+        row = next(row for row in report["question_rows"] if row["question_type"] == "training_status")
+        assert row["sends"] == 1
+        assert row["replies"] == 1
 
     def test_only_latest_manual_question_gets_reply_credit(self, fake_db):
         from mission_control.services.lead_nurture import get_learning_metrics

--- a/scripts/lead_nurture_report.py
+++ b/scripts/lead_nurture_report.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Print the Mission Control lead-conversation learning report.
+
+Usage:
+    railway run python3 scripts/lead_nurture_report.py
+    railway run python3 scripts/lead_nurture_report.py --days 30 --json
+
+This report is descriptive and approval-gated. It never edits sequence copy,
+changes A/B weights, creates drafts, or sends email.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from mission_control.services.lead_nurture import get_learning_metrics  # noqa: E402
+
+
+def render(report: dict) -> str:
+    lines = [
+        f"Lead nurture — last {report['days']} days",
+        (
+            f"Sends {report['sends']} · replies {report['replies']} "
+            f"({report['reply_rate']}%) · substantive {report['substantive_replies']} "
+            f"· assisted wins {report['assisted_wins']}"
+        ),
+        (
+            f"Trust: unsubscribes {report['unsubscribes']} · spam complaints "
+            f"{report['spam_complaints']} · active-after-reply {report['active_after_reply']} "
+            f"· draft conflicts {report['draft_conflicts']}"
+        ),
+        (
+            f"Workflow: coach response {report['median_coach_response_hours'] or '—'}h · "
+            f"suggestion acceptance "
+            f"{str(report['suggestion_acceptance_rate']) + '%' if report['suggestion_acceptance_rate'] is not None else '—'} "
+            f"· median edit "
+            f"{str(report['median_edit_percent']) + '%' if report['median_edit_percent'] is not None else '—'}"
+        ),
+        "",
+        f"{'question':<22}{'sends':>8}{'replies':>10}{'rate':>9}{'substantive':>14}{'median h':>10}{'state':>18}",
+    ]
+    for row in report["question_rows"]:
+        median = "—" if row["median_reply_hours"] is None else str(row["median_reply_hours"])
+        lines.append(
+            f"{row['question_type']:<22}{row['sends']:>8}{row['replies']:>10}"
+            f"{str(row['reply_rate']) + '%':>9}{row['substantive_replies']:>14}"
+            f"{median:>10}{row['sample_state']:>18}"
+        )
+    lines.extend(["", "Recommendations:"])
+    lines.extend(f"- {item}" for item in report["recommendations"])
+    lines.extend(["", report["measurement_note"]])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--days", type=int, default=90)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    if args.days < 1 or args.days > 730:
+        parser.error("--days must be between 1 and 730")
+    report = get_learning_metrics(args.days)
+    print(json.dumps(report, indent=2) if args.json else render(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase/migrations/20260822000001_gmail_lead_reply_loop.sql
+++ b/supabase/migrations/20260822000001_gmail_lead_reply_loop.sql
@@ -1,0 +1,108 @@
+-- Gmail lead reply loop: durable conversations, draft approvals, and reply attribution.
+-- Bodies are private operator data. Tables are service-role only.
+
+ALTER TABLE gg_sequence_sends
+    ADD COLUMN IF NOT EXISTS reply_token TEXT,
+    ADD COLUMN IF NOT EXISTS question_type TEXT DEFAULT 'other',
+    ADD COLUMN IF NOT EXISTS reply_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS first_reply_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS complained_at TIMESTAMPTZ;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sequence_sends_reply_token
+    ON gg_sequence_sends(reply_token)
+    WHERE reply_token IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS gg_lead_conversations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    gmail_thread_id TEXT NOT NULL UNIQUE,
+    contact_email TEXT NOT NULL,
+    contact_name TEXT DEFAULT '',
+    brand TEXT DEFAULT 'gravelgod',
+    deal_id UUID REFERENCES gg_deals(id) ON DELETE SET NULL,
+    status TEXT NOT NULL DEFAULT 'needs_reply'
+        CHECK (status IN (
+            'needs_reply', 'suggested', 'approved_for_gmail', 'gmail_drafted',
+            'waiting_on_lead', 'won', 'lost', 'closed', 'draft_conflict'
+        )),
+    intent TEXT DEFAULT 'unknown',
+    latest_question_type TEXT DEFAULT 'other',
+    last_sequence_send_id UUID REFERENCES gg_sequence_sends(id) ON DELETE SET NULL,
+    last_inbound_at TIMESTAMPTZ,
+    last_outbound_at TIMESTAMPTZ,
+    first_reply_latency_seconds INTEGER,
+    inbound_count INTEGER NOT NULL DEFAULT 0,
+    outbound_count INTEGER NOT NULL DEFAULT 0,
+    substantive_reply_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS gg_lead_messages (
+    gmail_message_id TEXT PRIMARY KEY,
+    conversation_id UUID NOT NULL REFERENCES gg_lead_conversations(id) ON DELETE CASCADE,
+    gmail_thread_id TEXT NOT NULL,
+    direction TEXT NOT NULL CHECK (direction IN ('inbound', 'outbound', 'draft')),
+    from_address TEXT NOT NULL DEFAULT '',
+    to_addresses JSONB NOT NULL DEFAULT '[]',
+    cc_addresses JSONB NOT NULL DEFAULT '[]',
+    subject TEXT NOT NULL DEFAULT '',
+    body_text TEXT NOT NULL DEFAULT '',
+    body_sha256 TEXT NOT NULL DEFAULT '',
+    message_at TIMESTAMPTZ NOT NULL,
+    sequence_send_id UUID REFERENCES gg_sequence_sends(id) ON DELETE SET NULL,
+    attribution_confidence TEXT DEFAULT 'none'
+        CHECK (attribution_confidence IN ('exact', 'email_time', 'none')),
+    question_type TEXT DEFAULT 'other',
+    reply_quality TEXT DEFAULT 'brief'
+        CHECK (reply_quality IN ('brief', 'substantive')),
+    word_count INTEGER NOT NULL DEFAULT 0,
+    is_trash BOOLEAN NOT NULL DEFAULT false,
+    ingested_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS gg_lead_reply_suggestions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    conversation_id UUID NOT NULL REFERENCES gg_lead_conversations(id) ON DELETE CASCADE,
+    inbound_message_id TEXT NOT NULL UNIQUE REFERENCES gg_lead_messages(gmail_message_id) ON DELETE CASCADE,
+    initial_draft_text TEXT NOT NULL DEFAULT '',
+    draft_text TEXT NOT NULL DEFAULT '',
+    suggested_question TEXT NOT NULL DEFAULT '',
+    question_type TEXT NOT NULL DEFAULT 'other',
+    needs_coach_answer BOOLEAN NOT NULL DEFAULT false,
+    rationale TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'suggested'
+        CHECK (status IN (
+            'suggested', 'needs_coach_answer', 'approved_for_gmail',
+            'gmail_drafted', 'sent', 'superseded', 'dismissed', 'draft_conflict'
+        )),
+    gmail_draft_id TEXT,
+    gmail_draft_message_id TEXT,
+    approved_at TIMESTAMPTZ,
+    drafted_at TIMESTAMPTZ,
+    sent_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lead_conversations_contact
+    ON gg_lead_conversations(contact_email, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_lead_conversations_status
+    ON gg_lead_conversations(status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_lead_messages_conversation
+    ON gg_lead_messages(conversation_id, message_at);
+CREATE INDEX IF NOT EXISTS idx_lead_messages_sequence_send
+    ON gg_lead_messages(sequence_send_id)
+    WHERE sequence_send_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_lead_suggestions_status
+    ON gg_lead_reply_suggestions(status, updated_at DESC);
+
+ALTER TABLE gg_lead_conversations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE gg_lead_messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE gg_lead_reply_suggestions ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON gg_lead_conversations FROM anon, authenticated;
+REVOKE ALL ON gg_lead_messages FROM anon, authenticated;
+REVOKE ALL ON gg_lead_reply_suggestions FROM anon, authenticated;
+GRANT ALL ON gg_lead_conversations TO service_role;
+GRANT ALL ON gg_lead_messages TO service_role;
+GRANT ALL ON gg_lead_reply_suggestions TO service_role;


### PR DESCRIPTION
## Outcome
- ingest known-lead Gmail threads into private Mission Control conversation records
- pause marketing immediately on a real reply while preserving post-purchase service sequences
- create one editable Matti-voice suggestion and require explicit approval before an unsent Gmail draft
- continue the actual thread with grounded details, a progressing question ladder, and occasional dry understatement instead of restarting an intake interview
- require one useful observation or practical suggestion by the third lead turn so nurture does not become endless questioning
- collapse consecutive inbound messages into one editor job and supersede an approved draft if a newer reply arrives before Gmail creates it
- surface pre-existing Gmail drafts as conflicts instead of creating duplicates
- measure actual sequence and coach-sent questions, substantive and second replies, assisted wins, coach response time, safety leaks, acceptance, and edit rate
- recommend approval-gated experiments only after a 30-send minimum; never rewrite live copy automatically

## Rollout gate
This PR is intentionally not deployed. Apply the 20260822000001 migration before deploying Mission Control, then install the account-local Apps Script bridge, run its 180-day backfill, verify one test draft, and enable the five-minute trigger.

## Validation
- 366 Mission Control tests passed with the two documented legacy triage auth suites excluded
- focused lead, sequence, and webhook suites passed
- local rendered editor preview reviewed at desktop width
- Apps Script syntax passed Node syntax validation
- staged diff check passed

## Known baselines
- The full Mission Control run retains 76 inherited test_triage and test_triage_tahoe 401 failures.
- The repository-wide GitHub job passed 7,239 tests and failed on three unrelated main-branch race-index mismatches: 3rides Gravel Winterberg, Dusty Bandita, and Epic Gran Canaria. This PR changes no race profile or index data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Gmail with full-mail OAuth, stores private message bodies, and can pause or unsubscribe marketing enrollments. Webhook-authenticated sync plus sequence Reply-To tagging make this security- and ops-critical.
> 
> **Overview**
> Adds an approval-gated Gmail lead reply loop so sequence replies become attributed conversations, marketing pauses on a real answer, and Matti edits one draft that never sends itself.
> 
> Sequence sends now carry a Gmail plus-address `reply_token` and question type. An account-local Apps Script syncs only known-lead threads into service-role tables, then creates an unsent Gmail draft after `/lead-replies` approval. Existing drafts become conflicts instead of duplicates; consecutive inbound messages collapse to one editor job.
> 
> Suggestions follow Reflect → Give → Ask: one grounded observation, one easy question, no pitch unless asked. Buying/support questions and the third lead turn require a coach answer before approval. Post-purchase sequences stay active. Spam complaints unsubscribe the enrollment.
> 
> Learning metrics (and `lead_nurture_report.py`) score actual sent questions, substantive/second replies, coach latency, draft edit rate, and active-after-reply leaks. Reports recommend tests after 30 sends; they never rewrite live copy. Migration must land before deploy; the five-minute Gmail trigger stays off until a dry run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d14be3b2a8cc4809c0ba1843c7bf8d19acf27dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->