### PR TITLE
Harden Gravel Weekly race-impact handoff

### DIFF
--- a/.github/workflows/weekly-broadcast.yml
+++ b/.github/workflows/weekly-broadcast.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: gravel-weekly-publish
@@ -79,6 +80,39 @@ jobs:
           grep -q "gravel-weekly-content-hash: $ISSUE_HASH" wordpress/output/gravel-weekly.html
           grep -q "gravel-weekly-content-hash: $ISSUE_HASH" "wordpress/output/gravel-weekly/$ISSUE_DATE/index.html"
           python scripts/preflight_quality.py
+
+      - name: Build issue-specific race-impact review
+        env:
+          ISSUE_DATE: ${{ inputs.issue_date }}
+        run: |
+          python scripts/render_gravel_weekly_race_impact_review.py \
+            "data/gravel-weekly/issues/$ISSUE_DATE.json" \
+            --output artifacts/gravel-weekly-race-impact-review.md
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: gravel-weekly-${{ inputs.issue_date }}-race-impact-review
+          path: artifacts/gravel-weekly-race-impact-review.md
+          retention-days: 90
+
+      - name: Open immutable race-impact review queue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_DATE: ${{ inputs.issue_date }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          if grep -q '<!-- meaningful-race-impact-count: 0 -->' artifacts/gravel-weekly-race-impact-review.md; then
+            echo "No actionable race impact; no review issue needed."
+            exit 0
+          fi
+          title="Gravel Weekly #$(printf '%03d' "$ISSUE_NUMBER") race-impact review"
+          gh label create gravel-weekly-race-impact --color 0e8a16 --description "Approved Gravel Weekly evidence awaiting controlled race-profile review" --force
+          existing="$(gh issue list --label gravel-weekly-race-impact --state all --limit 200 --json number,title --jq ".[] | select(.title == \"$title\") | .number" | head -1)"
+          if [[ -n "$existing" ]]; then
+            echo "Review issue #$existing already exists; preserving its history."
+          else
+            gh issue create --title "$title" --label gravel-weekly-race-impact --body-file artifacts/gravel-weekly-race-impact-review.md
+          fi
 
       - name: Setup SSH
         run: |

--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -37,6 +37,20 @@ Generate the latest page and dated archive:
 python3 wordpress/generate_gravel_weekly.py
 ```
 
+Render the controlled race-profile review for a published issue:
+
+```bash
+python3 scripts/render_gravel_weekly_race_impact_review.py \
+  data/gravel-weekly/issues/2026-08-28.json \
+  --output artifacts/gravel-weekly-race-impact-review.md
+```
+
+The publication validator requires the issue-level `raceImpacts` collection to
+exactly preserve the deduplicated union of story impacts, and every impact claim
+must resolve to a receipt on that story. The publish workflow uploads the
+immutable artifact and opens one idempotent GitHub review issue when actionable
+impacts exist. It never edits a race profile.
+
 Render a local draft for review without making it public:
 
 ```bash

--- a/scripts/render_gravel_weekly_race_impact_review.py
+++ b/scripts/render_gravel_weekly_race_impact_review.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Render an immutable, issue-specific review queue from a published issue."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from validate_gravel_weekly import validate_issue
+
+
+def _inline_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":")).replace("`", "\\u0060")
+
+
+def render_review(issue_value: Any) -> tuple[str, int]:
+    issue = validate_issue(issue_value)
+    if issue["status"] != "published":
+        raise ValueError("race-impact handoff requires a published issue snapshot")
+
+    receipts_by_claim: dict[str, dict[str, Any]] = {}
+    for story in issue["stories"]:
+        for receipt in story["receipts"]:
+            receipts_by_claim[receipt["claimId"]] = receipt
+
+    actionable = [impact for impact in issue["raceImpacts"] if impact["impactKind"] != "no_change"]
+    lines = [
+        f"<!-- meaningful-race-impact-count: {len(actionable)} -->",
+        f"# Gravel Weekly #{issue['issueNumber']:03d} race-impact review",
+        "",
+        f"Published issue: https://gravelgodcycling.com/gravel-weekly/{issue['slug']}/",
+        f"Issue ID: `{issue['issueId']}` · content hash: `{issue['contentHash']}`",
+        "",
+        "> Controlled review only. This artifact does not authorize or perform a source-repository edit.",
+        "> Confirm the evidence against the current owning profile, then use a normal branch, regression test, and pull request.",
+        "",
+    ]
+    if not actionable:
+        lines.extend(["No actionable race-profile change was proposed in this issue.", ""])
+        return "\n".join(lines), 0
+
+    for impact in actionable:
+        encoded = json.dumps(impact, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        impact_id = hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:12]
+        lines.extend([
+            f"## {impact['impactKind'].upper()} · {impact['raceId']} · `{impact['fieldPath'] or 'catalog'}`",
+            "",
+            f"Impact ID: `{impact_id}` · evidence confidence: {round(float(impact['confidence']) * 100)}% · owner: `{impact['owner']}`",
+            "",
+            f"Current value: `{_inline_json(impact.get('currentValue'))}`",
+            "",
+            f"Proposed value: `{_inline_json(impact.get('proposedValue'))}`",
+            "",
+            "### Evidence",
+            "",
+        ])
+        for claim_id in impact["claimIds"]:
+            receipt = receipts_by_claim[claim_id]
+            published = f" · {receipt['publishedAt'][:10]}" if receipt.get("publishedAt") else ""
+            timestamp = ""
+            if receipt.get("transcriptStartSeconds") is not None:
+                seconds = int(receipt["transcriptStartSeconds"])
+                timestamp = f" · {seconds // 60}:{seconds % 60:02d}"
+            lines.append(f"- `{claim_id}` · [{receipt['publisher']}]({receipt['canonicalUrl']}){published}{timestamp}")
+        lines.extend([
+            "",
+            "### Human disposition",
+            "",
+            "- [ ] Confirm current profile value and source freshness",
+            "- [ ] Accept as an objective change / route for subjective editorial review / reject with reason",
+            "- [ ] Add a failing regression fixture before any accepted change",
+            "- [ ] Apply through the owning repository's normal pull-request path",
+            "",
+        ])
+    return "\n".join(lines), len(actionable)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("issue", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    review, count = render_review(json.loads(args.issue.read_text(encoding="utf-8")))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(f"{review.rstrip()}\n", encoding="utf-8")
+    print(f"Rendered {count} actionable race impact(s): {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_gravel_weekly.py
+++ b/scripts/validate_gravel_weekly.py
@@ -178,6 +178,7 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
 
     stories = _list(issue.get("stories"), "stories", 30)
     story_ids: list[str] = []
+    story_impacts: list[dict[str, Any]] = []
     for index, raw_story in enumerate(stories):
         story = _record(raw_story, f"stories[{index}]")
         story_id = _text(story.get("candidateId"), f"stories[{index}].candidateId", 500)
@@ -201,10 +202,18 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
         receipts = _list(story.get("receipts"), f"stories[{index}].receipts", 100)
         if not receipts:
             raise IssueValidationError(f"stories[{index}].receipts must not be empty")
+        receipt_claim_ids: set[str] = set()
         for receipt_index, receipt in enumerate(receipts):
-            _receipt(receipt, f"stories[{index}].receipts[{receipt_index}]")
+            validated_receipt = _receipt(receipt, f"stories[{index}].receipts[{receipt_index}]")
+            receipt_claim_ids.add(validated_receipt["claimId"])
         for impact_index, impact in enumerate(_list(story.get("raceImpacts"), f"stories[{index}].raceImpacts")):
-            _impact(impact, f"stories[{index}].raceImpacts[{impact_index}]")
+            validated_impact = _impact(impact, f"stories[{index}].raceImpacts[{impact_index}]")
+            missing_claims = set(validated_impact["claimIds"]) - receipt_claim_ids
+            if missing_claims:
+                raise IssueValidationError(
+                    f"stories[{index}].raceImpacts[{impact_index}] references claims without story receipts: {sorted(missing_claims)}"
+                )
+            story_impacts.append(validated_impact)
     if len(story_ids) != len(set(story_ids)):
         raise IssueValidationError("story candidate IDs must be unique")
 
@@ -219,8 +228,16 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
 
     for index, item in enumerate(_list(issue.get("calendarWatch"), "calendarWatch", 100)):
         _text(item, f"calendarWatch[{index}]", 500)
-    for index, impact in enumerate(_list(issue.get("raceImpacts"), "raceImpacts")):
+    issue_impacts = [
         _impact(impact, f"raceImpacts[{index}]")
+        for index, impact in enumerate(_list(issue.get("raceImpacts"), "raceImpacts"))
+    ]
+    impact_key = lambda impact: json.dumps(impact, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    issue_impact_keys = [impact_key(impact) for impact in issue_impacts]
+    if len(issue_impact_keys) != len(set(issue_impact_keys)):
+        raise IssueValidationError("raceImpacts must not contain duplicates")
+    if set(issue_impact_keys) != {impact_key(impact) for impact in story_impacts}:
+        raise IssueValidationError("raceImpacts must exactly preserve the deduplicated union of story raceImpacts")
     retrospective_refs: list[tuple[str, str]] = []
     for index, retrospective in enumerate(_list(issue.get("retrospectives"), "retrospectives", 30)):
         item = _retrospective(retrospective, f"retrospectives[{index}]", status=status)

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -20,6 +20,7 @@ from validate_gravel_weekly import (  # noqa: E402
 )
 from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
 from prepare_gravel_weekly_issue import prepare_issue  # noqa: E402
+from render_gravel_weekly_race_impact_review import render_review  # noqa: E402
 
 
 def sample_issue():
@@ -217,6 +218,38 @@ def test_current_thing_requires_editorial_score_of_85():
         validate_issue(issue, verify_hash=False)
 
 
+def test_issue_race_impacts_exactly_preserve_story_impacts_and_receipts():
+    issue = sample_issue()
+    issue["raceImpacts"] = []
+    with pytest.raises(IssueValidationError, match="exactly preserve"):
+        validate_issue(issue, verify_hash=False)
+
+    missing_receipt = sample_issue()
+    missing_receipt["stories"][0]["raceImpacts"][0]["claimIds"] = ["claim_missing"]
+    missing_receipt["raceImpacts"][0]["claimIds"] = ["claim_missing"]
+    with pytest.raises(IssueValidationError, match="without story receipts"):
+        validate_issue(missing_receipt, verify_hash=False)
+
+
+def test_published_issue_renders_immutable_race_impact_review():
+    review, count = render_review(sample_issue())
+    assert count == 1
+    assert "meaningful-race-impact-count: 1" in review
+    assert "Gravel Weekly #001 race-impact review" in review
+    assert "gravel:unbound-gravel" in review
+    assert "claim_1" in review
+    assert "content hash" in review
+    assert "does not authorize or perform" in review
+
+    draft = sample_issue()
+    draft["status"] = "draft"
+    draft["editorialApproval"] = None
+    draft["publishedAt"] = None
+    draft["contentHash"] = compute_content_hash(draft)
+    with pytest.raises(ValueError, match="published issue"):
+        render_review(draft)
+
+
 def test_rendered_issue_preserves_site_infrastructure_and_honest_form():
     issue = sample_issue()
     page = build_page(issue, [issue], latest=True)
@@ -311,6 +344,10 @@ def test_deploy_path_and_legacy_redirect_are_wired():
     assert '"--sync-gravel-weekly"' in deploy
     assert "^gravel-tv/?$ /gravel-weekly/" in deploy
     assert '"gravel-weekly"' in deploy
+    workflow = (ROOT / ".github" / "workflows" / "weekly-broadcast.yml").read_text()
+    assert "issues: write" in workflow
+    assert "render_gravel_weekly_race_impact_review.py" in workflow
+    assert "meaningful-race-impact-count: 0" in workflow
 
 
 def test_email_preserves_legacy_subscribers_and_uses_approved_issue():


### PR DESCRIPTION
## What changed
- require issue-level race impacts to exactly preserve the deduplicated union of story impacts
- require every impact claim to resolve to a receipt carried by that story
- render an immutable, issue-specific race-impact review artifact
- upload the artifact and idempotently open a GitHub review issue for actionable impacts
- preserve the no-direct-edit boundary and exact content hash

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` (18 passed)
- workflow YAML parse
- `python3 -m pytest -q` (7,783 passed, 331 skipped)

No publication or race-profile edit was performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes publication validation and CI automation that creates GitHub issues; no direct race-profile or live-site edits, but incorrect workflow logic could spam or miss review issues.
> 
> **Overview**
> **Hardens the Gravel Weekly → race-profile handoff** so published issues cannot drift from story-level evidence, and actionable impacts surface as an immutable human review queue instead of silent profile edits.
> 
> **Validation** now requires issue-level `raceImpacts` to be exactly the deduplicated union of each story’s impacts (no duplicates, no mismatches), and every impact `claimId` must exist on that story’s receipts. Failures are explicit validation errors.
> 
> **New `render_gravel_weekly_race_impact_review.py`** builds a markdown artifact from a **published** issue only: actionable impacts (`impactKind` ≠ `no_change`), linked evidence, content hash, and a clear “controlled review only / no direct repo edit” boundary.
> 
> **Publish workflow** (`weekly-broadcast.yml`) gains `issues: write`, runs the renderer after publication checks, uploads the artifact (90-day retention), and **idempotently** opens a labeled GitHub issue when `meaningful-race-impact-count` &gt; 0 (skips when zero; reuses existing issue by title).
> 
> Docs and tests cover the contract, renderer output, and workflow wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f96c60162fc05b673ddede64f358f48030d081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->