### PR TITLE
Preserve Gravel Weekly decision receipts

### DIFF
--- a/.github/workflows/weekly-broadcast.yml
+++ b/.github/workflows/weekly-broadcast.yml
@@ -52,18 +52,32 @@ jobs:
           import os
           from pathlib import Path
           from scripts.validate_gravel_weekly import validate_issue
+          from scripts.validate_gravel_weekly_decisions import validate_decision_receipt
 
           issue_date = os.environ["ISSUE_DATE"]
           path = Path("data/gravel-weekly/issues") / f"{issue_date}.json"
+          decision_path = Path("data/gravel-weekly/decisions") / f"{issue_date}.json"
           if not path.exists():
               raise SystemExit(f"Approved issue not found: {path}")
+          if not decision_path.exists():
+              raise SystemExit(f"Editorial decision receipt not found: {decision_path}")
           issue = validate_issue(json.loads(path.read_text()))
           if issue["status"] != "published":
               raise SystemExit("Workflow requires status=published; model drafts and prepared issues cannot deploy")
+          validate_decision_receipt(json.loads(decision_path.read_text()), issue)
           with open(os.environ["GITHUB_OUTPUT"], "a") as output:
               output.write(f"hash={issue['contentHash']}\n")
               output.write(f"number={issue['issueNumber']}\n")
           PY
+
+      - name: Record human editorial decisions and approved-copy feedback
+        env:
+          ISSUE_DATE: ${{ inputs.issue_date }}
+          CONTROL_PLANE_INGEST_SECRET: ${{ secrets.CONTROL_PLANE_INGEST_SECRET }}
+        run: |
+          python scripts/record_gravel_weekly_decisions.py \
+            "data/gravel-weekly/decisions/$ISSUE_DATE.json" \
+            "data/gravel-weekly/issues/$ISSUE_DATE.json"
 
       - name: Generate publication and homepage
         run: |

--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -1,9 +1,11 @@
 # Gravel Weekly issue store
 
 Prepared review drafts live locally in ignored `drafts/YYYY-MM-DD.json`.
-Approved issue
-snapshots live in `issues/YYYY-MM-DD.json` and use
+Approved issue snapshots live in `issues/YYYY-MM-DD.json` and use
 `gravel-weekly-issue/v1` from the race-intelligence control plane.
+Each snapshot has a paired `decisions/YYYY-MM-DD.json` receipt containing every
+explicit approve/reject verdict, the exact model Take that Matti reviewed, the
+approved Take, and the human edit summary.
 
 The intelligence service may prepare candidates and reaction packets, but it
 does not write to `issues/`. An issue enters that directory only after Matti
@@ -35,9 +37,9 @@ python3 scripts/approve_gravel_weekly_issue.py \
 The approval packet must use `gravel-weekly-approval/v1`, decide every reviewed
 story exactly once, and supply the final headline, deck, Take, and edit summary
 for every approved story. The bridge preserves the reviewed facts, scores,
-receipts, and race impacts verbatim. It emits `status=approved` under the
-ignored `data/gravel-weekly/approved/` directory, which the deploy workflow
-refuses.
+receipts, and race impacts verbatim. It emits both a `status=approved` issue and
+a decision receipt under the ignored `data/gravel-weekly/approved/` directory,
+which the deploy workflow refuses.
 
 After a separate explicit publication instruction, seal the approved file:
 
@@ -49,8 +51,11 @@ python3 scripts/seal_gravel_weekly_issue.py \
 
 Sealing changes only publication state and timestamps, refuses to overwrite an
 existing historical snapshot by default, and writes the deployable immutable
-file under `data/gravel-weekly/issues/`. Deployment remains a separate manual
-workflow dispatch.
+issue under `data/gravel-weekly/issues/` plus its canonical receipt under
+`data/gravel-weekly/decisions/`. The publish workflow validates the pair and
+mirrors each idempotent decision into the control plane before deployment, so
+gate outcomes and approved-copy edits cannot silently fall out of the learning
+history. Deployment remains a separate manual workflow dispatch.
 
 Validate files and content hashes:
 

--- a/scripts/approve_gravel_weekly_issue.py
+++ b/scripts/approve_gravel_weekly_issue.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from validate_gravel_weekly import compute_content_hash, validate_issue
+from validate_gravel_weekly_decisions import DECISION_SCHEMA, RECEIPT_SCHEMA, validate_decision_receipt
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 APPROVED_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "approved"
@@ -50,8 +51,8 @@ def _approval_story(value: Any, index: int) -> dict[str, Any]:
     if decision not in {"approve", "reject"}:
         raise ValueError(f"approval.stories[{index}].decision must be approve or reject")
     if decision == "reject":
-        _text(item.get("reason"), f"approval.stories[{index}].reason", 2_000)
-        return {"candidateId": candidate_id, "decision": decision}
+        reason = _text(item.get("reason"), f"approval.stories[{index}].reason", 2_000)
+        return {"candidateId": candidate_id, "decision": decision, "reason": reason}
     return {
         "candidateId": candidate_id,
         "decision": decision,
@@ -148,19 +149,66 @@ def approve_issue(draft_value: Any, approval_value: Any) -> dict[str, Any]:
     return validate_issue(approved)
 
 
+def build_decision_receipt(draft_value: Any, approval_value: Any, approved_value: Any) -> dict[str, Any]:
+    """Bind every human story decision to the exact reviewed draft and approved copy."""
+    draft = validate_issue(draft_value)
+    approved = validate_issue(approved_value)
+    expected = approve_issue(draft, approval_value)
+    if approved != expected:
+        raise ValueError("approved issue does not match the supplied draft and approval packet")
+    approval = _record(approval_value, "approval")
+    decisions = [_approval_story(value, index) for index, value in enumerate(approval["stories"])]
+    approved_by_id = {story["candidateId"]: story for story in approved["stories"]}
+    draft_by_id = {story["candidateId"]: story for story in draft["stories"]}
+    records: list[dict[str, Any]] = []
+    for decision in decisions:
+        is_approved = decision["decision"] == "approve"
+        records.append({
+            "schemaVersion": DECISION_SCHEMA,
+            "issueId": approved["issueId"],
+            "candidateId": decision["candidateId"],
+            "decision": decision["decision"],
+            "reason": (
+                f"Approved for Gravel Weekly #{approved['issueNumber']:03d}."
+                if is_approved else decision["reason"]
+            ),
+            "decidedBy": approval["approver"],
+            "decidedAt": approval["approvedAt"],
+            "suggestedCopy": draft_by_id[decision["candidateId"]]["take"] if is_approved else None,
+            "approvedCopy": approved_by_id[decision["candidateId"]]["take"] if is_approved else None,
+            "editSummary": decision["editSummary"] if is_approved else None,
+        })
+    receipt = {
+        "schemaVersion": RECEIPT_SCHEMA,
+        "issueId": approved["issueId"],
+        "publicationDate": approved["publicationDate"],
+        "reviewedDraftContentHash": draft["contentHash"],
+        "decidedBy": approval["approver"],
+        "decidedAt": approval["approvedAt"],
+        "decisions": records,
+    }
+    return validate_decision_receipt(receipt, approved)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("draft", type=Path)
     parser.add_argument("approval", type=Path)
     parser.add_argument("--output", type=Path)
+    parser.add_argument("--decision-receipt-output", type=Path)
     args = parser.parse_args()
     draft = json.loads(args.draft.read_text(encoding="utf-8"))
     approval = json.loads(args.approval.read_text(encoding="utf-8"))
     issue = approve_issue(draft, approval)
     output = args.output or APPROVED_DIR / f"{issue['publicationDate']}.json"
+    receipt = build_decision_receipt(draft, approval, issue)
+    receipt_output = args.decision_receipt_output or APPROVED_DIR / f"{issue['publicationDate']}.decisions.json"
     output.parent.mkdir(parents=True, exist_ok=True)
+    receipt_output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(f"{json.dumps(issue, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
+    receipt_output.write_text(f"{json.dumps(receipt, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
     print(f"Approved but not published: {output}")
+    print(f"Durable decision receipt staged: {receipt_output}")
     return 0
 
 

--- a/scripts/record_gravel_weekly_decisions.py
+++ b/scripts/record_gravel_weekly_decisions.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Mirror a canonical Gravel Weekly decision receipt into the control plane."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from validate_gravel_weekly import validate_issue
+from validate_gravel_weekly_decisions import validate_decision_receipt
+
+DEFAULT_ENDPOINT = "https://race-intelligence-control-plane.vercel.app/api/editorial-decision"
+
+
+def post_decisions(receipt: dict, endpoint: str, secret: str) -> list[dict]:
+    responses: list[dict] = []
+    for decision in receipt["decisions"]:
+        request = urllib.request.Request(
+            endpoint,
+            data=json.dumps(decision, ensure_ascii=False).encode("utf-8"),
+            headers={"Authorization": f"Bearer {secret}", "Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:1_000]
+            raise RuntimeError(f"control-plane decision rejected with HTTP {exc.code}: {detail}") from exc
+        if not isinstance(payload, dict) or payload.get("accepted") is not True:
+            raise RuntimeError("control plane did not acknowledge the editorial decision")
+        responses.append(payload)
+    return responses
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("receipt", type=Path)
+    parser.add_argument("issue", type=Path)
+    parser.add_argument("--endpoint", default=os.environ.get("CONTROL_PLANE_EDITORIAL_DECISION_URL", DEFAULT_ENDPOINT))
+    args = parser.parse_args()
+    secret = os.environ.get("CONTROL_PLANE_INGEST_SECRET")
+    if not secret:
+        raise SystemExit("CONTROL_PLANE_INGEST_SECRET is required")
+    issue = validate_issue(json.loads(args.issue.read_text(encoding="utf-8")))
+    receipt = validate_decision_receipt(json.loads(args.receipt.read_text(encoding="utf-8")), issue)
+    responses = post_decisions(receipt, args.endpoint, secret)
+    recorded_voice = sum(bool(response.get("voiceEditRecorded")) for response in responses)
+    print(f"Recorded {len(responses)} editorial decision(s); {recorded_voice} approved voice edit(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/seal_gravel_weekly_issue.py
+++ b/scripts/seal_gravel_weekly_issue.py
@@ -10,6 +10,10 @@ from pathlib import Path
 from typing import Any
 
 from validate_gravel_weekly import ISSUE_DIR, compute_content_hash, validate_issue
+from validate_gravel_weekly_decisions import validate_decision_receipt
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DECISION_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "decisions"
 
 
 def _timestamp(value: str, name: str) -> datetime:
@@ -46,16 +50,27 @@ def main() -> int:
     parser.add_argument("approved", type=Path)
     parser.add_argument("--published-at", required=True)
     parser.add_argument("--output", type=Path)
+    parser.add_argument("--decision-receipt", type=Path)
+    parser.add_argument("--decision-output", type=Path)
     parser.add_argument("--overwrite", action="store_true")
     args = parser.parse_args()
     approved = json.loads(args.approved.read_text(encoding="utf-8"))
     issue = seal_issue(approved, args.published_at)
     output = args.output or ISSUE_DIR / f"{issue['publicationDate']}.json"
-    if output.exists() and not args.overwrite:
-        raise SystemExit(f"Refusing to replace immutable issue snapshot: {output}")
+    receipt_input = args.decision_receipt or args.approved.with_name(f"{issue['publicationDate']}.decisions.json")
+    if not receipt_input.exists():
+        raise SystemExit(f"Decision receipt not found: {receipt_input}")
+    receipt = validate_decision_receipt(json.loads(receipt_input.read_text(encoding="utf-8")), issue)
+    decision_output = args.decision_output or DECISION_DIR / f"{issue['publicationDate']}.json"
+    for path, label in ((output, "issue snapshot"), (decision_output, "decision receipt")):
+        if path.exists() and not args.overwrite:
+            raise SystemExit(f"Refusing to replace immutable {label}: {path}")
     output.parent.mkdir(parents=True, exist_ok=True)
+    decision_output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(f"{json.dumps(issue, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
+    decision_output.write_text(f"{json.dumps(receipt, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
     print(f"Sealed deployable issue snapshot: {output}")
+    print(f"Sealed decision receipt: {decision_output}")
     return 0
 
 

--- a/scripts/validate_gravel_weekly_decisions.py
+++ b/scripts/validate_gravel_weekly_decisions.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Validate the durable human-decision receipt paired with a Gravel Weekly issue."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+try:
+    from validate_gravel_weekly import validate_issue
+except ModuleNotFoundError:  # Imported as scripts.validate_gravel_weekly_decisions.
+    from scripts.validate_gravel_weekly import validate_issue
+
+RECEIPT_SCHEMA = "gravel-weekly-decision-receipt/v1"
+DECISION_SCHEMA = "editorial-decision/v1"
+OUTER_KEYS = {
+    "schemaVersion", "issueId", "publicationDate", "reviewedDraftContentHash",
+    "decidedBy", "decidedAt", "decisions",
+}
+DECISION_KEYS = {
+    "schemaVersion", "issueId", "candidateId", "decision", "reason",
+    "decidedBy", "decidedAt", "suggestedCopy", "approvedCopy", "editSummary",
+}
+
+
+def _record(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be an object")
+    return value
+
+
+def _text(value: Any, name: str, maximum: int) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} is required")
+    if len(value) > maximum:
+        raise ValueError(f"{name} exceeds {maximum} characters")
+    return value.strip()
+
+
+def _iso(value: Any, name: str) -> str:
+    text = _text(value, name, 100)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{name} must include a timezone")
+    return text
+
+
+def validate_decision_receipt(value: Any, issue_value: Any) -> dict[str, Any]:
+    """Fail closed unless the receipt exactly describes the approved issue copy."""
+    issue = validate_issue(issue_value)
+    if issue["status"] not in {"approved", "published"}:
+        raise ValueError("decision receipts require an approved or published issue")
+    receipt = _record(value, "decision receipt")
+    unknown = set(receipt) - OUTER_KEYS
+    if unknown:
+        raise ValueError(f"decision receipt has unsupported fields: {sorted(unknown)}")
+    if receipt.get("schemaVersion") != RECEIPT_SCHEMA:
+        raise ValueError("unsupported Gravel Weekly decision receipt schema")
+    if receipt.get("issueId") != issue["issueId"]:
+        raise ValueError("decision receipt issueId does not match issue")
+    if receipt.get("publicationDate") != issue["publicationDate"]:
+        raise ValueError("decision receipt publicationDate does not match issue")
+    draft_hash = _text(receipt.get("reviewedDraftContentHash"), "reviewedDraftContentHash", 64)
+    if not re.fullmatch(r"[0-9a-f]{64}", draft_hash):
+        raise ValueError("reviewedDraftContentHash must be a lowercase SHA-256 hash")
+    decided_by = _text(receipt.get("decidedBy"), "decidedBy", 300)
+    decided_at = _iso(receipt.get("decidedAt"), "decidedAt")
+    approval = issue["editorialApproval"]
+    if decided_by != approval["approver"] or decided_at != approval["approvedAt"]:
+        raise ValueError("decision receipt identity and time must match editorial approval")
+
+    raw_decisions = receipt.get("decisions")
+    if not isinstance(raw_decisions, list) or not raw_decisions:
+        raise ValueError("decision receipt decisions must be a non-empty list")
+    decisions: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, raw_value in enumerate(raw_decisions):
+        raw = _record(raw_value, f"decisions[{index}]")
+        extra = set(raw) - DECISION_KEYS
+        if extra:
+            raise ValueError(f"decisions[{index}] has unsupported fields: {sorted(extra)}")
+        if raw.get("schemaVersion") != DECISION_SCHEMA:
+            raise ValueError(f"decisions[{index}] has unsupported schema")
+        if raw.get("issueId") != issue["issueId"]:
+            raise ValueError(f"decisions[{index}].issueId does not match issue")
+        candidate_id = _text(raw.get("candidateId"), f"decisions[{index}].candidateId", 500)
+        if candidate_id in seen:
+            raise ValueError("decision receipt candidate IDs must be unique")
+        seen.add(candidate_id)
+        decision = raw.get("decision")
+        if decision not in {"approve", "reject"}:
+            raise ValueError(f"decisions[{index}].decision must be approve or reject")
+        reason = _text(raw.get("reason"), f"decisions[{index}].reason", 2_000)
+        if raw.get("decidedBy") != decided_by or raw.get("decidedAt") != decided_at:
+            raise ValueError(f"decisions[{index}] identity and time must match receipt")
+        approved_copy = raw.get("approvedCopy")
+        suggested_copy = raw.get("suggestedCopy")
+        edit_summary = raw.get("editSummary")
+        if decision == "approve":
+            suggested_copy = _text(suggested_copy, f"decisions[{index}].suggestedCopy", 8_000)
+            approved_copy = _text(approved_copy, f"decisions[{index}].approvedCopy", 8_000)
+            edit_summary = _text(edit_summary, f"decisions[{index}].editSummary", 2_000)
+        elif suggested_copy is not None or approved_copy is not None or edit_summary is not None:
+            raise ValueError(f"decisions[{index}] rejected decisions cannot carry approved copy")
+        decisions.append({
+            "schemaVersion": DECISION_SCHEMA,
+            "issueId": issue["issueId"],
+            "candidateId": candidate_id,
+            "decision": decision,
+            "reason": reason,
+            "decidedBy": decided_by,
+            "decidedAt": decided_at,
+            "suggestedCopy": suggested_copy,
+            "approvedCopy": approved_copy,
+            "editSummary": edit_summary,
+        })
+
+    approved_by_id = {
+        decision["candidateId"]: decision
+        for decision in decisions if decision["decision"] == "approve"
+    }
+    issue_stories = {story["candidateId"]: story for story in issue["stories"]}
+    if set(approved_by_id) != set(issue_stories):
+        raise ValueError("approved receipt decisions must exactly match issue stories")
+    for candidate_id, story in issue_stories.items():
+        if approved_by_id[candidate_id]["approvedCopy"] != story["take"]:
+            raise ValueError(f"approved copy does not match issue story {candidate_id}")
+
+    return {
+        "schemaVersion": RECEIPT_SCHEMA,
+        "issueId": issue["issueId"],
+        "publicationDate": issue["publicationDate"],
+        "reviewedDraftContentHash": draft_hash,
+        "decidedBy": decided_by,
+        "decidedAt": decided_at,
+        "decisions": decisions,
+    }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -20,9 +20,10 @@ from validate_gravel_weekly import (  # noqa: E402
 )
 from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
 from prepare_gravel_weekly_issue import prepare_issue  # noqa: E402
-from approve_gravel_weekly_issue import approve_issue  # noqa: E402
-from seal_gravel_weekly_issue import seal_issue  # noqa: E402
+from approve_gravel_weekly_issue import approve_issue, build_decision_receipt  # noqa: E402
+from seal_gravel_weekly_issue import main as seal_issue_main, seal_issue  # noqa: E402
 from render_gravel_weekly_race_impact_review import render_review  # noqa: E402
+from validate_gravel_weekly_decisions import validate_decision_receipt  # noqa: E402
 
 
 def sample_issue():
@@ -229,6 +230,35 @@ def test_human_approval_bridge_changes_only_editorial_copy_and_stays_non_deploya
         render_review(approved)
 
 
+def test_human_approval_produces_a_durable_control_plane_decision_receipt():
+    draft = sample_draft()
+    approval = sample_approval()
+    approved = approve_issue(draft, approval)
+    receipt = build_decision_receipt(draft, approval, approved)
+
+    assert receipt["reviewedDraftContentHash"] == draft["contentHash"]
+    assert receipt["decidedBy"] == "Matti Rowe"
+    assert receipt["decisions"] == [{
+        "schemaVersion": "editorial-decision/v1",
+        "issueId": "gravel-weekly-001",
+        "candidateId": "story_1",
+        "decision": "approve",
+        "reason": "Approved for Gravel Weekly #001.",
+        "decidedBy": "Matti Rowe",
+        "decidedAt": "2026-08-28T16:00:00Z",
+        "suggestedCopy": "Editable model draft, not Matti's approved view.",
+        "approvedCopy": "The approved take makes a concrete judgment.",
+        "editSummary": "Removed throat-clearing and sharpened the consequence.",
+    }]
+    assert validate_decision_receipt(receipt, approved) == receipt
+    assert validate_decision_receipt(receipt, seal_issue(approved, "2026-08-28T16:05:00Z")) == receipt
+
+    forged = copy.deepcopy(receipt)
+    forged["decisions"][0]["approvedCopy"] = "Different copy after approval."
+    with pytest.raises(ValueError, match="approved copy does not match"):
+        validate_decision_receipt(forged, approved)
+
+
 def test_approval_bridge_requires_an_exact_human_decision_for_every_reviewed_story():
     draft = sample_draft()
     missing = sample_approval()
@@ -285,6 +315,43 @@ def test_sealing_is_a_separate_copy_preserving_step_after_approval():
         seal_issue(approved, "2026-08-28T15:59:59Z")
     with pytest.raises(ValueError, match="include a timezone"):
         seal_issue(approved, "2026-08-28T16:05:00")
+
+
+def test_sealing_writes_the_issue_and_its_canonical_decision_receipt_together(tmp_path, monkeypatch):
+    draft = sample_draft()
+    approval = sample_approval()
+    approved = approve_issue(draft, approval)
+    receipt = build_decision_receipt(draft, approval, approved)
+    approved_path = tmp_path / "approved.json"
+    receipt_path = tmp_path / "receipt.json"
+    issue_output = tmp_path / "issues" / "2026-08-28.json"
+    decision_output = tmp_path / "decisions" / "2026-08-28.json"
+    approved_path.write_text(json.dumps(approved))
+    receipt_path.write_text(json.dumps(receipt))
+    monkeypatch.setattr(sys, "argv", [
+        "seal_gravel_weekly_issue.py", str(approved_path),
+        "--published-at", "2026-08-28T16:05:00Z",
+        "--decision-receipt", str(receipt_path),
+        "--output", str(issue_output),
+        "--decision-output", str(decision_output),
+    ])
+
+    assert seal_issue_main() == 0
+    sealed = json.loads(issue_output.read_text())
+    canonical_receipt = json.loads(decision_output.read_text())
+    assert sealed["status"] == "published"
+    assert validate_decision_receipt(canonical_receipt, sealed) == receipt
+
+    orphan_output = tmp_path / "orphan.json"
+    monkeypatch.setattr(sys, "argv", [
+        "seal_gravel_weekly_issue.py", str(approved_path),
+        "--published-at", "2026-08-28T16:05:00Z",
+        "--decision-receipt", str(tmp_path / "missing.json"),
+        "--output", str(orphan_output),
+    ])
+    with pytest.raises(SystemExit, match="Decision receipt not found"):
+        seal_issue_main()
+    assert not orphan_output.exists()
 
 
 @pytest.mark.parametrize("gate_mutation", ["missing", "hold", "party_hold", "no_point", "friend_fail", "friend_kill", "no_mechanics"])
@@ -461,6 +528,9 @@ def test_deploy_path_and_legacy_redirect_are_wired():
     assert "issues: write" in workflow
     assert "render_gravel_weekly_race_impact_review.py" in workflow
     assert "meaningful-race-impact-count: 0" in workflow
+    assert "validate_decision_receipt" in workflow
+    assert "record_gravel_weekly_decisions.py" in workflow
+    assert "CONTROL_PLANE_INGEST_SECRET" in workflow
 
 
 def test_email_preserves_legacy_subscribers_and_uses_approved_issue():


### PR DESCRIPTION
## Summary
- emit a durable decision receipt beside every human-approved Gravel Weekly issue
- bind approved voice feedback to the exact model Take Matti reviewed
- require issue and receipt to seal together and validate the pair before publication
- mirror idempotent approve/reject outcomes into the control plane using the shared ingest credential

## Verification
- python3 -m pytest tests/test_gravel_weekly.py -q (24 passed)
- python3 -m pytest tests/ -q (7,280 passed, 331 skipped)
- python3 scripts/preflight_quality.py (passed; 7 existing warnings)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Publish now depends on a paired receipt and a pre-deploy control-plane ingest call; failures block deployment but do not change public site content until deploy succeeds.
> 
> **Overview**
> Gravel Weekly now keeps a **durable decision receipt** next to every deployable issue, so human approve/reject verdicts and voice edits cannot drift from what actually shipped.
> 
> **Approval and sealing** emit and require `data/gravel-weekly/decisions/YYYY-MM-DD.json` alongside the issue snapshot. Receipts bind each story to the reviewed draft hash, model **suggested** Take, human **approved** Take, and edit summary; `validate_decision_receipt` fails closed if approved copy does not match the issue. Reject paths now retain `reason` for the receipt. Sealing writes issue + receipt together and refuses a missing or mismatched receipt.
> 
> **Publish workflow** loads both files, validates the pair, then runs `record_gravel_weekly_decisions.py` to POST each `editorial-decision/v1` record to the race-intelligence control plane (Bearer `CONTROL_PLANE_INGEST_SECRET`) before site generation and deploy.
> 
> Docs and tests cover receipt construction, tamper detection, sealing without a receipt, and workflow wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00d5f2c424834989f54a0d8bf279cc85dec25409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->