### PR TITLE
Add controlled all-brand coaching intake edge

### DIFF
--- a/tests/test_coaching.py
+++ b/tests/test_coaching.py
@@ -275,11 +275,14 @@ class TestServiceTiers:
     def test_setup_fee(self):
         tiers = build_tiers()
         assert "$99 setup fee" in tiers
+        assert "TrainingPeaks Premium is included" in tiers
+        assert "NOSETUP" not in tiers
+        assert "privately, case by case" in tiers
 
     def test_disclaimer(self):
         tiers = build_tiers()
         assert "skipped workouts" in tiers
-        assert "24 hours" in tiers
+        assert "two business days" in tiers
 
     def test_feature_lists_verbatim(self):
         tiers = build_tiers()
@@ -369,7 +372,7 @@ class TestApplicationClose:
     def test_line_copy(self):
         c = build_application_close()
         assert "Ten minutes of honest answers. I read every one myself." in c
-        assert "You&#39;ll hear from me within 48 hours &mdash; including if I don&#39;t think coaching is what you need." in c
+        assert "usually hear from me within two business days" in c
 
     def test_cta_link(self):
         c = build_application_close()
@@ -695,6 +698,8 @@ class TestRequiredContent:
     def test_disclaimer_and_setup_fee(self, coaching_html):
         assert "skipped workouts" in coaching_html
         assert "$99 setup fee" in coaching_html
+        assert "TrainingPeaks Premium is included" in coaching_html
+        assert "NOSETUP" not in coaching_html
 
     def test_hero_h1(self, coaching_html):
         assert "You could be better than you think." in coaching_html

--- a/tests/test_coaching_apply.py
+++ b/tests/test_coaching_apply.py
@@ -13,7 +13,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "wordpress"))
 
 from generate_coaching_apply import (
-    FORMSUBMIT_URL,
+    COACHING_INTAKE_WORKER_URL,
     build_nav,
     build_header,
     build_progress_bar,
@@ -30,6 +30,7 @@ from generate_coaching_apply import (
     build_section_11_mental_game,
     build_section_12_other,
     build_submit_buttons,
+    build_tier_selector,
     build_footer,
     build_jsonld,
     build_apply_css,
@@ -176,6 +177,18 @@ class TestSectionContent:
         assert 'name="sex"' in s
         assert 'name="age"' in s
         assert 'name="weight"' in s
+        for field in (
+                'date_of_birth', 'home_location', 'desired_start_date',
+                'preferred_contact_channel', 'trainingpeaks_connection_status',
+                'guardian_name', 'guardian_email', 'guardian_relationship'):
+            assert f'name="{field}"' in s
+        assert 'min="13"' in s
+        assert 'separate consent step' in s
+
+    def test_timezone_is_captured_without_becoming_required(self, apply_html, apply_js):
+        assert 'name="home_timezone"' in apply_html
+        assert 'Intl.DateTimeFormat().resolvedOptions().timeZone' in apply_js
+        assert 'id="home_timezone" required' not in apply_html
 
     def test_goals_radio(self):
         s = build_section_2_goals()
@@ -277,6 +290,15 @@ class TestButtons:
         assert "gg-apply-save-btn" in b
         assert "Save Progress" in b
 
+    def test_tier_selector_uses_min_mid_max_names(self):
+        selector = build_tier_selector()
+        assert 'name="tier"' in selector
+        assert '>Min<' in selector
+        assert '>Mid<' in selector
+        assert '>Max<' in selector
+        assert 'TrainingPeaks Premium is included' in selector
+        assert '>Premium<' not in selector
+
 
 # ── Brand Compliance ─────────────────────────────────────────
 
@@ -338,6 +360,9 @@ class TestGA4Events:
 
     def test_form_submitted_event(self, apply_js):
         assert "apply_form_submitted" in apply_js
+        assert "coaching_apply_started" in apply_js
+        assert "coaching_apply_submitted" in apply_js
+        assert "coaching_apply_error" in apply_js
 
     def test_progress_saved_event(self, apply_js):
         assert "apply_progress_saved" in apply_js
@@ -381,12 +406,25 @@ class TestJSFeatures:
     def test_flexible_checkbox_logic(self, apply_js):
         assert "flexible" in apply_js
 
-    def test_formsubmit_submission(self, apply_js):
-        assert FORMSUBMIT_URL in apply_js
-        assert "formsubmit.co" in apply_js
+    def test_worker_submission(self, apply_js):
+        assert COACHING_INTAKE_WORKER_URL in apply_js
+        assert "formsubmit.co" not in apply_js
+        assert '"Content-Type": "application/json"' in apply_js
 
-    def test_mailto_fallback(self, apply_js):
-        assert "mailto:gravelgodcoaching@gmail.com" in apply_js
+    def test_failed_submission_keeps_answers_and_allows_retry(self, apply_js):
+        assert "Your answers are still saved" in apply_js
+        assert 'submitBtn.disabled = false' in apply_js
+        assert "mailto:" not in apply_js
+
+    def test_query_tier_is_preserved(self, apply_js):
+        assert "new URLSearchParams(window.location.search)" in apply_js
+        assert '["min", "mid", "max"]' in apply_js
+        assert 'tier: data.tier' in apply_js
+
+    def test_submission_id_survives_retry_but_clears_on_success(self, apply_js):
+        assert 'getSubmissionId' in apply_js
+        assert 'coaching_intake_submission_id' in apply_js
+        assert 'data.submission_id = getSubmissionId()' in apply_js
 
     def test_format_submission(self, apply_js):
         assert "formatSubmission" in apply_js

--- a/tests/test_coaching_intake_worker.py
+++ b/tests/test_coaching_intake_worker.py
@@ -1,0 +1,79 @@
+"""Contract checks for the shared coaching-intake edge Worker."""
+
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKER = ROOT / "workers" / "coaching-intake" / "worker.js"
+WRANGLER = ROOT / "workers" / "coaching-intake" / "wrangler.jsonc"
+
+
+def test_worker_javascript_parses():
+    result = subprocess.run(
+        ["node", "--check", str(WORKER)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_worker_routes_all_brands_without_trusting_form_brand():
+    source = WORKER.read_text()
+    assert "'gravelgodcycling.com': 'gravelgod'" in source
+    assert "'roadielabs.com': 'roadielabs'" in source
+    assert "'xcskilabs.com': 'xcskilabs'" in source
+    assert "brandFromOrigin(origin)" in source
+    assert "data.brand" not in source
+
+
+def test_worker_has_honeypot_and_real_backend_submission():
+    source = WORKER.read_text()
+    assert "data.website" in source
+    assert "/api/coaching-intakes" in source
+    assert "X-Coaching-Intake-Secret" in source
+    assert "Could not submit. Please try again." in source
+
+
+def test_worker_does_not_create_checkout_from_browser_submission():
+    source = WORKER.read_text()
+    assert "create-coaching-checkout" not in source
+    assert "FIT_REVIEW" in source
+
+
+def test_worker_preserves_client_submission_receipt_for_safe_retry():
+    source = WORKER.read_text()
+    assert "UUID_RE.test(requestedSubmissionId)" in source
+    assert "submission_id: submissionId" in source
+    assert "delete questionnaire.submission_id" in source
+    assert "duplicate: Boolean(result.duplicate)" in source
+    assert "backend.status === 200 ? 200 : 201" in source
+
+
+def test_worker_does_not_reflect_cors_for_unknown_origins():
+    source = WORKER.read_text()
+    assert "if (brandFromOrigin(origin)) Object.assign(headers, corsHeaders(origin));" in source
+
+
+def test_worker_secret_is_not_committed():
+    config = WRANGLER.read_text()
+    assert '"COACHING_INTAKE_SECRET"' not in config
+    assert '"COACHING_CANARY_SECRET"' not in config
+    assert '"compatibility_date": "2026-08-25"' in config
+    assert '"compatibility_flags": ["nodejs_compat"]' in config
+    assert '"observability"' in config
+
+
+def test_worker_has_authenticated_edge_to_backend_canary():
+    source = WORKER.read_text()
+    assert "url.pathname === '/__canary'" in source
+    assert "request.method !== 'POST'" in source
+    assert 'X-Coaching-Canary-Secret' in source
+    assert 'COACHING_CANARY_SECRET' in source
+    assert '/api/coaching-canary' in source
+    assert 'X-Coaching-Intake-Secret' in source
+    assert 'crypto.subtle.timingSafeEqual' in source
+    assert "side_effects" not in source  # backend owns the safety claim
+
+
+def test_worker_uses_structured_error_logs():
+    source = WORKER.read_text()
+    assert "console.error('Coaching" not in source
+    assert 'console.error(JSON.stringify({' in source

--- a/tests/test_success_pages.py
+++ b/tests/test_success_pages.py
@@ -253,9 +253,9 @@ class TestCoachingSuccess:
         assert "gg-success-hero" in html
         assert "Welcome to Coaching" in html
 
-    def test_has_intake_link(self):
+    def test_does_not_reopen_completed_intake(self):
         html = build_coaching_success()
-        assert "/coaching/apply/" in html
+        assert "/coaching/apply/" not in html
 
     def test_cross_sells_races(self):
         html = build_coaching_success()
@@ -264,9 +264,11 @@ class TestCoachingSuccess:
 
     def test_has_next_steps(self):
         html = build_coaching_success()
-        assert "Fill Out the Intake Form" in html
-        assert "Expect an Email" in html
-        assert "We Train Together" in html
+        assert "Check Your Email" in html
+        assert "Connect TrainingPeaks" in html
+        assert "Run the First Block" in html
+        assert "do not stack it onto the next day" in html
+        assert "Within 24 Hours" not in html
 
 
 class TestConsultingSuccess:

--- a/wordpress/generate_coaching.py
+++ b/wordpress/generate_coaching.py
@@ -192,8 +192,8 @@ def build_tiers() -> str:
           <a href="{QUESTIONNAIRE_URL}?tier=max" class="gg-coach-tier-cta" data-cta="tier_max">GET STARTED</a>
         </div>
       </div>
-      <p class="gg-coach-tier-disclaimer">Coaching doesn&#39;t fix skipped workouts or feedback you don&#39;t act on. If this isn&#39;t a fit, I&#39;ll tell you within 24 hours.</p>
-      <p class="gg-coach-tier-setup-fee">All tiers include a one-time $99 setup fee: intake analysis, training-history review, and your first plan build.</p>
+      <p class="gg-coach-tier-disclaimer">Coaching doesn&#39;t fix skipped workouts or feedback you don&#39;t act on. I review applications and usually reply within two business days &mdash; including when I don&#39;t think coaching is the right fit.</p>
+      <p class="gg-coach-tier-setup-fee">TrainingPeaks Premium is included with every tier. Checkout includes a one-time $99 setup fee for intake analysis and your first plan build. Any waiver is offered privately, case by case.</p>
     </div>
   </section>'''
 
@@ -258,7 +258,7 @@ def build_faq() -> str:
         ),
         (
             "Can I cancel anytime?",
-            "Yes. No contracts, no cancellation fees. Your coaching access continues through the end of your current 4-week cycle.",
+            "Yes. There is no long-term commitment. Coaching renews every four weeks; cancel before the next renewal and your access continues through the paid cycle. There is no cancellation fee.",
         ),
     ]
 
@@ -290,7 +290,7 @@ def build_application_close() -> str:
     <div class="gg-coach-inner">
       <div class="gg-coach-final-cta">
         <p class="gg-coach-final-kicker">APPLICATION</p>
-        <p class="gg-coach-final-hook">Ten minutes of honest answers. I read every one myself. You&#39;ll hear from me within 48 hours &mdash; including if I don&#39;t think coaching is what you need.</p>
+        <p class="gg-coach-final-hook">Ten minutes of honest answers. I read every one myself. You&#39;ll usually hear from me within two business days &mdash; including if I don&#39;t think coaching is what you need.</p>
         <a href="{QUESTIONNAIRE_URL}" class="gg-coach-final-cta-link" data-cta="final_fill_intake">GET ME IN YOUR CORNER &rarr;</a>
         <p class="gg-coach-final-contact">Questions first? <a href="mailto:matt@gravelgodcycling.com">matt@gravelgodcycling.com</a> &mdash; I answer myself, usually within a day.</p>
       </div>

--- a/wordpress/generate_coaching_apply.py
+++ b/wordpress/generate_coaching_apply.py
@@ -39,9 +39,11 @@ from cookie_consent import get_consent_banner_html
 
 OUTPUT_DIR = Path(__file__).parent / "output"
 
-# Formsubmit.co endpoint — sends email to this address on submission
-FORMSUBMIT_EMAIL = "gravelgodcoaching@gmail.com"
-FORMSUBMIT_URL = f"https://formsubmit.co/{FORMSUBMIT_EMAIL}"
+# Shared brand-aware intake edge. The Worker authenticates to the onboarding
+# backend; the browser never receives the backend secret.
+COACHING_INTAKE_WORKER_URL = (
+    "https://coaching-intake.gravelgodcoaching.workers.dev"
+)
 
 
 def esc(text) -> str:
@@ -95,6 +97,47 @@ def build_section_1_basic_info() -> str:
         </div>
       </div>
 
+      <div class="gg-apply-inline">
+        <div class="gg-apply-group">
+          <label class="gg-apply-label" for="date_of_birth">Date of Birth</label>
+          <input type="date" id="date_of_birth" name="date_of_birth">
+          <div class="gg-apply-help">Optional. Used for age-group context and birthday reminders.</div>
+        </div>
+        <div class="gg-apply-group">
+          <label class="gg-apply-label" for="home_location">Home Location</label>
+          <input type="text" id="home_location" name="home_location" placeholder="City, state/province, country">
+          <div class="gg-apply-help">Used for climate, altitude, daylight, and travel context.</div>
+        </div>
+      </div>
+
+      <div class="gg-apply-inline">
+        <div class="gg-apply-group">
+          <label class="gg-apply-label" for="desired_start_date">When do you want coaching to start?</label>
+          <input type="date" id="desired_start_date" name="desired_start_date">
+        </div>
+        <div class="gg-apply-group">
+          <label class="gg-apply-label" for="preferred_contact_channel">Best place for time-sensitive coaching messages</label>
+          <select id="preferred_contact_channel" name="preferred_contact_channel">
+            <option value="">Select...</option>
+            <option value="email">Email</option>
+            <option value="trainingpeaks">TrainingPeaks</option>
+            <option value="text">Text / Messages</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="gg-apply-group">
+        <label class="gg-apply-label" for="trainingpeaks_connection_status">Are you already attached to my TrainingPeaks coaching account?</label>
+        <select id="trainingpeaks_connection_status" name="trainingpeaks_connection_status">
+          <option value="">Select...</option>
+          <option value="attached">Yes</option>
+          <option value="not_attached">No</option>
+          <option value="not_sure">Not sure</option>
+          <option value="no_account">I do not have a TrainingPeaks account yet</option>
+        </select>
+        <div class="gg-apply-help">This prevents duplicate setup instructions; I still verify the connection before releasing your plan.</div>
+      </div>
+
       <div class="gg-apply-inline-4">
         <div class="gg-apply-group">
           <label class="gg-apply-label" for="sex">Sex <span class="gg-apply-required">*</span></label>
@@ -106,7 +149,7 @@ def build_section_1_basic_info() -> str:
         </div>
         <div class="gg-apply-group">
           <label class="gg-apply-label" for="age">Age <span class="gg-apply-required">*</span></label>
-          <input type="number" id="age" name="age" required placeholder="35" min="16" max="90">
+          <input type="number" id="age" name="age" required placeholder="35" min="13" max="90">
         </div>
         <div class="gg-apply-group">
           <label class="gg-apply-label" for="weight">Weight <span class="gg-apply-required">*</span></label>
@@ -123,6 +166,31 @@ def build_section_1_basic_info() -> str:
             <input type="number" id="height_in" name="height_in" required placeholder="10" min="0" max="11" style="width:50px">
             <span class="gg-apply-unit">&#34;</span>
           </div>
+        </div>
+      </div>
+
+      <div id="guardian-details" class="gg-apply-conditional">
+        <div class="gg-apply-group">
+          <strong>For athletes under 18</strong>
+          <div class="gg-apply-help">A parent or legal guardian must complete the separate consent step before coaching can start.</div>
+        </div>
+        <div class="gg-apply-inline">
+          <div class="gg-apply-group">
+            <label class="gg-apply-label" for="guardian_name">Parent / Guardian Full Name</label>
+            <input type="text" id="guardian_name" name="guardian_name">
+          </div>
+          <div class="gg-apply-group">
+            <label class="gg-apply-label" for="guardian_email">Parent / Guardian Email</label>
+            <input type="email" id="guardian_email" name="guardian_email">
+          </div>
+        </div>
+        <div class="gg-apply-group">
+          <label class="gg-apply-label" for="guardian_relationship">Relationship to Athlete</label>
+          <select id="guardian_relationship" name="guardian_relationship">
+            <option value="">Select...</option>
+            <option value="parent">Parent</option>
+            <option value="legal_guardian">Legal guardian</option>
+          </select>
         </div>
       </div>'''
 
@@ -816,6 +884,19 @@ def build_submit_buttons() -> str:
       </div>'''
 
 
+def build_tier_selector() -> str:
+    return '''<div class="gg-apply-group gg-apply-tier-group">
+        <label class="gg-apply-label" for="coaching_tier">Coaching Tier <span class="gg-apply-required">*</span></label>
+        <select id="coaching_tier" name="tier" required>
+          <option value="">Select...</option>
+          <option value="min">Min</option>
+          <option value="mid">Mid</option>
+          <option value="max">Max</option>
+        </select>
+        <div class="gg-apply-help">TrainingPeaks Premium is included with coaching; it is not the name of a coaching tier.</div>
+      </div>'''
+
+
 def build_footer() -> str:
     return f'''<div class="gg-apply-confidential-wrap">
     <p class="gg-apply-confidential">Your information is kept confidential and used only for coaching purposes. Questions? Email gravelgodcoaching@gmail.com</p>
@@ -1346,6 +1427,48 @@ def build_apply_js() -> str:
     }
   }
 
+  var applyStartedTracked = false;
+  function trackApplyStarted() {
+    if (applyStartedTracked) { return; }
+    applyStartedTracked = true;
+    ga4("coaching_apply_started", {
+      tier: document.getElementById("coaching_tier").value || "unknown"
+    });
+  }
+
+  /* ── Preserve the tier selected on the coaching page ─────── */
+  function initializeTier() {
+    var tier = new URLSearchParams(window.location.search).get("tier");
+    if (["min", "mid", "max"].indexOf(tier) !== -1) {
+      document.getElementById("coaching_tier").value = tier;
+    }
+  }
+
+  function initializeTimezone() {
+    var field = document.getElementById("home_timezone");
+    if (!field || field.value) { return; }
+    try {
+      field.value = Intl.DateTimeFormat().resolvedOptions().timeZone || "";
+    } catch (e) {
+      field.value = "";
+    }
+  }
+
+  function getSubmissionId() {
+    var existing = localStorage.getItem("coaching_intake_submission_id");
+    if (existing) { return existing; }
+    var id;
+    if (window.crypto && typeof window.crypto.randomUUID === "function") {
+      id = window.crypto.randomUUID();
+    } else {
+      id = "10000000-1000-4000-8000-100000000000".replace(/[018]/g, function(c) {
+        return (c ^ window.crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16);
+      });
+    }
+    localStorage.setItem("coaching_intake_submission_id", id);
+    return id;
+  }
+
   /* ── Progress tracking ───────────────────────────── */
   function updateProgress() {
     var form = document.getElementById("intake-form");
@@ -1468,6 +1591,14 @@ def build_apply_js() -> str:
     } else {
       intervalsGroup.classList.remove("show");
     }
+
+    var age = parseInt(document.getElementById("age").value, 10);
+    var guardian = document.getElementById("guardian-details");
+    var isMinor = age >= 13 && age < 18;
+    guardian.classList.toggle("show", isMinor);
+    guardian.querySelectorAll("input, select").forEach(function(field) {
+      field.required = isMinor;
+    });
   }
 
   /* ── Radio option selection styling ──────────────── */
@@ -1523,10 +1654,12 @@ def build_apply_js() -> str:
   document.getElementById("weight").addEventListener("input", calculateMetrics);
   document.getElementById("sex").addEventListener("change", calculateMetrics);
   document.getElementById("training_platform").addEventListener("change", handleConditionals);
+  document.getElementById("age").addEventListener("input", handleConditionals);
 
   document.querySelectorAll("input, select, textarea").forEach(function(el) {
     el.addEventListener("change", updateProgress);
     el.addEventListener("input", updateProgress);
+    el.addEventListener("input", trackApplyStarted);
   });
 
   /* ── Save progress to localStorage ───────────────── */
@@ -1589,6 +1722,7 @@ def build_apply_js() -> str:
     var lines = [];
     lines.push("# Athlete Intake: " + data.name);
     lines.push("Email: " + data.email);
+    lines.push("Coaching Tier: " + data.tier);
     lines.push("Submitted: " + new Date().toISOString());
     lines.push("");
     lines.push("## Basic Info");
@@ -1679,7 +1813,7 @@ def build_apply_js() -> str:
     return lines.join("\\n");
   }
 
-  /* ── Form submission — Formsubmit.co ──────────────── */
+  /* ── Form submission — shared coaching intake Worker ─ */
   document.getElementById("intake-form").addEventListener("submit", function(e) {
     e.preventDefault();
     var submitBtn = document.getElementById("submit-btn");
@@ -1694,6 +1828,15 @@ def build_apply_js() -> str:
     data.long_ride_days = formData.getAll("long_ride_days");
     data.interval_days = formData.getAll("interval_days");
     data.off_days = formData.getAll("off_days");
+    data.submission_id = getSubmissionId();
+
+    var submittedAge = parseInt(data.age, 10);
+    if (submittedAge < 18 && (!data.guardian_name || !data.guardian_email || !data.guardian_relationship)) {
+      showMessage("error", "Please add your parent or legal guardian details.");
+      submitBtn.disabled = false;
+      submitBtn.textContent = "Submit Questionnaire";
+      return;
+    }
 
     /* Honeypot check */
     if (data.website) {
@@ -1717,43 +1860,43 @@ def build_apply_js() -> str:
       return;
     }
 
-    var output = formatSubmission(data);
-
-    /* Submit via Formsubmit.co — sends email to gravelgodcoaching@gmail.com */
-    var FORMSUBMIT_URL = "''' + FORMSUBMIT_URL + '''";
-    var payload = new FormData();
-    payload.append("_subject", "Coaching Application: " + data.name);
-    payload.append("_replyto", data.email);
-    payload.append("_captcha", "false");
-    payload.append("_template", "box");
-    payload.append("name", data.name);
-    payload.append("email", data.email);
-    payload.append("message", output);
-    payload.append("_honey", "");
-
-    fetch(FORMSUBMIT_URL, {
+    var COACHING_INTAKE_URL = "''' + COACHING_INTAKE_WORKER_URL + '''";
+    fetch(COACHING_INTAKE_URL, {
       method: "POST",
-      body: payload,
-      headers: { "Accept": "application/json" }
-    }).then(function(response) {
-      if (response.ok) {
-        localStorage.removeItem("athlete_questionnaire_progress");
-        ga4("apply_form_submitted", {
-          blindspot_count: (data.blindspots || "").split(",").filter(function(b) { return b; }).length,
-          has_ftp: data.ftp ? "yes" : "no",
-          primary_goal: data.primary_goal
-        });
-        showMessage("success", "Application submitted! I&#39;ll review your questionnaire and get back to you within 24 hours.");
-        submitBtn.textContent = "Submitted";
-      } else {
-        throw new Error("Server returned " + response.status);
+      body: JSON.stringify(data),
+      headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json"
       }
+    }).then(function(response) {
+      return response.json().catch(function() { return {}; }).then(function(result) {
+        if (!response.ok || !result.success) {
+          throw new Error(result.error || "Server returned " + response.status);
+        }
+        return result;
+      });
+    }).then(function() {
+      localStorage.removeItem("athlete_questionnaire_progress");
+      localStorage.removeItem("coaching_intake_submission_id");
+      ga4("apply_form_submitted", {
+        blindspot_count: (data.blindspots || "").split(",").filter(function(b) { return b; }).length,
+        has_ftp: data.ftp ? "yes" : "no",
+        primary_goal: data.primary_goal,
+        tier: data.tier
+      });
+      ga4("coaching_apply_submitted", {
+        tier: data.tier,
+        primary_goal: data.primary_goal,
+        transport_type: "beacon"
+      });
+      showMessage("success", "Application submitted. Check your email for confirmation; I&#39;ll review your intake and send the next steps from there.");
+      submitBtn.textContent = "Submitted";
     }).catch(function(err) {
-      /* Fallback: open email client with formatted body */
-      var subject = encodeURIComponent("Coaching Application: " + data.name);
-      var body = encodeURIComponent(output);
-      window.location.href = "mailto:gravelgodcoaching@gmail.com?subject=" + subject + "&body=" + body;
-      ga4("apply_form_fallback", { method: "mailto" });
+      showMessage("error", "I couldn&#39;t submit that. Your answers are still saved in this browser—please try again.");
+      submitBtn.disabled = false;
+      submitBtn.textContent = "Submit Questionnaire";
+      ga4("apply_form_error", { message: String(err.message || "unknown").slice(0, 80) });
+      ga4("coaching_apply_error", { stage: "submit" });
     });
   });
 
@@ -1783,6 +1926,8 @@ def build_apply_js() -> str:
 
   /* ── Initialize ──────────────────────────────────── */
   restoreProgress();
+  initializeTimezone();
+  initializeTier();
   updateProgress();
   handleConditionals();
 })();
@@ -1839,6 +1984,8 @@ def generate_apply_page(external_assets=None):
       <input type="hidden" name="estimated_category" id="estimated_category" value="">
       <input type="hidden" name="blindspots" id="blindspots" value="">
       <input type="hidden" name="inferred_traits" id="inferred_traits" value="">
+      <input type="hidden" name="home_timezone" id="home_timezone" value="">
+      {build_tier_selector()}
       {build_section_1_basic_info()}
       {build_section_2_goals()}
       {build_section_3_fitness()}

--- a/wordpress/generate_success_pages.py
+++ b/wordpress/generate_success_pages.py
@@ -330,28 +330,26 @@ def build_coaching_success() -> str:
     <div class="gg-success-step">
       <div class="gg-success-step-num">1</div>
       <div class="gg-success-step-text">
-        <h3>Fill Out the Intake Form</h3>
-        <p>If you haven't already, complete the athlete intake so I have
-        everything I need to build your plan.
-        <a href="{SITE_BASE_URL}/coaching/apply/">Complete intake &rarr;</a></p>
+        <h3>Check Your Email</h3>
+        <p>Your private onboarding guide includes your kickoff-call booking
+        link, what your tier includes, and exactly how we communicate.</p>
       </div>
     </div>
     <div class="gg-success-step">
       <div class="gg-success-step-num">2</div>
       <div class="gg-success-step-text">
-        <h3>Expect an Email Within 24 Hours</h3>
-        <p>I'll review your intake and reach out with initial questions,
-        your training philosophy alignment, and a timeline for your
-        first structured week.</p>
+        <h3>Connect TrainingPeaks</h3>
+        <p>If you are not already attached, <a href="{TRAININGPEAKS_ATTACH_URL}" target="_blank" rel="noopener">connect your account &rarr;</a>
+        TrainingPeaks Premium is included; do not purchase it separately.</p>
       </div>
     </div>
     <div class="gg-success-step">
       <div class="gg-success-step-num">3</div>
       <div class="gg-success-step-text">
-        <h3>We Train Together</h3>
-        <p>Your plan lands in your calendar. I review every session,
-        adjust the plan when life happens, and keep you accountable
-        through race day.</p>
+        <h3>Run the First Block</h3>
+        <p>Your TrainingPeaks calendar is the source of truth. Comment after
+        each workout; if you miss one, do not stack it onto the next day.
+        Tell me what happened and I will adjust it.</p>
       </div>
     </div>
   </div>"""

--- a/workers/coaching-intake/package-lock.json
+++ b/workers/coaching-intake/package-lock.json
@@ -1,0 +1,1538 @@
+{
+  "name": "coaching-intake-worker",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "coaching-intake-worker",
+      "devDependencies": {
+        "wrangler": "4.125.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260820.1.tgz",
+      "integrity": "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260820.1.tgz",
+      "integrity": "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260820.1.tgz",
+      "integrity": "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260820.1.tgz",
+      "integrity": "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260820.1.tgz",
+      "integrity": "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260820.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260820.0-alpha.tgz",
+      "integrity": "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260820.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260820.1.tgz",
+      "integrity": "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260820.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260820.1",
+        "@cloudflare/workerd-linux-64": "1.20260820.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260820.1",
+        "@cloudflare/workerd-windows-64": "1.20260820.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.125.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.125.0.tgz",
+      "integrity": "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260820.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260820.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260820.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/workers/coaching-intake/package.json
+++ b/workers/coaching-intake/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "coaching-intake-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "node --check worker.js",
+    "dry-run": "wrangler deploy --dry-run",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "4.125.0"
+  }
+}

--- a/workers/coaching-intake/worker.js
+++ b/workers/coaching-intake/worker.js
@@ -1,0 +1,231 @@
+/**
+ * Brand-aware coaching intake edge.
+ *
+ * Browser -> this Worker -> authenticated Railway onboarding case endpoint.
+ * A form submission creates FIT_REVIEW only. Fit approval, evidence
+ * verification, and payment handoff are separate authenticated backend steps;
+ * checkout is never created from an untrusted browser flag.
+ */
+
+const BRAND_BY_HOST = {
+  'gravelgodcycling.com': 'gravelgod',
+  'www.gravelgodcycling.com': 'gravelgod',
+  'roadielabs.com': 'roadielabs',
+  'www.roadielabs.com': 'roadielabs',
+  'xcskilabs.com': 'xcskilabs',
+  'www.xcskilabs.com': 'xcskilabs',
+};
+
+const VALID_TIERS = new Set(['min', 'mid', 'max']);
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.pathname === '/__canary') {
+      return handleCanary(request, env);
+    }
+    const origin = request.headers.get('Origin') || '';
+    const brand = brandFromOrigin(origin);
+
+    if (request.method === 'OPTIONS') {
+      return brand
+        ? new Response(null, { status: 204, headers: corsHeaders(origin) })
+        : new Response('Forbidden', { status: 403 });
+    }
+    if (request.method !== 'POST') {
+      return jsonResponse({ error: 'Method not allowed' }, 405, origin);
+    }
+    if (!brand) {
+      return jsonResponse({ error: 'Forbidden' }, 403, origin);
+    }
+    if (!env.PIPELINE_URL || !env.COACHING_INTAKE_SECRET) {
+      console.error(JSON.stringify({
+        message: 'coaching_intake_configuration_missing',
+      }));
+      return jsonResponse({ error: 'Intake is temporarily unavailable' }, 503, origin);
+    }
+
+    let data;
+    try {
+      data = await request.json();
+    } catch (_) {
+      return jsonResponse({ error: 'Invalid request' }, 400, origin);
+    }
+
+    const name = String(data.name || '').trim();
+    const email = String(data.email || '').trim().toLowerCase();
+    const tier = String(data.tier || '').trim().toLowerCase();
+    if (data.website) return jsonResponse({ error: 'Submission blocked' }, 400, origin);
+    if (!name) return jsonResponse({ error: 'Name is required' }, 400, origin);
+    if (!EMAIL_RE.test(email)) {
+      return jsonResponse({ error: 'Valid email is required' }, 400, origin);
+    }
+    if (!VALID_TIERS.has(tier)) {
+      return jsonResponse({ error: 'Select a coaching tier' }, 400, origin);
+    }
+
+    const requestedSubmissionId = String(data.submission_id || '').trim();
+    const submissionId = UUID_RE.test(requestedSubmissionId)
+      ? requestedSubmissionId
+      : crypto.randomUUID();
+    const questionnaire = { ...data };
+    delete questionnaire.website;
+    delete questionnaire.submission_id;
+
+    let backend;
+    try {
+      backend = await fetch(`${env.PIPELINE_URL.replace(/\/$/, '')}/api/coaching-intakes`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Coaching-Intake-Secret': env.COACHING_INTAKE_SECRET,
+        },
+        body: JSON.stringify({
+          submission_id: submissionId,
+          brand,
+          tier,
+          name,
+          email,
+          questionnaire,
+        }),
+      });
+    } catch (error) {
+      console.error(JSON.stringify({
+        message: 'coaching_intake_backend_unavailable', brand,
+      }));
+      return jsonResponse({ error: 'Could not submit. Please try again.' }, 502, origin);
+    }
+
+    let result = {};
+    try {
+      result = await backend.json();
+    } catch (_) {
+      result = {};
+    }
+    if (!backend.ok) {
+      console.error(JSON.stringify({
+        message: 'coaching_intake_backend_rejected',
+        brand,
+        status: backend.status,
+      }));
+      return jsonResponse(
+        { error: result.error || 'Could not submit. Please try again.' },
+        backend.status >= 500 ? 502 : backend.status,
+        origin,
+      );
+    }
+
+    return jsonResponse({
+      success: true,
+      case_id: result.case_id || submissionId,
+      state: result.state || 'FIT_REVIEW',
+      receipt_sent: Boolean(result.receipt_sent),
+      duplicate: Boolean(result.duplicate),
+    }, backend.status === 200 ? 200 : 201, origin);
+  },
+};
+
+async function handleCanary(request, env) {
+  if (request.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405, '');
+  }
+  if (!env.PIPELINE_URL || !env.COACHING_INTAKE_SECRET ||
+      !env.COACHING_CANARY_SECRET) {
+    console.error(JSON.stringify({
+      message: 'coaching_canary_configuration_missing',
+    }));
+    return jsonResponse({ error: 'Canary is not configured' }, 503, '');
+  }
+  const supplied = request.headers.get('X-Coaching-Canary-Secret') || '';
+  if (!(await secretsMatch(supplied, env.COACHING_CANARY_SECRET))) {
+    return jsonResponse({ error: 'Unauthorized' }, 401, '');
+  }
+
+  let backend;
+  try {
+    backend = await fetch(
+      `${env.PIPELINE_URL.replace(/\/$/, '')}/api/coaching-canary`,
+      {
+        method: 'POST',
+        headers: {
+          'X-Coaching-Intake-Secret': env.COACHING_INTAKE_SECRET,
+        },
+      },
+    );
+  } catch (_) {
+    console.error(JSON.stringify({
+      message: 'coaching_canary_backend_unavailable',
+    }));
+    return jsonResponse({
+      schema: 'coaching_edge_canary/v1',
+      status: 'failed',
+      edge_reachable: true,
+      error: 'Backend unavailable',
+    }, 502, '');
+  }
+
+  let result = {};
+  try {
+    // The canary response is a bounded internal JSON contract, not an
+    // arbitrary upstream payload.
+    result = await backend.json();
+  } catch (_) {
+    result = { status: 'failed', error: 'Invalid backend response' };
+  }
+  const response = {
+    ...result,
+    schema: 'coaching_edge_canary/v1',
+    edge_reachable: true,
+    backend_status: backend.status,
+  };
+  const status = backend.ok && result.status === 'ok' ? 200 : 503;
+  const log = {
+    message: 'coaching_edge_canary',
+    status: response.status || 'failed',
+    backend_status: backend.status,
+  };
+  if (status === 200) console.log(JSON.stringify(log));
+  else console.error(JSON.stringify(log));
+  return jsonResponse(response, status, '');
+}
+
+async function secretsMatch(provided, expected) {
+  const encoder = new TextEncoder();
+  const [providedHash, expectedHash] = await Promise.all([
+    crypto.subtle.digest('SHA-256', encoder.encode(provided)),
+    crypto.subtle.digest('SHA-256', encoder.encode(expected)),
+  ]);
+  return crypto.subtle.timingSafeEqual(providedHash, expectedHash);
+}
+
+function brandFromOrigin(origin) {
+  try {
+    return BRAND_BY_HOST[new URL(origin).hostname.toLowerCase()] || '';
+  } catch (_) {
+    return '';
+  }
+}
+
+function corsHeaders(origin) {
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Vary': 'Origin',
+    'X-Content-Type-Options': 'nosniff',
+  };
+}
+
+function jsonResponse(body, status, origin) {
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Content-Type-Options': 'nosniff',
+  };
+  if (brandFromOrigin(origin)) Object.assign(headers, corsHeaders(origin));
+  return new Response(JSON.stringify(body), {
+    status,
+    headers,
+  });
+}

--- a/workers/coaching-intake/wrangler.jsonc
+++ b/workers/coaching-intake/wrangler.jsonc
@@ -1,0 +1,15 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "coaching-intake",
+  "main": "worker.js",
+  "compatibility_date": "2026-08-25",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "enabled": true,
+    "logs": { "enabled": true, "head_sampling_rate": 1 },
+    "traces": { "enabled": true, "head_sampling_rate": 0.05 }
+  },
+  "vars": {
+    "PIPELINE_URL": "https://athlete-custom-training-plan-pipeline-production.up.railway.app"
+  }
+}


### PR DESCRIPTION
## Summary
- add the shared, origin-bound Cloudflare coaching intake Worker
- route Gravel God, Roadie Labs, and XC Ski Labs into FIT_REVIEW without creating checkout
- add stable submission receipts, minor guardian routing, Min/Mid/Max naming, and client/server funnel events
- replace public startup-code copy with the private case-by-case waiver policy

## Verification
- 276 passed, 2 skipped across coaching/apply/success/Worker contract tests
- worker JavaScript syntax check passed
- Wrangler 4.125.0 deployment dry-run passed

## Activation gate
Draft only. Do not merge/deploy the Worker or public forms until the approved privacy/processor disclosure and e-sign/legal packet are available. The Railway backend intake secret is configured; the backend production canary currently leaves the legal/e-sign gate intentionally blocked.