### PR TITLE
Add reconciled provider revenue ingestion

### DIFF
--- a/docs/provider-revenue-ingestion.md
+++ b/docs/provider-revenue-ingestion.md
@@ -1,0 +1,125 @@
+# Provider revenue ingestion
+
+Mission Control can ingest the reconciled, PII-minimized TrainingPeaks evidence
+without pretending that every source contains transaction- or customer-level
+identifiers. Validation is the default. Database writes require both `--apply`
+and the exact confirmation string.
+
+## Source contract
+
+The importer requires these five sanitized files in one directory:
+
+| File | Canonical destination | Boundary |
+| --- | --- | --- |
+| `gravel-god-trainingpeaks-coaching-provider-ledger.csv` | `gg_payments` | TrainingPeaks did not export payment transaction IDs. Each row receives a labeled, duplicate-aware synthetic fingerprint. `amount` and `net_amount` are provider Amount Received. |
+| `gravel-god-trainingpeaks-coaching-payout-ledger.csv` | `gg_provider_payouts` | Provider payout IDs remain SHA-256 values. Bank destinations are omitted. |
+| `gravel-god-trainingpeaks-coaching-customer-lifecycle.csv` | `gg_provider_customer_snapshots` | Customer keys are snapshot-local, not durable identities across exports. Names and email addresses are not imported. |
+| `gravel-god-trainingpeaks-coaching-lifecycle-monthly.csv` | `gg_provider_monthly_controls` | Dated activity counts are retained; the export does not support a churn-rate denominator. |
+| `gravel-god-trainingpeaks-marketplace-royalty-reconciliation.csv` | `gg_provider_monthly_controls` | Marketplace evidence is aggregate royalty control data. It is not promoted to purchaser-level transactions. |
+
+`gg_provider_import_batches` records the sanitized file hash, available upstream
+hashes, observation time, row count, evidence grade, boundary, and control
+totals. Reapplying identical inputs upserts the same transaction, payout,
+snapshot, and monthly-control keys.
+
+## Pinned baseline gate
+
+The default 2026-08-27 gate fails closed unless the source bundle reconciles to:
+
+- Coaching: 553 all-time payment rows; 213 operating-period rows; 209 succeeded;
+  4 refunded; $47,765.60 gross; $45,694.95 provider Amount Received.
+- Payouts: 351 all-time rows; 132 paid operating-period rows; $45,404.92 paid.
+- Customers: 36 snapshot rows; 17 paid; 8 paused; 11 canceled.
+- Lifecycle: 6 new starts; 5 inferred resumptions or migrations; 5 confirmed
+  terminal churns. No churn percentage is asserted.
+- Marketplace: 17 sale notices; $1,342.00 gross; $939.40 expected author share;
+  $793.80 paid; $145.60 pending.
+
+`--skip-2026-08-27-controls` exists only for fixtures and intentionally changed
+source profiles. It must not be used to force a failing production snapshot.
+
+## Runbook
+
+Validate without credentials or writes:
+
+```bash
+python3 scripts/import_provider_revenue.py \
+  --input-dir /absolute/path/to/sanitized/outputs \
+  --observed-at 2026-08-27T18:00:00+00:00 \
+  --receipt /absolute/path/to/provider-ingestion-dry-run.json
+```
+
+Apply migration `supabase/migrations/20260827000001_provider_revenue_truth.sql`
+to the Mission Control Supabase project before enabling apply mode. Then run:
+
+```bash
+python3 scripts/import_provider_revenue.py \
+  --input-dir /absolute/path/to/sanitized/outputs \
+  --observed-at 2026-08-27T18:00:00+00:00 \
+  --apply --confirm APPLY_PROVIDER_TRUTH \
+  --receipt /absolute/path/to/provider-ingestion-apply.json
+```
+
+Apply mode lazy-loads Supabase credentials; dry-run does not. `SUPABASE_URL` and
+`SUPABASE_SERVICE_KEY` must identify the same live project that owns Mission
+Control. Ordinary PostgREST roles are denied access to the new financial and
+lifecycle tables. The migration also replaces the old permissive
+`gg_payments` policy with the service-role-only pattern.
+
+## Live verification
+
+Run these queries in that Supabase project after apply:
+
+```sql
+select count(*) as rows,
+       sum(gross_amount) as gross,
+       sum(net_amount) as net
+from gg_payments
+where provider = 'trainingpeaks'
+  and provider_account = 'coaching'
+  and provider_metadata->>'in_operating_system_period' = 'true';
+
+select status, count(*) as rows
+from gg_payments
+where provider = 'trainingpeaks'
+  and provider_account = 'coaching'
+  and provider_metadata->>'in_operating_system_period' = 'true'
+group by status order by status;
+
+select count(*) as rows, sum(amount) as paid
+from gg_provider_payouts
+where provider = 'trainingpeaks'
+  and provider_account = 'coaching'
+  and status = 'paid'
+  and provider_metadata->>'in_operating_system_period' = 'true';
+
+select current_status, count(*) as customers
+from gg_provider_customer_snapshots
+where provider = 'trainingpeaks'
+  and provider_account = 'coaching'
+  and snapshot_sha256 = (
+    select source_payload_sha256
+    from gg_provider_import_batches
+    where provider = 'trainingpeaks'
+      and provider_account = 'coaching'
+      and source_kind = 'customer_lifecycle_snapshot'
+    order by observed_at desc limit 1
+  )
+group by current_status order by current_status;
+```
+
+Expected results are 213 / $47,765.60 / $45,694.95; 4 refunded and 209
+succeeded; 132 / $45,404.92; and 11 canceled, 17 paid, 8 paused.
+
+## Corrections and rollback
+
+The import is additive and idempotent; it does not delete provider rows that
+disappear from a later corrected export. Treat removal or re-keying as a
+reviewed correction migration so the audit trail remains explicit. If an apply
+is interrupted, rerun the exact command: batch and row conflict keys resume the
+upserts safely.
+
+Do not roll back by dropping `gg_payments`. For a pre-data schema rollback,
+drop the four new tables in dependency order, remove the provider columns and
+indexes added to `gg_payments`, and restore its prior policy. Once evidence has
+been imported, preserve it and use a forward corrective migration instead.

--- a/mission_control/services/provider_ingestion.py
+++ b/mission_control/services/provider_ingestion.py
@@ -1,0 +1,877 @@
+"""Idempotent ingestion of reconciled provider revenue evidence.
+
+The TrainingPeaks coaching export does not expose a payment transaction ID.
+Those rows therefore use a labeled synthetic fingerprint over normalized source
+facts plus a duplicate ordinal. Marketplace royalty rows remain aggregate
+monthly controls; they are never promoted to purchaser-level transactions.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+# Deliberately lazy-loaded by ``_database``.  Validation and dry-run must not
+# require the Supabase SDK or credentials; only an explicit apply does.
+db: Any | None = None
+
+
+FILES = {
+    "coaching_payments": "gravel-god-trainingpeaks-coaching-provider-ledger.csv",
+    "coaching_payouts": "gravel-god-trainingpeaks-coaching-payout-ledger.csv",
+    "coaching_customers": "gravel-god-trainingpeaks-coaching-customer-lifecycle.csv",
+    "coaching_monthly": "gravel-god-trainingpeaks-coaching-lifecycle-monthly.csv",
+    "marketplace_monthly": "gravel-god-trainingpeaks-marketplace-royalty-reconciliation.csv",
+}
+
+REQUIRED_COLUMNS = {
+    "coaching_payments": {
+        "source_row", "customer_key", "purchase_date", "status",
+        "athlete_charged_usd", "amount_received_usd", "fee_refund_delta_usd",
+        "product", "in_operating_system_period", "source_file_sha256",
+        "evidence_grade", "boundary",
+    },
+    "coaching_payouts": {
+        "source_row", "payout_key", "provider_id_sha256", "created_utc",
+        "arrival_date_utc", "amount_usd", "currency", "livemode", "status",
+        "type", "method", "in_operating_system_period", "source_file_sha256",
+        "evidence_grade", "boundary",
+    },
+    "coaching_customers": {
+        "customer_key", "first_success_date", "last_success_date",
+        "current_status", "current_product", "current_last_payment_date",
+        "current_next_payment_date", "payment_rows", "succeeded_rows",
+        "refunded_rows", "lifetime_athlete_charged_usd",
+        "lifetime_amount_received_usd", "period_athlete_charged_usd",
+        "period_amount_received_usd", "confirmed_cancel_events",
+        "latest_confirmed_cancel_date", "pause_events", "latest_pause_date",
+        "successful_payments_after_latest_cancel", "lifecycle_class",
+        "evidence_grade", "boundary",
+    },
+    "coaching_monthly": {
+        "month", "payment_rows", "succeeded_rows", "refunded_rows",
+        "distinct_paying_customers", "new_logo_starts",
+        "inferred_reactivations_or_migrations", "confirmed_terminal_churns",
+        "athlete_charged_usd", "amount_received_usd", "evidence_grade",
+        "boundary",
+    },
+    "marketplace_monthly": {
+        "sale_month", "sale_notice_count", "gross_list_price_usd",
+        "author_share_rate", "expected_author_royalty_usd", "paypal_payout_date",
+        "paypal_payout_usd", "settled_variance_usd", "pending_royalty_usd",
+        "settlement_status", "paypal_message_sha256", "evidence_grade",
+        "boundary",
+    },
+}
+
+FORBIDDEN_PII_COLUMNS = {
+    "name", "email", "contact_name", "contact_email", "customer_name",
+    "customer_email", "athlete_name", "athlete_email", "provider_customer_id",
+    "bank_destination", "bank_account_number", "routing_number",
+}
+
+EXPECTED_2026_08_27 = {
+    "payment_rows": 553,
+    "period_payment_rows": 213,
+    "period_succeeded_rows": 209,
+    "period_refunded_rows": 4,
+    "period_gross": Decimal("47765.60"),
+    "period_net": Decimal("45694.95"),
+    "payout_rows": 351,
+    "period_paid_payouts": 132,
+    "period_payout_amount": Decimal("45404.92"),
+    "customer_rows": 36,
+    "paid_customers": 17,
+    "paused_customers": 8,
+    "canceled_customers": 11,
+    "new_logo_starts": 6,
+    "inferred_reactivations": 5,
+    "confirmed_terminal_churns": 5,
+    "marketplace_sale_notices": 17,
+    "marketplace_gross": Decimal("1342.00"),
+    "marketplace_author_share": Decimal("939.40"),
+    "marketplace_paid": Decimal("793.80"),
+    "marketplace_pending": Decimal("145.60"),
+    "customer_payment_rows_total": 553,
+    "customer_period_gross": Decimal("47765.60"),
+    "customer_period_net": Decimal("45694.95"),
+    "monthly_period_payment_rows": 213,
+    "monthly_period_succeeded_rows": 209,
+    "monthly_period_refunded_rows": 4,
+    "monthly_period_gross": Decimal("47765.60"),
+    "monthly_period_net": Decimal("45694.95"),
+    "payout_reconciliation_gap": Decimal("290.03"),
+    "marketplace_settlement_gap": Decimal("0.00"),
+}
+
+
+class ProviderIngestionError(RuntimeError):
+    """Raised when source files fail closed-loop validation."""
+
+
+@dataclass
+class ImportBundle:
+    observed_at: str
+    batches: dict[str, dict[str, Any]]
+    payments: list[dict[str, Any]]
+    payouts: list[dict[str, Any]]
+    customer_snapshots: list[dict[str, Any]]
+    monthly_controls: list[dict[str, Any]]
+    controls: dict[str, Any]
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "status": "VALIDATED",
+            "observed_at": self.observed_at,
+            "batches": {key: value["row_count"] for key, value in self.batches.items()},
+            "canonical_rows": {
+                "gg_payments": len(self.payments),
+                "gg_provider_payouts": len(self.payouts),
+                "gg_provider_customer_snapshots": len(self.customer_snapshots),
+                "gg_provider_monthly_controls": len(self.monthly_controls),
+            },
+            "controls": self.controls,
+            "identity_boundary": (
+                "TrainingPeaks customer keys are snapshot-local; payment keys are labeled "
+                "synthetic fingerprints because the export has no transaction ID."
+            ),
+        }
+
+
+def _read_csv(path: Path, required_columns: set[str]) -> list[dict[str, str]]:
+    if not path.is_file():
+        raise ProviderIngestionError(f"Required provider file is missing: {path}")
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        columns = set(reader.fieldnames or [])
+        missing = sorted(required_columns - columns)
+        if missing:
+            raise ProviderIngestionError(
+                f"Required columns are missing from {path.name}: {', '.join(missing)}"
+            )
+        forbidden = sorted(columns & FORBIDDEN_PII_COLUMNS)
+        if forbidden:
+            raise ProviderIngestionError(
+                f"PII-bearing columns are forbidden in {path.name}: {', '.join(forbidden)}"
+            )
+        return list(reader)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _record_sha256(row: dict[str, Any]) -> str:
+    encoded = json.dumps(row, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _is_sha256(value: str) -> bool:
+    return len(value) == 64 and all(character in "0123456789abcdef" for character in value)
+
+
+def _decimal(value: str | None, field: str) -> Decimal:
+    try:
+        return Decimal(str(value or "0"))
+    except InvalidOperation as exc:
+        raise ProviderIngestionError(f"Invalid decimal for {field}: {value!r}") from exc
+
+
+def _money(value: Decimal | str | None) -> str:
+    amount = value if isinstance(value, Decimal) else _decimal(value, "money")
+    return format(amount.quantize(Decimal("0.01")), "f")
+
+
+def _observed_at(value: str | None) -> str:
+    if not value:
+        return datetime.now(timezone.utc).isoformat(timespec="seconds")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ProviderIngestionError(f"Invalid observed_at timestamp: {value!r}") from exc
+    if parsed.tzinfo is None:
+        raise ProviderIngestionError("observed_at must include a timezone offset")
+    return parsed.isoformat()
+
+
+def _integer(value: str | None, field: str) -> int:
+    try:
+        return int(str(value or "0"))
+    except ValueError as exc:
+        raise ProviderIngestionError(f"Invalid integer for {field}: {value!r}") from exc
+
+
+def _boolean(value: str | None) -> bool:
+    normalized = str(value or "").strip().casefold()
+    if normalized in {"true", "1", "yes"}:
+        return True
+    if normalized in {"false", "0", "no", ""}:
+        return False
+    raise ProviderIngestionError(f"Invalid boolean value: {value!r}")
+
+
+def _date_or_none(value: str | None) -> str | None:
+    cleaned = str(value or "").strip()
+    return cleaned or None
+
+
+def _assert_unique(
+    rows: list[dict[str, str]], field: str, label: str, *, skip_total: bool = False
+) -> None:
+    values = [
+        row[field]
+        for row in rows
+        if not (skip_total and row[field].startswith("TOTAL"))
+    ]
+    duplicates = sorted(value for value, count in Counter(values).items() if count > 1)
+    if duplicates:
+        raise ProviderIngestionError(
+            f"Duplicate {field} values in {label}: {', '.join(duplicates[:5])}"
+        )
+
+
+def _batch(
+    *,
+    provider_account: str,
+    source_kind: str,
+    path: Path,
+    rows: list[dict[str, str]],
+    observed_at: str,
+    control_totals: dict[str, Any],
+    evidence_grade: str,
+    boundary: str,
+) -> dict[str, Any]:
+    upstream = sorted({
+        row.get("source_file_sha256", "")
+        for row in rows
+        if row.get("source_file_sha256")
+    })
+    if any(not _is_sha256(digest) for digest in upstream):
+        raise ProviderIngestionError(f"Invalid upstream SHA-256 in {path.name}")
+    return {
+        "provider": "trainingpeaks",
+        "provider_account": provider_account,
+        "source_kind": source_kind,
+        "source_payload_sha256": _sha256_file(path),
+        "upstream_source_sha256": upstream,
+        "observed_at": observed_at,
+        "row_count": len(rows),
+        "control_totals": control_totals,
+        "evidence_grade": evidence_grade,
+        "source_boundary": boundary,
+    }
+
+
+def _payment_rows(
+    rows: list[dict[str, str]], payload_sha256: str, observed_at: str
+) -> list[dict[str, Any]]:
+    occurrences: Counter[str] = Counter()
+    output: list[dict[str, Any]] = []
+    for source in rows:
+        signature_fields = {
+            "customer_key": source["customer_key"],
+            "purchase_date": source["purchase_date"],
+            "status": source["status"],
+            "athlete_charged_usd": _money(source["athlete_charged_usd"]),
+            "amount_received_usd": _money(source["amount_received_usd"]),
+            "product": source["product"],
+        }
+        signature = json.dumps(signature_fields, sort_keys=True, separators=(",", ":"))
+        occurrences[signature] += 1
+        fingerprint = hashlib.sha256(
+            f"trainingpeaks:coaching:{signature}:duplicate={occurrences[signature]}".encode("utf-8")
+        ).hexdigest()
+        gross = _decimal(source["athlete_charged_usd"], "athlete_charged_usd")
+        net = _decimal(source["amount_received_usd"], "amount_received_usd")
+        reported_adjustment = _decimal(
+            source["fee_refund_delta_usd"], "fee_refund_delta_usd"
+        )
+        if gross - net != reported_adjustment:
+            raise ProviderIngestionError(
+                "Payment row gross-minus-net does not match fee_refund_delta_usd: "
+                f"source_row={source['source_row']}"
+            )
+        output.append({
+            "_batch_key": "coaching_payments",
+            "deal_id": None,
+            "athlete_id": None,
+            "amount": _money(net),
+            "source": "provider_import",
+            "stripe_payment_id": None,
+            "description": source["product"],
+            "paid_at": source["purchase_date"],
+            "provider": "trainingpeaks",
+            "provider_account": "coaching",
+            "provider_record_key": fingerprint,
+            "provider_record_key_kind": "synthetic_normalized_fingerprint_v1",
+            "customer_key": source["customer_key"],
+            "product_name": source["product"],
+            "status": source["status"],
+            "currency": "usd",
+            "gross_amount": _money(gross),
+            "provider_adjustment_amount": _money(gross - net),
+            "net_amount": _money(net),
+            "source_payload_sha256": payload_sha256,
+            "source_record_sha256": _record_sha256(source),
+            "evidence_grade": source["evidence_grade"],
+            "source_boundary": source["boundary"],
+            "provider_metadata": {
+                "in_operating_system_period": _boolean(source["in_operating_system_period"]),
+                "source_row": _integer(source["source_row"], "source_row"),
+            },
+            "observed_at": observed_at,
+            "updated_at": observed_at,
+        })
+    return output
+
+
+def _payout_rows(
+    rows: list[dict[str, str]], payload_sha256: str, observed_at: str
+) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for source in rows:
+        provider_key = source["provider_id_sha256"].strip()
+        if not _is_sha256(provider_key):
+            raise ProviderIngestionError("TrainingPeaks payout row is missing provider_id_sha256")
+        output.append({
+            "_batch_key": "coaching_payouts",
+            "provider": "trainingpeaks",
+            "provider_account": "coaching",
+            "provider_record_key": provider_key,
+            "provider_record_key_kind": "provider_id_sha256",
+            "status": source["status"],
+            "amount": _money(source["amount_usd"]),
+            "currency": source["currency"].casefold(),
+            "provider_created_at": _date_or_none(source["created_utc"]),
+            "arrival_date": _date_or_none(source["arrival_date_utc"]),
+            "payout_type": source["type"],
+            "payout_method": source["method"],
+            "livemode": _boolean(source["livemode"]),
+            "source_payload_sha256": payload_sha256,
+            "source_record_sha256": _record_sha256(source),
+            "evidence_grade": source["evidence_grade"],
+            "source_boundary": source["boundary"],
+            "provider_metadata": {
+                "in_operating_system_period": _boolean(source["in_operating_system_period"]),
+                "source_row": _integer(source["source_row"], "source_row"),
+            },
+            "observed_at": observed_at,
+            "updated_at": observed_at,
+        })
+    return output
+
+
+def _customer_rows(
+    rows: list[dict[str, str]], payload_sha256: str, observed_at: str
+) -> list[dict[str, Any]]:
+    money_map = {
+        "lifetime_gross_amount": "lifetime_athlete_charged_usd",
+        "lifetime_net_amount": "lifetime_amount_received_usd",
+        "period_gross_amount": "period_athlete_charged_usd",
+        "period_net_amount": "period_amount_received_usd",
+    }
+    integer_map = {
+        "payment_rows": "payment_rows",
+        "succeeded_rows": "succeeded_rows",
+        "refunded_rows": "refunded_rows",
+        "confirmed_cancel_events": "confirmed_cancel_events",
+        "pause_events": "pause_events",
+        "successes_after_latest_cancel": "successful_payments_after_latest_cancel",
+    }
+    output: list[dict[str, Any]] = []
+    for source in rows:
+        row: dict[str, Any] = {
+            "_batch_key": "coaching_customers",
+            "provider": "trainingpeaks",
+            "provider_account": "coaching",
+            "snapshot_sha256": payload_sha256,
+            "customer_key": source["customer_key"],
+            "customer_key_kind": "snapshot_local",
+            "first_success_date": _date_or_none(source["first_success_date"]),
+            "last_success_date": _date_or_none(source["last_success_date"]),
+            "current_status": source["current_status"],
+            "current_product": source["current_product"],
+            "current_last_payment_date": _date_or_none(source["current_last_payment_date"]),
+            "current_next_payment_date": _date_or_none(source["current_next_payment_date"]),
+            "latest_confirmed_cancel_date": _date_or_none(source["latest_confirmed_cancel_date"]),
+            "latest_pause_date": _date_or_none(source["latest_pause_date"]),
+            "lifecycle_class": source["lifecycle_class"],
+            "source_record_sha256": _record_sha256(source),
+            "evidence_grade": source["evidence_grade"],
+            "source_boundary": source["boundary"],
+            "observed_at": observed_at,
+        }
+        for target, source_name in money_map.items():
+            row[target] = _money(source[source_name])
+        for target, source_name in integer_map.items():
+            row[target] = _integer(source[source_name], source_name)
+        output.append(row)
+    return output
+
+
+def _monthly_rows(
+    rows: list[dict[str, str]],
+    *,
+    batch_key: str,
+    provider_account: str,
+    source_kind: str,
+    payload_sha256: str,
+    observed_at: str,
+    month_field: str,
+) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for source in rows:
+        month = source[month_field]
+        if not month or month.startswith("TOTAL"):
+            continue
+        metrics = {
+            key: value
+            for key, value in source.items()
+            if key not in {month_field, "evidence_grade", "boundary"}
+        }
+        output.append({
+            "_batch_key": batch_key,
+            "provider": "trainingpeaks",
+            "provider_account": provider_account,
+            "source_kind": source_kind,
+            "control_month": f"{month}-01",
+            "metrics": metrics,
+            "source_payload_sha256": payload_sha256,
+            "source_record_sha256": _record_sha256(source),
+            "evidence_grade": source["evidence_grade"],
+            "source_boundary": source["boundary"],
+            "observed_at": observed_at,
+            "updated_at": observed_at,
+        })
+    return output
+
+
+def _controls(
+    payments: list[dict[str, str]],
+    payouts: list[dict[str, str]],
+    customers: list[dict[str, str]],
+    lifecycle_monthly: list[dict[str, str]],
+    marketplace_monthly: list[dict[str, str]],
+) -> dict[str, Any]:
+    period_payments = [
+        row for row in payments if _boolean(row["in_operating_system_period"])
+    ]
+    period_payouts = [
+        row for row in payouts
+        if _boolean(row["in_operating_system_period"]) and row["status"] == "paid"
+    ]
+    lifecycle_detail = [
+        row for row in lifecycle_monthly if not row["month"].startswith("TOTAL")
+    ]
+    marketplace_detail = [
+        row for row in marketplace_monthly
+        if not row["sale_month"].startswith("TOTAL")
+    ]
+
+    period_gross = sum(
+        (_decimal(row["athlete_charged_usd"], "athlete_charged_usd")
+         for row in period_payments),
+        Decimal("0"),
+    )
+    period_net = sum(
+        (_decimal(row["amount_received_usd"], "amount_received_usd")
+         for row in period_payments),
+        Decimal("0"),
+    )
+    period_payout_amount = sum(
+        (_decimal(row["amount_usd"], "amount_usd") for row in period_payouts),
+        Decimal("0"),
+    )
+    marketplace_author_share = sum(
+        (_decimal(row["expected_author_royalty_usd"], "expected_author_royalty_usd")
+         for row in marketplace_detail),
+        Decimal("0"),
+    )
+    marketplace_paid = sum(
+        (_decimal(row["paypal_payout_usd"], "paypal_payout_usd")
+         for row in marketplace_detail),
+        Decimal("0"),
+    )
+    marketplace_pending = sum(
+        (_decimal(row["pending_royalty_usd"], "pending_royalty_usd")
+         for row in marketplace_detail),
+        Decimal("0"),
+    )
+    return {
+        "payment_rows": len(payments),
+        "period_payment_rows": len(period_payments),
+        "period_succeeded_rows": sum(row["status"] == "succeeded" for row in period_payments),
+        "period_refunded_rows": sum(row["status"] == "refunded" for row in period_payments),
+        "period_gross": period_gross,
+        "period_net": period_net,
+        "payout_rows": len(payouts),
+        "period_paid_payouts": len(period_payouts),
+        "period_payout_amount": period_payout_amount,
+        "customer_rows": len(customers),
+        "paid_customers": sum(row["current_status"] == "paid" for row in customers),
+        "paused_customers": sum(row["current_status"] == "paused" for row in customers),
+        "canceled_customers": sum(row["current_status"] == "canceled" for row in customers),
+        "new_logo_starts": sum(
+            _integer(row["new_logo_starts"], "new_logo_starts")
+            for row in lifecycle_detail
+        ),
+        "inferred_reactivations": sum(
+            _integer(
+                row["inferred_reactivations_or_migrations"],
+                "inferred_reactivations_or_migrations",
+            )
+            for row in lifecycle_detail
+        ),
+        "confirmed_terminal_churns": sum(
+            _integer(row["confirmed_terminal_churns"], "confirmed_terminal_churns")
+            for row in lifecycle_detail
+        ),
+        "marketplace_sale_notices": sum(
+            _integer(row["sale_notice_count"], "sale_notice_count")
+            for row in marketplace_detail
+        ),
+        "marketplace_gross": sum(
+            (_decimal(row["gross_list_price_usd"], "gross_list_price_usd")
+             for row in marketplace_detail),
+            Decimal("0"),
+        ),
+        "marketplace_author_share": marketplace_author_share,
+        "marketplace_paid": marketplace_paid,
+        "marketplace_pending": marketplace_pending,
+        "customer_payment_rows_total": sum(
+            _integer(row["payment_rows"], "payment_rows") for row in customers
+        ),
+        "customer_period_gross": sum(
+            (_decimal(row["period_athlete_charged_usd"], "period_athlete_charged_usd")
+             for row in customers),
+            Decimal("0"),
+        ),
+        "customer_period_net": sum(
+            (_decimal(row["period_amount_received_usd"], "period_amount_received_usd")
+             for row in customers),
+            Decimal("0"),
+        ),
+        "monthly_period_payment_rows": sum(
+            _integer(row["payment_rows"], "payment_rows") for row in lifecycle_detail
+        ),
+        "monthly_period_succeeded_rows": sum(
+            _integer(row["succeeded_rows"], "succeeded_rows")
+            for row in lifecycle_detail
+        ),
+        "monthly_period_refunded_rows": sum(
+            _integer(row["refunded_rows"], "refunded_rows")
+            for row in lifecycle_detail
+        ),
+        "monthly_period_gross": sum(
+            (_decimal(row["athlete_charged_usd"], "athlete_charged_usd")
+             for row in lifecycle_detail),
+            Decimal("0"),
+        ),
+        "monthly_period_net": sum(
+            (_decimal(row["amount_received_usd"], "amount_received_usd")
+             for row in lifecycle_detail),
+            Decimal("0"),
+        ),
+        "payout_reconciliation_gap": period_net - period_payout_amount,
+        "marketplace_settlement_gap": (
+            marketplace_author_share - marketplace_paid - marketplace_pending
+        ),
+    }
+
+
+def _json_safe_controls(controls: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: _money(value) if isinstance(value, Decimal) else value
+        for key, value in controls.items()
+    }
+
+
+def _validate_expected(controls: dict[str, Any]) -> None:
+    failures = []
+    for key, expected in EXPECTED_2026_08_27.items():
+        actual = controls.get(key)
+        if actual != expected:
+            failures.append(f"{key}: expected {expected}, got {actual}")
+    if failures:
+        raise ProviderIngestionError("Provider control failure: " + "; ".join(failures))
+
+
+def build_trainingpeaks_bundle(
+    input_dir: str | Path,
+    *,
+    observed_at: str | None = None,
+    enforce_2026_08_27_controls: bool = True,
+) -> ImportBundle:
+    """Parse, validate, and normalize the reconciled Gravel God provider files."""
+    root = Path(input_dir).expanduser().resolve()
+    paths = {key: root / filename for key, filename in FILES.items()}
+    source_rows = {
+        key: _read_csv(path, REQUIRED_COLUMNS[key])
+        for key, path in paths.items()
+    }
+    _assert_unique(
+        source_rows["coaching_payments"], "source_row", "coaching payment ledger"
+    )
+    _assert_unique(
+        source_rows["coaching_payouts"], "source_row", "coaching payout ledger"
+    )
+    _assert_unique(
+        source_rows["coaching_payouts"],
+        "provider_id_sha256",
+        "coaching payout ledger",
+    )
+    _assert_unique(
+        source_rows["coaching_customers"],
+        "customer_key",
+        "coaching customer snapshot",
+    )
+    _assert_unique(
+        source_rows["coaching_monthly"],
+        "month",
+        "coaching monthly controls",
+        skip_total=True,
+    )
+    _assert_unique(
+        source_rows["marketplace_monthly"],
+        "sale_month",
+        "marketplace monthly controls",
+        skip_total=True,
+    )
+    observed = _observed_at(observed_at)
+    controls = _controls(
+        source_rows["coaching_payments"],
+        source_rows["coaching_payouts"],
+        source_rows["coaching_customers"],
+        source_rows["coaching_monthly"],
+        source_rows["marketplace_monthly"],
+    )
+    if enforce_2026_08_27_controls:
+        _validate_expected(controls)
+    safe_controls = _json_safe_controls(controls)
+
+    batches = {
+        "coaching_payments": _batch(
+            provider_account="coaching",
+            source_kind="payment_ledger",
+            path=paths["coaching_payments"],
+            rows=source_rows["coaching_payments"],
+            observed_at=observed,
+            control_totals={
+                key: safe_controls[key]
+                for key in (
+                    "payment_rows", "period_payment_rows", "period_succeeded_rows",
+                    "period_refunded_rows", "period_gross", "period_net",
+                )
+            },
+            evidence_grade="A",
+            boundary=(
+                "Provider export has no payment transaction ID; deterministic "
+                "keys are labeled synthetic."
+            ),
+        ),
+        "coaching_payouts": _batch(
+            provider_account="coaching",
+            source_kind="payout_ledger",
+            path=paths["coaching_payouts"],
+            rows=source_rows["coaching_payouts"],
+            observed_at=observed,
+            control_totals={
+                key: safe_controls[key]
+                for key in ("payout_rows", "period_paid_payouts", "period_payout_amount")
+            },
+            evidence_grade="A",
+            boundary=(
+                "Provider payout IDs are retained only as SHA-256; bank deposits "
+                "remain unmatched."
+            ),
+        ),
+        "coaching_customers": _batch(
+            provider_account="coaching",
+            source_kind="customer_lifecycle_snapshot",
+            path=paths["coaching_customers"],
+            rows=source_rows["coaching_customers"],
+            observed_at=observed,
+            control_totals={
+                key: safe_controls[key]
+                for key in (
+                    "customer_rows", "paid_customers", "paused_customers",
+                    "canceled_customers",
+                )
+            },
+            evidence_grade="A/B",
+            boundary=(
+                "Customer keys are snapshot-local; six historical churn dates "
+                "and churn denominators remain incomplete."
+            ),
+        ),
+        "coaching_monthly": _batch(
+            provider_account="coaching",
+            source_kind="lifecycle_monthly_controls",
+            path=paths["coaching_monthly"],
+            rows=source_rows["coaching_monthly"],
+            observed_at=observed,
+            control_totals={
+                key: safe_controls[key]
+                for key in (
+                    "new_logo_starts", "inferred_reactivations",
+                    "confirmed_terminal_churns",
+                )
+            },
+            evidence_grade="A/B",
+            boundary=(
+                "Monthly payment activity and dated lifecycle counts; no "
+                "month-start denominator or churn rate."
+            ),
+        ),
+        "marketplace_monthly": _batch(
+            provider_account="marketplace",
+            source_kind="royalty_monthly_controls",
+            path=paths["marketplace_monthly"],
+            rows=source_rows["marketplace_monthly"],
+            observed_at=observed,
+            control_totals={
+                key: safe_controls[key]
+                for key in (
+                    "marketplace_sale_notices", "marketplace_gross", "marketplace_author_share",
+                    "marketplace_paid", "marketplace_pending",
+                )
+            },
+            evidence_grade="A/B",
+            boundary=(
+                "Aggregate monthly royalties only; purchaser-level marketplace "
+                "transactions are unavailable."
+            ),
+        ),
+    }
+
+    payments = _payment_rows(
+        source_rows["coaching_payments"],
+        batches["coaching_payments"]["source_payload_sha256"],
+        observed,
+    )
+    payouts = _payout_rows(
+        source_rows["coaching_payouts"],
+        batches["coaching_payouts"]["source_payload_sha256"],
+        observed,
+    )
+    customers = _customer_rows(
+        source_rows["coaching_customers"],
+        batches["coaching_customers"]["source_payload_sha256"],
+        observed,
+    )
+    monthly = _monthly_rows(
+        source_rows["coaching_monthly"],
+        batch_key="coaching_monthly",
+        provider_account="coaching",
+        source_kind="lifecycle",
+        payload_sha256=batches["coaching_monthly"]["source_payload_sha256"],
+        observed_at=observed,
+        month_field="month",
+    )
+    monthly.extend(_monthly_rows(
+        source_rows["marketplace_monthly"],
+        batch_key="marketplace_monthly",
+        provider_account="marketplace",
+        source_kind="royalty",
+        payload_sha256=batches["marketplace_monthly"]["source_payload_sha256"],
+        observed_at=observed,
+        month_field="sale_month",
+    ))
+    return ImportBundle(observed, batches, payments, payouts, customers, monthly, safe_controls)
+
+
+def _attach_batch_ids(
+    rows: list[dict[str, Any]], batch_ids: dict[str, str]
+) -> list[dict[str, Any]]:
+    prepared = []
+    for source in rows:
+        row = dict(source)
+        key = row.pop("_batch_key")
+        row["import_batch_id"] = batch_ids[key]
+        prepared.append(row)
+    return prepared
+
+
+def _database() -> Any:
+    """Return the write client only when apply mode actually needs it."""
+    global db
+    if db is None:
+        from mission_control import supabase_client
+
+        db = supabase_client
+    return db
+
+
+def apply_bundle(bundle: ImportBundle, *, batch_size: int = 500) -> dict[str, Any]:
+    """Idempotently write a prevalidated bundle to the migrated Mission Control schema."""
+    database = _database()
+    batch_ids: dict[str, str] = {}
+    for key, batch in bundle.batches.items():
+        stored = database.upsert(
+            "gg_provider_import_batches",
+            batch,
+            on_conflict="provider,provider_account,source_kind,source_payload_sha256",
+        )
+        if not stored.get("id"):
+            stored = database.select_one(
+                "gg_provider_import_batches",
+                match={
+                    "provider": batch["provider"],
+                    "provider_account": batch["provider_account"],
+                    "source_kind": batch["source_kind"],
+                    "source_payload_sha256": batch["source_payload_sha256"],
+                },
+            ) or {}
+        if not stored.get("id"):
+            raise ProviderIngestionError(f"Import batch {key} did not return a persistent id")
+        batch_ids[key] = str(stored["id"])
+
+    payments = _attach_batch_ids(bundle.payments, batch_ids)
+    payouts = _attach_batch_ids(bundle.payouts, batch_ids)
+    customers = _attach_batch_ids(bundle.customer_snapshots, batch_ids)
+    monthly = _attach_batch_ids(bundle.monthly_controls, batch_ids)
+    stored = {
+        "gg_payments": database.upsert_many(
+            "gg_payments", payments,
+            on_conflict="provider,provider_account,provider_record_key",
+            batch_size=batch_size,
+        ),
+        "gg_provider_payouts": database.upsert_many(
+            "gg_provider_payouts", payouts,
+            on_conflict="provider,provider_account,provider_record_key",
+            batch_size=batch_size,
+        ),
+        "gg_provider_customer_snapshots": database.upsert_many(
+            "gg_provider_customer_snapshots", customers,
+            on_conflict="provider,provider_account,snapshot_sha256,customer_key",
+            batch_size=batch_size,
+        ),
+        "gg_provider_monthly_controls": database.upsert_many(
+            "gg_provider_monthly_controls", monthly,
+            on_conflict="provider,provider_account,source_kind,control_month",
+            batch_size=batch_size,
+        ),
+    }
+    return {
+        "status": "APPLIED",
+        "batch_ids": batch_ids,
+        "attempted_rows": {
+            "gg_payments": len(payments),
+            "gg_provider_payouts": len(payouts),
+            "gg_provider_customer_snapshots": len(customers),
+            "gg_provider_monthly_controls": len(monthly),
+        },
+        "returned_rows": {table: len(rows) for table, rows in stored.items()},
+        "controls": bundle.controls,
+    }

--- a/mission_control/supabase_client.py
+++ b/mission_control/supabase_client.py
@@ -51,6 +51,30 @@ def upsert(table: str, data: dict, on_conflict: str = "") -> dict:
     return result.data[0] if result.data else {}
 
 
+def upsert_many(
+    table: str,
+    rows: list[dict],
+    on_conflict: str = "",
+    batch_size: int = 500,
+) -> list[dict]:
+    """Upsert rows in bounded batches and return all rows reported by Supabase."""
+    if batch_size < 1:
+        raise ValueError("batch_size must be at least 1")
+    if not rows:
+        return []
+
+    stored: list[dict] = []
+    for start in range(0, len(rows), batch_size):
+        batch = rows[start:start + batch_size]
+        if on_conflict:
+            q = _table(table).upsert(batch, on_conflict=on_conflict)
+        else:
+            q = _table(table).upsert(batch)
+        result = q.execute()
+        stored.extend(result.data or [])
+    return stored
+
+
 def update(table: str, data: dict, match: dict) -> dict:
     """Update rows matching conditions."""
     q = _table(table).update(data)

--- a/mission_control/tests/test_provider_ingestion.py
+++ b/mission_control/tests/test_provider_ingestion.py
@@ -1,0 +1,274 @@
+"""Tests for decision-grade provider revenue ingestion."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from mission_control import supabase_client
+from mission_control.services import provider_ingestion as ingestion
+
+
+def _write(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _fixture_dir(tmp_path: Path, *, duplicate_payment: bool = False) -> Path:
+    upstream = "a" * 64
+    payment = {
+        "source_row": "1",
+        "customer_key": "C001",
+        "purchase_date": "2026-08-27",
+        "status": "succeeded",
+        "athlete_charged_usd": "299.00",
+        "amount_received_usd": "290.03",
+        "fee_refund_delta_usd": "8.97",
+        "product": "Coaching Premium 2024",
+        "in_operating_system_period": "true",
+        "source_file_sha256": upstream,
+        "evidence_grade": "A",
+        "boundary": "Provider row has no exported payment transaction ID",
+    }
+    payments = [payment]
+    if duplicate_payment:
+        payments.append({**payment, "source_row": "2"})
+    _write(tmp_path / ingestion.FILES["coaching_payments"], payments)
+    _write(tmp_path / ingestion.FILES["coaching_payouts"], [{
+        "source_row": "1",
+        "payout_key": "P001",
+        "provider_id_sha256": "b" * 64,
+        "created_utc": "2026-08-27T00:40:00+00:00",
+        "arrival_date_utc": "2026-08-27",
+        "amount_usd": "290.03",
+        "currency": "usd",
+        "livemode": "true",
+        "status": "paid",
+        "type": "bank_account",
+        "method": "standard",
+        "in_operating_system_period": "true",
+        "source_file_sha256": "c" * 64,
+        "evidence_grade": "A",
+        "boundary": "Bank destination omitted",
+    }])
+    _write(tmp_path / ingestion.FILES["coaching_customers"], [{
+        "customer_key": "C001",
+        "first_success_date": "2026-08-27",
+        "last_success_date": "2026-08-27",
+        "current_status": "paid",
+        "current_product": "Coaching Premium 2024",
+        "current_last_payment_date": "2026-08-27",
+        "current_next_payment_date": "2026-09-27",
+        "payment_rows": "1",
+        "succeeded_rows": "1",
+        "refunded_rows": "0",
+        "lifetime_athlete_charged_usd": "299.00",
+        "lifetime_amount_received_usd": "290.03",
+        "period_athlete_charged_usd": "299.00",
+        "period_amount_received_usd": "290.03",
+        "confirmed_cancel_events": "0",
+        "latest_confirmed_cancel_date": "",
+        "pause_events": "0",
+        "latest_pause_date": "",
+        "successful_payments_after_latest_cancel": "0",
+        "lifecycle_class": "new_active_logo",
+        "evidence_grade": "A/B",
+        "boundary": "Snapshot-local customer key",
+    }])
+    _write(tmp_path / ingestion.FILES["coaching_monthly"], [{
+        "month": "2026-08",
+        "payment_rows": "1",
+        "succeeded_rows": "1",
+        "refunded_rows": "0",
+        "distinct_paying_customers": "1",
+        "new_logo_starts": "1",
+        "inferred_reactivations_or_migrations": "0",
+        "confirmed_terminal_churns": "0",
+        "athlete_charged_usd": "299.00",
+        "amount_received_usd": "290.03",
+        "evidence_grade": "A/B",
+        "boundary": "No churn denominator",
+    }])
+    _write(tmp_path / ingestion.FILES["marketplace_monthly"], [{
+        "sale_month": "2026-08",
+        "sale_notice_count": "1",
+        "gross_list_price_usd": "100.00",
+        "author_share_rate": "0.70",
+        "expected_author_royalty_usd": "70.00",
+        "paypal_payout_date": "",
+        "paypal_payout_usd": "0.00",
+        "settled_variance_usd": "",
+        "pending_royalty_usd": "70.00",
+        "settlement_status": "pending",
+        "paypal_message_sha256": "",
+        "evidence_grade": "B",
+        "boundary": "Aggregate only",
+    }])
+    return tmp_path
+
+
+def test_build_bundle_preserves_financial_and_identity_boundaries(tmp_path):
+    bundle = ingestion.build_trainingpeaks_bundle(
+        _fixture_dir(tmp_path),
+        observed_at="2026-08-27T18:00:00+00:00",
+        enforce_2026_08_27_controls=False,
+    )
+
+    payment = bundle.payments[0]
+    assert payment["amount"] == "290.03"
+    assert payment["gross_amount"] == "299.00"
+    assert payment["provider_adjustment_amount"] == "8.97"
+    assert payment["provider_record_key_kind"] == "synthetic_normalized_fingerprint_v1"
+    assert payment["stripe_payment_id"] is None
+    assert set(payment) >= {"source_payload_sha256", "source_record_sha256", "evidence_grade"}
+
+    payout = bundle.payouts[0]
+    assert payout["provider_metadata"] == {
+        "in_operating_system_period": True,
+        "source_row": 1,
+    }
+
+    customer = bundle.customer_snapshots[0]
+    assert customer["customer_key"] == "C001"
+    assert customer["customer_key_kind"] == "snapshot_local"
+    assert not ({"name", "email", "provider_customer_id"} & set(customer))
+    assert bundle.summary()["canonical_rows"] == {
+        "gg_payments": 1,
+        "gg_provider_payouts": 1,
+        "gg_provider_customer_snapshots": 1,
+        "gg_provider_monthly_controls": 2,
+    }
+
+
+def test_identical_payment_rows_receive_distinct_deterministic_keys(tmp_path):
+    source = _fixture_dir(tmp_path, duplicate_payment=True)
+    first = ingestion.build_trainingpeaks_bundle(
+        source, observed_at="2026-08-27T18:00:00+00:00", enforce_2026_08_27_controls=False
+    )
+    second = ingestion.build_trainingpeaks_bundle(
+        source, observed_at="2026-08-27T19:00:00+00:00", enforce_2026_08_27_controls=False
+    )
+    first_keys = [row["provider_record_key"] for row in first.payments]
+    second_keys = [row["provider_record_key"] for row in second.payments]
+    assert len(set(first_keys)) == 2
+    assert first_keys == second_keys
+
+
+def test_pinned_control_profile_fails_closed_on_fixture(tmp_path):
+    with pytest.raises(ingestion.ProviderIngestionError, match="payment_rows"):
+        ingestion.build_trainingpeaks_bundle(_fixture_dir(tmp_path))
+
+
+def test_payment_adjustment_must_reconcile(tmp_path):
+    source = _fixture_dir(tmp_path)
+    path = source / ingestion.FILES["coaching_payments"]
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    rows[0]["fee_refund_delta_usd"] = "0.00"
+    _write(path, rows)
+
+    with pytest.raises(ingestion.ProviderIngestionError, match="gross-minus-net"):
+        ingestion.build_trainingpeaks_bundle(
+            source, enforce_2026_08_27_controls=False
+        )
+
+
+def test_pii_bearing_columns_fail_closed(tmp_path):
+    source = _fixture_dir(tmp_path)
+    path = source / ingestion.FILES["coaching_customers"]
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    rows[0]["email"] = "forbidden@example.com"
+    _write(path, rows)
+
+    with pytest.raises(ingestion.ProviderIngestionError, match="PII-bearing"):
+        ingestion.build_trainingpeaks_bundle(
+            source, enforce_2026_08_27_controls=False
+        )
+
+
+def test_observation_timestamp_requires_timezone(tmp_path):
+    with pytest.raises(ingestion.ProviderIngestionError, match="timezone"):
+        ingestion.build_trainingpeaks_bundle(
+            _fixture_dir(tmp_path),
+            observed_at="2026-08-27T18:00:00",
+            enforce_2026_08_27_controls=False,
+        )
+
+
+def test_apply_bundle_uses_idempotent_conflict_keys(tmp_path, monkeypatch):
+    bundle = ingestion.build_trainingpeaks_bundle(
+        _fixture_dir(tmp_path),
+        observed_at="2026-08-27T18:00:00+00:00",
+        enforce_2026_08_27_controls=False,
+    )
+    calls: list[tuple[str, str, int]] = []
+
+    class FakeDb:
+        @staticmethod
+        def upsert(table, row, on_conflict=""):
+            calls.append((table, on_conflict, 1))
+            return {**row, "id": f"batch-{len(calls)}"}
+
+        @staticmethod
+        def select_one(*_args, **_kwargs):
+            raise AssertionError("upsert returned an id")
+
+        @staticmethod
+        def upsert_many(table, rows, on_conflict="", batch_size=500):
+            calls.append((table, on_conflict, len(rows)))
+            assert all("import_batch_id" in row for row in rows)
+            return rows
+
+    monkeypatch.setattr(ingestion, "db", FakeDb)
+    receipt = ingestion.apply_bundle(bundle, batch_size=2)
+    assert receipt["status"] == "APPLIED"
+    assert receipt["attempted_rows"]["gg_payments"] == 1
+    assert ("gg_payments", "provider,provider_account,provider_record_key", 1) in calls
+    assert (
+        "gg_provider_monthly_controls",
+        "provider,provider_account,source_kind,control_month",
+        2,
+    ) in calls
+
+
+def test_upsert_many_uses_bounded_batches_and_conflict_key(monkeypatch):
+    calls: list[tuple[str, list[dict], str | None]] = []
+
+    class Result:
+        def __init__(self, data):
+            self.data = data
+
+    class Query:
+        def __init__(self, table):
+            self.table = table
+            self.rows = []
+            self.conflict = None
+
+        def upsert(self, rows, on_conflict=None):
+            self.rows = rows
+            self.conflict = on_conflict
+            return self
+
+        def execute(self):
+            calls.append((self.table, self.rows, self.conflict))
+            return Result(self.rows)
+
+    monkeypatch.setattr(supabase_client, "_table", Query)
+    rows = [{"id": value} for value in range(5)]
+    stored = supabase_client.upsert_many(
+        "gg_payments", rows, on_conflict="provider,provider_record_key", batch_size=2
+    )
+
+    assert [len(batch) for _, batch, _ in calls] == [2, 2, 1]
+    assert all(conflict == "provider,provider_record_key" for _, _, conflict in calls)
+    assert stored == rows
+
+
+def test_upsert_many_rejects_invalid_batch_size():
+    with pytest.raises(ValueError, match="at least 1"):
+        supabase_client.upsert_many("gg_payments", [{}], batch_size=0)

--- a/scripts/import_provider_revenue.py
+++ b/scripts/import_provider_revenue.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Validate or apply reconciled Gravel God provider revenue files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from mission_control.services.provider_ingestion import (  # noqa: E402
+    ProviderIngestionError,
+    apply_bundle,
+    build_trainingpeaks_bundle,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate reconciled TrainingPeaks coaching, payout, lifecycle, and "
+            "marketplace-control files. Dry-run is the default."
+        )
+    )
+    parser.add_argument(
+        "--input-dir",
+        required=True,
+        help="Directory containing the five sanitized provider CSV files",
+    )
+    parser.add_argument(
+        "--observed-at",
+        help="ISO-8601 observation timestamp; defaults to current UTC",
+    )
+    parser.add_argument("--receipt", help="Optional JSON receipt path")
+    parser.add_argument("--batch-size", type=int, default=500)
+    parser.add_argument(
+        "--skip-2026-08-27-controls",
+        action="store_true",
+        help="Disable the pinned Gravel God baseline controls; intended only for fixtures/tests",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write idempotent rows to the migrated live database",
+    )
+    parser.add_argument(
+        "--confirm",
+        default="",
+        help="Required with --apply; must equal APPLY_PROVIDER_TRUTH",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.batch_size < 1:
+        raise ProviderIngestionError("--batch-size must be at least 1")
+    if args.apply and args.confirm != "APPLY_PROVIDER_TRUTH":
+        raise ProviderIngestionError(
+            "--apply requires --confirm APPLY_PROVIDER_TRUTH; no database write was attempted"
+        )
+
+    bundle = build_trainingpeaks_bundle(
+        args.input_dir,
+        observed_at=args.observed_at,
+        enforce_2026_08_27_controls=not args.skip_2026_08_27_controls,
+    )
+    result = apply_bundle(bundle, batch_size=args.batch_size) if args.apply else bundle.summary()
+    result["mode"] = "apply" if args.apply else "dry-run"
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.receipt:
+        receipt = Path(args.receipt).expanduser().resolve()
+        receipt.parent.mkdir(parents=True, exist_ok=True)
+        receipt.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ProviderIngestionError as exc:
+        print(json.dumps({"status": "FAILED", "error": str(exc)}), file=sys.stderr)
+        raise SystemExit(2) from None

--- a/supabase/migrations/20260827000001_provider_revenue_truth.sql
+++ b/supabase/migrations/20260827000001_provider_revenue_truth.sql
@@ -1,0 +1,167 @@
+-- Decision-grade provider revenue imports for Mission Control.
+--
+-- This migration extends the existing gg_payments table compatibly. Existing
+-- manual rows remain valid. Provider imports gain idempotency, source evidence,
+-- status, gross/net separation, and an explicit boundary when the upstream
+-- export does not contain a transaction identifier.
+
+CREATE TABLE gg_provider_import_batches (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    provider TEXT NOT NULL,
+    provider_account TEXT NOT NULL DEFAULT '',
+    source_kind TEXT NOT NULL,
+    source_payload_sha256 TEXT NOT NULL CHECK (length(source_payload_sha256) = 64),
+    upstream_source_sha256 JSONB NOT NULL DEFAULT '[]',
+    observed_at TIMESTAMPTZ NOT NULL,
+    row_count INTEGER NOT NULL CHECK (row_count >= 0),
+    control_totals JSONB NOT NULL DEFAULT '{}',
+    evidence_grade TEXT NOT NULL,
+    source_boundary TEXT NOT NULL DEFAULT '',
+    imported_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(provider, provider_account, source_kind, source_payload_sha256)
+);
+
+ALTER TABLE gg_payments
+    ADD COLUMN provider TEXT NOT NULL DEFAULT 'manual',
+    ADD COLUMN provider_account TEXT NOT NULL DEFAULT '',
+    ADD COLUMN provider_record_key TEXT,
+    ADD COLUMN provider_record_key_kind TEXT,
+    ADD COLUMN import_batch_id UUID REFERENCES gg_provider_import_batches(id),
+    ADD COLUMN customer_key TEXT,
+    ADD COLUMN product_name TEXT,
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'succeeded',
+    ADD COLUMN currency TEXT NOT NULL DEFAULT 'usd',
+    ADD COLUMN gross_amount DECIMAL,
+    ADD COLUMN provider_adjustment_amount DECIMAL,
+    ADD COLUMN net_amount DECIMAL,
+    ADD COLUMN source_payload_sha256 TEXT CHECK (source_payload_sha256 IS NULL OR length(source_payload_sha256) = 64),
+    ADD COLUMN source_record_sha256 TEXT CHECK (source_record_sha256 IS NULL OR length(source_record_sha256) = 64),
+    ADD COLUMN evidence_grade TEXT,
+    ADD COLUMN source_boundary TEXT NOT NULL DEFAULT '',
+    ADD COLUMN provider_metadata JSONB NOT NULL DEFAULT '{}',
+    ADD COLUMN observed_at TIMESTAMPTZ,
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ADD CONSTRAINT gg_payments_provider_record_unique
+        UNIQUE(provider, provider_account, provider_record_key);
+
+COMMENT ON COLUMN gg_payments.provider_record_key IS
+    'Provider ID when exported; otherwise a labeled synthetic fingerprint over normalized source facts plus duplicate ordinal.';
+COMMENT ON COLUMN gg_payments.provider_adjustment_amount IS
+    'Gross minus provider net. May combine fees and refund effects when the source export does not separate them.';
+COMMENT ON COLUMN gg_payments.customer_key IS
+    'PII-minimized source key. It is not a canonical customer identity unless the provider supplies a stable ID.';
+
+CREATE INDEX idx_payments_provider_status_month
+    ON gg_payments(provider, provider_account, status, paid_at);
+CREATE INDEX idx_payments_import_batch ON gg_payments(import_batch_id);
+
+CREATE TABLE gg_provider_payouts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    provider TEXT NOT NULL,
+    provider_account TEXT NOT NULL DEFAULT '',
+    provider_record_key TEXT NOT NULL,
+    provider_record_key_kind TEXT NOT NULL,
+    import_batch_id UUID NOT NULL REFERENCES gg_provider_import_batches(id),
+    status TEXT NOT NULL,
+    amount DECIMAL NOT NULL,
+    currency TEXT NOT NULL,
+    provider_created_at TIMESTAMPTZ,
+    arrival_date DATE,
+    payout_type TEXT,
+    payout_method TEXT,
+    livemode BOOLEAN,
+    source_payload_sha256 TEXT NOT NULL CHECK (length(source_payload_sha256) = 64),
+    source_record_sha256 TEXT NOT NULL CHECK (length(source_record_sha256) = 64),
+    evidence_grade TEXT NOT NULL,
+    source_boundary TEXT NOT NULL DEFAULT '',
+    provider_metadata JSONB NOT NULL DEFAULT '{}',
+    observed_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(provider, provider_account, provider_record_key)
+);
+
+CREATE INDEX idx_provider_payouts_arrival
+    ON gg_provider_payouts(provider, provider_account, arrival_date);
+
+CREATE TABLE gg_provider_customer_snapshots (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    provider TEXT NOT NULL,
+    provider_account TEXT NOT NULL DEFAULT '',
+    snapshot_sha256 TEXT NOT NULL CHECK (length(snapshot_sha256) = 64),
+    import_batch_id UUID NOT NULL REFERENCES gg_provider_import_batches(id),
+    customer_key TEXT NOT NULL,
+    customer_key_kind TEXT NOT NULL,
+    first_success_date DATE,
+    last_success_date DATE,
+    current_status TEXT NOT NULL,
+    current_product TEXT,
+    current_last_payment_date DATE,
+    current_next_payment_date DATE,
+    payment_rows INTEGER NOT NULL DEFAULT 0,
+    succeeded_rows INTEGER NOT NULL DEFAULT 0,
+    refunded_rows INTEGER NOT NULL DEFAULT 0,
+    lifetime_gross_amount DECIMAL,
+    lifetime_net_amount DECIMAL,
+    period_gross_amount DECIMAL,
+    period_net_amount DECIMAL,
+    confirmed_cancel_events INTEGER NOT NULL DEFAULT 0,
+    latest_confirmed_cancel_date DATE,
+    pause_events INTEGER NOT NULL DEFAULT 0,
+    latest_pause_date DATE,
+    successes_after_latest_cancel INTEGER NOT NULL DEFAULT 0,
+    lifecycle_class TEXT NOT NULL,
+    source_record_sha256 TEXT NOT NULL CHECK (length(source_record_sha256) = 64),
+    evidence_grade TEXT NOT NULL,
+    source_boundary TEXT NOT NULL DEFAULT '',
+    observed_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(provider, provider_account, snapshot_sha256, customer_key)
+);
+
+COMMENT ON COLUMN gg_provider_customer_snapshots.customer_key_kind IS
+    'snapshot_local means the key must not be joined to another snapshot as a stable identity.';
+
+CREATE INDEX idx_provider_customer_snapshot_status
+    ON gg_provider_customer_snapshots(provider, provider_account, observed_at, current_status);
+
+CREATE TABLE gg_provider_monthly_controls (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    provider TEXT NOT NULL,
+    provider_account TEXT NOT NULL DEFAULT '',
+    source_kind TEXT NOT NULL,
+    control_month DATE NOT NULL,
+    import_batch_id UUID NOT NULL REFERENCES gg_provider_import_batches(id),
+    metrics JSONB NOT NULL,
+    source_payload_sha256 TEXT NOT NULL CHECK (length(source_payload_sha256) = 64),
+    source_record_sha256 TEXT NOT NULL CHECK (length(source_record_sha256) = 64),
+    evidence_grade TEXT NOT NULL,
+    source_boundary TEXT NOT NULL DEFAULT '',
+    observed_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(provider, provider_account, source_kind, control_month)
+);
+
+CREATE INDEX idx_provider_monthly_controls_month
+    ON gg_provider_monthly_controls(provider, provider_account, source_kind, control_month);
+
+ALTER TABLE gg_provider_import_batches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE gg_provider_payouts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE gg_provider_customer_snapshots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE gg_provider_monthly_controls ENABLE ROW LEVEL SECURITY;
+
+-- The service-role key bypasses RLS.  Explicitly deny ordinary PostgREST roles
+-- so financial controls and lifecycle snapshots cannot be read anonymously.
+DROP POLICY IF EXISTS "service_role_all" ON gg_payments;
+DROP POLICY IF EXISTS "Service role only" ON gg_payments;
+CREATE POLICY "Service role only" ON gg_payments
+    FOR ALL USING (false) WITH CHECK (false);
+CREATE POLICY "Service role only" ON gg_provider_import_batches
+    FOR ALL USING (false) WITH CHECK (false);
+CREATE POLICY "Service role only" ON gg_provider_payouts
+    FOR ALL USING (false) WITH CHECK (false);
+CREATE POLICY "Service role only" ON gg_provider_customer_snapshots
+    FOR ALL USING (false) WITH CHECK (false);
+CREATE POLICY "Service role only" ON gg_provider_monthly_controls
+    FOR ALL USING (false) WITH CHECK (false);


### PR DESCRIPTION
## Outcome

Adds a decision-grade, idempotent TrainingPeaks provider-ingestion path for Mission Control. The importer validates the sanitized coaching payment, payout, customer-lifecycle, coaching-monthly, and marketplace-monthly evidence before any write.

## Boundaries preserved

- Coaching payment export lacks transaction IDs, so keys are explicitly labeled synthetic normalized fingerprints.
- Customer keys are snapshot-local and no names/emails are imported.
- Marketplace royalties remain aggregate monthly controls, not fabricated purchaser transactions.
- Dry-run is the default; writes require `--apply --confirm APPLY_PROVIDER_TRUTH`.
- New provider tables and the extended payments ledger deny ordinary PostgREST roles.

## Verified

- Real 2026-08-27 bundle: 553 payments, 351 payouts, 36 customer rows, 26 monthly controls.
- Cross-source controls: $47,765.60 period gross; $45,694.95 received; $45,404.92 payouts plus $290.03 gap; marketplace settlement gap $0.00.
- Migration executed against the actual Mission Control schema inside an explicit transaction and rolled back; new tables/columns were absent afterward.
- `python3 -m pytest tests/ -q --tb=short`: 7,307 passed, 298 skipped.
- `python3 -m pytest mission_control/tests/ -q --tb=short`: 516 passed.
- `python3 scripts/preflight_quality.py`: all checks passed (known environment/fixture warnings only).
- `python3 scripts/validate_citations.py`: all checks passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches financial ledger schema, bulk upserts of payment/payout data, and tightens `gg_payments` RLS; incorrect apply or policy regression could block legitimate access or corrupt revenue truth.
> 
> **Overview**
> Adds an end-to-end path to **validate and optionally load** reconciled, PII-minimized TrainingPeaks CSV evidence into Mission Control. Dry-run is default; writes go through `scripts/import_provider_revenue.py` with `--apply --confirm APPLY_PROVIDER_TRUTH`, and apply mode lazy-loads Supabase credentials so validation does not need them.
> 
> **`provider_ingestion`** parses five fixed filenames, rejects forbidden PII columns, enforces row uniqueness, reconciles gross/net/adjustments, and by default **fails closed** on a pinned 2026-08-27 control profile (counts and dollar totals across payments, payouts, customers, lifecycle, and marketplace). Coaching payments get **labeled synthetic fingerprints** when the export has no transaction ID; marketplace data stays **aggregate monthly controls** only. **`apply_bundle`** upserts import batches and canonical rows with stable conflict keys.
> 
> **Schema** (`20260827000001_provider_revenue_truth.sql`) adds `gg_provider_import_batches`, payouts, customer snapshots, and monthly controls; extends **`gg_payments`** with provider metadata and idempotency keys while keeping manual rows compatible. RLS on these tables (and a stricter **`gg_payments`** policy) denies ordinary PostgREST roles. **`upsert_many`** supports batched writes; docs and tests cover runbook, boundaries, and apply behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba5e265c5cf5526fcab69f157f9cf8d85aaae87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->