### PR TITLE
Prevent orphaned WordPress deploy arguments

### DIFF
--- a/scripts/push_wordpress.py
+++ b/scripts/push_wordpress.py
@@ -4252,7 +4252,7 @@ if __name__ == "__main__":
         args.purge_cache = True
 
     has_action = any([args.json, args.sync_index, args.sync_widget, args.sync_training,
-                      args.sync_guide, args.sync_guide_cluster, args.sync_bikepacking_guide,
+                      args.sync_guide, args.sync_guide_cluster,
                       args.sync_og, args.sync_tp, args.sync_homepage, args.sync_gravel_tv, args.sync_gravel_weekly, args.sync_about,
                       args.sync_coaching, args.sync_coaching_apply, args.sync_consulting,
                       args.sync_consult_intake,

--- a/tests/test_deploy_parity.py
+++ b/tests/test_deploy_parity.py
@@ -3,6 +3,7 @@ rules, SSH inventory parsing, and orphan/undeployed comparison."""
 
 from __future__ import annotations
 
+import ast
 import sys
 from pathlib import Path
 
@@ -16,6 +17,33 @@ import immune_check as immune
 
 
 ROOT = "/home/u/www/gravelgodcycling.com/public_html"
+
+
+class TestDeployCliParity:
+    def test_every_args_attribute_has_a_parser_argument(self):
+        """Prevent orphaned args references from crashing every deploy."""
+        source = (PROJECT_ROOT / "scripts" / "push_wordpress.py").read_text()
+        tree = ast.parse(source)
+        referenced = {
+            node.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "args"
+        }
+        parsed = {
+            arg.value[2:].replace("-", "_")
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_argument"
+            for arg in node.args
+            if isinstance(arg, ast.Constant)
+            and isinstance(arg.value, str)
+            and arg.value.startswith("--")
+        }
+
+        assert referenced <= parsed, f"args attributes missing parser options: {sorted(referenced - parsed)}"
 
 
 class TestImmuneWrapper:


### PR DESCRIPTION
## What
- remove the orphaned `sync_bikepacking_guide` Namespace access that crashed every real deploy
- add AST parity coverage requiring every `args.*` reference to have a declared parser option

## Verification
- 29 focused deploy/Gravel Weekly tests passed
- 7,778 passed, 328 skipped in full suite

The failed production command exited before any SSH action; no live mutation occurred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small deploy-script fix plus a static test; no production behavior change beyond allowing deploys to start again.
> 
> **Overview**
> Fixes a **pre-SSH deploy crash** caused by `has_action` reading `args.sync_bikepacking_guide` even though that flag was never defined on the argparse parser (likely left over after a removed sync path).
> 
> **`push_wordpress.py`** drops that reference from the `has_action` `any([...])` list so full deploy shortcuts no longer raise `AttributeError` before any sync runs.
> 
> **`tests/test_deploy_parity.py`** adds `TestDeployCliParity::test_every_args_attribute_has_a_parser_argument`, which AST-scans `push_wordpress.py` and fails CI if any `args.<name>` is used without a matching `--name` from `add_argument`, so the same class of bug cannot regress silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6aa9b876cb4e8d95c44644623c1117089b8e831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->