### PR TITLE
Add approved historical Current Thing timeline

### DIFF
--- a/scripts/validate_gravel_weekly_history.py
+++ b/scripts/validate_gravel_weekly_history.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Fail-closed validation for Gravel Weekly historical Current Thing entries."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime, time, timezone
+from pathlib import Path
+from typing import Any
+
+from validate_gravel_weekly import IssueValidationError, _impact, _iso, _list, _receipt, _record, _text
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+HISTORY_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "history"
+PASSING_GATES = {"party", "point", "friend", "craft", "hostileEditor"}
+
+
+def _day(value: Any, name: str) -> str:
+    raw = _text(value, name, 10)
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", raw):
+        raise IssueValidationError(f"{name} must be YYYY-MM-DD")
+    try:
+        datetime.strptime(raw, "%Y-%m-%d")
+    except ValueError as exc:
+        raise IssueValidationError(f"{name} is invalid") from exc
+    return raw
+
+
+def canonical_history_json(entry: dict[str, Any]) -> str:
+    payload = dict(entry)
+    payload.pop("contentHash", None)
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def compute_history_content_hash(entry: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_history_json(entry).encode("utf-8")).hexdigest()
+
+
+def _published_timestamp(receipt: dict[str, Any], name: str) -> datetime:
+    raw = receipt.get("publishedAt")
+    if raw is None:
+        raise IssueValidationError(f"{name}.publishedAt is required for historical chronology")
+    result = datetime.fromisoformat(_iso(raw, f"{name}.publishedAt").replace("Z", "+00:00"))
+    if result.tzinfo is None:
+        raise IssueValidationError(f"{name}.publishedAt must include a timezone")
+    return result.astimezone(timezone.utc)
+
+
+def validate_history_entry(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
+    entry = _record(value, "history entry")
+    if entry.get("schemaVersion") != "gravel-weekly-history-entry/v1":
+        raise IssueValidationError("unsupported Gravel Weekly history schema")
+    _text(entry.get("entryId"), "entryId", 500)
+    active_from = _day(entry.get("activeFrom"), "activeFrom")
+    active_through = _day(entry.get("activeThrough"), "activeThrough")
+    active_from_at = datetime.combine(datetime.strptime(active_from, "%Y-%m-%d").date(), time.min, tzinfo=timezone.utc)
+    active_through_at = datetime.combine(datetime.strptime(active_through, "%Y-%m-%d").date(), time.max, tzinfo=timezone.utc)
+    if active_through_at < active_from_at:
+        raise IssueValidationError("activeThrough must not precede activeFrom")
+    if (active_through_at - active_from_at).days > 180:
+        raise IssueValidationError("historical active period must not exceed 180 days")
+    status = entry.get("status")
+    if status not in {"draft", "approved", "published"}:
+        raise IssueValidationError("history status is invalid")
+    _text(entry.get("headline"), "headline", 300)
+    _text(entry.get("point"), "point", 1_000)
+    _text(entry.get("priorJudgment"), "priorJudgment", 1_000)
+    _text(entry.get("changedJudgment"), "changedJudgment", 1_000)
+    _text(entry.get("stakes"), "stakes", 1_500)
+    _text(entry.get("credibleOpposition"), "credibleOpposition", 1_000)
+    _text(entry.get("whatHappened"), "whatHappened", 3_000)
+    take = _text(entry.get("take"), "take", 8_000)
+    _text(entry.get("uncertainty"), "uncertainty", 2_000)
+    score = entry.get("editorialScore")
+    if not isinstance(score, int) or isinstance(score, bool) or not 85 <= score <= 100:
+        raise IssueValidationError("historical Current Thing editorialScore must be 85 to 100")
+    provenance = entry.get("takeProvenance")
+    if provenance not in {"model_draft", "human_approved"}:
+        raise IssueValidationError("takeProvenance is invalid")
+    if status != "draft" and provenance != "human_approved":
+        raise IssueValidationError("approved historical takes require human-approved provenance")
+    if status != "draft" and re.search(r"model draft|not matti(?:’|')s approved", take, re.IGNORECASE):
+        raise IssueValidationError("historical take still contains model-draft language")
+    gates = _record(entry.get("editorialGates"), "editorialGates")
+    if set(gates) != PASSING_GATES:
+        raise IssueValidationError("editorialGates must contain the five historical gates")
+    for gate_name, verdict in gates.items():
+        if verdict not in {"pass", "hold", "fail"}:
+            raise IssueValidationError(f"editorialGates.{gate_name} is invalid")
+        if status != "draft" and verdict != "pass":
+            raise IssueValidationError("approved historical entries require every editorial gate to pass")
+
+    contemporary = _list(entry.get("contemporaryReceipts"), "contemporaryReceipts", 100)
+    if not contemporary:
+        raise IssueValidationError("contemporaryReceipts must not be empty")
+    contemporary_publishers: set[str] = set()
+    claim_ids: set[str] = set()
+    receipt_keys: set[tuple[str, str]] = set()
+    for index, receipt_value in enumerate(contemporary):
+        name = f"contemporaryReceipts[{index}]"
+        receipt = _receipt(receipt_value, name)
+        published_at = _published_timestamp(receipt, name)
+        if published_at > active_through_at:
+            raise IssueValidationError(f"{name} is later evidence, not contemporary evidence")
+        contemporary_publishers.add(receipt["publisher"].strip().casefold())
+        claim_ids.add(receipt["claimId"])
+        receipt_keys.add((receipt["claimId"], receipt["canonicalUrl"]))
+    if status != "draft" and len(contemporary_publishers) < 2:
+        raise IssueValidationError("approved historical entries require two contemporary publishers")
+
+    later_evidence = _list(entry.get("laterEvidence"), "laterEvidence", 100)
+    for index, receipt_value in enumerate(later_evidence):
+        name = f"laterEvidence[{index}]"
+        receipt = _receipt(receipt_value, name)
+        if _published_timestamp(receipt, name) <= active_through_at:
+            raise IssueValidationError(f"{name} must postdate the active period")
+        key = (receipt["claimId"], receipt["canonicalUrl"])
+        if key in receipt_keys:
+            raise IssueValidationError("laterEvidence must not duplicate a contemporary receipt")
+        receipt_keys.add(key)
+        claim_ids.add(receipt["claimId"])
+
+    for index, impact_value in enumerate(_list(entry.get("raceImpacts"), "raceImpacts", 100)):
+        impact = _impact(impact_value, f"raceImpacts[{index}]")
+        missing = set(impact["claimIds"]) - claim_ids
+        if missing:
+            raise IssueValidationError(f"raceImpacts[{index}] references claims without historical receipts: {sorted(missing)}")
+    if entry.get("humanApprovalRequired") is not True or entry.get("autoPublishAllowed") is not False:
+        raise IssueValidationError("historical publication safety flags are invalid")
+    approval = entry.get("editorialApproval")
+    if status != "draft" and not isinstance(approval, dict):
+        raise IssueValidationError(f"{status} historical entries require editorial approval")
+    if isinstance(approval, dict):
+        _text(approval.get("approver"), "editorialApproval.approver", 300)
+        _iso(approval.get("approvedAt"), "editorialApproval.approvedAt")
+    if status == "published" and entry.get("publishedAt") is None:
+        raise IssueValidationError("published historical entries require publishedAt")
+    if entry.get("publishedAt") is not None:
+        _iso(entry["publishedAt"], "publishedAt")
+    _iso(entry.get("updatedAt"), "updatedAt")
+    expected = compute_history_content_hash(entry)
+    if verify_hash and _text(entry.get("contentHash"), "contentHash", 64) != expected:
+        raise IssueValidationError(f"contentHash mismatch: expected {expected}")
+    return entry
+
+
+def load_history_entries(history_dir: Path = HISTORY_DIR) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    if not history_dir.exists():
+        return entries
+    for path in sorted(history_dir.glob("*.json")):
+        try:
+            entries.append(validate_history_entry(json.loads(path.read_text(encoding="utf-8"))))
+        except (json.JSONDecodeError, IssueValidationError) as exc:
+            raise IssueValidationError(f"{path}: {exc}") from exc
+    ids = [entry["entryId"] for entry in entries]
+    if len(ids) != len(set(ids)):
+        raise IssueValidationError("historical entry IDs must be unique")
+    return sorted(entries, key=lambda entry: (entry["activeThrough"], entry["activeFrom"]), reverse=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*", type=Path)
+    args = parser.parse_args()
+    paths = args.paths or sorted(HISTORY_DIR.glob("*.json"))
+    for path in paths:
+        validate_history_entry(json.loads(path.read_text(encoding="utf-8")))
+        print(f"OK {path}")
+    print(f"Validated {len(paths)} Gravel Weekly historical entr{'y' if len(paths) == 1 else 'ies'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -11,12 +11,17 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
 sys.path.insert(0, str(ROOT / "wordpress"))
 
-from generate_gravel_weekly import build_page  # noqa: E402
+from generate_gravel_weekly import build_page, render_history_timeline  # noqa: E402
 from validate_gravel_weekly import (  # noqa: E402
     IssueValidationError,
     compute_content_hash,
     load_issues,
     validate_issue,
+)
+from validate_gravel_weekly_history import (  # noqa: E402
+    compute_history_content_hash,
+    load_history_entries,
+    validate_history_entry,
 )
 from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
 from prepare_gravel_weekly_issue import prepare_issue  # noqa: E402
@@ -81,6 +86,44 @@ def sample_issue():
     }
     issue["contentHash"] = compute_content_hash(issue)
     return issue
+
+
+def sample_history_entry():
+    entry = {
+        "schemaVersion": "gravel-weekly-history-entry/v1",
+        "entryId": "history-teamification-2026",
+        "activeFrom": "2026-02-10",
+        "activeThrough": "2026-05-26",
+        "status": "published",
+        "headline": "The privateer became gravel's unpaid control group",
+        "point": "Open registration survived while access to race-deciding support became less open.",
+        "priorJudgment": "Top-level gravel remained unusually accessible to independent riders.",
+        "changedJudgment": "The start stayed open while the competitive infrastructure became increasingly gated.",
+        "stakes": "Independent riders face a different path to competitive relevance.",
+        "credibleOpposition": "Teams can fund opportunity, and privateers can still win.",
+        "whatHappened": "Contemporary reporting documented the arrival of larger teams and later examined financial and tactical consequences.",
+        "take": "Gravel did not close the door. It installed a backstage entrance.",
+        "takeProvenance": "human_approved",
+        "uncertainty": "Team budgets and support access were not comprehensively public.",
+        "editorialScore": 91,
+        "editorialGates": {"party": "pass", "point": "pass", "friend": "pass", "craft": "pass", "hostileEditor": "pass"},
+        "contemporaryReceipts": [
+            {"claimId": "claim_team_1", "canonicalUrl": "https://www.cyclingnews.com/team-story/", "publisher": "Cyclingnews", "publishedAt": "2026-02-10T12:00:00Z", "quoteExcerpt": "A bounded contemporary excerpt.", "transcriptStartSeconds": None, "transcriptEndSeconds": None},
+            {"claimId": "claim_team_2", "canonicalUrl": "https://velo.outsideonline.com/team-story/", "publisher": "Velo", "publishedAt": "2026-05-26T12:00:00Z", "quoteExcerpt": "A second bounded contemporary excerpt.", "transcriptStartSeconds": None, "transcriptEndSeconds": None},
+        ],
+        "laterEvidence": [
+            {"claimId": "claim_team_later", "canonicalUrl": "https://example.com/later-analysis/", "publisher": "Official series", "publishedAt": "2026-06-10T12:00:00Z", "quoteExcerpt": "A later update.", "transcriptStartSeconds": None, "transcriptEndSeconds": None},
+        ],
+        "raceImpacts": [],
+        "humanApprovalRequired": True,
+        "autoPublishAllowed": False,
+        "editorialApproval": {"approver": "Matti Rowe", "approvedAt": "2026-08-28T16:00:00Z"},
+        "publishedAt": "2026-08-28T16:05:00Z",
+        "updatedAt": "2026-08-28T16:05:00Z",
+        "contentHash": "pending",
+    }
+    entry["contentHash"] = compute_history_content_hash(entry)
+    return entry
 
 
 def passing_editorial_gate():
@@ -510,6 +553,55 @@ def test_retrospective_must_reference_an_earlier_archived_story(tmp_path):
     (tmp_path / "2026-08-28.json").write_text(json.dumps(issue))
     with pytest.raises(IssueValidationError, match="archived issue"):
         load_issues(tmp_path)
+
+
+def test_historical_current_thing_requires_contemporary_corroboration_and_human_gates(tmp_path):
+    entry = sample_history_entry()
+    assert validate_history_entry(entry)["entryId"] == "history-teamification-2026"
+    (tmp_path / "2026-teamification.json").write_text(json.dumps(entry))
+    assert load_history_entries(tmp_path)[0]["entryId"] == entry["entryId"]
+
+    one_publisher = copy.deepcopy(entry)
+    one_publisher["contemporaryReceipts"][1]["publisher"] = "Cyclingnews"
+    with pytest.raises(IssueValidationError, match="two contemporary publishers"):
+        validate_history_entry(one_publisher, verify_hash=False)
+
+    held_gate = copy.deepcopy(entry)
+    held_gate["editorialGates"]["friend"] = "hold"
+    with pytest.raises(IssueValidationError, match="every editorial gate"):
+        validate_history_entry(held_gate, verify_hash=False)
+
+    model_take = copy.deepcopy(entry)
+    model_take["takeProvenance"] = "model_draft"
+    with pytest.raises(IssueValidationError, match="human-approved provenance"):
+        validate_history_entry(model_take, verify_hash=False)
+
+
+def test_historical_timeline_visually_separates_later_evidence_from_contemporary_receipts():
+    entry = sample_history_entry()
+    html = render_history_timeline([entry])
+    assert "THE SEASON AS A STORY" in html
+    assert "WHAT WAS KNOWABLE THEN" in html
+    assert "LATER EVIDENCE — NOT AVAILABLE THEN" in html
+    assert "WHY IT MATTERED" in html
+    assert "THE FAIR OBJECTION" in html
+    assert "The privateer became gravel" in html
+    assert "innerHTML" not in html
+    page = build_page(sample_issue(), [sample_issue()], latest=True, history_entries=[entry])
+    assert 'id="season-story"' in page
+    assert page.index("THE CURRENT THING") < page.index("THE SEASON AS A STORY") < page.index("PAST ISSUES")
+
+
+def test_historical_chronology_rejects_hindsight_in_contemporary_receipts_and_preexisting_later_evidence():
+    future_contemporary = sample_history_entry()
+    future_contemporary["contemporaryReceipts"][1]["publishedAt"] = "2026-06-01T12:00:00Z"
+    with pytest.raises(IssueValidationError, match="later evidence"):
+        validate_history_entry(future_contemporary, verify_hash=False)
+
+    early_later = sample_history_entry()
+    early_later["laterEvidence"][0]["publishedAt"] = "2026-05-20T12:00:00Z"
+    with pytest.raises(IssueValidationError, match="must postdate"):
+        validate_history_entry(early_later, verify_hash=False)
 
 
 def test_worker_accepts_new_and_legacy_publication_sources():

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -19,6 +19,7 @@ from brand_tokens import get_font_face_css, get_ga4_head_snippet, get_tokens_css
 from cookie_consent import get_consent_banner_html  # noqa: E402
 from shared_header import get_site_header_css, get_site_header_html, get_site_header_js  # noqa: E402
 from validate_gravel_weekly import load_issues, validate_issue  # noqa: E402
+from validate_gravel_weekly_history import HISTORY_DIR, load_history_entries  # noqa: E402
 
 ISSUE_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "issues"
 OUTPUT = PROJECT_ROOT / "wordpress" / "output" / "gravel-weekly.html"
@@ -188,6 +189,39 @@ def render_archive(issues: list[dict[str, Any]], active_issue_id: str) -> str:
     return f'<ol class="gw-archive">{"".join(items)}</ol>' if items else '<p class="gw-empty">The archive starts with Issue #001.</p>'
 
 
+def render_history_timeline(entries: list[dict[str, Any]]) -> str:
+    if not entries:
+        return '''<section class="gw-history" id="season-story">
+          <header class="gw-history-head"><span class="gw-label">THE PULSE OF GRAVEL</span><h2>THE SEASON AS A STORY</h2><p>The backfill is underway. Empty periods stay empty until a sourced point clears the gate.</p></header>
+        </section>'''
+    cards = []
+    for entry in entries:
+        active_label = display_date(entry["activeFrom"])
+        if entry["activeThrough"] != entry["activeFrom"]:
+            active_label = f'{active_label} → {display_date(entry["activeThrough"])}'
+        later = ""
+        if entry["laterEvidence"]:
+            later = f'''<details class="gw-history-later">
+              <summary>LATER EVIDENCE — NOT AVAILABLE THEN · {len(entry['laterEvidence'])}</summary>
+              {render_receipts(entry['laterEvidence'])}
+            </details>'''
+        cards.append(f'''<article class="gw-history-entry" id="{esc(entry['entryId'])}">
+          <header><span class="gw-history-date">{esc(active_label.upper())}</span><span class="gw-score">EDITORIAL SCORE {entry['editorialScore']}/100</span><h3>{esc(entry['headline'])}</h3></header>
+          <div class="gw-history-grid">
+            <section><h4>THE POINT</h4>{prose(entry['point'])}<h4>WHAT HAPPENED</h4>{prose(entry['whatHappened'])}<h4>WHY IT MATTERED</h4>{prose(entry['stakes'])}<h4>THE FAIR OBJECTION</h4>{prose(entry['credibleOpposition'])}</section>
+            <section class="gw-history-take"><h4>THE TAKE</h4>{prose(entry['take'])}</section>
+          </div>
+          <div class="gw-history-judgment"><b>WHAT CHANGED:</b> {esc(entry['priorJudgment'])} → {esc(entry['changedJudgment'])}</div>
+          <details class="gw-details"><summary>WHAT WAS KNOWABLE THEN · {len(entry['contemporaryReceipts'])}</summary>{render_receipts(entry['contemporaryReceipts'])}</details>
+          {later}
+          <p class="gw-history-uncertainty"><b>UNCERTAINTY:</b> {esc(entry['uncertainty'])}</p>
+        </article>''')
+    return f'''<section class="gw-history" id="season-story">
+      <header class="gw-history-head"><span class="gw-label">THE PULSE OF GRAVEL</span><h2>THE SEASON AS A STORY</h2><p>Only approved narrative change-points. Contemporary receipts stay separate from what we learned later.</p></header>
+      <div class="gw-history-line">{"".join(cards)}</div>
+    </section>'''
+
+
 def json_ld(issue: dict[str, Any], canonical_url: str) -> str:
     current = story_by_id(issue, issue.get("currentThingStoryId"))
     payload = {
@@ -305,6 +339,28 @@ def page_css() -> str:
   .gw-archive strong { font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-md); }
   .gw-archive p { margin: 0; max-width: 760px; font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-normal); }
   .gw-archive .gw-archive-take { font-size: var(--gg-font-size-sm); color: var(--gg-color-secondary-brown); }
+  .gw-history { margin-top: var(--gg-spacing-2xl); border: var(--gg-border-heavy); background: var(--gg-color-white); }
+  .gw-history-head { padding: var(--gg-spacing-lg); border-bottom: var(--gg-border-heavy); background: var(--gg-color-gold); }
+  .gw-history-head h2 { margin: var(--gg-spacing-xs) 0; font-size: clamp(2rem, 6vw, 4.4rem); line-height: .95; }
+  .gw-history-head p { max-width: 760px; margin: 0; font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-md); }
+  .gw-history-line { position: relative; padding: var(--gg-spacing-lg); }
+  .gw-history-line::before { content: ''; position: absolute; top: 0; bottom: 0; left: calc(var(--gg-spacing-lg) + 7px); width: var(--gg-border-width-standard); background: var(--gg-color-teal); }
+  .gw-history-entry { position: relative; margin: 0 0 var(--gg-spacing-xl) var(--gg-spacing-lg); border: var(--gg-border-heavy); background: var(--gg-color-warm-paper); }
+  .gw-history-entry:last-child { margin-bottom: 0; }
+  .gw-history-entry::before { content: ''; position: absolute; left: calc(var(--gg-spacing-lg) * -1 - 9px); top: var(--gg-spacing-md); width: 14px; height: 14px; border: var(--gg-border-standard); background: var(--gg-color-gold); }
+  .gw-history-entry > header { padding: var(--gg-spacing-md); border-bottom: var(--gg-border-standard); }
+  .gw-history-date { display: inline-block; margin-right: var(--gg-spacing-xs); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-bold); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-history-entry h3 { margin: var(--gg-spacing-sm) 0 0; max-width: 860px; font-family: var(--gg-font-editorial); font-size: clamp(1.7rem, 4vw, 3rem); line-height: 1; }
+  .gw-history-grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr); }
+  .gw-history-grid section { padding: var(--gg-spacing-md); }
+  .gw-history-grid h4 { margin: 0 0 var(--gg-spacing-xs); font-size: var(--gg-font-size-xs); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-history-grid h4:not(:first-child) { margin-top: var(--gg-spacing-md); }
+  .gw-history-grid p { font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-relaxed); }
+  .gw-history-take { border-left: var(--gg-border-standard); background: var(--gg-color-sand); font-weight: var(--gg-font-weight-semibold); }
+  .gw-history-judgment, .gw-history-uncertainty { margin: 0; padding: var(--gg-spacing-sm) var(--gg-spacing-md); border-top: var(--gg-border-standard); font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-normal); }
+  .gw-history-later { border-top: var(--gg-border-heavy); background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }
+  .gw-history-later summary { cursor: pointer; padding: var(--gg-spacing-sm) var(--gg-spacing-md); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-history-later a { color: var(--gg-color-gold); }
   .gw-retrospectives { margin-top: var(--gg-spacing-xl); padding: var(--gg-spacing-lg); border: var(--gg-border-heavy); background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }
   .gw-retrospectives > h2 { margin: 0; font-size: clamp(2rem, 6vw, 4rem); }
   .gw-retro-dek { margin: var(--gg-spacing-xs) 0 var(--gg-spacing-lg); font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-md); }
@@ -332,17 +388,18 @@ def page_css() -> str:
   .gw-empty { font-family: var(--gg-font-editorial); font-style: italic; color: var(--gg-color-secondary-brown); }
   code { font-family: var(--gg-font-data); overflow-wrap: anywhere; }
   @media (max-width: 720px) {
-    .gw-cover-lines, .gw-story-grid, .gw-utility-grid, .gw-memory-grid { grid-template-columns: 1fr; }
+    .gw-cover-lines, .gw-story-grid, .gw-utility-grid, .gw-memory-grid, .gw-history-grid { grid-template-columns: 1fr; }
     .gw-cover-lines span { border-right: 0; border-bottom: var(--gg-border-subtle); }
     .gw-cover-lines span:last-child { border-bottom: 0; }
     .gw-take { border-left: 0; border-top: var(--gg-border-standard); }
     .gw-memory-grid section + section { border-left: 0; border-top: var(--gg-border-standard); }
+    .gw-history-take { border-left: 0; border-top: var(--gg-border-standard); }
     .gw-story-head, .gw-story-grid section, .gw-utility, .gw-sub { padding: var(--gg-spacing-md); }
   }
 '''
 
 
-def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, latest: bool) -> str:
+def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, latest: bool, history_entries: list[dict[str, Any]] | None = None) -> str:
     canonical_path = "/gravel-weekly/" if latest or issue is None else f"/gravel-weekly/{issue['slug']}/"
     canonical_url = f"{SITE_URL}{canonical_path}"
     if issue:
@@ -409,6 +466,7 @@ def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, la
     <div class="gw-cover-lines"><span>WHAT HAPPENED</span><span>WHAT IT MEANS</span><span>WHAT CHANGES</span></div>
   </header>
   {issue_body}
+  {render_history_timeline(history_entries or []) if latest else ''}
   <section class="gw-utility" id="past-issues"><h2>PAST ISSUES</h2>{render_archive(issues, issue_id)}</section>
   {subscribe_block()}
 </main>
@@ -430,10 +488,12 @@ def main() -> int:
         print(f"Generated draft-only preview: {args.preview_output}")
         return 0
     all_issues = load_issues(ISSUE_DIR)
+    all_history_entries = load_history_entries(HISTORY_DIR)
+    public_history_entries = [entry for entry in all_history_entries if entry["status"] in {"approved", "published"}]
     public_issues = [issue for issue in all_issues if issue["status"] in {"approved", "published"}]
     latest_issue = public_issues[0] if public_issues else None
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT.write_text(build_page(latest_issue, public_issues, latest=True), encoding="utf-8")
+    OUTPUT.write_text(build_page(latest_issue, public_issues, latest=True, history_entries=public_history_entries), encoding="utf-8")
     for issue in public_issues:
         target = ARCHIVE_OUTPUT / issue["slug"] / "index.html"
         target.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- add a sealed `gravel-weekly-history-entry/v1` publication contract
- require score >=85, all five gates, human-approved take, two contemporary publishers, chronology-safe receipts, and explicit safety flags
- render an accessible Season as a Story timeline between the current issue and Past Issues
- distinguish contemporary receipts from later evidence visually and semantically

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` (27 passed)
- `python3 -m pytest tests/ -q` (7,283 passed, 331 skipped)
- `python3 scripts/preflight_quality.py` (passed; existing environment warnings only)
- `python3 scripts/validate_gravel_weekly_history.py` (0 entries, valid empty state)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what editorial narrative can appear on the public Gravel Weekly homepage and adds a strict publication contract; risk is bounded to static generation and validated JSON, not runtime auth or payments.
> 
> **Overview**
> Introduces **approved historical “Current Thing” backfill** as first-class JSON under `data/gravel-weekly/history`, with fail-closed validation via `validate_gravel_weekly_history.py` (`gravel-weekly-history-entry/v1`, SHA-256 `contentHash`, editorial score ≥85, five passing gates, human-approved takes, two contemporary publishers, chronology rules separating contemporary receipts from later evidence, and fixed safety flags).
> 
> The **latest Gravel Weekly page** now renders a **“THE SEASON AS A STORY”** section (`#season-story`) between the current issue and **PAST ISSUES**, loading only `approved`/`published` entries; dated archive pages omit it. Contemporary vs. later sourcing is called out in copy and styling (including a distinct “LATER EVIDENCE — NOT AVAILABLE THEN” block).
> 
> **Tests** cover the history contract (corroboration, gates, provenance, receipt dates) and page placement/rendering expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f578d22b8573ddc7099ae2b67c8e8003351b4ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->