### PR TITLE
Add a fail-closed Gravel Weekly approval bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ dry_run_results.json
 
 # Gravel Weekly model drafts remain local until Matti approves the take.
 data/gravel-weekly/drafts/
+# Human-approved snapshots remain local until an explicit sealing action moves
+# an immutable copy into data/gravel-weekly/issues/.
+data/gravel-weekly/approved/
 
 # Database backups
 *.json.bak

--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -25,6 +25,33 @@ python3 scripts/prepare_gravel_weekly_issue.py REVIEW.json \
   --publication-date 2026-08-28 --issue-number 1
 ```
 
+Apply Matti's explicit approval packet without making anything deployable:
+
+```bash
+python3 scripts/approve_gravel_weekly_issue.py \
+  data/gravel-weekly/drafts/2026-08-28.json APPROVAL.json
+```
+
+The approval packet must use `gravel-weekly-approval/v1`, decide every reviewed
+story exactly once, and supply the final headline, deck, Take, and edit summary
+for every approved story. The bridge preserves the reviewed facts, scores,
+receipts, and race impacts verbatim. It emits `status=approved` under the
+ignored `data/gravel-weekly/approved/` directory, which the deploy workflow
+refuses.
+
+After a separate explicit publication instruction, seal the approved file:
+
+```bash
+python3 scripts/seal_gravel_weekly_issue.py \
+  data/gravel-weekly/approved/2026-08-28.json \
+  --published-at 2026-08-28T16:05:00Z
+```
+
+Sealing changes only publication state and timestamps, refuses to overwrite an
+existing historical snapshot by default, and writes the deployable immutable
+file under `data/gravel-weekly/issues/`. Deployment remains a separate manual
+workflow dispatch.
+
 Validate files and content hashes:
 
 ```bash

--- a/scripts/approve_gravel_weekly_issue.py
+++ b/scripts/approve_gravel_weekly_issue.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Apply an explicit human approval packet to a Gravel Weekly draft.
+
+This produces an approved, still non-deployable snapshot. It deliberately
+cannot change factual reporting, receipts, scores, or race impacts from the
+reviewed draft; only the human-owned editorial fields may change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from validate_gravel_weekly import compute_content_hash, validate_issue
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+APPROVED_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "approved"
+APPROVAL_SCHEMA = "gravel-weekly-approval/v1"
+ALLOWED_APPROVAL_KEYS = {
+    "schemaVersion", "issueId", "approver", "approvedAt", "currentThingStoryId", "stories",
+}
+ALLOWED_STORY_DECISION_KEYS = {
+    "candidateId", "decision", "headline", "dek", "take", "editSummary", "reason",
+}
+
+
+def _record(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be an object")
+    return value
+
+
+def _text(value: Any, name: str, maximum: int) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} is required")
+    if len(value) > maximum:
+        raise ValueError(f"{name} exceeds {maximum} characters")
+    return value.strip()
+
+
+def _approval_story(value: Any, index: int) -> dict[str, Any]:
+    item = _record(value, f"approval.stories[{index}]")
+    unknown = set(item) - ALLOWED_STORY_DECISION_KEYS
+    if unknown:
+        raise ValueError(f"approval.stories[{index}] has unsupported fields: {sorted(unknown)}")
+    candidate_id = _text(item.get("candidateId"), f"approval.stories[{index}].candidateId", 500)
+    decision = item.get("decision")
+    if decision not in {"approve", "reject"}:
+        raise ValueError(f"approval.stories[{index}].decision must be approve or reject")
+    if decision == "reject":
+        _text(item.get("reason"), f"approval.stories[{index}].reason", 2_000)
+        return {"candidateId": candidate_id, "decision": decision}
+    return {
+        "candidateId": candidate_id,
+        "decision": decision,
+        "headline": _text(item.get("headline"), f"approval.stories[{index}].headline", 300),
+        "dek": _text(item.get("dek"), f"approval.stories[{index}].dek", 600),
+        "take": _text(item.get("take"), f"approval.stories[{index}].take", 8_000),
+        "editSummary": _text(item.get("editSummary"), f"approval.stories[{index}].editSummary", 2_000),
+    }
+
+
+def _dedupe_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for record in records:
+        key = json.dumps(record, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        if key not in seen:
+            result.append(record)
+            seen.add(key)
+    return result
+
+
+def approve_issue(draft_value: Any, approval_value: Any) -> dict[str, Any]:
+    draft = validate_issue(draft_value)
+    if draft["status"] != "draft":
+        raise ValueError("approval requires a status=draft issue")
+    approval = _record(approval_value, "approval")
+    unknown = set(approval) - ALLOWED_APPROVAL_KEYS
+    if unknown:
+        raise ValueError(f"approval has unsupported fields: {sorted(unknown)}")
+    if approval.get("schemaVersion") != APPROVAL_SCHEMA:
+        raise ValueError("unsupported Gravel Weekly approval schema")
+    if approval.get("issueId") != draft["issueId"]:
+        raise ValueError("approval.issueId must match the draft issueId")
+
+    decisions_raw = approval.get("stories")
+    if not isinstance(decisions_raw, list):
+        raise ValueError("approval.stories must be a list")
+    decisions = [_approval_story(value, index) for index, value in enumerate(decisions_raw)]
+    decision_ids = [item["candidateId"] for item in decisions]
+    if len(decision_ids) != len(set(decision_ids)):
+        raise ValueError("approval story candidate IDs must be unique")
+    draft_ids = [story["candidateId"] for story in draft["stories"]]
+    if set(decision_ids) != set(draft_ids):
+        missing = sorted(set(draft_ids) - set(decision_ids))
+        extra = sorted(set(decision_ids) - set(draft_ids))
+        raise ValueError(f"approval must decide every reviewed story exactly once; missing={missing}, extra={extra}")
+
+    decisions_by_id = {item["candidateId"]: item for item in decisions}
+    approved_stories: list[dict[str, Any]] = []
+    for draft_story in draft["stories"]:
+        decision = decisions_by_id[draft_story["candidateId"]]
+        if decision["decision"] == "reject":
+            continue
+        # Only these three fields come from the human approval. Every factual,
+        # evidentiary, scoring, and race-impact field remains the reviewed draft.
+        approved_stories.append({
+            **draft_story,
+            "headline": decision["headline"],
+            "dek": decision["dek"],
+            "take": decision["take"],
+            "takeProvenance": "human_approved",
+        })
+    if not approved_stories:
+        raise ValueError("an approved issue must contain at least one approved story")
+
+    approved_at = _text(approval.get("approvedAt"), "approval.approvedAt", 100)
+    approver = _text(approval.get("approver"), "approval.approver", 300)
+    current_id = approval.get("currentThingStoryId")
+    if current_id is not None:
+        current_id = _text(current_id, "approval.currentThingStoryId", 500)
+    approved_ids = {story["candidateId"] for story in approved_stories}
+    if current_id is not None and current_id not in approved_ids:
+        raise ValueError("approval.currentThingStoryId must reference an approved story")
+
+    all_impacts = _dedupe_records([
+        impact for story in approved_stories for impact in story["raceImpacts"]
+    ])
+    source_index = sorted({
+        receipt["canonicalUrl"] for story in approved_stories for receipt in story["receipts"]
+    })
+    approved = {
+        **draft,
+        "status": "approved",
+        "stories": approved_stories,
+        "currentThingStoryId": current_id,
+        "raceImpacts": all_impacts,
+        "sourceIndex": source_index,
+        "editorialApproval": {"approver": approver, "approvedAt": approved_at},
+        "publishedAt": None,
+        "updatedAt": approved_at,
+        "contentHash": "pending",
+    }
+    approved["contentHash"] = compute_content_hash(approved)
+    return validate_issue(approved)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("draft", type=Path)
+    parser.add_argument("approval", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    draft = json.loads(args.draft.read_text(encoding="utf-8"))
+    approval = json.loads(args.approval.read_text(encoding="utf-8"))
+    issue = approve_issue(draft, approval)
+    output = args.output or APPROVED_DIR / f"{issue['publicationDate']}.json"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(f"{json.dumps(issue, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
+    print(f"Approved but not published: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/seal_gravel_weekly_issue.py
+++ b/scripts/seal_gravel_weekly_issue.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Seal an approved Gravel Weekly issue as an immutable deployable snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from validate_gravel_weekly import ISSUE_DIR, compute_content_hash, validate_issue
+
+
+def _timestamp(value: str, name: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{name} must include a timezone")
+    return parsed
+
+
+def seal_issue(approved_value: Any, published_at: str) -> dict[str, Any]:
+    approved = validate_issue(approved_value)
+    if approved["status"] != "approved":
+        raise ValueError("sealing requires a status=approved issue")
+    published_time = _timestamp(published_at, "publishedAt")
+    approved_time = _timestamp(approved["editorialApproval"]["approvedAt"], "editorialApproval.approvedAt")
+    if published_time < approved_time:
+        raise ValueError("publishedAt cannot precede editorial approval")
+    sealed = {
+        **approved,
+        "status": "published",
+        "publishedAt": published_at,
+        "updatedAt": published_at,
+        "contentHash": "pending",
+    }
+    sealed["contentHash"] = compute_content_hash(sealed)
+    return validate_issue(sealed)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("approved", type=Path)
+    parser.add_argument("--published-at", required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+    approved = json.loads(args.approved.read_text(encoding="utf-8"))
+    issue = seal_issue(approved, args.published_at)
+    output = args.output or ISSUE_DIR / f"{issue['publicationDate']}.json"
+    if output.exists() and not args.overwrite:
+        raise SystemExit(f"Refusing to replace immutable issue snapshot: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(f"{json.dumps(issue, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
+    print(f"Sealed deployable issue snapshot: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -20,6 +20,8 @@ from validate_gravel_weekly import (  # noqa: E402
 )
 from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
 from prepare_gravel_weekly_issue import prepare_issue  # noqa: E402
+from approve_gravel_weekly_issue import approve_issue  # noqa: E402
+from seal_gravel_weekly_issue import seal_issue  # noqa: E402
 from render_gravel_weekly_race_impact_review import render_review  # noqa: E402
 
 
@@ -117,6 +119,40 @@ def passing_editorial_gate():
     }
 
 
+def sample_draft():
+    issue = sample_issue()
+    issue.update({
+        "status": "draft",
+        "editorialApproval": None,
+        "publishedAt": None,
+        "updatedAt": "2026-08-27T17:00:00Z",
+    })
+    issue["stories"][0]["headline"] = "MODEL DRAFT headline"
+    issue["stories"][0]["dek"] = "MODEL DRAFT deck"
+    issue["stories"][0]["take"] = "Editable model draft, not Matti's approved view."
+    issue["stories"][0]["takeProvenance"] = "model_draft"
+    issue["contentHash"] = compute_content_hash(issue)
+    return issue
+
+
+def sample_approval():
+    return {
+        "schemaVersion": "gravel-weekly-approval/v1",
+        "issueId": "gravel-weekly-001",
+        "approver": "Matti Rowe",
+        "approvedAt": "2026-08-28T16:00:00Z",
+        "currentThingStoryId": "story_1",
+        "stories": [{
+            "candidateId": "story_1",
+            "decision": "approve",
+            "headline": "The approved headline",
+            "dek": "The approved deck.",
+            "take": "The approved take makes a concrete judgment.",
+            "editSummary": "Removed throat-clearing and sharpened the consequence.",
+        }],
+    }
+
+
 def test_issue_contract_requires_receipts_approval_and_hash():
     issue = sample_issue()
     assert validate_issue(issue)["issueId"] == "gravel-weekly-001"
@@ -172,6 +208,83 @@ def test_review_prepares_a_draft_but_cannot_imply_approval():
     assert "DRAFT — NOT PUBLISHED" in preview
     assert "THE TAKE — MODEL DRAFT" in preview
     assert "application/ld+json" not in preview
+
+
+def test_human_approval_bridge_changes_only_editorial_copy_and_stays_non_deployable():
+    draft = sample_draft()
+    approved = approve_issue(draft, sample_approval())
+
+    assert approved["status"] == "approved"
+    assert approved["publishedAt"] is None
+    assert approved["editorialApproval"] == {
+        "approver": "Matti Rowe", "approvedAt": "2026-08-28T16:00:00Z",
+    }
+    assert approved["stories"][0]["headline"] == "The approved headline"
+    assert approved["stories"][0]["take"] == "The approved take makes a concrete judgment."
+    assert approved["stories"][0]["takeProvenance"] == "human_approved"
+    for field in ("score", "storyKind", "whatHappened", "receipts", "raceImpacts"):
+        assert approved["stories"][0][field] == draft["stories"][0][field]
+    assert approved["contentHash"] == compute_content_hash(approved)
+    with pytest.raises(ValueError, match="published issue"):
+        render_review(approved)
+
+
+def test_approval_bridge_requires_an_exact_human_decision_for_every_reviewed_story():
+    draft = sample_draft()
+    missing = sample_approval()
+    missing["stories"] = []
+    with pytest.raises(ValueError, match="decide every reviewed story"):
+        approve_issue(draft, missing)
+
+    extra = sample_approval()
+    extra["stories"].append({
+        "candidateId": "story_unreviewed", "decision": "reject", "reason": "Not reviewed.",
+    })
+    with pytest.raises(ValueError, match=r"extra=\['story_unreviewed'\]"):
+        approve_issue(draft, extra)
+
+    duplicate = sample_approval()
+    duplicate["stories"].append(copy.deepcopy(duplicate["stories"][0]))
+    with pytest.raises(ValueError, match="must be unique"):
+        approve_issue(draft, duplicate)
+
+    rejected = sample_approval()
+    rejected["stories"] = [{
+        "candidateId": "story_1", "decision": "reject", "reason": "The premise is still slop.",
+    }]
+    rejected["currentThingStoryId"] = None
+    with pytest.raises(ValueError, match="at least one approved story"):
+        approve_issue(draft, rejected)
+
+    misleading = sample_approval()
+    misleading["whatHappened"] = "Quietly replace the reviewed facts."
+    with pytest.raises(ValueError, match="unsupported fields"):
+        approve_issue(draft, misleading)
+
+
+def test_approval_bridge_rejects_copy_that_still_claims_to_be_a_model_draft():
+    approval = sample_approval()
+    approval["stories"][0]["take"] = "Editable model draft, not Matti's approved view."
+    with pytest.raises(IssueValidationError, match="model-draft"):
+        approve_issue(sample_draft(), approval)
+
+
+def test_sealing_is_a_separate_copy_preserving_step_after_approval():
+    approved = approve_issue(sample_draft(), sample_approval())
+    sealed = seal_issue(approved, "2026-08-28T16:05:00Z")
+
+    assert sealed["status"] == "published"
+    assert sealed["publishedAt"] == "2026-08-28T16:05:00Z"
+    assert sealed["stories"] == approved["stories"]
+    assert sealed["raceImpacts"] == approved["raceImpacts"]
+    assert sealed["contentHash"] == compute_content_hash(sealed)
+
+    with pytest.raises(ValueError, match="status=approved"):
+        seal_issue(sample_draft(), "2026-08-28T16:05:00Z")
+    with pytest.raises(ValueError, match="cannot precede"):
+        seal_issue(approved, "2026-08-28T15:59:59Z")
+    with pytest.raises(ValueError, match="include a timezone"):
+        seal_issue(approved, "2026-08-28T16:05:00")
 
 
 @pytest.mark.parametrize("gate_mutation", ["missing", "hold", "party_hold", "no_point", "friend_fail", "friend_kill", "no_mechanics"])


### PR DESCRIPTION
Adds the missing deterministic bridge from reviewed draft to approved snapshot, followed by a separate sealing step. Approval can change only human-owned copy; factual fields, receipts, scores, and race impacts remain fixed. Sealing changes only publication state and timestamps, refuses overwrite by default, and still requires the separate manual deploy workflow. Verified with 22 focused tests, 7,278 full-suite passes, 331 skips, and a passing preflight.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the publication path for editorial content and immutability rules; mistakes could block deploy or allow wrong copy, but changes are gated by validation, separate directories, and tests.
> 
> **Overview**
> Introduces a **fail-closed editorial pipeline** between reviewed drafts and deployable issue snapshots: human approval and publication sealing are now distinct, scripted steps instead of a single leap into `issues/`.
> 
> **`approve_gravel_weekly_issue.py`** accepts a `gravel-weekly-approval/v1` packet that must decide every draft story exactly once (approve with final headline, deck, take, and edit summary, or reject with a reason). Only those editorial fields change; facts, receipts, scores, and race impacts stay on the reviewed draft. Output is `status=approved`, still non-deployable, written under gitignored `data/gravel-weekly/approved/`.
> 
> **`seal_gravel_weekly_issue.py`** is the separate explicit publish step: it flips `status` to `published`, sets `publishedAt` (must be timezone-aware and not before approval), recomputes the content hash, and writes the immutable snapshot to `data/gravel-weekly/issues/`—refusing overwrite unless `--overwrite`. Manual deploy still only consumes published files in `issues/`.
> 
> Docs and `.gitignore` document the flow; **tests** cover editorial-only mutation, strict approval coverage, model-draft rejection, sealing guards, and that approved issues still cannot render the race-impact review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49a0fae606576232b503b2debbc6ba0b60f5dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->