### PR TITLE
intel-fix: workflow in-progress run mistaken for broken in Morning Intel

### DIFF
--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -442,7 +442,12 @@ def collect_workflows() -> dict:
                  "--limit", "1", "--json", "conclusion,updatedAt"],
                 capture_output=True, text=True, timeout=30)
             runs = json.loads(r.stdout or "[]")
-            out[f"{repo.split('/')[1]}/{wf}"] = runs[0]["conclusion"] if runs else "never-run"
+            # gh's conclusion is null/"" while the run is still in progress
+            # (not yet failed) — collapsing that to "in_progress" keeps the
+            # BROKEN section from flagging a run that just hasn't finished.
+            conclusion = (runs[0]["conclusion"] if runs else None) or (
+                "in_progress" if runs else "never-run")
+            out[f"{repo.split('/')[1]}/{wf}"] = conclusion
         except Exception as e:
             out[f"{repo.split('/')[1]}/{wf}"] = f"unknown ({type(e).__name__})"
     return {"latest": out}
@@ -1089,7 +1094,7 @@ def render_report(collected: dict) -> str:
     workflows = collected.get("workflows") or {}
     if workflows.get("ok"):
         for name, conclusion in (workflows.get("latest") or {}).items():
-            if conclusion != "success":
+            if conclusion not in ("success", "in_progress"):
                 broken.append(f"workflow {name}: {conclusion}")
     broken.extend(str(line) for line in (collected.get("report_issues") or []) if line)
     if broken:

--- a/tests/test_daily_intel.py
+++ b/tests/test_daily_intel.py
@@ -184,6 +184,14 @@ def test_render_report_failed_orders_are_first_and_broken_is_complete(collected)
     assert "possible tracking regression" in report
 
 
+def test_render_report_in_progress_workflow_is_not_broken(collected):
+    collected["workflows"]["latest"]["link-check.yml"] = "in_progress"
+
+    report = render_report(collected)
+
+    assert "workflow link-check.yml" not in report
+
+
 def test_render_report_includes_social_only_when_accounts_are_live(collected):
     collected["social"] = {
         "ok": True,


### PR DESCRIPTION
auto-authored by morning-intel-triage

**Linked intel issue:** #126

**Evidence:** `road-race-automation/link-check.yml` run `32725145902` started 2026-08-24T12:04:37Z, completed **successfully** at 12:07:56Z. Today's intel snapshot committed at 12:07:19Z — 37s before the run finished — so `gh run list --json conclusion` returned `null` for the still-running workflow, which `collect_workflows()` coerced to `""`, and `render_report()`'s BROKEN loop (`conclusion != "success"`) flagged as broken. The run was never actually failing.

**What changed and why:**
- `scripts/daily_intel.py::collect_workflows()` — normalize a missing/null `conclusion` to `"in_progress"` instead of leaving it falsy/blank.
- `scripts/daily_intel.py::render_report()` — exclude `"in_progress"` (alongside `"success"`) from the BROKEN section; a run that hasn't finished yet isn't broken.
- Added `tests/test_daily_intel.py::test_render_report_in_progress_workflow_is_not_broken`.

**Test output:**
```
$ pytest tests/test_daily_intel.py tests/test_seo_weekly.py tests/test_aeo_weekly.py -q
........................................................................ [ 69%]
...............................                                          [100%]
103 passed in 1.52s
```
(Ran the full `tests/` suite too; failures there are pre-existing missing-dependency import errors in unrelated files — `requests`/`PIL` not installed in this sandbox, e.g. `scripts/sync_tire_reviews.py` — not caused by this change.)

**Rollback note:** single self-contained change to `collect_workflows()`/`render_report()`'s BROKEN loop in `scripts/daily_intel.py`; revert this commit to restore prior (buggy) behavior. No data migration, no deploy, no external state touched — this only changes what the daily report prints.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P26p1k7ZVBjSkzmqcuGXk3)_