### PR TITLE
Preserve the 2025 Gravel Weekly source census

### DIFF
--- a/data/gravel-weekly/backfill/2025.json
+++ b/data/gravel-weekly/backfill/2025.json
@@ -1,0 +1,439 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2025,
+  "asOf": "2025-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/38",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33138955480",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 255,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2024-12-28",
+      "periodEndedAt": "2025-01-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2025-01-04",
+      "periodEndedAt": "2025-01-10",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-01-11",
+      "periodEndedAt": "2025-01-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2025-01-18",
+      "periodEndedAt": "2025-01-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2025-01-25",
+      "periodEndedAt": "2025-01-31",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-02-01",
+      "periodEndedAt": "2025-02-07",
+      "sourceCardCount": 5,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-02-08",
+      "periodEndedAt": "2025-02-14",
+      "sourceCardCount": 5,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-02-15",
+      "periodEndedAt": "2025-02-21",
+      "sourceCardCount": 8,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-02-22",
+      "periodEndedAt": "2025-02-28",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-03-01",
+      "periodEndedAt": "2025-03-07",
+      "sourceCardCount": 7,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-03-08",
+      "periodEndedAt": "2025-03-14",
+      "sourceCardCount": 6,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-03-15",
+      "periodEndedAt": "2025-03-21",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-03-22",
+      "periodEndedAt": "2025-03-28",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-03-29",
+      "periodEndedAt": "2025-04-04",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-04-05",
+      "periodEndedAt": "2025-04-11",
+      "sourceCardCount": 8,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-04-12",
+      "periodEndedAt": "2025-04-18",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-04-19",
+      "periodEndedAt": "2025-04-25",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-04-26",
+      "periodEndedAt": "2025-05-02",
+      "sourceCardCount": 11,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-05-03",
+      "periodEndedAt": "2025-05-09",
+      "sourceCardCount": 13,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-05-10",
+      "periodEndedAt": "2025-05-16",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-05-17",
+      "periodEndedAt": "2025-05-23",
+      "sourceCardCount": 17,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-05-24",
+      "periodEndedAt": "2025-05-30",
+      "sourceCardCount": 22,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-05-31",
+      "periodEndedAt": "2025-06-06",
+      "sourceCardCount": 19,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-06-07",
+      "periodEndedAt": "2025-06-13",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-06-14",
+      "periodEndedAt": "2025-06-20",
+      "sourceCardCount": 7,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-06-21",
+      "periodEndedAt": "2025-06-27",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-06-28",
+      "periodEndedAt": "2025-07-04",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-07-05",
+      "periodEndedAt": "2025-07-11",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-07-12",
+      "periodEndedAt": "2025-07-18",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-07-19",
+      "periodEndedAt": "2025-07-25",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-07-26",
+      "periodEndedAt": "2025-08-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2025-08-02",
+      "periodEndedAt": "2025-08-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2025-08-09",
+      "periodEndedAt": "2025-08-15",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-08-16",
+      "periodEndedAt": "2025-08-22",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-08-23",
+      "periodEndedAt": "2025-08-29",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-08-30",
+      "periodEndedAt": "2025-09-05",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-09-06",
+      "periodEndedAt": "2025-09-12",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-09-13",
+      "periodEndedAt": "2025-09-19",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-09-20",
+      "periodEndedAt": "2025-09-26",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-09-27",
+      "periodEndedAt": "2025-10-03",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-10-04",
+      "periodEndedAt": "2025-10-10",
+      "sourceCardCount": 12,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-10-11",
+      "periodEndedAt": "2025-10-17",
+      "sourceCardCount": 17,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-10-18",
+      "periodEndedAt": "2025-10-24",
+      "sourceCardCount": 8,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-10-25",
+      "periodEndedAt": "2025-10-31",
+      "sourceCardCount": 5,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-11-01",
+      "periodEndedAt": "2025-11-07",
+      "sourceCardCount": 5,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-11-08",
+      "periodEndedAt": "2025-11-14",
+      "sourceCardCount": 6,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-11-15",
+      "periodEndedAt": "2025-11-21",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-11-22",
+      "periodEndedAt": "2025-11-28",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-11-29",
+      "periodEndedAt": "2025-12-05",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-12-06",
+      "periodEndedAt": "2025-12-12",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-12-13",
+      "periodEndedAt": "2025-12-19",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-12-20",
+      "periodEndedAt": "2025-12-26",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2025-12-27",
+      "periodEndedAt": "2026-01-02",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    }
+  ],
+  "updatedAt": "2026-08-28T03:38:00Z"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -602,6 +602,19 @@ def test_historical_drafts_never_cross_the_public_loader(tmp_path):
     assert [entry["entryId"] for entry in load_public_history_entries(tmp_path)] == [approved["entryId"]]
 
 
+def test_2025_backfill_ledger_preserves_the_complete_census_without_claiming_review():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2025.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 255
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 5
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 48
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 0
+    assert validated["complete"] is False
+
+
 def test_2026_backfill_ledger_accounts_for_every_window_without_claiming_completion():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2026.json").read_text())


### PR DESCRIPTION
## Summary
- preserve the completed 2025 Cyclingnews archive census as a durable annual assigning ledger
- account for all 53 contiguous Saturday–Friday windows and 255 source cards
- record five zero-source windows as explicit gaps and leave all 48 nonempty windows pending review
- add regression coverage for counts and the no-premature-completion boundary

## Safety
- source metadata remains discovery-only
- no narrative is selected, drafted, approved, or published
- no race record changes
- `humanApprovalRequired: true` and `autoPublishAllowed: false`

## Verification
- 2025 and 2026 ledger validators: pass
- targeted Gravel Weekly tests: 30 passed
- repository preflight: pass (7 existing/environment warnings)
- full pytest: 7,831 passed, 331 skipped, 26 warnings
- `git diff --check`: pass

Source census: wattgod/race-intelligence-control-plane#38
Research auditions: wattgod/race-intelligence-control-plane#50
Program ledger: wattgod/race-intelligence-control-plane#47

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only ledger and regression test; no publishing, drafting, or race-record changes.
> 
> **Overview**
> Adds **`data/gravel-weekly/backfill/2025.json`**, a durable **2025** assigning ledger that freezes the completed Cyclingnews source census (255 cards across 53 Saturday–Friday windows) without advancing editorial work.
> 
> Each week records **`sourceCardCount`**, **`disposition`**, and a **`reason`**: five zero-card windows are **`explicit_gap`**, and the other 48 are **`pending_review`** with empty **`entryIds`**. The file stays **`complete: false`** with **`humanApprovalRequired: true`** and **`autoPublishAllowed: false`**, and links to the control-plane source ledger run and program issue.
> 
> A new test **`test_2025_backfill_ledger_preserves_the_complete_census_without_claiming_review`** runs the existing **`validate_backfill_ledger`** path on the checked-in file and asserts week/card/disposition totals and that nothing is marked covered or complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd88a841c9dea06d21d88c539dec5574b479e904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->