### PR TITLE
Add Gravel Weekly memory timeline

### DIFF
--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -10,6 +10,14 @@ does not write to `issues/`. An issue enters that directory only after Matti
 approves The Take. Published files are historical snapshots: corrections are appended
 to `corrections`; old copy is not silently rewritten.
 
+Later issues can revisit an earlier story through `retrospectives`. Each entry
+must name the prior issue and story, classify the take as `aged_well`,
+`aged_poorly`, or `still_developing`, explain what changed, include fresh
+receipts, and carry human-approved assessment provenance before publication.
+The loader verifies that every retrospective points backward to a real archived
+story. The Past Issues section also preserves each issue's Current Thing, deck,
+and Take excerpt so the archive reads as a timeline instead of a link dump.
+
 Build a fail-closed draft from a control-plane review artifact:
 
 ```bash

--- a/scripts/prepare_gravel_weekly_issue.py
+++ b/scripts/prepare_gravel_weekly_issue.py
@@ -146,6 +146,7 @@ def prepare_issue(review_value: Any, publication_date: str, issue_number: int, *
         "stories": stories,
         "calendarWatch": [],
         "raceImpacts": _dedupe_records(all_impacts),
+        "retrospectives": [],
         "corrections": [],
         "sourceIndex": sorted(set(source_urls)),
         "editorialApproval": None,

--- a/scripts/validate_gravel_weekly.py
+++ b/scripts/validate_gravel_weekly.py
@@ -23,6 +23,7 @@ IMPACT_KINDS = {
     "no_change", "verify_field", "propose_fact", "editorial_review",
     "new_race_candidate",
 }
+RETROSPECTIVE_VERDICTS = {"aged_well", "aged_poorly", "still_developing"}
 
 
 class IssueValidationError(ValueError):
@@ -118,6 +119,30 @@ def _impact(value: Any, name: str) -> dict[str, Any]:
     return item
 
 
+def _retrospective(value: Any, name: str, *, status: str) -> dict[str, Any]:
+    item = _record(value, name)
+    if item.get("verdict") not in RETROSPECTIVE_VERDICTS:
+        raise IssueValidationError(f"{name}.verdict is invalid")
+    _text(item.get("priorIssueId"), f"{name}.priorIssueId", 500)
+    _text(item.get("priorStoryId"), f"{name}.priorStoryId", 500)
+    _text(item.get("headline"), f"{name}.headline", 300)
+    _text(item.get("whatChanged"), f"{name}.whatChanged", 2_000)
+    assessment = _text(item.get("assessment"), f"{name}.assessment", 4_000)
+    provenance = item.get("assessmentProvenance")
+    if provenance not in {"model_draft", "human_approved"}:
+        raise IssueValidationError(f"{name}.assessmentProvenance is invalid")
+    if status != "draft" and provenance != "human_approved":
+        raise IssueValidationError(f"{name}.assessment requires human-approved provenance")
+    if status != "draft" and re.search(r"model draft|not matti(?:’|')s approved", assessment, re.IGNORECASE):
+        raise IssueValidationError(f"{name}.assessment still contains model-draft language")
+    receipts = _list(item.get("receipts"), f"{name}.receipts", 100)
+    if not receipts:
+        raise IssueValidationError(f"{name}.receipts must not be empty")
+    for index, receipt in enumerate(receipts):
+        _receipt(receipt, f"{name}.receipts[{index}]")
+    return item
+
+
 def canonical_issue_json(issue: dict[str, Any]) -> str:
     payload = dict(issue)
     payload.pop("contentHash", None)
@@ -196,6 +221,12 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
         _text(item, f"calendarWatch[{index}]", 500)
     for index, impact in enumerate(_list(issue.get("raceImpacts"), "raceImpacts")):
         _impact(impact, f"raceImpacts[{index}]")
+    retrospective_refs: list[tuple[str, str]] = []
+    for index, retrospective in enumerate(_list(issue.get("retrospectives"), "retrospectives", 30)):
+        item = _retrospective(retrospective, f"retrospectives[{index}]", status=status)
+        retrospective_refs.append((item["priorIssueId"], item["priorStoryId"]))
+    if len(retrospective_refs) != len(set(retrospective_refs)):
+        raise IssueValidationError("retrospectives must not revisit the same prior story twice")
     for index, correction_value in enumerate(_list(issue.get("corrections"), "corrections", 100)):
         correction = _record(correction_value, f"corrections[{index}]")
         _iso(correction.get("publishedAt"), f"corrections[{index}].publishedAt")
@@ -240,6 +271,17 @@ def load_issues(issue_dir: Path = ISSUE_DIR) -> list[dict[str, Any]]:
         raise IssueValidationError("issue numbers must be unique")
     if len(dates) != len(set(dates)):
         raise IssueValidationError("publication dates must be unique")
+    by_id = {issue["issueId"]: issue for issue in issues}
+    for issue in issues:
+        for index, retrospective in enumerate(issue["retrospectives"]):
+            prior = by_id.get(retrospective["priorIssueId"])
+            name = f"{issue['issueId']}.retrospectives[{index}]"
+            if prior is None:
+                raise IssueValidationError(f"{name}.priorIssueId must reference an archived issue")
+            if prior["publicationDate"] >= issue["publicationDate"]:
+                raise IssueValidationError(f"{name} must reference an earlier issue")
+            if not any(story["candidateId"] == retrospective["priorStoryId"] for story in prior["stories"]):
+                raise IssueValidationError(f"{name}.priorStoryId must reference a story in the prior issue")
     return sorted(issues, key=lambda issue: issue["publicationDate"], reverse=True)
 
 

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -1,6 +1,7 @@
 """Contract and infrastructure tests for Gravel Weekly."""
 
 import copy
+import json
 import sys
 from pathlib import Path
 
@@ -14,6 +15,7 @@ from generate_gravel_weekly import build_page  # noqa: E402
 from validate_gravel_weekly import (  # noqa: E402
     IssueValidationError,
     compute_content_hash,
+    load_issues,
     validate_issue,
 )
 from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
@@ -65,6 +67,7 @@ def sample_issue():
         }],
         "calendarWatch": ["Registration closes Friday."],
         "raceImpacts": [impact],
+        "retrospectives": [],
         "corrections": [],
         "sourceIndex": ["https://www.cyclingnews.com/example/"],
         "editorialApproval": {"approver": "Matti Rowe", "approvedAt": "2026-08-28T16:00:00Z"},
@@ -229,6 +232,71 @@ def test_rendered_issue_preserves_site_infrastructure_and_honest_form():
     assert page.count("Hamburger mobile menu") == 1
     assert "/gravel-weekly/2026-08-28/" in page
     assert "rounded" not in page.lower()
+
+
+def test_retrospective_requires_receipts_and_human_approval_then_renders_memory_timeline(tmp_path):
+    prior = sample_issue()
+    current = copy.deepcopy(prior)
+    current.update({
+        "issueId": "gravel-weekly-002",
+        "issueNumber": 2,
+        "publicationDate": "2026-09-04",
+        "slug": "2026-09-04",
+        "title": "Gravel Weekly — September 4, 2026",
+        "publishedAt": "2026-09-04T16:05:00Z",
+        "updatedAt": "2026-09-04T16:05:00Z",
+        "retrospectives": [{
+            "verdict": "aged_poorly",
+            "priorIssueId": prior["issueId"],
+            "priorStoryId": "story_1",
+            "headline": "The tidy explanation did not survive the next week",
+            "whatChanged": "The organizer published a second revision that contradicted the original rationale.",
+            "assessment": "We treated a moving target like a settled argument. That was too confident.",
+            "assessmentProvenance": "human_approved",
+            "receipts": [prior["stories"][0]["receipts"][0]],
+        }],
+    })
+    current["contentHash"] = compute_content_hash(current)
+    prior_path = tmp_path / "2026-08-28.json"
+    current_path = tmp_path / "2026-09-04.json"
+    prior_path.write_text(json.dumps(prior))
+    current_path.write_text(json.dumps(current))
+
+    issues = load_issues(tmp_path)
+    page = build_page(current, issues, latest=True)
+    assert "THE RECEIPTS ON US" in page
+    assert "THIS AGED POORLY" in page
+    assert "/gravel-weekly/2026-08-28/#story_1" in page
+    assert "We treated a moving target" in page
+    assert "THE TAKE:" in page
+
+    model_assessment = copy.deepcopy(current)
+    model_assessment["retrospectives"][0]["assessmentProvenance"] = "model_draft"
+    with pytest.raises(IssueValidationError, match="human-approved provenance"):
+        validate_issue(model_assessment, verify_hash=False)
+
+    missing_receipts = copy.deepcopy(current)
+    missing_receipts["retrospectives"][0]["receipts"] = []
+    with pytest.raises(IssueValidationError, match="receipts"):
+        validate_issue(missing_receipts, verify_hash=False)
+
+
+def test_retrospective_must_reference_an_earlier_archived_story(tmp_path):
+    issue = sample_issue()
+    issue["retrospectives"] = [{
+        "verdict": "still_developing",
+        "priorIssueId": "missing-issue",
+        "priorStoryId": "story_1",
+        "headline": "The prediction is still moving",
+        "whatChanged": "New evidence arrived without resolving the original question.",
+        "assessment": "Keep the take open until the organizer publishes the final course.",
+        "assessmentProvenance": "human_approved",
+        "receipts": [issue["stories"][0]["receipts"][0]],
+    }]
+    issue["contentHash"] = compute_content_hash(issue)
+    (tmp_path / "2026-08-28.json").write_text(json.dumps(issue))
+    with pytest.raises(IssueValidationError, match="archived issue"):
+        load_issues(tmp_path)
 
 
 def test_worker_accepts_new_and_legacy_publication_sources():

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -101,6 +101,37 @@ def render_impacts(impacts: list[dict[str, Any]]) -> str:
     return f'<ul class="gw-impacts">{"".join(items)}</ul>'
 
 
+def render_retrospectives(retrospectives: list[dict[str, Any]], issues: list[dict[str, Any]], *, draft: bool) -> str:
+    if not retrospectives:
+        return ""
+    issue_by_id = {issue["issueId"]: issue for issue in issues}
+    verdict_labels = {
+        "aged_well": "THIS AGED WELL",
+        "aged_poorly": "THIS AGED POORLY",
+        "still_developing": "STILL DEVELOPING",
+    }
+    cards = []
+    for item in retrospectives:
+        prior = issue_by_id.get(item["priorIssueId"])
+        label = verdict_labels[item["verdict"]]
+        prior_label = f"Earlier take · {item['priorIssueId']}"
+        if prior:
+            prior_label = f"Issue #{prior['issueNumber']:03d} · {display_date(prior['publicationDate'])}"
+            prior_link = f'<a href="/gravel-weekly/{esc(prior["slug"])}/#{esc(item["priorStoryId"])}">{esc(prior_label)}</a>'
+        else:
+            prior_link = f"<span>{esc(prior_label)}</span>"
+        assessment_label = "THE REASSESSMENT — MODEL DRAFT" if draft else "THE REASSESSMENT"
+        cards.append(f'''<article class="gw-memory gw-memory--{esc(item['verdict'])}">
+          <header><span class="gw-memory-verdict">{esc(label)}</span>{prior_link}<h3>{esc(item['headline'])}</h3></header>
+          <div class="gw-memory-grid">
+            <section><h4>WHAT CHANGED</h4>{prose(item['whatChanged'])}</section>
+            <section><h4>{assessment_label}</h4>{prose(item['assessment'])}</section>
+          </div>
+          <details class="gw-details"><summary>RECEIPTS · {len(item['receipts'])}</summary>{render_receipts(item['receipts'])}</details>
+        </article>''')
+    return f'<section class="gw-retrospectives"><h2>THE RECEIPTS ON US</h2><p class="gw-retro-dek">Old takes do not disappear when the timeline moves on.</p>{"".join(cards)}</section>'
+
+
 def render_story(story: dict[str, Any], *, current: bool = False, draft: bool = False) -> str:
     label = "THE CURRENT THING" if current else story["storyKind"].replace("_", " ").upper()
     take_label = "THE TAKE — MODEL DRAFT" if draft else "THE TAKE"
@@ -137,11 +168,21 @@ def render_archive(issues: list[dict[str, Any]], active_issue_id: str) -> str:
     for issue in issues:
         current = story_by_id(issue, issue.get("currentThingStoryId"))
         label = current["headline"] if current else issue["title"]
+        deck = current["dek"] if current else "No manufactured Current Thing cleared the gate."
+        take = ""
+        if current:
+            compact_take = " ".join(current["take"].split())
+            excerpt = compact_take[:240].rstrip()
+            if len(compact_take) > 240:
+                excerpt += "…"
+            take = f'<p class="gw-archive-take"><b>THE TAKE:</b> {esc(excerpt)}</p>'
         active = ' aria-current="page"' if issue["issueId"] == active_issue_id else ""
         items.append(f'''<li>
           <a href="/gravel-weekly/{esc(issue['slug'])}/"{active}>
             <span>ISSUE #{issue['issueNumber']:03d} · {esc(display_date(issue['publicationDate']).upper())}</span>
             <strong>{esc(label)}</strong>
+            <p>{esc(deck)}</p>
+            {take}
           </a>
         </li>''')
     return f'<ol class="gw-archive">{"".join(items)}</ol>' if items else '<p class="gw-empty">The archive starts with Issue #001.</p>'
@@ -262,6 +303,22 @@ def page_css() -> str:
   .gw-archive a { display: grid; gap: var(--gg-spacing-xs); padding: var(--gg-spacing-md); color: var(--gg-color-near-black); text-decoration: none; }
   .gw-archive span { font-size: var(--gg-font-size-xs); letter-spacing: var(--gg-letter-spacing-wide); }
   .gw-archive strong { font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-md); }
+  .gw-archive p { margin: 0; max-width: 760px; font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-normal); }
+  .gw-archive .gw-archive-take { font-size: var(--gg-font-size-sm); color: var(--gg-color-secondary-brown); }
+  .gw-retrospectives { margin-top: var(--gg-spacing-xl); padding: var(--gg-spacing-lg); border: var(--gg-border-heavy); background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }
+  .gw-retrospectives > h2 { margin: 0; font-size: clamp(2rem, 6vw, 4rem); }
+  .gw-retro-dek { margin: var(--gg-spacing-xs) 0 var(--gg-spacing-lg); font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-md); }
+  .gw-memory { margin-top: var(--gg-spacing-md); border: var(--gg-border-heavy); background: var(--gg-color-white); color: var(--gg-color-near-black); }
+  .gw-memory > header { padding: var(--gg-spacing-md); border-bottom: var(--gg-border-standard); }
+  .gw-memory > header > a, .gw-memory > header > span:not(.gw-memory-verdict) { display: inline-block; color: var(--gg-color-primary-brown); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-bold); }
+  .gw-memory-verdict { display: inline-block; margin-right: var(--gg-spacing-xs); padding: var(--gg-spacing-2xs) var(--gg-spacing-xs); border: var(--gg-border-subtle); background: var(--gg-color-gold); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); }
+  .gw-memory--aged_poorly .gw-memory-verdict { background: var(--gg-color-teal); color: var(--gg-color-white); }
+  .gw-memory > header h3 { margin: var(--gg-spacing-sm) 0 0; font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-xl); }
+  .gw-memory-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .gw-memory-grid section { padding: var(--gg-spacing-md); }
+  .gw-memory-grid section + section { border-left: var(--gg-border-standard); background: var(--gg-color-sand); }
+  .gw-memory-grid h4 { margin: 0 0 var(--gg-spacing-xs); font-size: var(--gg-font-size-xs); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-memory-grid p { font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-relaxed); }
   .gw-corrections { border: var(--gg-border-heavy); background: var(--gg-color-gold); margin-top: var(--gg-spacing-xl); padding: var(--gg-spacing-lg); }
   .gw-corrections h2 { margin-top: 0; }
   .gw-sub { margin-top: var(--gg-spacing-2xl); padding: var(--gg-spacing-xl); border: var(--gg-border-heavy); background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }
@@ -275,10 +332,11 @@ def page_css() -> str:
   .gw-empty { font-family: var(--gg-font-editorial); font-style: italic; color: var(--gg-color-secondary-brown); }
   code { font-family: var(--gg-font-data); overflow-wrap: anywhere; }
   @media (max-width: 720px) {
-    .gw-cover-lines, .gw-story-grid, .gw-utility-grid { grid-template-columns: 1fr; }
+    .gw-cover-lines, .gw-story-grid, .gw-utility-grid, .gw-memory-grid { grid-template-columns: 1fr; }
     .gw-cover-lines span { border-right: 0; border-bottom: var(--gg-border-subtle); }
     .gw-cover-lines span:last-child { border-bottom: 0; }
     .gw-take { border-left: 0; border-top: var(--gg-border-standard); }
+    .gw-memory-grid section + section { border-left: 0; border-top: var(--gg-border-standard); }
     .gw-story-head, .gw-story-grid section, .gw-utility, .gw-sub { padding: var(--gg-spacing-md); }
   }
 '''
@@ -305,6 +363,7 @@ def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, la
           <section class="gw-utility"><h2>CALENDAR WATCH</h2><ul class="gw-watch">{watch}</ul></section>
           <section class="gw-utility"><h2>RACE INTELLIGENCE</h2>{render_impacts(issue['raceImpacts'])}</section>
         </div>
+        {render_retrospectives(issue['retrospectives'], issues, draft=is_draft)}
         {corrections}'''
         schema = "" if is_draft else f'<script type="application/ld+json">{json_ld(issue, canonical_url)}</script>'
         issue_number = issue["issueNumber"]


### PR DESCRIPTION
## What changed
- add fail-closed This Aged Well / Poorly / Still Developing issue records
- require fresh receipts and human-approved reassessment provenance for public issues
- verify every retrospective points to an earlier archived story
- turn Past Issues into a Current Thing timeline with deck and Take excerpts
- render retrospective cards with links back to the original take

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` (16 passed)
- `python3 scripts/validate_gravel_weekly.py`
- `python3 wordpress/generate_gravel_weekly.py`
- `python3 -m pytest -q` (7,777 passed, 331 skipped)

No issue was published and the live shell is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the published issue schema and fail-closed validation paths; mistakes could block issue publication or render incorrect archive links, but scope stays within editorial HTML generation and local JSON validation.
> 
> **Overview**
> Adds a **`retrospectives`** array to the Gravel Weekly issue contract so later issues can revisit an earlier story with verdicts (`aged_well`, `aged_poorly`, `still_developing`), **what changed**, a human-approved **reassessment**, and non-empty **receipts**. Draft preparation now seeds `retrospectives: []`; validation mirrors take rules (human approval and no model-draft phrasing on published issues) and **`load_issues`** enforces that each retrospective points to a **real, earlier** archived issue and story, with no duplicate revisits.
> 
> The WordPress generator renders a **“THE RECEIPTS ON US”** section with linked memory cards back to the original take, and **Past Issues** now shows each issue’s Current Thing **deck** and a **Take** excerpt so the archive reads as a timeline. README and tests cover the new contract and rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b59acafbb9441ed9e6cfe53156f930b3dace3e47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->