### PR TITLE
Add GA4 conversion authority audit and cta_click correction

### DIFF
--- a/.github/workflows/ga4-conversion-audit.yml
+++ b/.github/workflows/ga4-conversion-audit.yml
@@ -1,0 +1,80 @@
+name: GA4 Conversion Authority Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Audit only, or remove cta_click from GA4 key events"
+        required: true
+        default: audit
+        type: choice
+        options:
+          - audit
+          - demote_cta_click
+      start_date:
+        description: "Report start date (YYYY-MM-DD)"
+        required: true
+        default: "2026-07-30"
+      end_date:
+        description: "Report end date (YYYY-MM-DD)"
+        required: true
+        default: "2026-08-26"
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Audit live GA4 conversion authority
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install GA4 client dependencies
+        run: pip install --quiet google-auth requests
+      - name: Validate and write service-account credentials
+        env:
+          GA4_CREDENTIALS_JSON: ${{ secrets.GA4_CREDENTIALS_JSON }}
+        run: |
+          python3 - <<'PY'
+          import json, os, pathlib
+          raw = os.environ.get("GA4_CREDENTIALS_JSON", "")
+          if not raw:
+              raise SystemExit("GA4_CREDENTIALS_JSON is not configured")
+          parsed = json.loads(raw)
+          required = {"client_email", "private_key", "token_uri"}
+          if not required.issubset(parsed):
+              raise SystemExit("GA4_CREDENTIALS_JSON has an invalid shape")
+          path = pathlib.Path(os.environ["RUNNER_TEMP"]) / "ga4-credentials.json"
+          path.write_text(json.dumps(parsed))
+          path.chmod(0o600)
+          PY
+      - name: Audit conversion authority
+        env:
+          GA4_PROPERTY_ID: ${{ secrets.GG_GA4_PROPERTY_ID }}
+          MODE: ${{ inputs.mode }}
+          START_DATE: ${{ inputs.start_date }}
+          END_DATE: ${{ inputs.end_date }}
+        run: |
+          if [ -z "$GA4_PROPERTY_ID" ]; then
+            echo "::error::GG_GA4_PROPERTY_ID is not configured"
+            exit 1
+          fi
+          python3 scripts/ga4_conversion_audit.py \
+            --property "$GA4_PROPERTY_ID" \
+            --credentials "${RUNNER_TEMP}/ga4-credentials.json" \
+            --start-date "$START_DATE" \
+            --end-date "$END_DATE" \
+            --mode "$MODE" \
+            --output "${RUNNER_TEMP}/ga4-conversion-audit.json"
+      - name: Upload audit receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: ga4-conversion-audit-${{ github.run_id }}
+          path: ${{ runner.temp }}/ga4-conversion-audit.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/GA4_CONVERSION_AUTHORITY.md
+++ b/docs/GA4_CONVERSION_AUTHORITY.md
@@ -1,0 +1,22 @@
+# GA4 conversion authority
+
+GA4 is the behavioral funnel record. It is not the financial source of truth.
+The provider ledger owns successful payment, refunds, fees, and cash settlement.
+
+The manual **GA4 Conversion Authority Audit** workflow reads the Gravel God GA4
+property through the existing service account and writes a receipt containing:
+
+- the live key-event registry before and after the requested action;
+- event counts, users, and key-event counts for the selected period;
+- purchase rows by `transactionId` and their reported purchase revenue;
+- controls for missing and duplicate transaction IDs; and
+- the exact key-event action taken.
+
+`audit` mode is entirely read-only. `demote_cta_click` can delete only the exact
+`cta_click` key-event resource belonging to the configured property. It then
+reads the registry again and fails if `cta_click` remains keyed. The underlying
+`cta_click` event continues to be collected as a diagnostic funnel event.
+
+This correction intentionally does not mark additional events as key events.
+Each promoted event must first prove a durable business outcome and a stable
+join to the canonical customer/order/payment model.

--- a/scripts/ga4_conversion_audit.py
+++ b/scripts/ga4_conversion_audit.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Audit and narrowly correct Gravel God GA4 key-event configuration.
+
+The default mode is read-only.  The only supported mutation removes
+``cta_click`` from the property's key-event registry, then reads the registry
+again and records before/after state.  Event collection is not changed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ADMIN_ROOT = "https://analyticsadmin.googleapis.com/v1beta"
+DATA_ROOT = "https://analyticsdata.googleapis.com/v1beta"
+READ_SCOPE = "https://www.googleapis.com/auth/analytics.readonly"
+EDIT_SCOPE = "https://www.googleapis.com/auth/analytics.edit"
+PROPERTY_RE = re.compile(r"^properties/(\d+)$")
+KEY_EVENT_RE = re.compile(r"^properties/(\d+)/keyEvents/([^/]+)$")
+MAX_PAGES = 20
+
+
+class Ga4AuditError(RuntimeError):
+    """Safe operator-facing failure."""
+
+
+def normalize_property(value: str) -> str:
+    candidate = str(value or "").strip()
+    if candidate.isdigit():
+        candidate = f"properties/{candidate}"
+    if not PROPERTY_RE.fullmatch(candidate):
+        raise Ga4AuditError(
+            "property must be a numeric GA4 property ID or properties/ID")
+    return candidate
+
+
+def parse_window(start_date: str, end_date: str) -> tuple[date, date]:
+    try:
+        start = date.fromisoformat(start_date)
+        end = date.fromisoformat(end_date)
+    except (TypeError, ValueError) as exc:
+        raise Ga4AuditError("dates must use YYYY-MM-DD") from exc
+    if end < start:
+        raise Ga4AuditError("end date must be on or after start date")
+    if (end - start).days > 92:
+        raise Ga4AuditError("audit window must be 93 days or fewer")
+    return start, end
+
+
+def authorized_session(credentials_path: Path, edit: bool = False):
+    from google.auth.transport.requests import AuthorizedSession
+    from google.oauth2.service_account import Credentials
+
+    scopes = [READ_SCOPE, EDIT_SCOPE] if edit else [READ_SCOPE]
+    credentials = Credentials.from_service_account_file(
+        str(credentials_path), scopes=scopes)
+    return AuthorizedSession(credentials)
+
+
+def _json_response(response: Any, operation: str) -> dict:
+    status = int(getattr(response, "status_code", 0) or 0)
+    if status < 200 or status >= 300:
+        error_status = "unknown"
+        try:
+            body = response.json()
+            error_status = str(
+                (body.get("error") or {}).get("status") or "unknown")[:80]
+        except (TypeError, ValueError, AttributeError):
+            pass
+        raise Ga4AuditError(
+            f"{operation} failed (HTTP {status}, status={error_status})")
+    if status == 204 or not getattr(response, "content", b""):
+        return {}
+    try:
+        body = response.json()
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise Ga4AuditError(f"{operation} returned invalid JSON") from exc
+    if not isinstance(body, dict):
+        raise Ga4AuditError(f"{operation} returned an invalid response shape")
+    return body
+
+
+def list_key_events(session: Any, property_name: str) -> list[dict]:
+    events = []
+    page_token = ""
+    for _ in range(MAX_PAGES):
+        params = {"pageSize": 200}
+        if page_token:
+            params["pageToken"] = page_token
+        response = session.get(
+            f"{ADMIN_ROOT}/{property_name}/keyEvents", params=params,
+            timeout=30)
+        body = _json_response(response, "key-event list")
+        for event in body.get("keyEvents") or []:
+            if not isinstance(event, dict):
+                continue
+            name = str(event.get("name") or "")
+            event_name = str(event.get("eventName") or "")
+            if not KEY_EVENT_RE.fullmatch(name) or not event_name:
+                raise Ga4AuditError("key-event list returned an invalid resource")
+            events.append({
+                "name": name,
+                "event_name": event_name,
+                "counting_method": str(event.get("countingMethod") or "unspecified"),
+                "default_value": event.get("defaultValue"),
+                "create_time": str(event.get("createTime") or ""),
+            })
+        page_token = str(body.get("nextPageToken") or "")
+        if not page_token:
+            return sorted(events, key=lambda item: item["event_name"])
+    raise Ga4AuditError("key-event pagination exceeded the safety limit")
+
+
+def _run_report(session: Any, property_name: str, body: dict,
+                operation: str) -> dict:
+    response = session.post(
+        f"{DATA_ROOT}/{property_name}:runReport", json=body, timeout=60)
+    return _json_response(response, operation)
+
+
+def _metric_map(report: dict, row: dict) -> dict[str, str]:
+    headers = [str(item.get("name") or "")
+               for item in report.get("metricHeaders") or []]
+    values = [str(item.get("value") or "0")
+              for item in row.get("metricValues") or []]
+    return dict(zip(headers, values))
+
+
+def event_report(session: Any, property_name: str,
+                 start: date, end: date) -> list[dict]:
+    body = {
+        "dateRanges": [{"startDate": start.isoformat(),
+                        "endDate": end.isoformat()}],
+        "dimensions": [{"name": "eventName"}],
+        "metrics": [
+            {"name": "eventCount"},
+            {"name": "totalUsers"},
+            {"name": "keyEvents"},
+        ],
+        "limit": "10000",
+    }
+    report = _run_report(
+        session, property_name, body, "event performance report")
+    rows = []
+    for row in report.get("rows") or []:
+        dimensions = row.get("dimensionValues") or []
+        event_name = str((dimensions[0] if dimensions else {}).get("value") or "")
+        if not event_name:
+            continue
+        metrics = _metric_map(report, row)
+        rows.append({
+            "event_name": event_name,
+            "event_count": int(float(metrics.get("eventCount", "0"))),
+            "total_users": int(float(metrics.get("totalUsers", "0"))),
+            "key_events": float(metrics.get("keyEvents", "0")),
+        })
+    return sorted(rows, key=lambda item: (-item["key_events"], item["event_name"]))
+
+
+def purchase_report(session: Any, property_name: str,
+                    start: date, end: date) -> list[dict]:
+    body = {
+        "dateRanges": [{"startDate": start.isoformat(),
+                        "endDate": end.isoformat()}],
+        "dimensions": [{"name": "transactionId"}],
+        "metrics": [
+            {"name": "eventCount"},
+            {"name": "totalUsers"},
+            {"name": "purchaseRevenue"},
+        ],
+        "dimensionFilter": {
+            "filter": {
+                "fieldName": "eventName",
+                "stringFilter": {
+                    "matchType": "EXACT", "value": "purchase",
+                    "caseSensitive": True,
+                },
+            },
+        },
+        "limit": "10000",
+    }
+    report = _run_report(
+        session, property_name, body, "purchase transaction report")
+    rows = []
+    for row in report.get("rows") or []:
+        dimensions = row.get("dimensionValues") or []
+        transaction_id = str(
+            (dimensions[0] if dimensions else {}).get("value") or "(not set)")
+        metrics = _metric_map(report, row)
+        rows.append({
+            # Transaction IDs are retained because they are the required
+            # reconciliation join and are not customer PII.
+            "transaction_id": transaction_id,
+            "event_count": int(float(metrics.get("eventCount", "0"))),
+            "total_users": int(float(metrics.get("totalUsers", "0"))),
+            "purchase_revenue": float(metrics.get("purchaseRevenue", "0")),
+        })
+    return sorted(rows, key=lambda item: item["transaction_id"])
+
+
+def _event_controls(events: list[dict], key_events: list[dict]) -> dict:
+    keyed_names = {item["event_name"] for item in key_events}
+    key_rows = [item for item in events if item["event_name"] in keyed_names]
+    total = sum(item["key_events"] for item in key_rows)
+    cta = next((item for item in key_rows
+                if item["event_name"] == "cta_click"), None)
+    return {
+        "configured_key_event_count": len(key_events),
+        "observed_key_events": total,
+        "cta_click_key_events": cta["key_events"] if cta else 0,
+        "cta_click_share_of_observed_key_events": (
+            round(cta["key_events"] / total, 6) if cta and total else 0),
+    }
+
+
+def _purchase_controls(rows: list[dict]) -> dict:
+    missing = {"", "(not set)", "(other)"}
+    reported = [item for item in rows if item["transaction_id"] not in missing]
+    return {
+        "purchase_events": sum(item["event_count"] for item in rows),
+        "reported_transaction_ids": len(reported),
+        "missing_transaction_id_events": sum(
+            item["event_count"] for item in rows
+            if item["transaction_id"] in missing),
+        "duplicate_transaction_id_rows": sum(
+            1 for item in reported if item["event_count"] > 1),
+        "purchase_revenue": round(
+            sum(item["purchase_revenue"] for item in rows), 2),
+    }
+
+
+def build_audit(session: Any, property_name: str, start: date, end: date,
+                mode: str = "audit") -> dict:
+    before = list_key_events(session, property_name)
+    events = event_report(session, property_name, start, end)
+    purchases = purchase_report(session, property_name, start, end)
+    action = {
+        "requested": mode,
+        "status": "read_only",
+        "deleted_resource": "",
+    }
+    after = before
+    if mode == "demote_cta_click":
+        matches = [item for item in before if item["event_name"] == "cta_click"]
+        if len(matches) > 1:
+            raise Ga4AuditError("multiple cta_click key-event resources found")
+        if matches:
+            resource = matches[0]["name"]
+            match = KEY_EVENT_RE.fullmatch(resource)
+            property_id = PROPERTY_RE.fullmatch(property_name).group(1)
+            if not match or match.group(1) != property_id:
+                raise Ga4AuditError("cta_click resource does not belong to the property")
+            response = session.delete(
+                f"{ADMIN_ROOT}/{resource}", timeout=30)
+            _json_response(response, "cta_click key-event deletion")
+            action = {
+                "requested": mode,
+                "status": "deleted",
+                "deleted_resource": resource,
+            }
+            after = list_key_events(session, property_name)
+            if any(item["event_name"] == "cta_click" for item in after):
+                raise Ga4AuditError("cta_click remained a key event after deletion")
+        else:
+            action = {
+                "requested": mode,
+                "status": "already_not_a_key_event",
+                "deleted_resource": "",
+            }
+
+    return {
+        "schema": "ga4_conversion_authority_audit/v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "property": property_name,
+        "period": {
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+            "timezone": "property_reporting_timezone",
+        },
+        "key_events_before": before,
+        "key_events_after": after,
+        "event_performance": events,
+        "purchase_transactions": purchases,
+        "controls": {
+            "before": _event_controls(events, before),
+            "after": _event_controls(events, after),
+            "purchases": _purchase_controls(purchases),
+        },
+        "action": action,
+        "boundaries": [
+            "GA4 is behavioral evidence and does not establish collected cash.",
+            "Reports can change during the GA4 attribution and processing window.",
+            "Key-event deletion does not stop collection of the underlying event.",
+            "Purchase transaction IDs still require a provider-ledger join.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--property", required=True)
+    parser.add_argument("--credentials", type=Path, required=True)
+    parser.add_argument("--start-date", required=True)
+    parser.add_argument("--end-date", required=True)
+    parser.add_argument("--mode", choices=("audit", "demote_cta_click"),
+                        default="audit")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    property_name = normalize_property(args.property)
+    start, end = parse_window(args.start_date, args.end_date)
+    session = authorized_session(
+        args.credentials, edit=args.mode == "demote_cta_click")
+    receipt = build_audit(session, property_name, start, end, mode=args.mode)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    print(json.dumps({
+        "schema": receipt["schema"],
+        "property": receipt["property"],
+        "period": receipt["period"],
+        "controls": receipt["controls"],
+        "action": receipt["action"],
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ga4_conversion_audit.py
+++ b/tests/test_ga4_conversion_audit.py
@@ -1,0 +1,156 @@
+import importlib.util
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "ga4_conversion_audit.py"
+SPEC = importlib.util.spec_from_file_location("ga4_conversion_audit", SCRIPT)
+audit = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(audit)
+
+
+class Response:
+    def __init__(self, body=None, status=200):
+        self._body = {} if body is None else body
+        self.status_code = status
+        self.content = b"" if status == 204 else b"{}"
+
+    def json(self):
+        return self._body
+
+
+class Session:
+    def __init__(self):
+        self.deleted = []
+        self.after_delete = False
+        self.posts = 0
+
+    @staticmethod
+    def _key_events(include_cta=True):
+        rows = [{
+            "name": "properties/123/keyEvents/purchase-key",
+            "eventName": "purchase", "countingMethod": "ONCE_PER_EVENT",
+        }, {
+            "name": "properties/123/keyEvents/email-key",
+            "eventName": "email_capture", "countingMethod": "ONCE_PER_EVENT",
+        }]
+        if include_cta:
+            rows.append({
+                "name": "properties/123/keyEvents/cta-key",
+                "eventName": "cta_click", "countingMethod": "ONCE_PER_EVENT",
+            })
+        return rows
+
+    def get(self, url, **kwargs):
+        assert url.endswith("/properties/123/keyEvents")
+        return Response({"keyEvents": self._key_events(not self.after_delete)})
+
+    def post(self, url, json=None, **kwargs):
+        assert url.endswith("/properties/123:runReport")
+        self.posts += 1
+        if self.posts == 1:
+            return Response({
+                "metricHeaders": [
+                    {"name": "eventCount"}, {"name": "totalUsers"},
+                    {"name": "keyEvents"},
+                ],
+                "rows": [
+                    {"dimensionValues": [{"value": "cta_click"}],
+                     "metricValues": [
+                         {"value": "178"}, {"value": "132"}, {"value": "178"}]},
+                    {"dimensionValues": [{"value": "purchase"}],
+                     "metricValues": [
+                         {"value": "7"}, {"value": "7"}, {"value": "7"}]},
+                    {"dimensionValues": [{"value": "email_capture"}],
+                     "metricValues": [
+                         {"value": "9"}, {"value": "9"}, {"value": "9"}]},
+                ],
+            })
+        return Response({
+            "metricHeaders": [
+                {"name": "eventCount"}, {"name": "totalUsers"},
+                {"name": "purchaseRevenue"},
+            ],
+            "rows": [
+                {"dimensionValues": [{"value": "order-1"}],
+                 "metricValues": [
+                     {"value": "2"}, {"value": "1"}, {"value": "200"}]},
+                {"dimensionValues": [{"value": "(not set)"}],
+                 "metricValues": [
+                     {"value": "1"}, {"value": "1"}, {"value": "145"}]},
+            ],
+        })
+
+    def delete(self, url, **kwargs):
+        self.deleted.append(url)
+        self.after_delete = True
+        return Response({}, status=200)
+
+
+def test_normalization_and_window_validation():
+    assert audit.normalize_property("123") == "properties/123"
+    assert audit.normalize_property("properties/123") == "properties/123"
+    with pytest.raises(audit.Ga4AuditError):
+        audit.normalize_property("accounts/123")
+    assert audit.parse_window("2026-07-30", "2026-08-26") == (
+        date(2026, 7, 30), date(2026, 8, 26))
+    with pytest.raises(audit.Ga4AuditError):
+        audit.parse_window("2026-08-27", "2026-08-26")
+
+
+def test_read_only_audit_preserves_key_events_and_surfaces_authority_gaps():
+    session = Session()
+    receipt = audit.build_audit(
+        session, "properties/123", date(2026, 7, 30), date(2026, 8, 26))
+
+    assert session.deleted == []
+    assert receipt["action"]["status"] == "read_only"
+    assert receipt["controls"]["before"] == {
+        "configured_key_event_count": 3,
+        "observed_key_events": 194.0,
+        "cta_click_key_events": 178.0,
+        "cta_click_share_of_observed_key_events": 0.917526,
+    }
+    assert receipt["controls"]["purchases"] == {
+        "purchase_events": 3,
+        "reported_transaction_ids": 1,
+        "missing_transaction_id_events": 1,
+        "duplicate_transaction_id_rows": 1,
+        "purchase_revenue": 345.0,
+    }
+
+
+def test_demote_cta_click_deletes_only_the_exact_key_event_and_reads_back():
+    session = Session()
+    receipt = audit.build_audit(
+        session, "properties/123", date(2026, 7, 30), date(2026, 8, 26),
+        mode="demote_cta_click")
+
+    assert session.deleted == [
+        f"{audit.ADMIN_ROOT}/properties/123/keyEvents/cta-key"]
+    assert receipt["action"]["status"] == "deleted"
+    assert {item["event_name"] for item in receipt["key_events_after"]} == {
+        "purchase", "email_capture"}
+    assert receipt["controls"]["after"]["cta_click_key_events"] == 0
+
+
+def test_demote_is_idempotent_when_cta_click_is_already_not_keyed():
+    session = Session()
+    session.after_delete = True
+    receipt = audit.build_audit(
+        session, "properties/123", date(2026, 7, 30), date(2026, 8, 26),
+        mode="demote_cta_click")
+    assert session.deleted == []
+    assert receipt["action"]["status"] == "already_not_a_key_event"
+
+
+def test_provider_errors_are_sanitized():
+    response = Response({
+        "error": {"status": "PERMISSION_DENIED", "message": "secret detail"}},
+        status=403)
+    with pytest.raises(audit.Ga4AuditError) as error:
+        audit._json_response(response, "key-event list")
+    assert "PERMISSION_DENIED" in str(error.value)
+    assert "secret detail" not in str(error.value)


### PR DESCRIPTION
## Outcome

Adds an authenticated GA4 conversion-authority receipt using the existing Gravel God service account. Audit mode is read-only. The sole supported mutation removes `cta_click` from the GA4 key-event registry, then reads the registry back and fails closed if the event remains keyed.

## Receipt

- live key-event resources before/after
- event counts, users, and key-event counts
- purchase revenue by `transactionId`
- missing and duplicate transaction-ID controls
- exact action status and evidence boundaries

`cta_click` remains collected as a diagnostic event. This does not promote any new event or claim GA4 as financial truth.

## Verification

- focused tests: 5 passed
- Python 3.11 compile: passed
- workflow YAML parse and shell syntax: passed
- diff check: passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `demote_cta_click` mutates live GA4 key-event configuration via the Admin API; scope is narrow and manual, but it affects how conversions are reported in GA4.
> 
> **Overview**
> Adds a **manual GitHub Actions workflow** and `scripts/ga4_conversion_audit.py` to produce a JSON **conversion-authority receipt** for the Gravel God GA4 property (reusing `GA4_CREDENTIALS_JSON` and `GG_GA4_PROPERTY_ID`).
> 
> **Audit** mode is read-only: live key-event registry, event performance (counts/users/key events), purchase rows by `transactionId`, and controls for missing/duplicate IDs and `cta_click` share of keyed conversions.
> 
> **`demote_cta_click`** is the only mutation: it deletes the property-scoped `cta_click` key-event resource, re-lists the registry, and **fails** if `cta_click` is still keyed. Collection of `cta_click` as a normal event is unchanged; no new events are promoted. Docs in `docs/GA4_CONVERSION_AUTHORITY.md` state GA4 is behavioral, not financial truth.
> 
> Tests cover read-only receipts, demotion/idempotency, and sanitized API errors. The workflow uploads the receipt as a 30-day artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a650531e0a2806e1639c543c5a7b9b89eaf7cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->