### PR TITLE
Harden Gravel Weekly shell launch validation

### DIFF
--- a/mission_control/tests/conftest.py
+++ b/mission_control/tests/conftest.py
@@ -280,7 +280,10 @@ def client(fake_db):
         app = app_mod.create_app()
         app.router.lifespan_context = noop_lifespan
 
-        with TestClient(app) as c:
+        with TestClient(
+            app,
+            headers={"Authorization": "Bearer test-secret-for-tests"},
+        ) as c:
             yield c
     finally:
         app_mod.lifespan = original_lifespan

--- a/mission_control/tests/test_lead_nurture.py
+++ b/mission_control/tests/test_lead_nurture.py
@@ -508,7 +508,10 @@ class TestGmailSyncEndpoints:
 
 class TestLeadReplyEditor:
     def test_editor_is_admin_protected_and_renders_when_authorized(self, client):
-        assert client.get("/lead-replies").status_code == 401
+        assert client.get(
+            "/lead-replies",
+            headers={"Authorization": ""},
+        ).status_code == 401
         response = client.get(
             "/lead-replies",
             headers={"Authorization": "Bearer test-secret-for-tests"},

--- a/scripts/validate_blog_content.py
+++ b/scripts/validate_blog_content.py
@@ -57,6 +57,26 @@ PYTHON_REPR_PATTERNS = [
     (re.compile(r"\[\{['\"]"), "list-of-dicts ([{'...} or [{\"...}])"),
 ]
 
+EXPECTED_BODY_SCRIPT_MARKERS = (
+    "gg-consent-banner",
+    "source: 'editorial'",
+)
+
+
+def body_scripts_are_expected(content: str) -> bool:
+    """Allow only the centralized consent and editorial CTA scripts in body."""
+    if "</head>" not in content or "</body>" not in content:
+        return False
+    body = content.split("</head>", 1)[1].split("</body>", 1)[0]
+    scripts = re.findall(r"<script[^>]*>(.*?)</script>", body, flags=re.DOTALL | re.IGNORECASE)
+    matched: list[str] = []
+    for script in scripts:
+        marker = next((value for value in EXPECTED_BODY_SCRIPT_MARKERS if value in script), None)
+        if marker is None or marker in matched:
+            return False
+        matched.append(marker)
+    return True
+
 
 class Validator:
     def __init__(self):
@@ -243,13 +263,11 @@ def check_html_quality(v):
             f"{label}: has CTA section",
         )
 
-        # No unescaped script tags in body
+        # Only centralized consent and editorial CTA tracking may execute in body.
         if "</head>" in content and "</body>" in content:
-            body = content.split("</head>")[1].split("</body>")[0]
-            script_count = body.count("<script")
             v.check(
-                script_count <= 1,  # Only JSON-LD allowed
-                f"{label}: no unexpected <script> in body ({script_count} found)",
+                body_scripts_are_expected(content),
+                f"{label}: body scripts are centralized and expected",
             )
 
 

--- a/tests/test_validate_blog_content.py
+++ b/tests/test_validate_blog_content.py
@@ -16,6 +16,7 @@ from validate_blog_content import (
     PYTHON_REPR_PATTERNS,
     TAKEAWAY_BAD_PATTERNS,
     Validator,
+    body_scripts_are_expected,
     check_hero_images,
     check_no_python_repr,
     check_t4_content_quality,
@@ -32,6 +33,24 @@ def _any_pattern_matches(text):
         if pattern.search(text):
             return True
     return False
+
+
+class TestExpectedBodyScripts:
+    def test_centralized_consent_and_editorial_tracking_are_allowed(self):
+        content = """<html><head></head><body>
+        <script>document.getElementById('gg-consent-banner')</script>
+        <script>gtag('event', 'cta_click', {source: 'editorial'})</script>
+        </body></html>"""
+        assert body_scripts_are_expected(content)
+
+    def test_arbitrary_or_duplicate_body_scripts_fail(self):
+        arbitrary = "<html><head></head><body><script>alert(1)</script></body></html>"
+        duplicate = """<html><head></head><body>
+        <script>document.getElementById('gg-consent-banner')</script>
+        <script>document.getElementById('gg-consent-banner')</script>
+        </body></html>"""
+        assert not body_scripts_are_expected(arbitrary)
+        assert not body_scripts_are_expected(duplicate)
 
 
 # ── True positives: these MUST be caught ──

--- a/wordpress/generate_homepage.py
+++ b/wordpress/generate_homepage.py
@@ -1199,7 +1199,7 @@ def build_training_cta() -> str:
         <h2>Train for the course, not just the distance</h2>
         <p>Every generic plan treats gravel like a road race with dirt. This isn&rsquo;t that. Training plans matched to your target race&rsquo;s exact terrain, elevation profile, and typical conditions. Built around your schedule, your fitness, and your goal.</p>
         <p class="gg-hp-cta-price" data-ab="training_price">Custom-built for your target event &mdash; $15 a week.</p>
-      <a href="{esc(TRAINING_PLANS_URL)}" class="gg-hp-cta-btn" data-ga="cta_click" data-ga-label="training_plan">Get Your Plan &rarr;</a>
+      <a href="{esc(TRAINING_PLANS_URL)}" class="gg-hp-cta-btn" data-ab="training_cta_btn" data-ga="cta_click" data-ga-label="training_plan">Get Your Plan &rarr;</a>
       </div>
       <div class="gg-hp-cta-right" role="img" aria-label="Training plan preview"></div>
     </div>


### PR DESCRIPTION
## What
- restore the homepage training CTA selector required by the active A/B configuration
- allow only the centralized consent and editorial CTA scripts in generated blog bodies
- authenticate the shared Mission Control admin test client while keeping explicit unauthenticated security checks

## Why
Fresh generation exposed source/output drift and a validator false positive while preparing the empty Gravel Weekly launch shell. These fixes keep the gates strict without publishing an unapproved issue.

## Verification
- 7,778 passed, 327 skipped
- blog content gate: 127 passed
- YouTube validation: 262 enriched profiles, 0 errors
- preflight quality: passed
- citation validation: passed
- banned color scan: passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to validation rules, test fixtures, and a single `data-ab` attribute on generated HTML; no production auth or payment logic is modified.
> 
> **Overview**
> Tightens **Gravel Weekly / launch preflight** by fixing validator drift, test auth behavior, and a missing homepage experiment hook.
> 
> **Blog content gate:** Replaces the old “at most one `<script>` in the body” rule with **`body_scripts_are_expected`**, which only permits the centralized consent banner (`gg-consent-banner`) and editorial CTA tracking (`source: 'editorial'`), and rejects arbitrary or duplicate body scripts. Unit tests cover the allow/deny cases.
> 
> **Mission Control tests:** The shared `TestClient` fixture now sends **`Authorization: Bearer test-secret-for-tests`** by default so admin routes work without repeating headers; the lead-replies test still asserts **401** by passing an explicit empty `Authorization` header.
> 
> **Homepage generator:** Restores **`data-ab="training_cta_btn"`** on the training plan CTA so it matches the active A/B **`conversion_selector`** configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a09888ee24f81c2a1724a65e50d73bf7185ba207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->