### PR TITLE
Wrap Gravel Weekly shared-header JavaScript

### DIFF
--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -225,6 +225,8 @@ def test_rendered_issue_preserves_site_infrastructure_and_honest_form():
     assert "textContent" in page
     assert "innerHTML" not in page
     assert "get_site_header_js" not in page
+    assert "</main>\n<script>\n// ── Hamburger mobile menu" in page
+    assert page.count("Hamburger mobile menu") == 1
     assert "/gravel-weekly/2026-08-28/" in page
     assert "rounded" not in page.lower()
 

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -353,7 +353,7 @@ def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, la
   <section class="gw-utility" id="past-issues"><h2>PAST ISSUES</h2>{render_archive(issues, issue_id)}</section>
   {subscribe_block()}
 </main>
-{get_site_header_js()}
+<script>{get_site_header_js()}</script>
 {get_consent_banner_html()}
 </body>
 </html>'''


### PR DESCRIPTION
## What
- wrap the shared-header JavaScript in a script element on Gravel Weekly pages
- assert the script is wrapped exactly once

## Incident
Visual QA found the launch shell rendering shared-header JavaScript as body text. The corrected page was hot-deployed and cache-purged; live browser readback now reports zero raw-JS text nodes, one privacy footer, and zero console errors.

## Verification
- 14 focused Gravel Weekly tests passed
- 7,778 passed, 328 skipped in full suite
- live `/gravel-weekly/` visual QA passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small HTML template change with focused test coverage; no auth, data, or subscription logic touched.
> 
> **Overview**
> Fixes Gravel Weekly pages rendering **shared site-header JavaScript as visible body text** instead of executing it. The generator now outputs `<script>{get_site_header_js()}</script>` immediately after `</main>`, rather than injecting the raw JS string.
> 
> Tests lock in the contract: the hamburger menu block must appear **once**, inside a `<script>` tag that follows `</main>`, so duplicate or unwrapped header JS cannot regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832d2a10d2af11e9003ec67a21318f0d73469a61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->