### PR TITLE
Complete the 2026 Gravel Weekly assigning desk

### DIFF
--- a/data/gravel-weekly/backfill/2026.json
+++ b/data/gravel-weekly/backfill/2026.json
@@ -22,17 +22,19 @@
       "periodStartedAt": "2026-01-03",
       "periodEndedAt": "2026-01-09",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "reason": "The only source card was a routine Specialized Diverge product review; it supplied neither a consequential change nor a story worth preserving as the week's Current Thing."
     },
     {
       "periodStartedAt": "2026-01-10",
       "periodEndedAt": "2026-01-16",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-teamification-2026"
+      ],
+      "reason": "Specialized's January off-road superteam launch supplies the first dated change-point in the season-long shift from privateers toward integrated teams."
     },
     {
       "periodStartedAt": "2026-01-17",
@@ -48,17 +50,21 @@
       "periodStartedAt": "2026-01-24",
       "periodEndedAt": "2026-01-30",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-teamification-2026"
+      ],
+      "reason": "Trek Driftless's expanded roster adds a second concrete team structure to the teamification draft."
     },
     {
       "periodStartedAt": "2026-01-31",
       "periodEndedAt": "2026-02-06",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-teamification-2026"
+      ],
+      "reason": "Q36.5's four-rider women's off-road team makes the structural shift broader than one manufacturer or men's roster."
     },
     {
       "periodStartedAt": "2026-02-07",
@@ -74,33 +80,39 @@
       "periodStartedAt": "2026-02-14",
       "periodEndedAt": "2026-02-20",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-admissions-office-2026"
+      ],
+      "reason": "Life Time's 86-rider wildcard audition for six places exposes the scarcity and career consequences of access to its fixed main field."
     },
     {
       "periodStartedAt": "2026-02-21",
       "periodEndedAt": "2026-02-27",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-teamification-2026"
+      ],
+      "reason": "The Aegis off-road partnership shows established and U23 riders assembling shared race labor around the Life Time series."
     },
     {
       "periodStartedAt": "2026-02-28",
       "periodEndedAt": "2026-03-06",
       "sourceCardCount": 7,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "reason": "The cards suggest equipment-category convergence and road riders moving into gravel, but the week lacks a verified consequence strong enough to turn that observation into a durable story."
     },
     {
       "periodStartedAt": "2026-03-07",
       "periodEndedAt": "2026-03-13",
       "sourceCardCount": 13,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-teamification-2026"
+      ],
+      "reason": "Cyclingnews's March roster census documents enough teams, collectives, and privateers to establish the new competitive landscape before racing tests its tactics."
     },
     {
       "periodStartedAt": "2026-03-14",
@@ -117,9 +129,9 @@
       "periodStartedAt": "2026-03-21",
       "periodEndedAt": "2026-03-27",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "reason": "A road-bike gravel FKT, 32-inch-wheel speculation, and aero-wheel launches point toward an equipment arms race, but no single claim yet establishes who gained, lost, or changed course."
     },
     {
       "periodStartedAt": "2026-03-28",
@@ -135,33 +147,37 @@
       "periodStartedAt": "2026-04-04",
       "periodEndedAt": "2026-04-10",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-organizer-controlled-safety-2026"
+      ],
+      "reason": "Life Time's separate elite feed zones and restricted crew and media access at UNBOUND and Leadville are a direct organizer-controlled safety intervention."
     },
     {
       "periodStartedAt": "2026-04-11",
       "periodEndedAt": "2026-04-17",
       "sourceCardCount": 9,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "reason": "The cards begin an equipment-and-global-championship arc, but they do not yet clear the point, stakes, and credible-opposition gates as a standalone Current Thing."
     },
     {
       "periodStartedAt": "2026-04-18",
       "periodEndedAt": "2026-04-24",
       "sourceCardCount": 6,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "reason": "International racing and World Series coverage may advance gravel's globalization, but the present evidence is event anticipation rather than a consequential change."
     },
     {
       "periodStartedAt": "2026-04-25",
       "periodEndedAt": "2026-05-01",
       "sourceCardCount": 11,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-traka-womens-traffic-tax-2026"
+      ],
+      "reason": "The Traka's published start and drafting rules establish the organizer-controlled design that the following week's rider accounts tested."
     },
     {
       "periodStartedAt": "2026-05-02",
@@ -177,9 +193,9 @@
       "periodStartedAt": "2026-05-09",
       "periodEndedAt": "2026-05-15",
       "sourceCardCount": 6,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "reason": "World Series previews and equipment coverage continue the global-championship arc, but a preview is not itself a season-changing event and no stronger point has cleared review."
     },
     {
       "periodStartedAt": "2026-05-16",
@@ -235,9 +251,9 @@
       "periodStartedAt": "2026-06-20",
       "periodEndedAt": "2026-06-26",
       "sourceCardCount": 6,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "reason": "The source set is primarily routine race-result and roundup coverage; it records outcomes but does not support a distinct judgment change worth retelling."
     },
     {
       "periodStartedAt": "2026-06-27",
@@ -253,41 +269,43 @@
       "periodStartedAt": "2026-07-04",
       "periodEndedAt": "2026-07-10",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "reason": "The lone card is a routine UCI Gravel World Series result with no demonstrated consequence beyond the finishing order."
     },
     {
       "periodStartedAt": "2026-07-11",
       "periodEndedAt": "2026-07-17",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "reason": "The cards may advance the global-series and world-championship arc, but the assigning desk still needs a concrete changed judgment rather than international-calendar aggregation."
     },
     {
       "periodStartedAt": "2026-07-18",
       "periodEndedAt": "2026-07-24",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "reason": "Global racing and adventure coverage supplies context but not yet a defensible mechanism, affected party, and consequence for a standalone historical story."
     },
     {
       "periodStartedAt": "2026-07-25",
       "periodEndedAt": "2026-07-31",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "reason": "The only card is an Argon 18 bike review; product novelty without a verified sporting or cultural consequence does not clear the Current Thing gate."
     },
     {
       "periodStartedAt": "2026-08-01",
       "periodEndedAt": "2026-08-07",
       "sourceCardCount": 7,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Census complete; no assigning-desk disposition recorded yet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-admissions-office-2026"
+      ],
+      "reason": "Kylee Hanel's U23 series lead after winning Unbound Gravel 100 supplies an early, visible result from Life Time's development pathway without proving long-term career success."
     },
     {
       "periodStartedAt": "2026-08-08",
@@ -319,5 +337,5 @@
       "reason": "The Bonk Bros pass produced research leads, but no lead has yet cleared verification and editorial disposition."
     }
   ],
-  "updatedAt": "2026-08-28T03:06:00Z"
+  "updatedAt": "2026-08-28T03:25:00Z"
 }

--- a/data/gravel-weekly/history/2026-life-time-admissions-office.json
+++ b/data/gravel-weekly/history/2026-life-time-admissions-office.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "gravel-weekly-history-entry/v1",
   "entryId": "history-life-time-admissions-office-2026",
-  "activeFrom": "2026-03-19",
+  "activeFrom": "2026-02-19",
   "activeThrough": "2026-08-12",
   "status": "draft",
   "headline": "Gravel Built a Governing Body by Accident",
@@ -10,10 +10,10 @@
   "changedJudgment": "By 2026, its selection and continuity policies had consequences that increasingly resembled those of a career institution, even though Life Time remained a private event company rather than a federation or employer.",
   "stakes": "A roster decision can determine whether a privateer receives entries, compensation eligibility, sponsor visibility, a development pathway, pregnancy continuity, and a coherent season in the most commercially important domestic off-road series.",
   "credibleOpposition": "Life Time is a private promoter funding opportunities rather than monopolizing the sport; athletes remain free to race elsewhere, performance pathways became clearer in 2026, and institutional responsibility should not be inferred merely because one series became desirable.",
-  "whatHappened": "Life Time described the 2026 Grand Prix as the professional home of off-road racing, selected a fixed elite roster, added conditional finisher compensation and pregnancy protection, expanded and funded its U23 pathway, made midseason wildcard replacements, and announced a new performance qualifier that would determine most remaining 2027 roster positions.",
+  "whatHappened": "Life Time put 86 wildcard contenders through two opening races for six main-field positions, described the 2026 Grand Prix as the professional home of off-road racing, selected a fixed elite roster, added conditional finisher compensation and pregnancy protection, expanded and funded its U23 pathway, made midseason wildcard replacements, and announced a new performance qualifier that would determine most remaining 2027 roster positions. The U23 pathway then produced a visible leader in Kylee Hanel after her Unbound Gravel 100 win.",
   "take": "Model draft, not Matti's approved view: Gravel hates governing bodies so much it accidentally built one out of race entries. Life Time now decides who gets access, protection, money, visibility, and a path back. Much of this is good: pregnancy protection is overdue, U23 support matters, and a performance qualifier beats a velvet-rope mystery. But good power is still power. When a single series can rescue or derail a privateer's year with one roster decision, it deserves scrutiny closer to a federation than applause for merely putting on six very good bike races.",
   "takeProvenance": "model_draft",
-  "uncertainty": "The available record does not establish that Life Time is an employer or governing federation, does not fully explain the discretion used in initial 2026 selections, and predates the promised detailed 2027 qualifier scoring, tie-break, and eligibility rules. Source pages supply day-level publication dates normalized here to midnight UTC.",
+  "uncertainty": "The available record does not establish that Life Time is an employer or governing federation, does not fully explain the discretion used in initial 2026 selections, and predates the promised detailed 2027 qualifier scoring, tie-break, and eligibility rules. One strong U23 season also does not establish that the pathway will produce sustainable professional careers. Source pages without precise timestamps supply day-level publication dates normalized here to midnight UTC.",
   "editorialScore": 89,
   "editorialGates": {
     "party": "pass",
@@ -23,6 +23,15 @@
     "hostileEditor": "hold"
   },
   "contemporaryReceipts": [
+    {
+      "claimId": "claim_ltgp_wildcard_audition_pool_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/talent-pool-is-deep-on-wildcard-roster-revealed-for-2026-life-time-grand-prix-which-includes-former-champion-haley-smith-and-dutch-veteran-piotr-havik/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-02-19T19:07:19Z",
+      "quoteExcerpt": "27 women and 59 men ... to capture six spots",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
     {
       "claimId": "claim_ltgp_professional_home_2026",
       "canonicalUrl": "https://www.lifetimegrandprix.com/2026/03/19/new-for-2026/",
@@ -69,6 +78,15 @@
       "transcriptEndSeconds": null
     },
     {
+      "claimId": "claim_ltgp_u23_pathway_visible_result_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/despite-being-10-years-younger-than-the-big-kids-multi-discipline-u23-talent-kylee-hanel-thriving-in-long-grueling-races-of-gravel-with-leadville-looming/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-08-04T00:00:00Z",
+      "quoteExcerpt": "leads Life Time Grand Prix U23 competition after win at Unbound Gravel 100",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
       "claimId": "claim_ltgp_2027_qualifier_2026",
       "canonicalUrl": "https://www.lifetimegrandprix.com/2026/08/12/life-time-announces-2027-life-time-grand-prix-structure/",
       "publisher": "Life Time Grand Prix",
@@ -103,6 +121,6 @@
   "autoPublishAllowed": false,
   "editorialApproval": null,
   "publishedAt": null,
-  "updatedAt": "2026-08-28T02:18:00Z",
-  "contentHash": "a8603990e375f2dd917e082e3f33a71beea9638a7e12c2762f64ac0d3528da5c"
+  "updatedAt": "2026-08-28T03:25:00Z",
+  "contentHash": "aeaca309dcf601dd4aa212bd4caec421961229809e9c980d6c8d435ce6e3aed9"
 }

--- a/data/gravel-weekly/history/2026-organizer-controlled-safety.json
+++ b/data/gravel-weekly/history/2026-organizer-controlled-safety.json
@@ -10,7 +10,7 @@
   "changedJudgment": "Once the danger is created by the professional apparatus surrounding the race, self-reliance is no defense. Media operations, traffic control, and support-zone design require explicit standards, trained operators, and accountable review.",
   "stakes": "The distinction determines whether riders must simply accept preventable injury risk, whether organizers learn across events, whether media access outranks athlete safety, and whether a safety improvement protects everyone or merely shifts cost onto riders with enough crew and money.",
   "credibleOpposition": "A six-to-twelve-hour gravel race cannot be closed like a road circuit, natural and rider-created risk cannot be eliminated, the Mid South incident caused no injury, and early rider feedback indicates UNBOUND's longer elite-only feeds substantially improved safety despite logistical tradeoffs.",
-  "whatHappened": "At The Mid South, a media buggy carrying race coverage personnel drove into the line of the two leading women, forcing Sofía Gómez Villafañe and Paige Onweller to brake and swerve; the organizer called it an operational failure. UNBOUND's 2026 elite guide then replaced the prior two-checkpoint support model with three elite-only feed zones, prohibited elite support at amateur checkpoints, and introduced right-side feeding. After the race, riders said the separation and added space improved safety, while also warning that the three-zone logistics split scarce crew resources. By June, riders were publicly connecting media vehicles, intersections, and feeds as recurring organizer-controlled risks rather than isolated gravel chaos.",
+  "whatHappened": "At The Mid South, a media buggy carrying race coverage personnel drove into the line of the two leading women, forcing Sofía Gómez Villafañe and Paige Onweller to brake and swerve; the organizer called it an operational failure. In April, Life Time announced separate elite feed zones and restricted crew and media access at UNBOUND and Leadville. UNBOUND's 2026 elite guide then replaced the prior two-checkpoint support model with three elite-only feed zones, prohibited elite support at amateur checkpoints, and introduced right-side feeding. After the race, riders said the separation and added space improved safety, while also warning that the three-zone logistics split scarce crew resources. By June, riders were publicly connecting media vehicles, intersections, and feeds as recurring organizer-controlled risks rather than isolated gravel chaos.",
   "take": "Model draft, not Matti's approved view: Rocks are part of the product. Weather is part of the product. A camera buggy arriving in the leaders' line like a drunk mall cop is not part of the product. Gravel found money for livestreams, prize purses, and Formula 1 bike programs before it found a shared operating standard for the machines filming the race. That is not the spirit of gravel; it is unfinished event production. UNBOUND's new feeds show organizers can respond, but a safety fix that quietly requires three crews and endless resources is not finished either. Control the controllables, then publish what worked and what did not so the next promoter does not have to learn with somebody else's collarbone.",
   "takeProvenance": "model_draft",
   "uncertainty": "The available record does not quantify incident rates across races, prove that the UNBOUND changes were caused by the Mid South incident, establish whether the new feed design reduced risk under normal rather than mud-split field conditions, or supply a common organizer standard for media and intersection operations. The official guide dates are taken from verified PDF metadata; other source pages provide day-level publication dates normalized here to midnight UTC.",
@@ -38,6 +38,15 @@
       "publisher": "Cyclingnews",
       "publishedAt": "2026-03-16T00:00:00Z",
       "quoteExcerpt": "This was an operational failure, and we own it",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_elite_feed_zones_announced_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/rules/unbound-gravel-and-leadville-trail-100-introduce-new-rules-to-reduce-danger-and-congestion-at-feed-zone-areas/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-04-09T00:00:00Z",
+      "quoteExcerpt": "New 'Elite Feed Zones' will be introduced this year",
       "transcriptStartSeconds": null,
       "transcriptEndSeconds": null
     },
@@ -106,10 +115,22 @@
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_unbound_2025_two_checkpoint_support",
+        "claim_lifetime_elite_feed_zones_announced_2026",
         "claim_unbound_2026_right_side_feeding",
         "claim_unbound_2026_elite_only_feeds",
         "claim_unbound_separate_feeds_improved_safety_2026",
         "claim_unbound_feed_resource_tradeoff_2026"
+      ],
+      "confidence": 0.95,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:leadville-100",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_lifetime_elite_feed_zones_announced_2026"
       ],
       "confidence": 0.95,
       "owner": "Gravel God race editorial review",
@@ -120,6 +141,6 @@
   "autoPublishAllowed": false,
   "editorialApproval": null,
   "publishedAt": null,
-  "updatedAt": "2026-08-28T03:05:00Z",
-  "contentHash": "b96ec00b4732e01f295da6f41c9fb5751da40cff3cd7c4fec955bced5c10458f"
+  "updatedAt": "2026-08-28T03:25:00Z",
+  "contentHash": "74ad808b1c33a56aa684765fb1d58ba1483ac7d709fe6e62f4c69c077f0371e8"
 }

--- a/data/gravel-weekly/history/2026-unbound-teamification.json
+++ b/data/gravel-weekly/history/2026-unbound-teamification.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "gravel-weekly-history-entry/v1",
   "entryId": "history-unbound-teamification-2026",
-  "activeFrom": "2026-02-10",
+  "activeFrom": "2026-01-15",
   "activeThrough": "2026-06-02",
   "status": "draft",
   "headline": "A Flat Tire Made Gravel Admit Teams Exist",
@@ -10,10 +10,10 @@
   "changedJudgment": "At the sharp end of Unbound, integrated tactics, interchangeable labor, course reconnaissance, engineering, and support could now compound into an advantage no individual privateer could reproduce alone.",
   "stakes": "If the organization rather than the rider is becoming the competitive unit, privateers face a different labor market and a different race. Organizers, sponsors, and media must decide whether to regulate team behavior, create viable independent pathways, or at least stop selling a corporate contest as frontier individualism.",
   "credibleOpposition": "Mads Würtz Schmidt appeared to be the strongest rider, the wheel exchange was a rational response to an emergency rather than proof of a scripted plan, cooperation has always existed in gravel, and a single dominant result cannot establish that privateers are obsolete or that team tactics should be restricted.",
-  "whatHappened": "In February, Cyclingnews framed 2026 as a turning point from the privateer default toward professional teams. Days before Unbound, another report found that traditional in-race team tactics still seemed difficult in gravel. During the men's race, Specialized teammates Würtz Schmidt and Swenson escaped together; when Würtz Schmidt punctured, Swenson gave him a wheel and sacrificed his own race because the team's best chance was Würtz Schmidt. Beers did not help chase his teammates and finished second, while Swenson recovered to fifth. Afterward, Beers described two years of Specialized testing, including sensor-equipped reconnaissance and racing, feeding an in-house simulation model used to develop the bike ridden to the leading results.",
+  "whatHappened": "Starting in January, new and expanded squads made the shift visible: Specialized assembled an off-road superteam with unified support and equipment, Trek Driftless expanded, Q36.5 launched a women's off-road team, and Aegis created a cross-disciplinary collective. By March, Cyclingnews could document a full landscape of teams, collectives, and privateers while riders still disagreed about whether those structures would produce road-style tactics. Days before Unbound, another report found that traditional in-race team tactics still seemed difficult in gravel. During the men's race, Specialized teammates Würtz Schmidt and Swenson escaped together; when Würtz Schmidt punctured, Swenson gave him a wheel and sacrificed his own race because the team's best chance was Würtz Schmidt. Beers did not help chase his teammates and finished second, while Swenson recovered to fifth. Afterward, Beers described two years of Specialized testing, including sensor-equipped reconnaissance and racing, feeding an in-house simulation model used to develop the bike ridden to the leading results.",
   "take": "Model draft, not Matti's approved view: Gravel spent years pretending matching jerseys were just friends at the same sleepover. Then Keegan Swenson handed the strongest rider his wheel and his shot at Unbound, Matt Beers declined to chase, and Specialized went 1-2-5 on a bike informed by two years of black-box data. The privateer myth did not die because teams are evil. It died because pretending they are not teams became stupid. Stop asking riders to cosplay as rugged individualists while brands build Formula 1 programs around them. The honest argument now is what independent riders are owed in a race increasingly contested by organizations.",
   "takeProvenance": "model_draft",
-  "uncertainty": "The record does not disclose Specialized's budget, establish every pre-race instruction, quantify the bike-development advantage, prove that Würtz Schmidt would have lost without the wheel exchange, or show that comparable tactics will determine most future races. The official event page links the 2026 timing portal, but the result chronology here relies on two established publications because the portal does not expose readable result rows to this archive. Source pages provide day-level publication dates normalized here to midnight UTC.",
+  "uncertainty": "The new structures differ substantially in salary, shared equipment, staff support, and expected tactics; a roster announcement alone does not prove road-style cooperation. The record does not disclose Specialized's budget, establish every pre-race instruction, quantify the bike-development advantage, prove that Würtz Schmidt would have lost without the wheel exchange, or show that comparable tactics will determine most future races. The official event page links the 2026 timing portal, but the result chronology here relies on two established publications because the portal does not expose readable result rows to this archive. Source pages provide day-level publication dates normalized here to midnight UTC.",
   "editorialScore": 94,
   "editorialGates": {
     "party": "pass",
@@ -24,11 +24,56 @@
   },
   "contemporaryReceipts": [
     {
+      "claimId": "claim_specialized_offroad_superteam_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/womens-cycling/specialized-is-really-stepping-things-up-this-year-geerike-schreurs-joins-former-unbound-gravel-adversaries-villafane-and-langvad-on-off-road-super-team/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-01-15T00:00:00Z",
+      "quoteExcerpt": "one of the first superteams for women in off-road racing",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_trek_driftless_expands_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/a-team-that-can-thrive-together-paige-onweller-and-toby-roed-anchor-trek-driftless-off-road-team-with-three-new-teammates-and-a-focus-on-us-gravel-races/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-01-29T00:00:00Z",
+      "quoteExcerpt": "A trio of versatile riders were added to the roster",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_q365_womens_offroad_team_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/alexis-skarda-and-maddy-nutt-anchor-new-q36-5-womens-off-road-racing-expedition-with-early-2026-objectives-at-the-traka-and-unbound-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-02-04T00:00:00Z",
+      "quoteExcerpt": "announced a four-rider women's gravel racing team for 2026",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
       "claimId": "claim_gravel_privateer_default_challenged_2026",
       "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/riders-making-six-figures-race-against-some-who-arent-making-a-cent-are-pro-gravel-teams-about-to-be-the-end-of-the-privateer/",
       "publisher": "Cyclingnews",
       "publishedAt": "2026-02-10T00:00:00Z",
       "quoteExcerpt": "The privateer model will still exist and thrive, but it won't be the dominant pathway anymore.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_aegis_offroad_collective_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/womens-cycling/get-the-grit-still-be-friends-and-race-together-lauren-stephens-emma-langley-and-u23-rider-kylee-hanel-form-off-road-partnership-to-pursue-life-time-grand-prix-rewards/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-02-25T00:00:00Z",
+      "quoteExcerpt": "will have teammates for the first time at Life Time Grand Prix races",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_teams_roster_landscape_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/for-better-or-worse-teams-are-here-the-rosters-in-2026-as-riders-join-forces-for-off-road-alliances-as-the-next-evolution-of-gravel-and-endurance-mtb-racing-takes-shape/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-03-12T00:00:00Z",
+      "quoteExcerpt": "teams are coming to gravel racing with a rush in 2026",
       "transcriptStartSeconds": null,
       "transcriptEndSeconds": null
     },
@@ -99,6 +144,6 @@
   "autoPublishAllowed": false,
   "editorialApproval": null,
   "publishedAt": null,
-  "updatedAt": "2026-08-28T03:05:00Z",
-  "contentHash": "7514279d3334eeedd219975fefb6f3f278ebaf6d5820c09cd7a2046a2abcfbc5"
+  "updatedAt": "2026-08-28T03:25:00Z",
+  "contentHash": "6b42baedb9568ba738b17aca8475d1e95debc9b62159dae17d5a85e03113c511"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -609,8 +609,11 @@ def test_2026_backfill_ledger_accounts_for_every_window_without_claiming_complet
 
     assert len(validated["weeks"]) == 35
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 230
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 13
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 21
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 22
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 7
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 4
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 1
     assert validated["complete"] is False
 
     missing_window = copy.deepcopy(ledger)


### PR DESCRIPTION
## Summary
- assign every closed 2026 weekly source window as covered, held, rejected, or an explicit gap
- add dated teamification, Life Time access/U23, and organizer-safety receipts to existing historical drafts
- leave only the still-open Aug 22–28 window pending; no story is approved or published

## 2026 accounting
- 35 contiguous windows / 230 source cards
- 22 covered by five draft narratives
- 7 held for evidence
- 4 rejected as routine product/result aggregation
- 1 explicit zero-source gap
- 1 live window pending

## Safety
- all historical entries remain `draft`
- `humanApprovalRequired: true`
- `autoPublishAllowed: false`
- race impacts are review-only; no race record was changed

## Verification
- Gravel Weekly history validator: pass
- 2026 ledger validator: pass
- targeted Gravel Weekly tests: 29 passed
- repository preflight: pass (7 existing/environment warnings)
- full pytest: 7,830 passed, 331 skipped, 26 warnings
- `git diff --check`: pass

Related: wattgod/race-intelligence-control-plane#44
Related: wattgod/race-intelligence-control-plane#47

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and test expectations only; entries stay draft with human approval required and no auto-publish or direct race record changes.
> 
> **Overview**
> **Closes editorial accounting for almost all 2026 weekly source windows** in `data/gravel-weekly/backfill/2026.json`: former `pending_review` weeks are now labeled `covered_by_draft` (linked to existing draft `entryIds`), `held_for_evidence`, or `rejected`, with per-week reasons; only Aug 22–28 stays `pending_review`.
> 
> **Strengthens three draft history entries** with earlier `activeFrom` dates, added Cyclingnews/Life Time receipts, and expanded `whatHappened` / `uncertainty` for teamification (Jan–Mar roster arc), Life Time admissions (wildcard pool, U23 visible result), and organizer safety (April elite feed-zone announcement plus a Leadville `raceImpacts` review hook).
> 
> **Updates** `test_2026_backfill_ledger_accounts_for_every_window_without_claiming_completion` to match the new disposition counts; ledger `complete` remains false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46eec9af477f7f81d58f8b9a2a7a69f670fbb06e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->