### PR TITLE
Fix immune scanner fingerprint bug for volatile-detail findings

### DIFF
--- a/scripts/immune_check.py
+++ b/scripts/immune_check.py
@@ -514,7 +514,27 @@ def now_iso() -> str:
 
 
 def fingerprint(f: Finding) -> str:
-    """Stable identity for a finding, so the baseline can recognise a recurrence."""
+    """Stable identity for a finding, so the baseline can recognise a recurrence.
+    
+    For certain finding codes with inherently volatile details (e.g. WAF-challenged
+    URL lists that shift run-to-run, or transport-noise blockers), we fingerprint
+    on the code alone so the finding can stabilize against the baseline even when
+    the specific URLs/counts vary. The full detail is still preserved in the
+    finding payload for human visibility.
+    """
+    # Finding codes with volatile details that should fingerprint on code alone:
+    # - live-check-challenged: list of WAF-challenged URLs changes each run
+    # - prep-kit-check-blocked: transport noise, no stable URL list
+    # - deploy-parity-skipped: informational skip, detail is static but code-only is cleaner
+    VOLATILE_CODES = {
+        "live-check-challenged",
+        "prep-kit-check-blocked", 
+        "deploy-parity-skipped",
+    }
+    
+    if f.code in VOLATILE_CODES:
+        return f.code
+    
     return f"{f.code}::{f.detail}"
 
 

--- a/tests/test_immune_waf.py
+++ b/tests/test_immune_waf.py
@@ -152,3 +152,99 @@ def test_rc1_without_parsable_dead_lines_flags_drift(monkeypatch):
 def test_clean_run_yields_nothing(monkeypatch):
     findings = parse(monkeypatch, "All links alive.\n", 0)
     assert findings == []
+
+
+# ── Fingerprint stability for volatile-detail findings ──────────────────────
+def test_volatile_code_fingerprints_on_code_alone():
+    """Findings with inherently volatile details (e.g. live-check-challenged with
+    shifting WAF-challenged URL lists) must fingerprint on code alone, not detail,
+    so they can stabilize against baseline.json even when the specific URLs change.
+    """
+    f1 = immune_check.Finding(
+        "live-check-challenged", immune_check.YELLOW, "low",
+        "Live Check Challenged by WAF",
+        "12 URLs unverifiable: https://example.com/a/ https://example.com/b/",
+        "WAF variance", None, "check_links")
+    f2 = immune_check.Finding(
+        "live-check-challenged", immune_check.YELLOW, "low",
+        "Live Check Challenged by WAF", 
+        "8 URLs unverifiable: https://example.com/c/ https://example.com/d/",
+        "WAF variance", None, "check_links")
+    assert immune_check.fingerprint(f1) == immune_check.fingerprint(f2) == "live-check-challenged"
+
+
+def test_prep_kit_blocked_fingerprints_stable():
+    """prep-kit-check-blocked (transport noise, no stable URL list) should also
+    fingerprint on code alone."""
+    f1 = immune_check.Finding(
+        "prep-kit-check-blocked", immune_check.YELLOW, "low",
+        "Prep-Kit Coverage Partially Blocked",
+        "some kit URLs returned non-404 errors (WAF challenge / timeout) — coverage unverified for those",
+        "Transport noise", None, "check_prep_kit_coverage")
+    f2 = immune_check.Finding(
+        "prep-kit-check-blocked", immune_check.YELLOW, "low",
+        "Prep-Kit Coverage Partially Blocked",
+        "different detail text here for variation",
+        "Transport noise", None, "check_prep_kit_coverage")
+    assert immune_check.fingerprint(f1) == immune_check.fingerprint(f2) == "prep-kit-check-blocked"
+
+
+def test_deploy_parity_skipped_fingerprints_stable():
+    """deploy-parity-skipped (informational skip) should fingerprint on code alone."""
+    f = immune_check.Finding(
+        "deploy-parity-skipped", immune_check.GREEN, "low",
+        "Deploy Parity Skipped",
+        "no SSH creds in this environment — live-tree drift unverified (not a defect)",
+        "Informational skip", None, "deploy_parity")
+    assert immune_check.fingerprint(f) == "deploy-parity-skipped"
+
+
+def test_normal_findings_still_fingerprint_with_detail():
+    """Findings that don't have volatile details should continue using code::detail."""
+    f1 = immune_check.Finding(
+        "prep-kit-missing", immune_check.YELLOW, "high",
+        "Prep kit missing: dirty-kanza",
+        "https://gravelgodcycling.com/race/dirty-kanza/prep-kit/",
+        "Generate the kit", None, "check_prep_kit_coverage")
+    f2 = immune_check.Finding(
+        "prep-kit-missing", immune_check.YELLOW, "high",
+        "Prep kit missing: unbound-gravel",
+        "https://gravelgodcycling.com/race/unbound-gravel/prep-kit/",
+        "Generate the kit", None, "check_prep_kit_coverage")
+    fp1 = immune_check.fingerprint(f1)
+    fp2 = immune_check.fingerprint(f2)
+    # Different races should have different fingerprints
+    assert fp1 != fp2
+    assert fp1 == "prep-kit-missing::https://gravelgodcycling.com/race/dirty-kanza/prep-kit/"
+    assert fp2 == "prep-kit-missing::https://gravelgodcycling.com/race/unbound-gravel/prep-kit/"
+
+
+def test_second_scan_with_different_challenged_urls_is_not_new(monkeypatch):
+    """End-to-end: two scans with different WAF-challenged URLs should produce the
+    same fingerprint, so the second run marks new:false (the core bug being fixed)."""
+    # First scan: 2 challenged URLs
+    stdout1 = (
+        "\nWAF-CHALLENGED (2): still behind SiteGround's bot challenge after retries\n"
+        "   202  https://gravelgodcycling.com/a/\n"
+        "   202  https://gravelgodcycling.com/b/\n")
+    findings1 = parse(monkeypatch, stdout1, 2)
+    assert len(findings1) == 1
+    fp1 = immune_check.fingerprint(findings1[0])
+    
+    # Second scan: different 2 challenged URLs
+    stdout2 = (
+        "\nWAF-CHALLENGED (2): still behind SiteGround's bot challenge after retries\n"
+        "   202  https://gravelgodcycling.com/c/\n"
+        "   202  https://gravelgodcycling.com/d/\n")
+    findings2 = parse(monkeypatch, stdout2, 2)
+    assert len(findings2) == 1
+    fp2 = immune_check.fingerprint(findings2[0])
+    
+    # Same fingerprint despite different URLs
+    assert fp1 == fp2 == "live-check-challenged"
+    
+    # Simulate baseline acceptance: if first run's fingerprint is in baseline,
+    # second run should be marked new:false
+    baseline = {fp1}
+    immune_check.mark_new(findings2, baseline)
+    assert not findings2[0].new


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #50

## Problem

The `fingerprint()` function in `scripts/immune_check.py` was baking volatile details (shifting URL lists, counts, etc.) into the identity string for certain finding codes, causing them to never match `baseline.json` and re-alert as "new" every day despite no underlying change.

Specifically:
- `live-check-challenged`: detail includes the literal, shifting list of WAF-challenged URLs
- `prep-kit-check-blocked`: transport noise with no stable detail
- `deploy-parity-skipped`: informational skip with static detail

This meant these findings could structurally never stabilize against the baseline, forcing manual re-triage every day.

## Solution

Modified `fingerprint()` to recognize finding codes with inherently volatile details and fingerprint them on code alone, not `code::detail`. The full detail is still preserved in the finding payload for human visibility.

## Testing

Added comprehensive unit tests:
- `test_volatile_code_fingerprints_on_code_alone`: verifies volatile codes use code-only fingerprints
- `test_prep_kit_blocked_fingerprints_stable`: verifies prep-kit-blocked stability
- `test_deploy_parity_skipped_fingerprints_stable`: verifies deploy-parity-skipped stability
- `test_normal_findings_still_fingerprint_with_detail`: ensures non-volatile findings still use `code::detail`
- `test_second_scan_with_different_challenged_urls_is_not_new`: end-to-end verification that second scan with different challenged URLs marks `new: false`

All tests pass:
```
tests/test_immune_waf.py::test_volatile_code_fingerprints_on_code_alone PASSED
tests/test_immune_waf.py::test_prep_kit_blocked_fingerprints_stable PASSED
tests/test_immune_waf.py::test_deploy_parity_skipped_fingerprints_stable PASSED
tests/test_immune_waf.py::test_normal_findings_still_fingerprint_with_detail PASSED
tests/test_immune_waf.py::test_second_scan_with_different_challenged_urls_is_not_new PASSED
```

## Impact

This is a checker/tooling fix with no production deploy required. After this fix:
- WAF-challenged findings with different URL mixes will now produce the same fingerprint
- Second and subsequent scans will correctly mark these as `new: false` when the baseline is accepted
- Same fix applies to `prep-kit-check-blocked` and `deploy-parity-skipped`

This same class of bug also affects road-race-automation#11 and xc-ski-labs#2 (mentioned in issue comments as tracked cross-repo).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb0770ae-5611-44ab-ad3a-43ea2349fff5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb0770ae-5611-44ab-ad3a-43ea2349fff5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

