### PR TITLE
Stage Traka traffic and Leadville category history drafts

### DIFF
--- a/data/gravel-weekly/backfill/2026.json
+++ b/data/gravel-weekly/backfill/2026.json
@@ -38,9 +38,11 @@
       "periodStartedAt": "2026-01-17",
       "periodEndedAt": "2026-01-23",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Leadville equipment-boundary lead remains held; this window still needs a final disposition."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-leadville-category-border-2026"
+      ],
+      "reason": "Life Time's drop-bar prohibition establishes the opening category-boundary judgment later tested by Leadville's emergency course change."
     },
     {
       "periodStartedAt": "2026-01-24",
@@ -165,9 +167,11 @@
       "periodStartedAt": "2026-05-02",
       "periodEndedAt": "2026-05-08",
       "sourceCardCount": 11,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "The Traka women's-race traffic lead still requires measured GPS, wave, and rider evidence."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-traka-womens-traffic-tax-2026"
+      ],
+      "reason": "The Traka rules, two independent rider accounts, and the documented start-control failure support a narrow draft without claiming a result change."
     },
     {
       "periodStartedAt": "2026-05-09",
@@ -291,17 +295,20 @@
       "sourceCardCount": 10,
       "disposition": "covered_by_draft",
       "entryIds": [
+        "history-leadville-category-border-2026",
         "history-life-time-admissions-office-2026"
       ],
-      "reason": "Life Time's performance-based 2027 qualifier advances the career-institution draft."
+      "reason": "Life Time's performance-based 2027 qualifier advances the career-institution draft, while the verified Leadville reroute advances the equipment-category draft."
     },
     {
       "periodStartedAt": "2026-08-15",
       "periodEndedAt": "2026-08-21",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-leadville-category-border-2026"
+      ],
+      "reason": "Post-race reporting tests the handlebar rule against the smoother wildfire-rerouted course while preserving the two-way-descent safety counterargument."
     },
     {
       "periodStartedAt": "2026-08-22",
@@ -312,5 +319,5 @@
       "reason": "The Bonk Bros pass produced research leads, but no lead has yet cleared verification and editorial disposition."
     }
   ],
-  "updatedAt": "2026-08-28T03:05:00Z"
+  "updatedAt": "2026-08-28T03:06:00Z"
 }

--- a/data/gravel-weekly/history/2026-leadville-category-border.json
+++ b/data/gravel-weekly/history/2026-leadville-category-border.json
@@ -1,0 +1,116 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-leadville-category-border-2026",
+  "activeFrom": "2026-07-17",
+  "activeThrough": "2026-08-17",
+  "status": "draft",
+  "headline": "Leadville Banned the Bike Its New Course Wanted",
+  "point": "As gravel bikes become more capable and mountain bikes become more aerodynamic, the border between the categories is no longer reliably described by terrain. In 2026 Leadville enforced that border through handlebars, then a wildfire reroute made the prohibited setup look unusually well suited to the course.",
+  "priorJudgment": "Leadville was plainly a mountain-bike race, and the occasional drop-bar build was clever optimization inside a category whose course still defined its equipment.",
+  "changedJudgment": "The equipment rule revealed that the category now needs active governance because the bikes and terrain have converged. That can be legitimate for safety or competitive equity, but organizers should say which value they are protecting and measure whether the restriction delivers it.",
+  "stakes": "The rule affects safety in two-way traffic, privateer equipment costs, manufacturer development, rider experimentation, the meaning of a mountain-bike race, and whether organizers address structural hazards or substitute an easy-to-inspect component ban.",
+  "credibleOpposition": "Leadville retained the high-speed, rough, two-way Columbine descent even after the wildfire reroute, flat and drop bars handle differently there, a uniform cockpit can reduce mixed-equipment unpredictability, and the emergency reroute was required by a wildfire rather than designed to embarrass the rule. One rider's view that drops would have been faster is not a controlled equipment test or a safety study.",
+  "whatHappened": "In January, Life Time prohibited drop-style handlebars at Leadville and Little Sugar, citing rider safety and course compatibility, after drop-bar mountain bikes had moved from fringe experiments to winning Leadville setups. Critics argued that the rule was easier to enforce than the event's two-way-traffic hazards and could suppress useful experimentation. In July, the Willow Fire forced Hagerman Pass Road, Sugarloaf Mountain, and Powerline out of the 2026 route. The revised course kept Columbine but removed substantial climbing and added long paved and smoother dirt sections. After racing it, Lauren De Crescenzo wrote that the course was unusually favorable to drop bars even while acknowledging the handling rationale on narrow, two-way descents.",
+  "take": "Model draft, not Matti's approved view: Leadville spent January drawing a bright legal border around mountain biking, then the Willow Fire erased half the geography supporting the argument. The replacement course had long pavement, hero dirt, less climbing, and the aerodynamic manners of a gravel race wearing a belt buckle. The fastest-looking tool was now contraband. That does not prove drop bars were safe on Columbine, and a wildfire is not a gotcha. It does prove the category is no longer hiding in the dirt; the promoter is choosing it. Fine. Choose it honestly. If the rule is about two-way descent safety, measure that. If it is about equipment equity or preserving mountain-bike identity, say so. Do not make a handlebar carry every anxiety the event has about what kind of race it has become.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "No controlled comparison establishes the speed or safety difference between cockpit types on the 2026 route, the rule may have prevented incidents that leave no observable record, and the wildfire reroute was an emergency response. The official rules page is mutable and undated, so the January implementation date is established through two contemporary publications; the current page is used only to verify that the restriction remains official.",
+  "editorialScore": 93,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_leadville_drop_bar_ban_reported_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/bikes/gravel/sorry-tom-pidcock-leadville-has-just-banned-your-new-drop-bar-pinarello/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-01-19T09:54:03Z",
+      "quoteExcerpt": "ban drop bar setups from competition at some mountain bike events",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_leadville_drop_bar_ban_critique_2026",
+      "canonicalUrl": "https://www.cyclingweekly.com/gravel/life-time-bans-drops-bars-at-leadville-respectfully-what-are-they-thinking",
+      "publisher": "Cycling Weekly",
+      "publishedAt": "2026-01-19T00:00:00Z",
+      "quoteExcerpt": "Technology bans are cheap and enforceable",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_leadville_official_drop_bar_rule_2026",
+      "canonicalUrl": "https://www.leadvilleraceseries.com/official-rules/",
+      "publisher": "Leadville Race Series",
+      "publishedAt": "2026-01-19T00:00:00Z",
+      "quoteExcerpt": "For rider safety and course compatibility, drop-style handlebars are no longer permitted",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_leadville_wildfire_course_exclusions_2026",
+      "canonicalUrl": "https://www.leadvilleraceseries.com/letter-from-the-race-director-7-31-26/",
+      "publisher": "Leadville Race Series",
+      "publishedAt": "2026-07-31T00:00:00Z",
+      "quoteExcerpt": "Hagerman Pass Road, Sugar Loaf Mountain, and Power Line are all within the burn area",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_leadville_revised_course_profile_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/leadville-trail-100-mtb-continues-with-modified-route-in-2026-due-to-area-impact-from-wildfires/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-08-12T18:05:37Z",
+      "quoteExcerpt": "102-mile route ... reduced by less than three miles",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_leadville_course_invited_drop_bars_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/the-leadville-nobody-knew-revised-course-eliminates-final-gut-punch-of-powerline-climb-but-columbine-and-elevation-keep-you-humble/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-08-17T16:28:24Z",
+      "quoteExcerpt": "this was the Leadville course for drop bars",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_leadville_course_counterweight_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/the-leadville-nobody-knew-revised-course-eliminates-final-gut-punch-of-powerline-climb-but-columbine-and-elevation-keep-you-humble/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-08-17T16:28:24Z",
+      "quoteExcerpt": "flat bars and drop bars handle differently",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:leadville-100",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_leadville_drop_bar_ban_reported_2026",
+        "claim_leadville_drop_bar_ban_critique_2026",
+        "claim_leadville_official_drop_bar_rule_2026",
+        "claim_leadville_wildfire_course_exclusions_2026",
+        "claim_leadville_revised_course_profile_2026",
+        "claim_leadville_course_invited_drop_bars_2026",
+        "claim_leadville_course_counterweight_2026"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T02:58:33Z",
+  "contentHash": "4717c8f1a16e4df408dc32af49ca27e71c6e19b00c0b9c99f19837f635bd3124"
+}

--- a/data/gravel-weekly/history/2026-traka-womens-traffic-tax.json
+++ b/data/gravel-weekly/history/2026-traka-womens-traffic-tax.json
@@ -1,0 +1,114 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-traka-womens-traffic-tax-2026",
+  "activeFrom": "2026-05-01",
+  "activeThrough": "2026-05-27",
+  "status": "draft",
+  "headline": "The Women Had to Race The Traka and Everybody Else",
+  "point": "A mass-participation race does not preserve an elite women's race merely by giving it a separate start. If start control, wave spacing, traffic, and cross-category drafting rules make one field spend its race navigating everyone else, the event has transferred an operating problem to those riders.",
+  "priorJudgment": "Mixing professionals and amateurs on the same spectacular course was part of gravel's democratic appeal, and the inevitable overtaking was an equal inconvenience that competent riders simply managed.",
+  "changedJudgment": "Shared access is not neutral when the wave design and its enforcement make the women's field absorb a disproportionate traffic and rules-compliance tax. The festival can remain inclusive without using an elite field as moving course management.",
+  "stakes": "The design determines whether the elite women's competition can exist as its own race, whether amateurs receive a fair and comprehensible start, whether rule compliance is realistically possible on narrow terrain, and whether mass participation is an experience the organizer designs or a cost it quietly assigns.",
+  "credibleOpposition": "The Traka never promised closed roads or a laboratory race, its published rules anticipated that Open riders could catch elite women, some amateurs moved when asked, the narrow Girona terrain challenges every field, and Geerike Schreurs explicitly praised the course while arguing that gravel riders must adapt. No available GPS analysis proves the traffic changed the podium.",
+  "whatHappened": "The Traka 360 started on May 1 with pro men, pro women, and Open riders scheduled in closely spaced waves. The organizer's rules already anticipated that Open riders could catch the elite women while allowing drafting only between riders of the same gender. Multiple riders then reported that hundreds of amateur men were accidentally released before the pro women; when the race director tried to send them back, some continued. Geerike Schreurs and Lauren De Crescenzo independently described the women's field navigating those riders while also trying to avoid prohibited cross-gender drafting. De Crescenzo later wrote that the intermixing affected the women's race even though it largely disappeared from the event's main storyline.",
+  "take": "Model draft, not Matti's approved view: Gravel loves telling amateurs they can race on the same course as the pros. At The Traka, the women got the premium package: 325 kilometres, technical Girona gravel, drafting compliance, traffic control, and a flock of amateur men attached like they had selected the free guided-tour add-on. The men got a bike race. The women got a bike race plus unpaid air-traffic control. That is not charming pro-am chaos. It is an organizer deciding which field will finance the festival with concentration and risk. Keep the democratic spectacle. Space the waves, enforce the corrals, and let the elite women's race be something more specific than a gendered obstacle course.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The evidence does not quantify time loss, establish the exact number of riders released early, prove a result changed, or show that every Open rider behaved badly. The organizer PDF is dated to the first day of its May 2025 WordPress path because no day-level publication timestamp was recoverable; it establishes the planned category geometry, while rider and reporter accounts establish the 2026 execution failure. Current 2027 rules are excluded from the factual mechanism.",
+  "editorialScore": 95,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_traka_rules_open_may_catch_elite_women",
+      "canonicalUrl": "https://www.thetraka.com/wp-content/uploads/2025/05/THE-TRAKA-REGULATION_ENG_OK.pdf",
+      "publisher": "The Traka",
+      "publishedAt": "2025-05-01T00:00:00Z",
+      "quoteExcerpt": "some Open riders may catch up to elite women",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_traka_rules_same_gender_drafting",
+      "canonicalUrl": "https://www.thetraka.com/wp-content/uploads/2025/05/THE-TRAKA-REGULATION_ENG_OK.pdf",
+      "publisher": "The Traka",
+      "publishedAt": "2025-05-01T00:00:00Z",
+      "quoteExcerpt": "Men can draft behind other men",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_traka_360_race_date_and_result",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/the-traka-360-mads-wurtz-schmidt-completes-the-double-with-dominant-victory-as-rosa-kloser-wins-with-impressive-90km-solo-on-challenging-girona-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-01T16:33:06Z",
+      "quoteExcerpt": "European champion Mads Würtz Schmidt and Rosa Klöser claimed victories",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_traka_field_scale_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/let-us-have-our-race-geerike-schreurs-and-lauren-de-crescenzo-share-stories-from-the-traka-360-as-pro-women-navigate-around-all-the-chaos-of-the-amateurs/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-08T00:00:00Z",
+      "quoteExcerpt": "1,121 riders were in the same event, 77% amateurs",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_traka_amateurs_released_before_women_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/let-us-have-our-race-geerike-schreurs-and-lauren-de-crescenzo-share-stories-from-the-traka-360-as-pro-women-navigate-around-all-the-chaos-of-the-amateurs/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-08T00:00:00Z",
+      "quoteExcerpt": "a wave of age-group men sent ahead of the pro women",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_traka_women_traffic_cost_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/let-us-have-our-race-geerike-schreurs-and-lauren-de-crescenzo-share-stories-from-the-traka-360-as-pro-women-navigate-around-all-the-chaos-of-the-amateurs/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-08T00:00:00Z",
+      "quoteExcerpt": "extremely draining, mentally and physically",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_traka_de_crescenzo_followup_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/unbound-gravel-200-has-the-history-but-the-traka-pushed-me-into-entirely-new-kinds-of-discomfort-lauren-de-crescenzo-compares-the-two-titans-of-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-27T00:00:00Z",
+      "quoteExcerpt": "accidentally let hundreds of amateurs start before the pro women",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:the-traka",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_traka_rules_open_may_catch_elite_women",
+        "claim_traka_rules_same_gender_drafting",
+        "claim_traka_amateurs_released_before_women_2026",
+        "claim_traka_women_traffic_cost_2026",
+        "claim_traka_de_crescenzo_followup_2026"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T02:58:33Z",
+  "contentHash": "80cfb49c2c07e027b88e655aa0db3add05a11f30facd4b17603f937e417727ce"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -609,8 +609,8 @@ def test_2026_backfill_ledger_accounts_for_every_window_without_claiming_complet
 
     assert len(validated["weeks"]) == 35
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 230
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 10
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 24
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 13
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 21
     assert validated["complete"] is False
 
     missing_window = copy.deepcopy(ledger)


### PR DESCRIPTION
## Summary
- stage an evidence-grounded Traka traffic-tax history draft without claiming the podium changed
- stage a Leadville category-boundary draft that preserves the wildfire and two-way-descent counterarguments
- advance the 2026 backfill ledger from 10 to 13 covered weekly windows and reduce pending windows from 24 to 21
- keep both entries model-draft, human-approval-required, and non-public

## Verification
- python3 scripts/validate_gravel_weekly_history.py on both new entries
- python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2026.json
- pytest -q tests/test_gravel_weekly.py: 29 passed
- python3 scripts/preflight_quality.py: passed with 7 existing/environment warnings
- pytest -q: 7,830 passed, 331 skipped
- git diff --check

## Safety
No publication, database mutation, race auto-fix, or human-voice approval is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content and ledger JSON plus test count assertions only; drafts remain non-public with human approval required and no publication or auto-fix paths.
> 
> **Overview**
> Adds two **model-draft** Gravel Weekly history entries—`history-leadville-category-border-2026` (drop-bar ban vs. wildfire reroute) and `history-traka-womens-traffic-tax-2026` (elite women’s field vs. start-control/traffic)—each with receipts, uncertainty bounds, and `editorial_review` race impacts that require human approval and do not auto-publish.
> 
> Updates **`data/gravel-weekly/backfill/2026.json`** so three weekly windows move from `pending_review` to `covered_by_draft` (Jan 17–23 and May 2–8 for the new entries; Aug 15–21 for Leadville post-race), links the Leadville draft on the Aug 8–14 window alongside Life Time, and bumps ledger `updatedAt`. **`tests/test_gravel_weekly.py`** now expects **13** `covered_by_draft` and **21** `pending_review` weeks while `complete` stays false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1728b40a7fe4a29c886c3d34fc6276bf2b15b6a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->