### PR TITLE
feat: canonicalize standalone Stripe revenue

### DIFF
--- a/.github/workflows/stripe-provider-ingestion.yml
+++ b/.github/workflows/stripe-provider-ingestion.yml
@@ -1,0 +1,119 @@
+name: Stripe Provider Truth Ingestion
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: Successful athlete-pipeline Stripe reconciliation run ID
+        required: true
+        type: string
+      confirm:
+        description: Type APPLY_STRIPE_PROVIDER_TRUTH
+        required: true
+        type: string
+  repository_dispatch:
+    types: [stripe_provider_receipt_ready]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stripe-provider-truth
+  cancel-in-progress: false
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SOURCE_REPOSITORY: wattgod/athlete-custom-training-plan-pipeline
+      SOURCE_RUN_ID: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.source_run_id || inputs.source_run_id }}
+      SOURCE_ARTIFACT: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.artifact_name || format('stripe-reconciliation-{0}', inputs.source_run_id) }}
+      APPLY_CONFIRM: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.confirm || inputs.confirm }}
+      GH_TOKEN: ${{ secrets.GH_PAT }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+    steps:
+      - name: Validate dispatch authority
+        env:
+          DISPATCH_SOURCE_REPOSITORY: ${{ github.event.client_payload.source_repository }}
+        run: |
+          if ! [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "::error::source_run_id must be a GitHub Actions run ID"
+            exit 1
+          fi
+          if [ "$APPLY_CONFIRM" != "APPLY_STRIPE_PROVIDER_TRUTH" ]; then
+            echo "::error::Explicit provider-truth confirmation is missing"
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "repository_dispatch" ] && \
+             [ "$DISPATCH_SOURCE_REPOSITORY" != "$SOURCE_REPOSITORY" ]; then
+            echo "::error::Untrusted source repository"
+            exit 1
+          fi
+          if [ -z "$GH_TOKEN" ] || [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_KEY" ]; then
+            echo "::error::GH_PAT and Mission Control Supabase secrets are required"
+            exit 1
+          fi
+
+      - name: Verify source workflow run
+        run: |
+          gh api "repos/$SOURCE_REPOSITORY/actions/runs/$SOURCE_RUN_ID" > "$RUNNER_TEMP/source-run.json"
+          python3 - <<'PY'
+          import json, os, pathlib
+          run = json.loads((pathlib.Path(os.environ["RUNNER_TEMP"]) / "source-run.json").read_text())
+          expected = {
+              "name": "Stripe Revenue Reconciliation",
+              "head_branch": "main",
+              "event": "workflow_dispatch",
+              "conclusion": "success",
+          }
+          failures = {key: run.get(key) for key, value in expected.items() if run.get(key) != value}
+          if failures:
+              raise SystemExit(f"source workflow is not an accepted successful main run: {failures}")
+          print({"run_id": run["id"], "head_sha": run["head_sha"], "conclusion": run["conclusion"]})
+          PY
+
+      - name: Download sanitized source receipt
+        run: |
+          mkdir -p "$RUNNER_TEMP/source"
+          gh run download "$SOURCE_RUN_ID" \
+            --repo "$SOURCE_REPOSITORY" \
+            --name "$SOURCE_ARTIFACT" \
+            --dir "$RUNNER_TEMP/source"
+          test -s "$RUNNER_TEMP/source/stripe-reconciliation.json"
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install canonical runtime
+        run: pip install -r requirements.txt
+
+      - name: Fail-closed dry run
+        run: |
+          python scripts/import_stripe_provider_revenue.py \
+            --receipt-file "$RUNNER_TEMP/source/stripe-reconciliation.json" \
+            --output-receipt "$RUNNER_TEMP/stripe-provider-dry-run.json"
+
+      - name: Apply and verify direct readback
+        run: |
+          python scripts/import_stripe_provider_revenue.py \
+            --receipt-file "$RUNNER_TEMP/source/stripe-reconciliation.json" \
+            --apply --confirm APPLY_STRIPE_PROVIDER_TRUTH \
+            --output-receipt "$RUNNER_TEMP/stripe-provider-apply.json"
+
+      - name: Upload ingestion receipts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stripe-provider-ingestion-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/source-run.json
+            ${{ runner.temp }}/stripe-provider-dry-run.json
+            ${{ runner.temp }}/stripe-provider-apply.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Run tests
         run: |
           pytest tests/ -q --tb=short
+          pytest \
+            mission_control/tests/test_provider_ingestion.py \
+            mission_control/tests/test_stripe_provider_ingestion.py \
+            -q --tb=short
 
       - name: Validate citations
         run: |
@@ -58,4 +62,3 @@ jobs:
       - name: Check citation quality
         run: |
           python scripts/audit_citation_quality.py 2>&1 | tail -20
-

--- a/docs/stripe-provider-revenue-ingestion.md
+++ b/docs/stripe-provider-revenue-ingestion.md
@@ -1,0 +1,109 @@
+# Standalone Stripe provider ingestion
+
+Mission Control ingests the authenticated, privacy-safe standalone Stripe
+receipt as a separate revenue authority. This path is operationally isolated
+from Checkout and fulfillment: an export, validation, or database failure never
+blocks or changes a customer order.
+
+## Canonical mapping
+
+| Receipt evidence | Destination | Financial meaning |
+| --- | --- | --- |
+| Successful charges | `gg_payments` | Settlement-currency gross, processing adjustment, and net. Purchaser presentment money remains labeled in metadata. |
+| Succeeded refunds | `gg_payments` | Separate negative payment rows. The original charge may be outside the bounded receipt period. |
+| Paid payouts | `gg_provider_payouts` | Positive provider payout amount. Bank destination and deposit matching remain out of scope. |
+| All balance transactions | `gg_provider_balance_transactions` | Settlement ledger for charges, refunds, provider fees, and payouts. |
+| Created-at monthly controls | `gg_provider_monthly_controls` | Monthly charge, refund, payout, Checkout, offer-allocation, and balance controls. |
+
+Raw Stripe IDs, names, email addresses, payment methods, and bank destinations
+are rejected. Stable `srk_…` keys are server-HMAC references, not reversible
+provider identifiers. The importer validates every reported total from source
+rows, checks paid Checkout-to-charge joins, verifies charge/refund/payout links
+through the balance ledger, requires complete paid-invoice line items, and then
+applies pinned 2026-08-27 controls.
+
+## Migration plan
+
+Apply
+[`20260828000001_stripe_provider_balance_truth.sql`](../supabase/migrations/20260828000001_stripe_provider_balance_truth.sql)
+before enabling apply mode.
+
+- Lock profile: one new-table catalog lock and indexes built on that empty
+  table. Existing `gg_payments` and provider rows are not rewritten.
+- Runtime risk: no Checkout, fulfillment, email, or customer-facing path reads
+  this table. Import failures are reporting failures only.
+- Idempotency: the table is unique on provider, account, and HMAC record key;
+  every canonical destination is upserted with its real unique key.
+- Production-like proof: validate the full authenticated 1,685-row receipt,
+  apply it, repeat the exact apply, and require identical row keys and totals on
+  direct service-role readback.
+
+## Runbook
+
+Dry-run without database credentials or writes:
+
+```bash
+python3 scripts/import_stripe_provider_revenue.py \
+  --receipt-file /absolute/path/to/stripe-reconciliation.json \
+  --output-receipt /absolute/path/to/stripe-provider-dry-run.json
+```
+
+Apply after the migration:
+
+```bash
+python3 scripts/import_stripe_provider_revenue.py \
+  --receipt-file /absolute/path/to/stripe-reconciliation.json \
+  --apply --confirm APPLY_STRIPE_PROVIDER_TRUTH \
+  --output-receipt /absolute/path/to/stripe-provider-apply.json
+```
+
+Apply mode uses `SUPABASE_URL` and `SUPABASE_SERVICE_KEY`. The apply receipt is
+not successful until direct readback proves the exact batch key sets, row
+counts, and financial sums. A rerun is safe after an interrupted upsert.
+
+## Pinned baseline
+
+The production 2025-08-27 through 2026-08-27 receipt must validate to:
+
+- 1,685 raw sanitized rows and 92 canonical payment rows: 91 successful
+  charges plus one separate refund;
+- $2,273.70 settlement charge activity, $194.16 processing fees, and $2,079.54
+  charge net;
+- $6.92 of separate fee net and a $1.30 refund, yielding 70 paid payouts and
+  $2,071.32;
+- a zero-cent settlement cash loop and zero current available/pending balance;
+- six custom-plan charges for $1,023 and two consulting charges for $300;
+- 83 merchant-label-ambiguous recurring charges: 82 USD charges for $945 and
+  one EUR charge for €5;
+- 876 synthetic expired/unpaid monitor Sessions excluded from abandonment,
+  217 non-synthetic expired/unpaid Sessions, and eight paid Sessions.
+
+`--skip-2026-08-27-controls` is for tests or a reviewed period rollover. It is
+not an override for a failing production receipt.
+
+## Deploy order
+
+1. Ship the exporter source-link correction and create a fresh receipt.
+2. Merge the Mission Control migration, importer, tests, and ingestion workflow.
+3. Apply the migration and verify the new table is service-role-only.
+4. Manually ingest the fresh receipt twice and prove idempotent live readback.
+5. Only then enable the exporter repository dispatch for recurring ingestion.
+
+## Rollback
+
+Disable `.github/workflows/stripe-provider-ingestion.yml` first. The importer
+does not delete rows that disappear from a later rolling receipt; reviewed
+corrections remain forward migrations.
+
+For a code-only rollback, revert the importer/workflow commit. For an exact data
+rollback before downstream adoption, delete only rows whose provider is
+`stripe` and whose provider account equals the imported HMAC account key, then
+delete their matching import batches. For a schema rollback after those rows
+are gone:
+
+```sql
+drop table if exists gg_provider_balance_transactions;
+```
+
+Never drop `gg_payments`, `gg_provider_payouts`, or
+`gg_provider_monthly_controls`; they also contain TrainingPeaks evidence.

--- a/mission_control/services/stripe_provider_ingestion.py
+++ b/mission_control/services/stripe_provider_ingestion.py
@@ -1,0 +1,1171 @@
+"""Fail-closed ingestion of the privacy-safe standalone Stripe receipt."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from mission_control.services.provider_ingestion import ProviderIngestionError
+
+db: Any | None = None
+
+SCHEMA = "stripe_revenue_reconciliation/v1"
+PROVIDER = "stripe"
+SOURCE_KIND = "reconciliation_receipt"
+RECORD_KEY_KIND = "hmac_sha256_provider_id_v1"
+MONTHLY_SOURCE_KIND = "stripe_reconciliation"
+RECORD_KEY_RE = re.compile(r"^srk_[0-9a-f]{64}$")
+EMAIL_RE = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.IGNORECASE)
+RAW_STRIPE_ID_RE = re.compile(
+    r"\b(?:acct|cs|pi|cus|ch|re|po|txn|sub|in|prod|price)_[A-Za-z0-9_]+\b"
+)
+
+FORBIDDEN_KEYS = {
+    "email",
+    "phone",
+    "address",
+    "billing_details",
+    "shipping",
+    "payment_method",
+    "payment_method_details",
+    "bank_account",
+    "bank_destination",
+    "destination",
+    "receipt_url",
+    "customer_name",
+    "athlete_name",
+    "contact_name",
+    "first_name",
+    "last_name",
+    "description",
+    "price_nickname",
+}
+
+REQUIRED_INVOICE_LINE_FIELDS = {
+    "price_record_key",
+    "product_record_key",
+    "merchant_product_name",
+    "offer_family",
+    "currency",
+    "amount_cents",
+    "quantity",
+    "period_start_at",
+    "period_end_at",
+}
+
+REQUIRED_ROW_FIELDS = {
+    "products": {
+        "record_key",
+        "created_at",
+        "name",
+        "offer_family",
+        "active",
+        "livemode",
+    },
+    "prices": {
+        "record_key",
+        "product_record_key",
+        "created_at",
+        "currency",
+        "unit_amount_cents",
+        "recurring_interval",
+        "recurring_interval_count",
+        "offer_family",
+        "active",
+        "livemode",
+    },
+    "checkout_sessions": {
+        "record_key",
+        "payment_intent_record_key",
+        "subscription_record_key",
+        "customer_record_key",
+        "created_at",
+        "currency",
+        "amount_total_cents",
+        "amount_discount_cents",
+        "amount_tax_cents",
+        "status",
+        "payment_status",
+        "mode",
+        "offer_family",
+        "brand",
+        "synthetic",
+        "livemode",
+    },
+    "invoices": {
+        "record_key",
+        "subscription_record_key",
+        "customer_record_key",
+        "created_at",
+        "currency",
+        "status",
+        "amount_due_cents",
+        "amount_paid_cents",
+        "amount_remaining_cents",
+        "offer_family",
+        "brand",
+        "line_items",
+        "line_items_complete",
+        "livemode",
+    },
+    "charges": {
+        "record_key",
+        "payment_intent_record_key",
+        "invoice_record_key",
+        "customer_record_key",
+        "balance_transaction_record_key",
+        "created_at",
+        "currency",
+        "status",
+        "paid",
+        "captured",
+        "disputed",
+        "gross_cents",
+        "refunded_cents",
+        "gross_less_refunds_cents",
+        "offer_family",
+        "brand",
+        "livemode",
+    },
+    "refunds": {
+        "record_key",
+        "charge_record_key",
+        "payment_intent_record_key",
+        "balance_transaction_record_key",
+        "created_at",
+        "currency",
+        "status",
+        "amount_cents",
+    },
+    "balance_transactions": {
+        "record_key",
+        "source_record_key",
+        "created_at",
+        "available_at",
+        "currency",
+        "type",
+        "reporting_category",
+        "status",
+        "amount_cents",
+        "fee_cents",
+        "net_cents",
+    },
+    "payouts": {
+        "record_key",
+        "balance_transaction_record_key",
+        "created_at",
+        "arrival_at",
+        "currency",
+        "status",
+        "amount_cents",
+        "automatic",
+    },
+}
+
+EXPECTED_2026_08_27 = {
+    "period": {
+        "start_date": "2025-08-27",
+        "end_date_inclusive": "2026-08-27",
+        "timezone": "UTC",
+    },
+    "raw_rows": {
+        "products": 17,
+        "prices": 52,
+        "checkout_sessions": 1101,
+        "invoices": 89,
+        "charges": 121,
+        "refunds": 1,
+        "balance_transactions": 234,
+        "payouts": 70,
+    },
+    "successful_charges": {
+        "eur": {"count": 1, "amount_cents": 500},
+        "usd": {"count": 90, "amount_cents": 226800},
+    },
+    "succeeded_refunds": {"usd": {"count": 1, "amount_cents": 130}},
+    "paid_payouts": {"usd": {"count": 70, "amount_cents": 207132}},
+    "paid_invoices": {
+        "eur": {"count": 1, "amount_cents": 500},
+        "usd": {"count": 82, "amount_cents": 94500},
+    },
+    "balance_activity_by_category": {
+        "usd": {
+            "charge": {
+                "count": 91,
+                "amount_cents": 227370,
+                "fee_cents": 19416,
+                "net_cents": 207954,
+            },
+            "fee": {
+                "count": 72,
+                "amount_cents": -680,
+                "fee_cents": 12,
+                "net_cents": -692,
+            },
+            "payout": {
+                "count": 70,
+                "amount_cents": -207132,
+                "fee_cents": 0,
+                "net_cents": -207132,
+            },
+            "refund": {
+                "count": 1,
+                "amount_cents": -130,
+                "fee_cents": 0,
+                "net_cents": -130,
+            },
+        },
+    },
+    "current_balance": {"usd": {"available_cents": 0, "pending_cents": 0}},
+    "checkout_sessions": {
+        "synthetic_expired_unpaid": 876,
+        "non_synthetic_expired_unpaid": 217,
+        "non_synthetic_paid": 8,
+    },
+    "offer_allocation": {
+        "consulting": {"usd": {"count": 2, "amount_cents": 30000}},
+        "training_plan": {"usd": {"count": 6, "amount_cents": 102300}},
+        "unknown": {
+            "eur": {"count": 1, "amount_cents": 500},
+            "usd": {"count": 82, "amount_cents": 94500},
+        },
+    },
+    "invoice_line_items_complete": 89,
+}
+
+
+@dataclass
+class StripeImportBundle:
+    observed_at: str
+    batch: dict[str, Any]
+    payments: list[dict[str, Any]]
+    payouts: list[dict[str, Any]]
+    balance_transactions: list[dict[str, Any]]
+    monthly_controls: list[dict[str, Any]]
+    controls: dict[str, Any]
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "status": "VALIDATED",
+            "observed_at": self.observed_at,
+            "provider_account": self.batch["provider_account"],
+            "source_payload_sha256": self.batch["source_payload_sha256"],
+            "source_rows": self.batch["row_count"],
+            "canonical_rows": {
+                "gg_payments": len(self.payments),
+                "gg_provider_payouts": len(self.payouts),
+                "gg_provider_balance_transactions": len(self.balance_transactions),
+                "gg_provider_monthly_controls": len(self.monthly_controls),
+            },
+            "controls": self.controls,
+            "identity_boundary": (
+                "Provider and customer identities are stable HMAC record keys; raw Stripe "
+                "IDs and customer PII are absent. GA4 transaction IDs remain unjoined."
+            ),
+        }
+
+
+def _record_sha256(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _payload_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _timestamp(value: Any, field: str, *, allow_empty: bool = False) -> str | None:
+    cleaned = str(value or "").strip()
+    if not cleaned and allow_empty:
+        return None
+    try:
+        parsed = datetime.fromisoformat(cleaned.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ProviderIngestionError(
+            f"Invalid timezone-aware timestamp for {field}"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise ProviderIngestionError(f"Timestamp must include a timezone for {field}")
+    return parsed.isoformat()
+
+
+def _integer(value: Any, field: str) -> int:
+    if isinstance(value, bool):
+        raise ProviderIngestionError(f"Boolean is not an integer for {field}")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ProviderIngestionError(f"Invalid integer for {field}: {value!r}") from exc
+
+
+def _money_from_cents(value: Any, field: str) -> str:
+    cents = _integer(value, field)
+    return format((Decimal(cents) / Decimal(100)).quantize(Decimal("0.01")), "f")
+
+
+def _decimal(value: Any, field: str) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError) as exc:
+        raise ProviderIngestionError(f"Invalid decimal for {field}: {value!r}") from exc
+
+
+def _assert_record_key(value: Any, field: str, *, allow_empty: bool = False) -> str:
+    candidate = str(value or "")
+    if allow_empty and not candidate:
+        return ""
+    if not RECORD_KEY_RE.fullmatch(candidate):
+        raise ProviderIngestionError(f"Invalid HMAC record key for {field}")
+    return candidate
+
+
+def _assert_privacy_projection(value: Any, path: tuple[Any, ...] = ()) -> None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            normalized = str(key).casefold()
+            if normalized in FORBIDDEN_KEYS:
+                raise ProviderIngestionError(
+                    f"Forbidden PII/provider field in receipt: {'.'.join(map(str, path + (key,)))}"
+                )
+            if normalized == "name" and not (
+                path == ("provider",)
+                or len(path) >= 2
+                and path[:2] == ("rows", "products")
+            ):
+                raise ProviderIngestionError(
+                    "Only provider and merchant product names are allowed"
+                )
+            _assert_privacy_projection(nested, path + (key,))
+        return
+    if isinstance(value, list):
+        for index, nested in enumerate(value):
+            _assert_privacy_projection(nested, path + (index,))
+        return
+    if isinstance(value, str):
+        if EMAIL_RE.search(value):
+            raise ProviderIngestionError(
+                "Email-like value is forbidden in Stripe receipt"
+            )
+        if path[:1] != ("privacy",) and RAW_STRIPE_ID_RE.search(value):
+            raise ProviderIngestionError("Raw Stripe object ID is forbidden in receipt")
+
+
+def _assert_exact_row_contract(rows: dict[str, Any]) -> None:
+    if set(rows) != set(REQUIRED_ROW_FIELDS):
+        raise ProviderIngestionError(
+            "Stripe row collections do not match the versioned receipt contract"
+        )
+    for collection, required in REQUIRED_ROW_FIELDS.items():
+        values = rows[collection]
+        if not isinstance(values, list):
+            raise ProviderIngestionError(f"rows.{collection} must be a list")
+        seen: set[str] = set()
+        for index, row in enumerate(values):
+            if not isinstance(row, dict) or not required.issubset(row):
+                raise ProviderIngestionError(
+                    f"rows.{collection}[{index}] is missing required fields"
+                )
+            key = _assert_record_key(
+                row.get("record_key"), f"{collection}[{index}].record_key"
+            )
+            if key in seen:
+                raise ProviderIngestionError(
+                    f"Duplicate record key in rows.{collection}"
+                )
+            seen.add(key)
+
+
+def _totals(rows: Iterable[dict[str, Any]], amount_field: str) -> dict[str, Any]:
+    totals: dict[str, dict[str, int]] = {}
+    for row in rows:
+        currency = str(row.get("currency") or "unknown").casefold()
+        bucket = totals.setdefault(currency, {"count": 0, "amount_cents": 0})
+        bucket["count"] += 1
+        bucket["amount_cents"] += _integer(row.get(amount_field), amount_field)
+    return totals
+
+
+def _balance_totals(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    totals: dict[str, dict[str, dict[str, int]]] = {}
+    for row in rows:
+        currency = str(row.get("currency") or "unknown").casefold()
+        category = str(row.get("reporting_category") or "unknown").casefold()
+        bucket = totals.setdefault(currency, {}).setdefault(
+            category,
+            {
+                "count": 0,
+                "amount_cents": 0,
+                "fee_cents": 0,
+                "net_cents": 0,
+            },
+        )
+        bucket["count"] += 1
+        for field in ("amount_cents", "fee_cents", "net_cents"):
+            bucket[field] += _integer(row.get(field), field)
+    return totals
+
+
+def _offer_totals(rows: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    totals: dict[str, dict[str, dict[str, int]]] = {}
+    for row in rows:
+        offer = str(row.get("offer_family") or "unknown")
+        currency = str(row.get("currency") or "unknown").casefold()
+        bucket = totals.setdefault(offer, {}).setdefault(
+            currency, {"count": 0, "amount_cents": 0}
+        )
+        bucket["count"] += 1
+        bucket["amount_cents"] += _integer(row.get("gross_cents"), "gross_cents")
+    return totals
+
+
+def _checkout_controls(rows: Iterable[dict[str, Any]]) -> dict[str, int]:
+    result = {
+        "synthetic_expired_unpaid": 0,
+        "non_synthetic_expired_unpaid": 0,
+        "non_synthetic_paid": 0,
+    }
+    for row in rows:
+        if (
+            row.get("synthetic")
+            and row.get("status") == "expired"
+            and row.get("payment_status") == "unpaid"
+        ):
+            result["synthetic_expired_unpaid"] += 1
+        elif (
+            not row.get("synthetic")
+            and row.get("status") == "expired"
+            and row.get("payment_status") == "unpaid"
+        ):
+            result["non_synthetic_expired_unpaid"] += 1
+        elif not row.get("synthetic") and row.get("payment_status") == "paid":
+            result["non_synthetic_paid"] += 1
+    return result
+
+
+def _month(value: str) -> str:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return f"{parsed.year:04d}-{parsed.month:02d}"
+
+
+def _months(period: dict[str, Any]) -> list[str]:
+    start = date.fromisoformat(str(period["start_date"]))
+    end = date.fromisoformat(str(period["end_date_inclusive"]))
+    if start > end:
+        raise ProviderIngestionError("Stripe receipt period is reversed")
+    output = []
+    year, month = start.year, start.month
+    while (year, month) <= (end.year, end.month):
+        output.append(f"{year:04d}-{month:02d}")
+        if month == 12:
+            year, month = year + 1, 1
+        else:
+            month += 1
+    return output
+
+
+def _validate_receipt(
+    receipt: dict[str, Any], *, enforce_2026_08_27_controls: bool
+) -> dict[str, Any]:
+    if receipt.get("schema") != SCHEMA:
+        raise ProviderIngestionError(
+            f"Unsupported Stripe receipt schema: {receipt.get('schema')!r}"
+        )
+    provider = receipt.get("provider")
+    privacy = receipt.get("privacy")
+    rows = receipt.get("rows")
+    controls = receipt.get("controls")
+    period = receipt.get("period")
+    if not all(
+        isinstance(value, dict) for value in (provider, privacy, rows, controls, period)
+    ):
+        raise ProviderIngestionError("Stripe receipt is missing a required object")
+    if provider.get("name") != PROVIDER:
+        raise ProviderIngestionError("Receipt provider must be stripe")
+    _assert_record_key(
+        provider.get("account_record_key"), "provider.account_record_key"
+    )
+    if (
+        provider.get("charges_enabled") is not True
+        or provider.get("payouts_enabled") is not True
+    ):
+        raise ProviderIngestionError("Stripe charges and payouts must both be enabled")
+    if privacy.get("projection") != "financial_and_offer_fields_only":
+        raise ProviderIngestionError("Unexpected Stripe privacy projection")
+    if privacy.get("record_keys") != "hmac_sha256_using_server_secret":
+        raise ProviderIngestionError(
+            "Stripe record keys are not the required server HMACs"
+        )
+    if not str(receipt.get("side_effects") or "").startswith(
+        "read_only_provider_list_and_retrieve_calls"
+    ):
+        raise ProviderIngestionError(
+            "Stripe receipt does not assert read-only provider access"
+        )
+    _assert_privacy_projection(receipt)
+    _assert_exact_row_contract(rows)
+    _timestamp(receipt.get("generated_at"), "generated_at")
+    _months(period)
+
+    for collection, values in rows.items():
+        for index, row in enumerate(values):
+            _timestamp(row.get("created_at"), f"{collection}[{index}].created_at")
+            if "available_at" in row:
+                _timestamp(
+                    row.get("available_at"),
+                    f"{collection}[{index}].available_at",
+                    allow_empty=True,
+                )
+            if "arrival_at" in row:
+                _timestamp(
+                    row.get("arrival_at"),
+                    f"{collection}[{index}].arrival_at",
+                    allow_empty=True,
+                )
+            for field, value in row.items():
+                if field.endswith("_record_key"):
+                    _assert_record_key(
+                        value, f"{collection}[{index}].{field}", allow_empty=True
+                    )
+                if field.endswith("_cents"):
+                    _integer(value, f"{collection}[{index}].{field}")
+
+    successful = [
+        row
+        for row in rows["charges"]
+        if row["paid"] is True
+        and row["captured"] is True
+        and row["status"] == "succeeded"
+    ]
+    refunds = [row for row in rows["refunds"] if row["status"] == "succeeded"]
+    payouts = [row for row in rows["payouts"] if row["status"] == "paid"]
+    paid_invoices = [row for row in rows["invoices"] if row["status"] == "paid"]
+    recomputed = {
+        "successful_charges": _totals(successful, "gross_cents"),
+        "succeeded_refunds": _totals(refunds, "amount_cents"),
+        "paid_payouts": _totals(payouts, "amount_cents"),
+        "paid_invoices": _totals(paid_invoices, "amount_paid_cents"),
+        "balance_activity_by_category": _balance_totals(rows["balance_transactions"]),
+    }
+    for key, value in recomputed.items():
+        if controls.get(key) != value:
+            raise ProviderIngestionError(
+                f"Stripe receipt control does not reconcile: {key}"
+            )
+
+    if any(not invoice["line_items_complete"] for invoice in rows["invoices"]):
+        raise ProviderIngestionError("A Stripe invoice has incomplete line items")
+
+    product_keys = {row["record_key"] for row in rows["products"]}
+    price_keys = {row["record_key"] for row in rows["prices"]}
+    for price in rows["prices"]:
+        if (
+            price["product_record_key"]
+            and price["product_record_key"] not in product_keys
+        ):
+            raise ProviderIngestionError("Stripe price references a missing product")
+    for invoice in rows["invoices"]:
+        if not isinstance(invoice["line_items"], list):
+            raise ProviderIngestionError("Stripe invoice line_items must be a list")
+        for line in invoice["line_items"]:
+            if not isinstance(line, dict) or not REQUIRED_INVOICE_LINE_FIELDS.issubset(
+                line
+            ):
+                raise ProviderIngestionError(
+                    "Stripe invoice line is missing required fields"
+                )
+            _assert_record_key(
+                line["price_record_key"],
+                "invoice.line.price_record_key",
+                allow_empty=True,
+            )
+            _assert_record_key(
+                line["product_record_key"],
+                "invoice.line.product_record_key",
+                allow_empty=True,
+            )
+            _integer(line["amount_cents"], "invoice.line.amount_cents")
+            _integer(line["quantity"], "invoice.line.quantity")
+            _timestamp(line["period_start_at"], "invoice.line.period_start_at")
+            _timestamp(line["period_end_at"], "invoice.line.period_end_at")
+            if (
+                line.get("price_record_key")
+                and line["price_record_key"] not in price_keys
+            ):
+                raise ProviderIngestionError(
+                    "Stripe invoice line references a missing price"
+                )
+            if (
+                line.get("product_record_key")
+                and line["product_record_key"] not in product_keys
+            ):
+                raise ProviderIngestionError(
+                    "Stripe invoice line references a missing product"
+                )
+
+    balance_by_key = {row["record_key"]: row for row in rows["balance_transactions"]}
+    for collection, source_rows, category in (
+        ("charges", successful, "charge"),
+        ("refunds", refunds, "refund"),
+        ("payouts", payouts, "payout"),
+    ):
+        for row in source_rows:
+            balance = balance_by_key.get(row["balance_transaction_record_key"])
+            if not balance:
+                raise ProviderIngestionError(
+                    f"{collection} row is missing its balance transaction"
+                )
+            if balance["reporting_category"] != category:
+                raise ProviderIngestionError(f"{collection} balance category mismatch")
+            if balance["source_record_key"] != row["record_key"]:
+                raise ProviderIngestionError(
+                    f"{collection} balance source HMAC does not join"
+                )
+
+    paid_session_intents = {
+        row["payment_intent_record_key"]
+        for row in rows["checkout_sessions"]
+        if not row["synthetic"] and row["payment_status"] == "paid"
+    }
+    charge_intents = {row["payment_intent_record_key"] for row in successful}
+    if "" in paid_session_intents or not paid_session_intents.issubset(charge_intents):
+        raise ProviderIngestionError(
+            "Paid Checkout Sessions do not join to successful charges"
+        )
+
+    raw_rows = {key: len(value) for key, value in rows.items()}
+    derived = {
+        "raw_rows": raw_rows,
+        **recomputed,
+        "current_balance": controls.get("current_balance"),
+        "checkout_sessions": _checkout_controls(rows["checkout_sessions"]),
+        "offer_allocation": _offer_totals(successful),
+        "cash_loop_net_cents": {
+            currency: sum(category["net_cents"] for category in categories.values())
+            for currency, categories in recomputed[
+                "balance_activity_by_category"
+            ].items()
+        },
+        "canonical_payment_rows": len(successful) + len(refunds),
+        "invoice_line_items_complete": len(rows["invoices"]),
+    }
+    if enforce_2026_08_27_controls:
+        failures = []
+        for key, expected in EXPECTED_2026_08_27.items():
+            actual = period if key == "period" else derived.get(key)
+            if actual != expected:
+                failures.append(f"{key}: expected {expected!r}, got {actual!r}")
+        if derived["cash_loop_net_cents"] != {"usd": 0}:
+            failures.append(
+                f"cash_loop_net_cents: expected {{'usd': 0}}, got {derived['cash_loop_net_cents']!r}"
+            )
+        if failures:
+            raise ProviderIngestionError(
+                "Pinned Stripe control failure: " + "; ".join(failures)
+            )
+    return derived
+
+
+def _product_name(charge: dict[str, Any], invoices: dict[str, dict[str, Any]]) -> str:
+    labels = {
+        "training_plan": "Custom Training Plan",
+        "consulting": "Consulting",
+        "consult_addon": "Consulting add-on",
+        "coaching": "Coaching",
+    }
+    offer = str(charge.get("offer_family") or "unknown")
+    if offer in labels:
+        return labels[offer]
+    invoice = invoices.get(str(charge.get("invoice_record_key") or ""), {})
+    names = sorted(
+        {
+            str(line.get("merchant_product_name") or "").strip()
+            for line in invoice.get("line_items", [])
+            if str(line.get("merchant_product_name") or "").strip()
+        }
+    )
+    return names[0] if len(names) == 1 else "Unattributed Stripe charge"
+
+
+def _payment_rows(
+    receipt: dict[str, Any], payload_sha256: str, observed_at: str
+) -> list[dict[str, Any]]:
+    rows = receipt["rows"]
+    balances = {row["record_key"]: row for row in rows["balance_transactions"]}
+    invoices = {row["record_key"]: row for row in rows["invoices"]}
+    output: list[dict[str, Any]] = []
+    successful = [
+        row
+        for row in rows["charges"]
+        if row["paid"] is True
+        and row["captured"] is True
+        and row["status"] == "succeeded"
+    ]
+    for charge in successful:
+        balance = balances[charge["balance_transaction_record_key"]]
+        gross = _integer(balance["amount_cents"], "balance.amount_cents")
+        net = _integer(balance["net_cents"], "balance.net_cents")
+        product_name = _product_name(charge, invoices)
+        output.append(
+            {
+                "deal_id": None,
+                "athlete_id": None,
+                "amount": _money_from_cents(net, "balance.net_cents"),
+                "source": "provider_import",
+                "stripe_payment_id": None,
+                "description": product_name,
+                "paid_at": charge["created_at"],
+                "provider": PROVIDER,
+                "provider_account": receipt["provider"]["account_record_key"],
+                "provider_record_key": charge["record_key"],
+                "provider_record_key_kind": RECORD_KEY_KIND,
+                "customer_key": charge["customer_record_key"] or None,
+                "product_name": product_name,
+                "status": "succeeded",
+                "currency": balance["currency"],
+                "gross_amount": _money_from_cents(gross, "balance.amount_cents"),
+                "provider_adjustment_amount": _money_from_cents(
+                    gross - net, "provider_adjustment_cents"
+                ),
+                "net_amount": _money_from_cents(net, "balance.net_cents"),
+                "source_payload_sha256": payload_sha256,
+                "source_record_sha256": _record_sha256(
+                    {"charge": charge, "balance": balance}
+                ),
+                "evidence_grade": "A",
+                "source_boundary": (
+                    "PII-free provider receipt; raw Stripe IDs and bank-deposit matching are absent."
+                ),
+                "provider_metadata": {
+                    "balance_transaction_record_key": charge[
+                        "balance_transaction_record_key"
+                    ],
+                    "payment_intent_record_key": charge["payment_intent_record_key"]
+                    or None,
+                    "invoice_record_key": charge["invoice_record_key"] or None,
+                    "presentment_currency": charge["currency"],
+                    "presentment_gross_cents": charge["gross_cents"],
+                    "presentment_refunded_cents": charge["refunded_cents"],
+                    "offer_family": charge["offer_family"],
+                    "brand": charge["brand"],
+                    "livemode": charge["livemode"],
+                    "disputed": charge["disputed"],
+                    "in_operating_system_period": True,
+                },
+                "observed_at": observed_at,
+                "updated_at": observed_at,
+            }
+        )
+    for refund in rows["refunds"]:
+        if refund["status"] != "succeeded":
+            continue
+        balance = balances[refund["balance_transaction_record_key"]]
+        gross = _integer(balance["amount_cents"], "refund balance.amount_cents")
+        net = _integer(balance["net_cents"], "refund balance.net_cents")
+        output.append(
+            {
+                "deal_id": None,
+                "athlete_id": None,
+                "amount": _money_from_cents(net, "refund balance.net_cents"),
+                "source": "provider_import",
+                "stripe_payment_id": None,
+                "description": "Stripe refund",
+                "paid_at": refund["created_at"],
+                "provider": PROVIDER,
+                "provider_account": receipt["provider"]["account_record_key"],
+                "provider_record_key": refund["record_key"],
+                "provider_record_key_kind": RECORD_KEY_KIND,
+                "customer_key": None,
+                "product_name": "Refund",
+                "status": "refunded",
+                "currency": balance["currency"],
+                "gross_amount": _money_from_cents(gross, "refund balance.amount_cents"),
+                "provider_adjustment_amount": _money_from_cents(
+                    gross - net, "refund provider_adjustment_cents"
+                ),
+                "net_amount": _money_from_cents(net, "refund balance.net_cents"),
+                "source_payload_sha256": payload_sha256,
+                "source_record_sha256": _record_sha256(
+                    {"refund": refund, "balance": balance}
+                ),
+                "evidence_grade": "A",
+                "source_boundary": (
+                    "Refund is a separate negative canonical payment; its originating charge "
+                    "can fall outside the bounded receipt period."
+                ),
+                "provider_metadata": {
+                    "balance_transaction_record_key": refund[
+                        "balance_transaction_record_key"
+                    ],
+                    "charge_record_key": refund["charge_record_key"] or None,
+                    "payment_intent_record_key": refund["payment_intent_record_key"]
+                    or None,
+                    "presentment_currency": refund["currency"],
+                    "presentment_amount_cents": refund["amount_cents"],
+                    "in_operating_system_period": True,
+                },
+                "observed_at": observed_at,
+                "updated_at": observed_at,
+            }
+        )
+    return output
+
+
+def _payout_rows(
+    receipt: dict[str, Any], payload_sha256: str, observed_at: str
+) -> list[dict[str, Any]]:
+    output = []
+    for payout in receipt["rows"]["payouts"]:
+        if payout["status"] != "paid":
+            continue
+        arrival = _timestamp(
+            payout["arrival_at"], "payout.arrival_at", allow_empty=True
+        )
+        output.append(
+            {
+                "provider": PROVIDER,
+                "provider_account": receipt["provider"]["account_record_key"],
+                "provider_record_key": payout["record_key"],
+                "provider_record_key_kind": RECORD_KEY_KIND,
+                "status": payout["status"],
+                "amount": _money_from_cents(
+                    payout["amount_cents"], "payout.amount_cents"
+                ),
+                "currency": payout["currency"],
+                "provider_created_at": payout["created_at"],
+                "arrival_date": arrival[:10] if arrival else None,
+                "payout_type": "automatic" if payout["automatic"] else "manual",
+                "payout_method": None,
+                "livemode": None,
+                "source_payload_sha256": payload_sha256,
+                "source_record_sha256": _record_sha256(payout),
+                "evidence_grade": "A",
+                "source_boundary": (
+                    "PII-free provider payout; bank destination and bank-deposit match are absent."
+                ),
+                "provider_metadata": {
+                    "balance_transaction_record_key": payout[
+                        "balance_transaction_record_key"
+                    ],
+                    "automatic": payout["automatic"],
+                    "in_operating_system_period": True,
+                },
+                "observed_at": observed_at,
+                "updated_at": observed_at,
+            }
+        )
+    return output
+
+
+def _balance_rows(
+    receipt: dict[str, Any], payload_sha256: str, observed_at: str
+) -> list[dict[str, Any]]:
+    source_keys = {
+        row["record_key"]
+        for collection in ("charges", "refunds", "payouts")
+        for row in receipt["rows"][collection]
+    }
+    output = []
+    for balance in receipt["rows"]["balance_transactions"]:
+        output.append(
+            {
+                "provider": PROVIDER,
+                "provider_account": receipt["provider"]["account_record_key"],
+                "provider_record_key": balance["record_key"],
+                "provider_record_key_kind": RECORD_KEY_KIND,
+                "source_record_key": balance["source_record_key"] or None,
+                "transaction_type": balance["type"],
+                "reporting_category": balance["reporting_category"],
+                "status": balance["status"],
+                "amount": _money_from_cents(
+                    balance["amount_cents"], "balance.amount_cents"
+                ),
+                "fee_amount": _money_from_cents(
+                    balance["fee_cents"], "balance.fee_cents"
+                ),
+                "net_amount": _money_from_cents(
+                    balance["net_cents"], "balance.net_cents"
+                ),
+                "currency": balance["currency"],
+                "provider_created_at": balance["created_at"],
+                "available_at": _timestamp(
+                    balance["available_at"], "balance.available_at", allow_empty=True
+                ),
+                "source_payload_sha256": payload_sha256,
+                "source_record_sha256": _record_sha256(balance),
+                "evidence_grade": "A",
+                "source_boundary": (
+                    "Settlement ledger from a PII-free provider receipt; bank matching is absent."
+                ),
+                "provider_metadata": {
+                    "source_record_present_in_period": balance["source_record_key"]
+                    in source_keys,
+                    "in_operating_system_period": True,
+                },
+                "observed_at": observed_at,
+                "updated_at": observed_at,
+            }
+        )
+    return output
+
+
+def _monthly_rows(
+    receipt: dict[str, Any], payload_sha256: str, observed_at: str
+) -> list[dict[str, Any]]:
+    rows = receipt["rows"]
+    output = []
+    for month in _months(receipt["period"]):
+        charges = [
+            row
+            for row in rows["charges"]
+            if _month(row["created_at"]) == month
+            and row["paid"] is True
+            and row["captured"] is True
+            and row["status"] == "succeeded"
+        ]
+        refunds = [
+            row
+            for row in rows["refunds"]
+            if _month(row["created_at"]) == month and row["status"] == "succeeded"
+        ]
+        payouts = [
+            row
+            for row in rows["payouts"]
+            if _month(row["created_at"]) == month and row["status"] == "paid"
+        ]
+        balance = [
+            row
+            for row in rows["balance_transactions"]
+            if _month(row["created_at"]) == month
+        ]
+        sessions = [
+            row
+            for row in rows["checkout_sessions"]
+            if _month(row["created_at"]) == month
+        ]
+        metrics = {
+            "successful_charges": _totals(charges, "gross_cents"),
+            "succeeded_refunds": _totals(refunds, "amount_cents"),
+            "paid_payouts": _totals(payouts, "amount_cents"),
+            "balance_activity_by_category": _balance_totals(balance),
+            "checkout_sessions": _checkout_controls(sessions),
+            "offer_allocation": _offer_totals(charges),
+        }
+        output.append(
+            {
+                "provider": PROVIDER,
+                "provider_account": receipt["provider"]["account_record_key"],
+                "source_kind": MONTHLY_SOURCE_KIND,
+                "control_month": f"{month}-01",
+                "metrics": metrics,
+                "source_payload_sha256": payload_sha256,
+                "source_record_sha256": _record_sha256(
+                    {"month": month, "metrics": metrics}
+                ),
+                "evidence_grade": "A",
+                "source_boundary": (
+                    "Created-at monthly flow controls; current balance is observation-time, "
+                    "and bank matching is outside the receipt."
+                ),
+                "observed_at": observed_at,
+                "updated_at": observed_at,
+            }
+        )
+    return output
+
+
+def build_stripe_bundle(
+    receipt_path: str | Path,
+    *,
+    enforce_2026_08_27_controls: bool = True,
+) -> StripeImportBundle:
+    """Load, validate, and normalize one sanitized Stripe reconciliation receipt."""
+    path = Path(receipt_path).expanduser().resolve()
+    if not path.is_file():
+        raise ProviderIngestionError(f"Stripe receipt is missing: {path}")
+    try:
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ProviderIngestionError("Stripe receipt is not valid UTF-8 JSON") from exc
+    if not isinstance(receipt, dict):
+        raise ProviderIngestionError("Stripe receipt root must be an object")
+    controls = _validate_receipt(
+        receipt, enforce_2026_08_27_controls=enforce_2026_08_27_controls
+    )
+    observed_at = str(_timestamp(receipt["generated_at"], "generated_at"))
+    payload_sha256 = _payload_sha256(path)
+    provider_account = receipt["provider"]["account_record_key"]
+    batch = {
+        "provider": PROVIDER,
+        "provider_account": provider_account,
+        "source_kind": SOURCE_KIND,
+        "source_payload_sha256": payload_sha256,
+        "upstream_source_sha256": [],
+        "observed_at": observed_at,
+        "row_count": sum(controls["raw_rows"].values()),
+        "control_totals": controls,
+        "evidence_grade": "A",
+        "source_boundary": (
+            "PII-safe authenticated Stripe read receipt; raw provider IDs, GA4 raw "
+            "transaction IDs, fulfillment joins, and bank-deposit matching are absent."
+        ),
+    }
+    return StripeImportBundle(
+        observed_at=observed_at,
+        batch=batch,
+        payments=_payment_rows(receipt, payload_sha256, observed_at),
+        payouts=_payout_rows(receipt, payload_sha256, observed_at),
+        balance_transactions=_balance_rows(receipt, payload_sha256, observed_at),
+        monthly_controls=_monthly_rows(receipt, payload_sha256, observed_at),
+        controls=controls,
+    )
+
+
+def _database() -> Any:
+    global db
+    if db is None:
+        from mission_control import supabase_client
+
+        db = supabase_client
+    return db
+
+
+def _with_batch_id(rows: list[dict[str, Any]], batch_id: str) -> list[dict[str, Any]]:
+    return [{**row, "import_batch_id": batch_id} for row in rows]
+
+
+def _money_sums(rows: list[dict[str, Any]], fields: tuple[str, ...]) -> dict[str, str]:
+    return {
+        field: format(
+            sum((_decimal(row[field], field) for row in rows), Decimal(0)).quantize(
+                Decimal("0.01")
+            ),
+            "f",
+        )
+        for field in fields
+    }
+
+
+def _verify_readback(
+    database: Any, bundle: StripeImportBundle, batch_id: str
+) -> dict[str, Any]:
+    expected = {
+        "gg_payments": bundle.payments,
+        "gg_provider_payouts": bundle.payouts,
+        "gg_provider_balance_transactions": bundle.balance_transactions,
+        "gg_provider_monthly_controls": bundle.monthly_controls,
+    }
+    actual = {
+        table: database.select(table, match={"import_batch_id": batch_id})
+        for table in expected
+    }
+    key_field = {
+        "gg_payments": "provider_record_key",
+        "gg_provider_payouts": "provider_record_key",
+        "gg_provider_balance_transactions": "provider_record_key",
+        "gg_provider_monthly_controls": "control_month",
+    }
+    for table, expected_rows in expected.items():
+        field = key_field[table]
+        expected_keys = {row[field] for row in expected_rows}
+        actual_keys = {row[field] for row in actual[table]}
+        if len(actual[table]) != len(expected_rows) or actual_keys != expected_keys:
+            raise ProviderIngestionError(f"Live readback key mismatch for {table}")
+    return {
+        "status": "VERIFIED",
+        "batch_id": batch_id,
+        "rows": {table: len(rows) for table, rows in actual.items()},
+        "financial_sums": {
+            "gg_payments": _money_sums(
+                actual["gg_payments"],
+                ("amount", "gross_amount", "provider_adjustment_amount", "net_amount"),
+            ),
+            "gg_provider_payouts": _money_sums(
+                actual["gg_provider_payouts"], ("amount",)
+            ),
+            "gg_provider_balance_transactions": _money_sums(
+                actual["gg_provider_balance_transactions"],
+                ("amount", "fee_amount", "net_amount"),
+            ),
+        },
+    }
+
+
+def apply_stripe_bundle(
+    bundle: StripeImportBundle, *, batch_size: int = 500
+) -> dict[str, Any]:
+    """Idempotently apply a prevalidated Stripe bundle and verify live readback."""
+    if batch_size < 1:
+        raise ProviderIngestionError("batch_size must be at least 1")
+    database = _database()
+    stored_batch = database.upsert(
+        "gg_provider_import_batches",
+        bundle.batch,
+        on_conflict="provider,provider_account,source_kind,source_payload_sha256",
+    )
+    if not stored_batch.get("id"):
+        stored_batch = (
+            database.select_one(
+                "gg_provider_import_batches",
+                match={
+                    key: bundle.batch[key]
+                    for key in (
+                        "provider",
+                        "provider_account",
+                        "source_kind",
+                        "source_payload_sha256",
+                    )
+                },
+            )
+            or {}
+        )
+    if not stored_batch.get("id"):
+        raise ProviderIngestionError(
+            "Stripe import batch did not return a persistent id"
+        )
+    batch_id = str(stored_batch["id"])
+    prepared = {
+        "gg_payments": _with_batch_id(bundle.payments, batch_id),
+        "gg_provider_payouts": _with_batch_id(bundle.payouts, batch_id),
+        "gg_provider_balance_transactions": _with_batch_id(
+            bundle.balance_transactions, batch_id
+        ),
+        "gg_provider_monthly_controls": _with_batch_id(
+            bundle.monthly_controls, batch_id
+        ),
+    }
+    conflicts = {
+        "gg_payments": "provider,provider_account,provider_record_key",
+        "gg_provider_payouts": "provider,provider_account,provider_record_key",
+        "gg_provider_balance_transactions": (
+            "provider,provider_account,provider_record_key"
+        ),
+        "gg_provider_monthly_controls": (
+            "provider,provider_account,source_kind,control_month"
+        ),
+    }
+    returned = {
+        table: database.upsert_many(
+            table, rows, on_conflict=conflicts[table], batch_size=batch_size
+        )
+        for table, rows in prepared.items()
+    }
+    readback = _verify_readback(database, bundle, batch_id)
+    return {
+        "status": "APPLIED_AND_VERIFIED",
+        "batch_id": batch_id,
+        "attempted_rows": {table: len(rows) for table, rows in prepared.items()},
+        "returned_rows": {table: len(rows) for table, rows in returned.items()},
+        "controls": bundle.controls,
+        "readback": readback,
+    }

--- a/mission_control/tests/test_stripe_provider_ingestion.py
+++ b/mission_control/tests/test_stripe_provider_ingestion.py
@@ -1,0 +1,348 @@
+"""Tests for privacy-safe, idempotent Stripe provider ingestion."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from mission_control.services import stripe_provider_ingestion as ingestion
+
+
+def _key(character: str) -> str:
+    return "srk_" + character * 64
+
+
+def _receipt() -> dict:
+    charge_key = _key("1")
+    refund_key = _key("2")
+    payout_key = _key("3")
+    charge_balance_key = _key("4")
+    refund_balance_key = _key("5")
+    payout_balance_key = _key("6")
+    product_key = _key("7")
+    price_key = _key("8")
+    intent_key = _key("9")
+    account_key = _key("a")
+    customer_key = _key("b")
+    session_key = _key("c")
+    invoice_key = _key("d")
+    subscription_key = _key("e")
+    created = "2026-08-27T18:00:00+00:00"
+    rows = {
+        "products": [
+            {
+                "record_key": product_key,
+                "created_at": created,
+                "name": "Custom Training Plan",
+                "offer_family": "training_plan",
+                "active": True,
+                "livemode": True,
+            }
+        ],
+        "prices": [
+            {
+                "record_key": price_key,
+                "product_record_key": product_key,
+                "created_at": created,
+                "currency": "usd",
+                "unit_amount_cents": 10000,
+                "recurring_interval": "",
+                "recurring_interval_count": 0,
+                "offer_family": "training_plan",
+                "active": True,
+                "livemode": True,
+            }
+        ],
+        "checkout_sessions": [
+            {
+                "record_key": session_key,
+                "payment_intent_record_key": intent_key,
+                "subscription_record_key": "",
+                "customer_record_key": customer_key,
+                "created_at": created,
+                "currency": "usd",
+                "amount_total_cents": 10000,
+                "amount_discount_cents": 0,
+                "amount_tax_cents": 0,
+                "status": "complete",
+                "payment_status": "paid",
+                "mode": "payment",
+                "offer_family": "training_plan",
+                "brand": "gravelgod",
+                "synthetic": False,
+                "livemode": True,
+            }
+        ],
+        "invoices": [
+            {
+                "record_key": invoice_key,
+                "subscription_record_key": subscription_key,
+                "customer_record_key": customer_key,
+                "created_at": created,
+                "currency": "usd",
+                "status": "paid",
+                "amount_due_cents": 10000,
+                "amount_paid_cents": 10000,
+                "amount_remaining_cents": 0,
+                "offer_family": "training_plan",
+                "brand": "gravelgod",
+                "line_items": [
+                    {
+                        "price_record_key": price_key,
+                        "product_record_key": product_key,
+                        "merchant_product_name": "Custom Training Plan",
+                        "offer_family": "training_plan",
+                        "currency": "usd",
+                        "amount_cents": 10000,
+                        "quantity": 1,
+                        "period_start_at": created,
+                        "period_end_at": created,
+                    }
+                ],
+                "line_items_complete": True,
+                "livemode": True,
+            }
+        ],
+        "charges": [
+            {
+                "record_key": charge_key,
+                "payment_intent_record_key": intent_key,
+                "invoice_record_key": invoice_key,
+                "customer_record_key": customer_key,
+                "balance_transaction_record_key": charge_balance_key,
+                "created_at": created,
+                "currency": "usd",
+                "status": "succeeded",
+                "paid": True,
+                "captured": True,
+                "disputed": False,
+                "gross_cents": 10000,
+                "refunded_cents": 1000,
+                "gross_less_refunds_cents": 9000,
+                "offer_family": "training_plan",
+                "brand": "gravelgod",
+                "livemode": True,
+            }
+        ],
+        "refunds": [
+            {
+                "record_key": refund_key,
+                "charge_record_key": charge_key,
+                "payment_intent_record_key": intent_key,
+                "balance_transaction_record_key": refund_balance_key,
+                "created_at": created,
+                "currency": "usd",
+                "status": "succeeded",
+                "amount_cents": 1000,
+            }
+        ],
+        "balance_transactions": [
+            {
+                "record_key": charge_balance_key,
+                "source_record_key": charge_key,
+                "created_at": created,
+                "available_at": created,
+                "currency": "usd",
+                "type": "charge",
+                "reporting_category": "charge",
+                "status": "available",
+                "amount_cents": 10000,
+                "fee_cents": 300,
+                "net_cents": 9700,
+            },
+            {
+                "record_key": refund_balance_key,
+                "source_record_key": refund_key,
+                "created_at": created,
+                "available_at": created,
+                "currency": "usd",
+                "type": "refund",
+                "reporting_category": "refund",
+                "status": "available",
+                "amount_cents": -1000,
+                "fee_cents": 0,
+                "net_cents": -1000,
+            },
+            {
+                "record_key": payout_balance_key,
+                "source_record_key": payout_key,
+                "created_at": created,
+                "available_at": created,
+                "currency": "usd",
+                "type": "payout",
+                "reporting_category": "payout",
+                "status": "available",
+                "amount_cents": -8700,
+                "fee_cents": 0,
+                "net_cents": -8700,
+            },
+        ],
+        "payouts": [
+            {
+                "record_key": payout_key,
+                "balance_transaction_record_key": payout_balance_key,
+                "created_at": created,
+                "arrival_at": created,
+                "currency": "usd",
+                "status": "paid",
+                "amount_cents": 8700,
+                "automatic": True,
+            }
+        ],
+    }
+    successful = rows["charges"]
+    refunds = rows["refunds"]
+    payouts = rows["payouts"]
+    invoices = rows["invoices"]
+    return {
+        "schema": ingestion.SCHEMA,
+        "generated_at": created,
+        "period": {
+            "start_date": "2026-08-27",
+            "end_date_inclusive": "2026-08-27",
+            "timezone": "UTC",
+        },
+        "provider": {
+            "name": "stripe",
+            "account_record_key": account_key,
+            "charges_enabled": True,
+            "payouts_enabled": True,
+        },
+        "privacy": {
+            "projection": "financial_and_offer_fields_only",
+            "record_keys": "hmac_sha256_using_server_secret",
+            "included_merchant_fields": ["product_name"],
+            "excluded": ["provider_ids", "names", "emails", "phones", "addresses"],
+        },
+        "controls": {
+            "successful_charges": ingestion._totals(successful, "gross_cents"),
+            "succeeded_refunds": ingestion._totals(refunds, "amount_cents"),
+            "paid_payouts": ingestion._totals(payouts, "amount_cents"),
+            "paid_invoices": ingestion._totals(invoices, "amount_paid_cents"),
+            "balance_activity_by_category": ingestion._balance_totals(
+                rows["balance_transactions"]
+            ),
+            "current_balance": {"usd": {"available_cents": 0, "pending_cents": 0}},
+        },
+        "rows": rows,
+        "boundaries": ["Bank matching is outside this receipt."],
+        "side_effects": "read_only_provider_list_and_retrieve_calls; no mutation",
+    }
+
+
+def _write(tmp_path: Path, receipt: dict | None = None) -> Path:
+    path = tmp_path / "stripe-reconciliation.json"
+    path.write_text(json.dumps(receipt or _receipt(), sort_keys=True), encoding="utf-8")
+    return path
+
+
+def test_build_bundle_preserves_settlement_and_privacy_boundaries(tmp_path):
+    bundle = ingestion.build_stripe_bundle(
+        _write(tmp_path), enforce_2026_08_27_controls=False
+    )
+    assert bundle.batch["provider_account"].startswith("srk_")
+    assert bundle.batch["row_count"] == 10
+    assert len(bundle.payments) == 2
+    charge, refund = bundle.payments
+    assert charge["gross_amount"] == "100.00"
+    assert charge["provider_adjustment_amount"] == "3.00"
+    assert charge["net_amount"] == "97.00"
+    assert charge["product_name"] == "Custom Training Plan"
+    assert refund["amount"] == "-10.00"
+    assert refund["status"] == "refunded"
+    assert len(bundle.payouts) == 1
+    assert len(bundle.balance_transactions) == 3
+    assert len(bundle.monthly_controls) == 1
+    assert bundle.summary()["canonical_rows"] == {
+        "gg_payments": 2,
+        "gg_provider_payouts": 1,
+        "gg_provider_balance_transactions": 3,
+        "gg_provider_monthly_controls": 1,
+    }
+
+
+def test_balance_source_hmac_must_join(tmp_path):
+    receipt = _receipt()
+    receipt["rows"]["balance_transactions"][0]["source_record_key"] = _key("f")
+    with pytest.raises(
+        ingestion.ProviderIngestionError, match="source HMAC does not join"
+    ):
+        ingestion.build_stripe_bundle(
+            _write(tmp_path, receipt), enforce_2026_08_27_controls=False
+        )
+
+
+def test_recomputed_controls_fail_closed(tmp_path):
+    receipt = _receipt()
+    receipt["controls"]["successful_charges"]["usd"]["amount_cents"] = 1
+    with pytest.raises(ingestion.ProviderIngestionError, match="does not reconcile"):
+        ingestion.build_stripe_bundle(
+            _write(tmp_path, receipt), enforce_2026_08_27_controls=False
+        )
+
+
+def test_pii_and_raw_provider_ids_fail_closed(tmp_path):
+    for field, value in (("email", "private@example.com"), ("note", "ch_private")):
+        receipt = _receipt()
+        receipt["rows"]["charges"][0][field] = value
+        with pytest.raises(ingestion.ProviderIngestionError):
+            ingestion.build_stripe_bundle(
+                _write(tmp_path, receipt), enforce_2026_08_27_controls=False
+            )
+
+
+def test_pinned_controls_reject_fixture(tmp_path):
+    with pytest.raises(ingestion.ProviderIngestionError, match="Pinned Stripe control"):
+        ingestion.build_stripe_bundle(_write(tmp_path))
+
+
+def test_apply_is_idempotent_and_readback_verified(tmp_path, monkeypatch):
+    bundle = ingestion.build_stripe_bundle(
+        _write(tmp_path), enforce_2026_08_27_controls=False
+    )
+    tables: dict[str, list[dict]] = {}
+    calls: list[tuple[str, str, int]] = []
+
+    class FakeDb:
+        @staticmethod
+        def upsert(table, row, on_conflict=""):
+            calls.append((table, on_conflict, 1))
+            return {**row, "id": "batch-1"}
+
+        @staticmethod
+        def select_one(*_args, **_kwargs):
+            raise AssertionError("upsert returned an id")
+
+        @staticmethod
+        def upsert_many(table, rows, on_conflict="", batch_size=500):
+            calls.append((table, on_conflict, len(rows)))
+            tables[table] = copy.deepcopy(rows)
+            return rows
+
+        @staticmethod
+        def select(table, match=None):
+            return [
+                row
+                for row in tables.get(table, [])
+                if not match
+                or all(row.get(key) == value for key, value in match.items())
+            ]
+
+    monkeypatch.setattr(ingestion, "db", FakeDb)
+    first = ingestion.apply_stripe_bundle(bundle, batch_size=2)
+    second = ingestion.apply_stripe_bundle(bundle, batch_size=2)
+    assert first["status"] == second["status"] == "APPLIED_AND_VERIFIED"
+    assert first["readback"]["rows"] == {
+        "gg_payments": 2,
+        "gg_provider_payouts": 1,
+        "gg_provider_balance_transactions": 3,
+        "gg_provider_monthly_controls": 1,
+    }
+    assert (
+        "gg_provider_balance_transactions",
+        "provider,provider_account,provider_record_key",
+        3,
+    ) in calls

--- a/scripts/import_stripe_provider_revenue.py
+++ b/scripts/import_stripe_provider_revenue.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate or apply a privacy-safe standalone Stripe reconciliation receipt."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from mission_control.services.provider_ingestion import (
+    ProviderIngestionError,
+)
+from mission_control.services.stripe_provider_ingestion import (
+    apply_stripe_bundle,
+    build_stripe_bundle,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate and normalize one authenticated, PII-safe Stripe provider "
+            "receipt. Dry-run is the default."
+        )
+    )
+    parser.add_argument(
+        "--receipt-file", required=True, help="Sanitized Stripe JSON receipt"
+    )
+    parser.add_argument(
+        "--output-receipt", help="Optional dry-run/apply JSON receipt path"
+    )
+    parser.add_argument("--batch-size", type=int, default=500)
+    parser.add_argument(
+        "--skip-2026-08-27-controls",
+        action="store_true",
+        help="Disable the pinned live baseline; intended only for fixtures or a reviewed rollover",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write idempotent rows to the migrated Mission Control database",
+    )
+    parser.add_argument(
+        "--confirm",
+        default="",
+        help="Required with --apply; must equal APPLY_STRIPE_PROVIDER_TRUTH",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.batch_size < 1:
+        raise ProviderIngestionError("--batch-size must be at least 1")
+    if args.apply and args.confirm != "APPLY_STRIPE_PROVIDER_TRUTH":
+        raise ProviderIngestionError(
+            "--apply requires --confirm APPLY_STRIPE_PROVIDER_TRUTH; "
+            "no database write was attempted"
+        )
+    bundle = build_stripe_bundle(
+        args.receipt_file,
+        enforce_2026_08_27_controls=not args.skip_2026_08_27_controls,
+    )
+    result = (
+        apply_stripe_bundle(bundle, batch_size=args.batch_size)
+        if args.apply
+        else bundle.summary()
+    )
+    result["mode"] = "apply" if args.apply else "dry-run"
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output_receipt:
+        output = Path(args.output_receipt).expanduser().resolve()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ProviderIngestionError as exc:
+        print(json.dumps({"status": "FAILED", "error": str(exc)}), file=sys.stderr)
+        raise SystemExit(2) from None

--- a/supabase/migrations/20260828000001_stripe_provider_balance_truth.sql
+++ b/supabase/migrations/20260828000001_stripe_provider_balance_truth.sql
@@ -1,0 +1,52 @@
+-- Canonical settlement ledger for privacy-safe standalone Stripe imports.
+--
+-- This migration is additive. It creates one empty table and indexes that
+-- table before any importer is enabled; no existing provider row is rewritten.
+
+CREATE TABLE gg_provider_balance_transactions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    provider TEXT NOT NULL,
+    provider_account TEXT NOT NULL DEFAULT '',
+    provider_record_key TEXT NOT NULL,
+    provider_record_key_kind TEXT NOT NULL,
+    import_batch_id UUID NOT NULL REFERENCES gg_provider_import_batches(id),
+    source_record_key TEXT,
+    transaction_type TEXT NOT NULL,
+    reporting_category TEXT NOT NULL,
+    status TEXT NOT NULL,
+    amount DECIMAL NOT NULL,
+    fee_amount DECIMAL NOT NULL,
+    net_amount DECIMAL NOT NULL,
+    currency TEXT NOT NULL,
+    provider_created_at TIMESTAMPTZ NOT NULL,
+    available_at TIMESTAMPTZ,
+    source_payload_sha256 TEXT NOT NULL
+        CHECK (length(source_payload_sha256) = 64),
+    source_record_sha256 TEXT NOT NULL
+        CHECK (length(source_record_sha256) = 64),
+    evidence_grade TEXT NOT NULL,
+    source_boundary TEXT NOT NULL DEFAULT '',
+    provider_metadata JSONB NOT NULL DEFAULT '{}',
+    observed_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(provider, provider_account, provider_record_key)
+);
+
+COMMENT ON TABLE gg_provider_balance_transactions IS
+    'Provider settlement activity. Amount, fee_amount, and net_amount use the settlement currency, not necessarily the purchaser presentment currency.';
+COMMENT ON COLUMN gg_provider_balance_transactions.source_record_key IS
+    'PII-safe HMAC reference to the source charge, refund, payout, or other provider object when supplied.';
+
+CREATE INDEX idx_provider_balance_transactions_created
+    ON gg_provider_balance_transactions(
+        provider, provider_account, provider_created_at, reporting_category
+    );
+CREATE INDEX idx_provider_balance_transactions_import_batch
+    ON gg_provider_balance_transactions(import_batch_id);
+
+ALTER TABLE gg_provider_balance_transactions ENABLE ROW LEVEL SECURITY;
+
+-- The service role bypasses RLS. Explicitly deny ordinary PostgREST roles.
+CREATE POLICY "Service role only" ON gg_provider_balance_transactions
+    FOR ALL USING (false) WITH CHECK (false);


### PR DESCRIPTION
## Summary
- add an additive, service-role-only Stripe settlement-ledger table
- validate the authenticated PII-safe receipt from raw rows through provider controls and two-way financial joins
- normalize 91 charges plus one refund, 70 payouts, 234 balance rows, and 13 monthly controls into Mission Control
- require explicit apply confirmation and direct live readback of exact keys, counts, and financial sums
- add a guarded cross-repository ingestion workflow without touching Checkout or fulfillment

## Decision-grade controls
- receipt schema and read-only side effects are pinned
- raw provider IDs, customer PII, payment methods, and bank destinations fail closed
- all charge/refund/payout balance edges must resolve in both directions
- all 89 invoice line-item projections must be complete
- the 2025-08-27 through 2026-08-27 profile pins 1,685 raw rows, a zero-cent settlement loop, offer allocation, and synthetic Checkout exclusions
- dry-run is the default; apply requires `APPLY_STRIPE_PROVIDER_TRUTH`

## Migration safety
- additive create-table migration only; no existing row rewrite
- indexes build on the new empty table
- importer workflow is isolated from customer orders and can be disabled independently
- rollback and exact provider/account data-removal boundaries are documented

## Verification
- fresh production receipt from source run `33129926247`, exporter merge SHA `73bba04fde842db4dcef4aa62db108e7d740a389`
- production receipt SHA-256 `5056835cec1f22a6d147e6c4f49b3bfd377458028d190e1d37779bbaddd55843`
- live profile dry-run: 1,685 source rows; 92 payments; 70 payouts; 234 balance rows; 13 monthly controls; 89 complete invoice projections; cash loop `usd=0`
- exporter comparison: controls and row counts unchanged; two-way links 91/91 charges, 1/1 refunds, 70/70 payouts
- `pytest mission_control/tests/test_provider_ingestion.py mission_control/tests/test_stripe_provider_ingestion.py -q` (15 passed)
- Python 3.11 compile passed
- Ruff passed
- `python scripts/preflight_quality.py` passed with nine pre-existing/environment warnings
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes financial rows to shared `gg_payments` and related provider tables via service-role upserts, though apply is gated, validated, and isolated from customer order paths; incorrect ingestion could skew reporting until rolled back per documented boundaries.
> 
> **Overview**
> Adds a **standalone Stripe revenue authority** path that ingests a privacy-safe reconciliation receipt from the athlete pipeline into Mission Control, isolated from Checkout and fulfillment.
> 
> A new **fail-closed importer** validates the `stripe_revenue_reconciliation/v1` receipt (PII/raw Stripe IDs rejected, controls reconciled from raw rows, balance-ledger joins, pinned 2026-08-27 production baseline) and maps evidence into `gg_payments`, `gg_provider_payouts`, **`gg_provider_balance_transactions`** (new table), and `gg_provider_monthly_controls`. Apply mode requires `APPLY_STRIPE_PROVIDER_TRUTH`, upserts idempotently, and **verifies live readback** of keys, counts, and financial sums.
> 
> Ships **`scripts/import_stripe_provider_revenue.py`**, an additive **Supabase migration** with service-role-only RLS on the balance ledger, **runbook/docs**, **pytest** coverage, CI inclusion of provider ingestion tests, and a **guarded GitHub Actions workflow** that validates source run provenance, downloads the artifact, dry-runs, then applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7bf2ae68bc0b5bda984a03e0884242644c91cb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->