### PR TITLE
Stage first evidence-backed 2026 history draft

### DIFF
--- a/data/gravel-weekly/history/2026-life-time-admissions-office.json
+++ b/data/gravel-weekly/history/2026-life-time-admissions-office.json
@@ -1,0 +1,108 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-life-time-admissions-office-2026",
+  "activeFrom": "2026-03-19",
+  "activeThrough": "2026-08-12",
+  "status": "draft",
+  "headline": "Gravel Built a Governing Body by Accident",
+  "point": "Once one private series decides who receives roster access, compensation, pregnancy protection, development support, visibility, and a path into the following season, it is no longer merely awarding points; it is governing careers.",
+  "priorJudgment": "The Life Time Grand Prix was a valuable invitation-only race series layered over a broader gravel calendar.",
+  "changedJudgment": "By 2026, its selection and continuity policies had consequences that increasingly resembled those of a career institution, even though Life Time remained a private event company rather than a federation or employer.",
+  "stakes": "A roster decision can determine whether a privateer receives entries, compensation eligibility, sponsor visibility, a development pathway, pregnancy continuity, and a coherent season in the most commercially important domestic off-road series.",
+  "credibleOpposition": "Life Time is a private promoter funding opportunities rather than monopolizing the sport; athletes remain free to race elsewhere, performance pathways became clearer in 2026, and institutional responsibility should not be inferred merely because one series became desirable.",
+  "whatHappened": "Life Time described the 2026 Grand Prix as the professional home of off-road racing, selected a fixed elite roster, added conditional finisher compensation and pregnancy protection, expanded and funded its U23 pathway, made midseason wildcard replacements, and announced a new performance qualifier that would determine most remaining 2027 roster positions.",
+  "take": "Model draft, not Matti's approved view: Gravel hates governing bodies so much it accidentally built one out of race entries. Life Time now decides who gets access, protection, money, visibility, and a path back. Much of this is good: pregnancy protection is overdue, U23 support matters, and a performance qualifier beats a velvet-rope mystery. But good power is still power. When a single series can rescue or derail a privateer's year with one roster decision, it deserves scrutiny closer to a federation than applause for merely putting on six very good bike races.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The available record does not establish that Life Time is an employer or governing federation, does not fully explain the discretion used in initial 2026 selections, and predates the promised detailed 2027 qualifier scoring, tie-break, and eligibility rules. Source pages supply day-level publication dates normalized here to midnight UTC.",
+  "editorialScore": 89,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "hold"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_ltgp_professional_home_2026",
+      "canonicalUrl": "https://www.lifetimegrandprix.com/2026/03/19/new-for-2026/",
+      "publisher": "Life Time Grand Prix",
+      "publishedAt": "2026-03-19T00:00:00Z",
+      "quoteExcerpt": "Entering Year 5, the Life Time Grand Prix continues its evolution as the professional home for off-road racing.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_ltgp_selection_consequences_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/from-homecoming-happiness-to-shoe-kick-in-the-kidneys-riders-react-to-life-time-grand-prix-selections-for-2026-off-road-series/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-11-12T00:00:00Z",
+      "quoteExcerpt": "There were still six spots to be earned by wildcard selections after Unbound Gravel 200.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_ltgp_pregnancy_protection_2026",
+      "canonicalUrl": "https://www.lifetimegrandprix.com/2026/04/02/the-countdown-is-on-to-the-first-round-of-the-2026-life-time-grand-prix/",
+      "publisher": "Life Time Grand Prix",
+      "publishedAt": "2026-04-02T00:00:00Z",
+      "quoteExcerpt": "The policy allows selected athletes to withdraw from the series without penalty and guarantees them a protected roster spot for the following season.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_ltgp_u23_pathway_2026",
+      "canonicalUrl": "https://www.lifetimegrandprix.com/2026/06/11/life-time-expands-u23-program-increasing-athlete-roster-and-introducing-race-entry-support/",
+      "publisher": "Life Time Grand Prix",
+      "publishedAt": "2026-06-11T00:00:00Z",
+      "quoteExcerpt": "By both expanding the size of the U23 roster and covering race entry fees, Life Time is addressing two of the most significant barriers.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_ltgp_midseason_replacement_2026",
+      "canonicalUrl": "https://www.lifetimegrandprix.com/2026/07/01/roster-update-two-new-wild-cards/",
+      "publisher": "Life Time Grand Prix",
+      "publishedAt": "2026-07-01T00:00:00Z",
+      "quoteExcerpt": "Following the withdrawal of two male athletes, two new Wild Cards have been added to the field.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_ltgp_2027_qualifier_2026",
+      "canonicalUrl": "https://www.lifetimegrandprix.com/2026/08/12/life-time-announces-2027-life-time-grand-prix-structure/",
+      "publisher": "Life Time Grand Prix",
+      "publishedAt": "2026-08-12T00:00:00Z",
+      "quoteExcerpt": "Beginning in 2027, entry into the 25-woman and 25-man Life Time Grand Prix fields will be determined primarily through performance.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "no_change",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": null,
+      "claimIds": [],
+      "confidence": 0.95,
+      "owner": "Gravel God historical editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "no_change",
+      "raceId": "gravel:rad-dirt-fest",
+      "fieldPath": null,
+      "claimIds": [],
+      "confidence": 0.9,
+      "owner": "Gravel God historical editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T02:18:00Z",
+  "contentHash": "a8603990e375f2dd917e082e3f33a71beea9638a7e12c2762f64ac0d3528da5c"
+}

--- a/scripts/validate_gravel_weekly_history.py
+++ b/scripts/validate_gravel_weekly_history.py
@@ -162,6 +162,11 @@ def load_history_entries(history_dir: Path = HISTORY_DIR) -> list[dict[str, Any]
     return sorted(entries, key=lambda entry: (entry["activeThrough"], entry["activeFrom"]), reverse=True)
 
 
+def load_public_history_entries(history_dir: Path = HISTORY_DIR) -> list[dict[str, Any]]:
+    """Load only history entries that have cleared the editorial publication boundary."""
+    return [entry for entry in load_history_entries(history_dir) if entry["status"] in {"approved", "published"}]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("paths", nargs="*", type=Path)

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -21,6 +21,7 @@ from validate_gravel_weekly import (  # noqa: E402
 from validate_gravel_weekly_history import (  # noqa: E402
     compute_history_content_hash,
     load_history_entries,
+    load_public_history_entries,
     validate_history_entry,
 )
 from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
@@ -575,6 +576,29 @@ def test_historical_current_thing_requires_contemporary_corroboration_and_human_
     model_take["takeProvenance"] = "model_draft"
     with pytest.raises(IssueValidationError, match="human-approved provenance"):
         validate_history_entry(model_take, verify_hash=False)
+
+
+def test_historical_drafts_never_cross_the_public_loader(tmp_path):
+    approved = sample_history_entry()
+    draft = copy.deepcopy(approved)
+    draft.update({
+        "entryId": "history-held-model-draft-2026",
+        "status": "draft",
+        "take": "Model draft, not Matti's approved view: this stays backstage.",
+        "takeProvenance": "model_draft",
+        "editorialApproval": None,
+    })
+    draft["editorialGates"]["hostileEditor"] = "hold"
+    approved["contentHash"] = compute_history_content_hash(approved)
+    draft["contentHash"] = compute_history_content_hash(draft)
+    (tmp_path / "approved.json").write_text(json.dumps(approved))
+    (tmp_path / "draft.json").write_text(json.dumps(draft))
+
+    assert {entry["entryId"] for entry in load_history_entries(tmp_path)} == {
+        approved["entryId"],
+        draft["entryId"],
+    }
+    assert [entry["entryId"] for entry in load_public_history_entries(tmp_path)] == [approved["entryId"]]
 
 
 def test_historical_timeline_visually_separates_later_evidence_from_contemporary_receipts():

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -19,7 +19,7 @@ from brand_tokens import get_font_face_css, get_ga4_head_snippet, get_tokens_css
 from cookie_consent import get_consent_banner_html  # noqa: E402
 from shared_header import get_site_header_css, get_site_header_html, get_site_header_js  # noqa: E402
 from validate_gravel_weekly import load_issues, validate_issue  # noqa: E402
-from validate_gravel_weekly_history import HISTORY_DIR, load_history_entries  # noqa: E402
+from validate_gravel_weekly_history import HISTORY_DIR, load_public_history_entries  # noqa: E402
 
 ISSUE_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "issues"
 OUTPUT = PROJECT_ROOT / "wordpress" / "output" / "gravel-weekly.html"
@@ -488,8 +488,7 @@ def main() -> int:
         print(f"Generated draft-only preview: {args.preview_output}")
         return 0
     all_issues = load_issues(ISSUE_DIR)
-    all_history_entries = load_history_entries(HISTORY_DIR)
-    public_history_entries = [entry for entry in all_history_entries if entry["status"] in {"approved", "published"}]
+    public_history_entries = load_public_history_entries(HISTORY_DIR)
     public_issues = [issue for issue in all_issues if issue["status"] in {"approved", "published"}]
     latest_issue = public_issues[0] if public_issues else None
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What
- stage the first hidden 2026 Gravel Weekly historical Current Thing candidate
- preserve six dated contemporary receipts and explicit uncertainty
- keep the hostile-editor verdict at HOLD and prohibit automatic publication
- centralize and test the public history-loader boundary so drafts cannot render

## Editorial state
The take is a model draft, not Matti-approved copy. It remains backstage until every gate passes and human approval is recorded. Race impacts are context-only `no_change` proposals.

## Verification
- `python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2026-life-time-admissions-office.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q` (28 passed)
- `python3 -m pytest tests/` (7,289 passed, 331 skipped)
- `python3 scripts/preflight_quality.py` (all checks passed; 7 existing/environment warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON plus a small publication-boundary refactor; draft content is excluded from public HTML generation by design.
> 
> **Overview**
> Adds a **backstage** Gravel Weekly historical “Current Thing” draft for March–August 2026 on Life Time Grand Prix roster power (six contemporary receipts, explicit uncertainty, `model_draft` take, hostile-editor **hold**, no auto-publish). Race impacts are context-only `no_change` proposals.
> 
> Introduces **`load_public_history_entries`** so only `approved`/`published` history feeds the site generator, with a test that drafts never leak into that path. **`generate_gravel_weekly.py`** now uses that helper instead of an inline status filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b38eff5456c239f297fddf2626daf9ae1c254799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->