### PR TITLE
Stage two 2026 history drafts and annual backfill ledger

### DIFF
--- a/data/gravel-weekly/backfill/2026.json
+++ b/data/gravel-weekly/backfill/2026.json
@@ -1,0 +1,316 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2026,
+  "asOf": "2026-08-27T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/36",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33133357634",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 230,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2025-12-27",
+      "periodEndedAt": "2026-01-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2026-01-03",
+      "periodEndedAt": "2026-01-09",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-01-10",
+      "periodEndedAt": "2026-01-16",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-01-17",
+      "periodEndedAt": "2026-01-23",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Leadville equipment-boundary lead remains held; this window still needs a final disposition."
+    },
+    {
+      "periodStartedAt": "2026-01-24",
+      "periodEndedAt": "2026-01-30",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-01-31",
+      "periodEndedAt": "2026-02-06",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-02-07",
+      "periodEndedAt": "2026-02-13",
+      "sourceCardCount": 8,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-teamification-2026"
+      ],
+      "reason": "The pre-season privateer-versus-team thesis is preserved in the Unbound teamification draft."
+    },
+    {
+      "periodStartedAt": "2026-02-14",
+      "periodEndedAt": "2026-02-20",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-02-21",
+      "periodEndedAt": "2026-02-27",
+      "sourceCardCount": 5,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-02-28",
+      "periodEndedAt": "2026-03-06",
+      "sourceCardCount": 7,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-03-07",
+      "periodEndedAt": "2026-03-13",
+      "sourceCardCount": 13,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-03-14",
+      "periodEndedAt": "2026-03-20",
+      "sourceCardCount": 4,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-admissions-office-2026",
+        "history-organizer-controlled-safety-2026"
+      ],
+      "reason": "The Life Time institutional-policy and Mid South media-vehicle change-points both have dated receipts in this window."
+    },
+    {
+      "periodStartedAt": "2026-03-21",
+      "periodEndedAt": "2026-03-27",
+      "sourceCardCount": 5,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-03-28",
+      "periodEndedAt": "2026-04-03",
+      "sourceCardCount": 7,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-admissions-office-2026"
+      ],
+      "reason": "Life Time's pregnancy-protection announcement advances the career-institution draft."
+    },
+    {
+      "periodStartedAt": "2026-04-04",
+      "periodEndedAt": "2026-04-10",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-04-11",
+      "periodEndedAt": "2026-04-17",
+      "sourceCardCount": 9,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-04-18",
+      "periodEndedAt": "2026-04-24",
+      "sourceCardCount": 6,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-04-25",
+      "periodEndedAt": "2026-05-01",
+      "sourceCardCount": 11,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-05-02",
+      "periodEndedAt": "2026-05-08",
+      "sourceCardCount": 11,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "The Traka women's-race traffic lead still requires measured GPS, wave, and rider evidence."
+    },
+    {
+      "periodStartedAt": "2026-05-09",
+      "periodEndedAt": "2026-05-15",
+      "sourceCardCount": 6,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-05-16",
+      "periodEndedAt": "2026-05-22",
+      "sourceCardCount": 6,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-organizer-controlled-safety-2026"
+      ],
+      "reason": "The verified 2025-to-2026 UNBOUND feed-rule delta advances the organizer-controlled safety draft."
+    },
+    {
+      "periodStartedAt": "2026-05-23",
+      "periodEndedAt": "2026-05-29",
+      "sourceCardCount": 20,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-teamification-2026"
+      ],
+      "reason": "Pre-Unbound reporting establishes the live uncertainty over whether in-race team tactics could matter."
+    },
+    {
+      "periodStartedAt": "2026-05-30",
+      "periodEndedAt": "2026-06-05",
+      "sourceCardCount": 27,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-teamification-2026"
+      ],
+      "reason": "Race chronology, the wheel sacrifice, the 1-2-5 result, and instrumented bike development complete the Unbound teamification mechanism."
+    },
+    {
+      "periodStartedAt": "2026-06-06",
+      "periodEndedAt": "2026-06-12",
+      "sourceCardCount": 6,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-admissions-office-2026"
+      ],
+      "reason": "Life Time's expanded and funded U23 pathway advances the career-institution draft."
+    },
+    {
+      "periodStartedAt": "2026-06-13",
+      "periodEndedAt": "2026-06-19",
+      "sourceCardCount": 5,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-organizer-controlled-safety-2026"
+      ],
+      "reason": "Multi-rider reporting connects media, intersection, and feed risks while documenting the benefits and resource costs of UNBOUND's changes."
+    },
+    {
+      "periodStartedAt": "2026-06-20",
+      "periodEndedAt": "2026-06-26",
+      "sourceCardCount": 6,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-06-27",
+      "periodEndedAt": "2026-07-03",
+      "sourceCardCount": 4,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-admissions-office-2026"
+      ],
+      "reason": "Life Time's midseason wildcard replacements advance the career-institution draft."
+    },
+    {
+      "periodStartedAt": "2026-07-04",
+      "periodEndedAt": "2026-07-10",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-07-11",
+      "periodEndedAt": "2026-07-17",
+      "sourceCardCount": 5,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-07-18",
+      "periodEndedAt": "2026-07-24",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-07-25",
+      "periodEndedAt": "2026-07-31",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-08-01",
+      "periodEndedAt": "2026-08-07",
+      "sourceCardCount": 7,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-08-08",
+      "periodEndedAt": "2026-08-14",
+      "sourceCardCount": 10,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-admissions-office-2026"
+      ],
+      "reason": "Life Time's performance-based 2027 qualifier advances the career-institution draft."
+    },
+    {
+      "periodStartedAt": "2026-08-15",
+      "periodEndedAt": "2026-08-21",
+      "sourceCardCount": 5,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Census complete; no assigning-desk disposition recorded yet."
+    },
+    {
+      "periodStartedAt": "2026-08-22",
+      "periodEndedAt": "2026-08-28",
+      "sourceCardCount": 13,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "The Bonk Bros pass produced research leads, but no lead has yet cleared verification and editorial disposition."
+    }
+  ],
+  "updatedAt": "2026-08-28T03:05:00Z"
+}

--- a/data/gravel-weekly/history/2026-organizer-controlled-safety.json
+++ b/data/gravel-weekly/history/2026-organizer-controlled-safety.json
@@ -1,0 +1,125 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-organizer-controlled-safety-2026",
+  "activeFrom": "2026-03-13",
+  "activeThrough": "2026-06-17",
+  "status": "draft",
+  "headline": "Professional Gravel Built the Camera Car Before the Safety System",
+  "point": "Gravel's terrain is supposed to be dangerous; an accredited media vehicle, an unmanaged intersection, or a feed zone designed by the organizer is not terrain. In 2026 riders increasingly treated those controllable hazards as operational failures, and organizers began changing rules in response.",
+  "priorJudgment": "Open roads, chaotic feeds, mixed fields, and moving media were unpleasant but largely inseparable from the self-reliance and enormous footprint of mass-participation gravel racing.",
+  "changedJudgment": "Once the danger is created by the professional apparatus surrounding the race, self-reliance is no defense. Media operations, traffic control, and support-zone design require explicit standards, trained operators, and accountable review.",
+  "stakes": "The distinction determines whether riders must simply accept preventable injury risk, whether organizers learn across events, whether media access outranks athlete safety, and whether a safety improvement protects everyone or merely shifts cost onto riders with enough crew and money.",
+  "credibleOpposition": "A six-to-twelve-hour gravel race cannot be closed like a road circuit, natural and rider-created risk cannot be eliminated, the Mid South incident caused no injury, and early rider feedback indicates UNBOUND's longer elite-only feeds substantially improved safety despite logistical tradeoffs.",
+  "whatHappened": "At The Mid South, a media buggy carrying race coverage personnel drove into the line of the two leading women, forcing Sofía Gómez Villafañe and Paige Onweller to brake and swerve; the organizer called it an operational failure. UNBOUND's 2026 elite guide then replaced the prior two-checkpoint support model with three elite-only feed zones, prohibited elite support at amateur checkpoints, and introduced right-side feeding. After the race, riders said the separation and added space improved safety, while also warning that the three-zone logistics split scarce crew resources. By June, riders were publicly connecting media vehicles, intersections, and feeds as recurring organizer-controlled risks rather than isolated gravel chaos.",
+  "take": "Model draft, not Matti's approved view: Rocks are part of the product. Weather is part of the product. A camera buggy arriving in the leaders' line like a drunk mall cop is not part of the product. Gravel found money for livestreams, prize purses, and Formula 1 bike programs before it found a shared operating standard for the machines filming the race. That is not the spirit of gravel; it is unfinished event production. UNBOUND's new feeds show organizers can respond, but a safety fix that quietly requires three crews and endless resources is not finished either. Control the controllables, then publish what worked and what did not so the next promoter does not have to learn with somebody else's collarbone.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The available record does not quantify incident rates across races, prove that the UNBOUND changes were caused by the Mid South incident, establish whether the new feed design reduced risk under normal rather than mud-split field conditions, or supply a common organizer standard for media and intersection operations. The official guide dates are taken from verified PDF metadata; other source pages provide day-level publication dates normalized here to midnight UTC.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_unbound_2025_two_checkpoint_support",
+      "canonicalUrl": "https://www.unboundgravel.com/wp-content/uploads/2025/05/2025LTGPTechGuideUNBOUNDGravel_FINAL.pdf",
+      "publisher": "UNBOUND Gravel",
+      "publishedAt": "2025-05-22T00:00:00Z",
+      "quoteExcerpt": "All elite athletes will be required to check in at Checkpoint 1 and Checkpoint 2.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_mid_south_media_vehicle_failure_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/its-unacceptable-that-our-safety-keeps-being-compromised-for-the-shot-two-riders-almost-run-over-by-driver-of-media-vehicle-at-mid-south-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-03-16T00:00:00Z",
+      "quoteExcerpt": "This was an operational failure, and we own it",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_2026_right_side_feeding",
+      "canonicalUrl": "https://www.unboundgravel.com/wp-content/uploads/2026/05/2026LTGPTechGuideUNBOUNDGravel.pdf",
+      "publisher": "UNBOUND Gravel",
+      "publishedAt": "2026-05-22T00:00:00Z",
+      "quoteExcerpt": "New in 2026 – All feeds must occur from the RIGHT side of the road.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_2026_elite_only_feeds",
+      "canonicalUrl": "https://www.unboundgravel.com/wp-content/uploads/2026/05/2026LTGPTechGuideUNBOUNDGravel.pdf",
+      "publisher": "UNBOUND Gravel",
+      "publishedAt": "2026-05-22T00:00:00Z",
+      "quoteExcerpt": "Elite athletes may NOT receive feeding, mechanical or any other support at the Amateur Checkpoints.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_riders_safety_priority_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/i-would-trade-all-the-prize-money-for-safety-top-gravel-pros-voice-concerns-about-mayhem-with-media-vehicles-intersections-and-feed-zones/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-06-17T00:00:00Z",
+      "quoteExcerpt": "Safety should be number one. I would trade all the prize money for safety.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_separate_feeds_improved_safety_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/i-would-trade-all-the-prize-money-for-safety-top-gravel-pros-voice-concerns-about-mayhem-with-media-vehicles-intersections-and-feed-zones/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-06-17T00:00:00Z",
+      "quoteExcerpt": "the elite feeds were separate so that improved safety",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_feed_resource_tradeoff_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/i-would-trade-all-the-prize-money-for-safety-top-gravel-pros-voice-concerns-about-mayhem-with-media-vehicles-intersections-and-feed-zones/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-06-17T00:00:00Z",
+      "quoteExcerpt": "Unless you have endless resources in this industry, which is pretty rare, I think it stressed a lot of people.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:mid-south",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_mid_south_media_vehicle_failure_2026"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_unbound_2025_two_checkpoint_support",
+        "claim_unbound_2026_right_side_feeding",
+        "claim_unbound_2026_elite_only_feeds",
+        "claim_unbound_separate_feeds_improved_safety_2026",
+        "claim_unbound_feed_resource_tradeoff_2026"
+      ],
+      "confidence": 0.95,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T03:05:00Z",
+  "contentHash": "b96ec00b4732e01f295da6f41c9fb5751da40cff3cd7c4fec955bced5c10458f"
+}

--- a/data/gravel-weekly/history/2026-unbound-teamification.json
+++ b/data/gravel-weekly/history/2026-unbound-teamification.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-unbound-teamification-2026",
+  "activeFrom": "2026-02-10",
+  "activeThrough": "2026-06-02",
+  "status": "draft",
+  "headline": "A Flat Tire Made Gravel Admit Teams Exist",
+  "point": "When Keegan Swenson surrendered his wheel and his own chance to win, Matt Beers declined to chase, and Specialized converted two years of instrumented development into a 1-2-5 men's result, the competitive unit at the front of Unbound was no longer merely the rider. It was the organization.",
+  "priorJudgment": "Gravel teams were mostly shared jerseys, travel, mechanics, and feed support layered around a race whose decisive contest remained individual and chaotic enough for a resourceful privateer to win.",
+  "changedJudgment": "At the sharp end of Unbound, integrated tactics, interchangeable labor, course reconnaissance, engineering, and support could now compound into an advantage no individual privateer could reproduce alone.",
+  "stakes": "If the organization rather than the rider is becoming the competitive unit, privateers face a different labor market and a different race. Organizers, sponsors, and media must decide whether to regulate team behavior, create viable independent pathways, or at least stop selling a corporate contest as frontier individualism.",
+  "credibleOpposition": "Mads Würtz Schmidt appeared to be the strongest rider, the wheel exchange was a rational response to an emergency rather than proof of a scripted plan, cooperation has always existed in gravel, and a single dominant result cannot establish that privateers are obsolete or that team tactics should be restricted.",
+  "whatHappened": "In February, Cyclingnews framed 2026 as a turning point from the privateer default toward professional teams. Days before Unbound, another report found that traditional in-race team tactics still seemed difficult in gravel. During the men's race, Specialized teammates Würtz Schmidt and Swenson escaped together; when Würtz Schmidt punctured, Swenson gave him a wheel and sacrificed his own race because the team's best chance was Würtz Schmidt. Beers did not help chase his teammates and finished second, while Swenson recovered to fifth. Afterward, Beers described two years of Specialized testing, including sensor-equipped reconnaissance and racing, feeding an in-house simulation model used to develop the bike ridden to the leading results.",
+  "take": "Model draft, not Matti's approved view: Gravel spent years pretending matching jerseys were just friends at the same sleepover. Then Keegan Swenson handed the strongest rider his wheel and his shot at Unbound, Matt Beers declined to chase, and Specialized went 1-2-5 on a bike informed by two years of black-box data. The privateer myth did not die because teams are evil. It died because pretending they are not teams became stupid. Stop asking riders to cosplay as rugged individualists while brands build Formula 1 programs around them. The honest argument now is what independent riders are owed in a race increasingly contested by organizations.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The record does not disclose Specialized's budget, establish every pre-race instruction, quantify the bike-development advantage, prove that Würtz Schmidt would have lost without the wheel exchange, or show that comparable tactics will determine most future races. The official event page links the 2026 timing portal, but the result chronology here relies on two established publications because the portal does not expose readable result rows to this archive. Source pages provide day-level publication dates normalized here to midnight UTC.",
+  "editorialScore": 94,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_gravel_privateer_default_challenged_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/riders-making-six-figures-race-against-some-who-arent-making-a-cent-are-pro-gravel-teams-about-to-be-the-end-of-the-privateer/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-02-10T00:00:00Z",
+      "quoteExcerpt": "The privateer model will still exist and thrive, but it won't be the dominant pathway anymore.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_team_tactics_pre_unbound_uncertain_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/a-loss-of-community-two-tier-finances-and-a-tactical-conundrum-are-professional-teams-reshaping-the-gravel-scene/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-26T00:00:00Z",
+      "quoteExcerpt": "Team tactics don’t exist – yet",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_specialized_unbound_one_two_2026",
+      "canonicalUrl": "https://www.cyclingweekly.com/gravel/mads-wurtz-schmidt-wins-unbound-gravel",
+      "publisher": "Cycling Weekly",
+      "publishedAt": "2026-05-30T00:00:00Z",
+      "quoteExcerpt": "Specialized Off-Road played its cards perfectly to take the first two spots on the podium.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_swenson_wheel_sacrifice_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/if-i-give-him-the-wheel-he-can-win-the-story-of-keegan-swensons-sacrifice-to-help-mads-wurtz-schmidt-triumph-at-unbound-gravel-200/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-31T00:00:00Z",
+      "quoteExcerpt": "the goal was that one of us had to win the race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_specialized_unbound_telemetry_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/bikes/pro-bikes/telemetry-boxes-years-of-recon-and-very-complex-math-matt-beers-explains-how-specialized-dominated-unbound-2026-with-its-new-bike/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-06-02T00:00:00Z",
+      "quoteExcerpt": "We had a little black box on the saddle that took data from the race.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_specialized_crux_top_results_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/bikes/pro-bikes/telemetry-boxes-years-of-recon-and-very-complex-math-matt-beers-explains-how-specialized-dominated-unbound-2026-with-its-new-bike/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-06-02T00:00:00Z",
+      "quoteExcerpt": "riders on the new Crux 5 from Specialized claimed the top three spots in the elite men's 200-mile race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_specialized_unbound_one_two_2026",
+        "claim_swenson_wheel_sacrifice_2026",
+        "claim_specialized_unbound_telemetry_2026",
+        "claim_specialized_crux_top_results_2026"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T03:05:00Z",
+  "contentHash": "7514279d3334eeedd219975fefb6f3f278ebaf6d5820c09cd7a2046a2abcfbc5"
+}

--- a/scripts/validate_gravel_weekly_backfill.py
+++ b/scripts/validate_gravel_weekly_backfill.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Validate the year-level accounting ledger for Gravel Weekly history backfill."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from validate_gravel_weekly import IssueValidationError, _iso, _list, _record, _text, _url
+from validate_gravel_weekly_history import HISTORY_DIR, load_history_entries
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+BACKFILL_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "backfill"
+DISPOSITIONS = {
+    "explicit_gap",
+    "pending_review",
+    "covered_by_draft",
+    "held_for_evidence",
+    "rejected",
+    "approved",
+}
+
+
+def _day(value: Any, name: str) -> str:
+    raw = _text(value, name, 10)
+    try:
+        parsed = datetime.strptime(raw, "%Y-%m-%d")
+    except ValueError as exc:
+        raise IssueValidationError(f"{name} must be YYYY-MM-DD") from exc
+    return parsed.date().isoformat()
+
+
+def validate_backfill_ledger(value: Any, history_entries: list[dict[str, Any]]) -> dict[str, Any]:
+    ledger = _record(value, "backfill ledger")
+    if ledger.get("schemaVersion") != "gravel-weekly-backfill-ledger/v1":
+        raise IssueValidationError("unsupported Gravel Weekly backfill ledger schema")
+    year = ledger.get("year")
+    if not isinstance(year, int) or isinstance(year, bool) or not 2000 <= year <= 2100:
+        raise IssueValidationError("backfill year is invalid")
+    _iso(ledger.get("asOf"), "asOf")
+    _url(ledger.get("sourceLedgerIssue"), "sourceLedgerIssue")
+    _url(ledger.get("sourceLedgerRun"), "sourceLedgerRun")
+    _url(ledger.get("programIssue"), "programIssue")
+    source_total = ledger.get("sourceCardCount")
+    if not isinstance(source_total, int) or isinstance(source_total, bool) or source_total < 0:
+        raise IssueValidationError("sourceCardCount is invalid")
+    if ledger.get("humanApprovalRequired") is not True or ledger.get("autoPublishAllowed") is not False:
+        raise IssueValidationError("backfill publication safety flags are invalid")
+
+    histories = {entry["entryId"]: entry for entry in history_entries}
+    weeks = _list(ledger.get("weeks"), "weeks", 54)
+    if not weeks:
+        raise IssueValidationError("backfill ledger requires weekly accounting")
+    previous_end: datetime | None = None
+    counted_sources = 0
+    pending = 0
+    for index, week_value in enumerate(weeks):
+        name = f"weeks[{index}]"
+        week = _record(week_value, name)
+        started = datetime.strptime(_day(week.get("periodStartedAt"), f"{name}.periodStartedAt"), "%Y-%m-%d")
+        ended = datetime.strptime(_day(week.get("periodEndedAt"), f"{name}.periodEndedAt"), "%Y-%m-%d")
+        if (ended - started).days != 6 or started.weekday() != 5 or ended.weekday() != 4:
+            raise IssueValidationError(f"{name} must be one Saturday-through-Friday window")
+        if previous_end is not None and started != previous_end + timedelta(days=1):
+            raise IssueValidationError("backfill weeks must be contiguous and ordered")
+        previous_end = ended
+        count = week.get("sourceCardCount")
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise IssueValidationError(f"{name}.sourceCardCount is invalid")
+        counted_sources += count
+        disposition = week.get("disposition")
+        if disposition not in DISPOSITIONS:
+            raise IssueValidationError(f"{name}.disposition is invalid")
+        entry_ids = [
+            _text(entry_id_value, f"{name}.entryIds[{entry_index}]", 500)
+            for entry_index, entry_id_value in enumerate(_list(week.get("entryIds"), f"{name}.entryIds", 20))
+        ]
+        if len(entry_ids) != len(set(entry_ids)):
+            raise IssueValidationError(f"{name}.entryIds contains duplicates")
+        for entry_id in entry_ids:
+            entry = histories.get(entry_id)
+            if entry is None:
+                raise IssueValidationError(f"{name} references unknown history entry {entry_id}")
+            if not any(started.date() <= datetime.fromisoformat(receipt["publishedAt"].replace("Z", "+00:00")).date() <= ended.date() for receipt in entry["contemporaryReceipts"]):
+                raise IssueValidationError(f"{name} links {entry_id} without a contemporary receipt in that week")
+        reason = _text(week.get("reason"), f"{name}.reason", 1_000)
+        if disposition == "explicit_gap" and (count != 0 or entry_ids):
+            raise IssueValidationError("explicit gaps require zero source cards and no entries")
+        if disposition == "pending_review" and (count == 0 or entry_ids):
+            raise IssueValidationError("pending windows require source cards and no linked entries")
+        if disposition in {"covered_by_draft", "approved"} and not entry_ids:
+            raise IssueValidationError(f"{disposition} windows require linked history entries")
+        if disposition == "covered_by_draft" and any(histories[entry_id]["status"] != "draft" for entry_id in entry_ids):
+            raise IssueValidationError("covered_by_draft windows must link only draft entries")
+        if disposition == "approved" and any(histories[entry_id]["status"] not in {"approved", "published"} for entry_id in entry_ids):
+            raise IssueValidationError("approved windows require approved or published entries")
+        if disposition == "pending_review":
+            pending += 1
+        if not reason:
+            raise IssueValidationError(f"{name}.reason is required")
+    if counted_sources != source_total:
+        raise IssueValidationError(f"weekly source-card sum {counted_sources} does not match {source_total}")
+    complete = ledger.get("complete")
+    if not isinstance(complete, bool) or complete != (pending == 0):
+        raise IssueValidationError("complete must be true exactly when no weekly window remains pending")
+    _iso(ledger.get("updatedAt"), "updatedAt")
+    return ledger
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*", type=Path)
+    args = parser.parse_args()
+    histories = load_history_entries(HISTORY_DIR)
+    paths = args.paths or sorted(BACKFILL_DIR.glob("*.json"))
+    for path in paths:
+        validate_backfill_ledger(json.loads(path.read_text(encoding="utf-8")), histories)
+        print(f"OK {path}")
+    print(f"Validated {len(paths)} Gravel Weekly backfill ledger{'s' if len(paths) != 1 else ''}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -24,6 +24,7 @@ from validate_gravel_weekly_history import (  # noqa: E402
     load_public_history_entries,
     validate_history_entry,
 )
+from validate_gravel_weekly_backfill import validate_backfill_ledger  # noqa: E402
 from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
 from prepare_gravel_weekly_issue import prepare_issue  # noqa: E402
 from approve_gravel_weekly_issue import approve_issue, build_decision_receipt  # noqa: E402
@@ -599,6 +600,33 @@ def test_historical_drafts_never_cross_the_public_loader(tmp_path):
         draft["entryId"],
     }
     assert [entry["entryId"] for entry in load_public_history_entries(tmp_path)] == [approved["entryId"]]
+
+
+def test_2026_backfill_ledger_accounts_for_every_window_without_claiming_completion():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2026.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 35
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 230
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 10
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 24
+    assert validated["complete"] is False
+
+    missing_window = copy.deepcopy(ledger)
+    missing_window["weeks"].pop(10)
+    with pytest.raises(IssueValidationError, match="contiguous"):
+        validate_backfill_ledger(missing_window, histories)
+
+    dishonest_gap = copy.deepcopy(ledger)
+    dishonest_gap["weeks"][1]["disposition"] = "explicit_gap"
+    with pytest.raises(IssueValidationError, match="explicit gaps"):
+        validate_backfill_ledger(dishonest_gap, histories)
+
+    premature_completion = copy.deepcopy(ledger)
+    premature_completion["complete"] = True
+    with pytest.raises(IssueValidationError, match="no weekly window remains pending"):
+        validate_backfill_ledger(premature_completion, histories)
 
 
 def test_historical_timeline_visually_separates_later_evidence_from_contemporary_receipts():


### PR DESCRIPTION
## What
- stage a 94-point hidden draft on Unbound teamification
- stage a 96-point hidden draft on organizer-controlled safety
- translate both stories into controlled race-editorial review requests without mutating race data
- add a durable 35-window 2026 backfill ledger and fail-closed validator
- reject missing windows, dishonest source gaps, unknown history links, and premature completion

## Current 2026 accounting
- 35 Friday-ended windows represented
- 10 windows covered by three hidden drafts
- 1 explicit source gap
- 24 windows still honestly pending
- `complete: false`

## Publication boundary
Both new entries remain `status: draft`, `takeProvenance: model_draft`, require human approval, and prohibit automatic publication or race mutation.

## Verification
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2026.json`
- `python3 scripts/validate_gravel_weekly_history.py`
- `python3 -m pytest tests/test_gravel_weekly.py -q` (29 passed)
- `python3 -m pytest tests/` (7,290 passed, 331 skipped)
- `python3 scripts/preflight_quality.py` (all checks passed; 7 existing/environment warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and validation-only Python; drafts cannot auto-publish and race data is not mutated.
> 
> **Overview**
> Adds **two draft Gravel Weekly history entries** (Unbound teamification and organizer-controlled safety) with sourced receipts, model-draft takes, human-approval gates, and **non-mutating** `raceImpacts` editorial-review hooks for Unbound and Mid South.
> 
> Introduces a **2026 backfill ledger** (`complete: false`) that accounts for **35** Saturday–Friday windows, **230** source cards, one explicit gap, **10** weeks linked to draft entries (including the pre-existing Life Time draft), and **24** weeks left `pending_review`.
> 
> Adds **`validate_gravel_weekly_backfill.py`** plus tests that fail closed on contiguous weeks, honest dispositions, receipt-in-window links, source-card totals, and forbidding `complete: true` while any window is still pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fdfeaaeccb931d60f83625ca425115a3a2d8a23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->