### PR TITLE
Add 2025 cross-category drafting history

### DIFF
--- a/data/gravel-weekly/backfill/2025.json
+++ b/data/gravel-weekly/backfill/2025.json
@@ -122,25 +122,31 @@
       "periodStartedAt": "2025-03-29",
       "periodEndedAt": "2025-04-04",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-cross-category-drafting-2025"
+      ],
+      "reason": "Life Time publicly acknowledged that cross-category drafting materially distorted the elite women's race and introduced the series' first formal prohibition."
     },
     {
       "periodStartedAt": "2025-04-05",
       "periodEndedAt": "2025-04-11",
       "sourceCardCount": 8,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-cross-category-drafting-2025"
+      ],
+      "reason": "Sea Otter's separate-day soft launch exposed the central tradeoff: geometry could prevent the interference more reliably than policing it after the fields mixed."
     },
     {
       "periodStartedAt": "2025-04-12",
       "periodEndedAt": "2025-04-18",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-cross-category-drafting-2025"
+      ],
+      "reason": "The published draft-zone, evidence, appeal, and last-place mechanics turned a fairness principle into a high-stakes surveillance problem."
     },
     {
       "periodStartedAt": "2025-04-19",

--- a/data/gravel-weekly/history/2025-life-time-cross-category-drafting.json
+++ b/data/gravel-weekly/history/2025-life-time-cross-category-drafting.json
@@ -1,0 +1,124 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-life-time-cross-category-drafting-2025",
+  "activeFrom": "2025-04-02",
+  "activeThrough": "2025-04-16",
+  "status": "draft",
+  "headline": "Life Time Banned the Draft Its Own Race Created",
+  "point": "Life Time's anti-drafting rule was real progress and an institutional confession: staggered starts had not fully protected the elite women's race from categories the organizer placed on the same course. Instead of eliminating that contact, the series made fairness depend on athletes obeying an invisible moving boundary and officials happening to document it.",
+  "priorJudgment": "Cross-category drafting was an awkward but fundamentally gravel-shaped consequence of professionals and amateurs sharing the same enormous event, and larger start gaps were enough to let the women's race form on its own.",
+  "changedJudgment": "Once results, prize money, and a $380,000 professional series can be altered by riders outside the category, inter-field contact is no longer harmless festival texture. A rule may deter the advantage, but an organizer that creates the field geometry still owns the burden of making that rule observable, proportional, and realistically obeyable.",
+  "stakes": "The policy governed whether elite women could contest an independent race, whether riders outside the lead group received the same competitive protection, how hundreds of thousands of dollars in series money could be assigned, and whether an athlete could be sent to last place based on surveillance that remote 200-mile courses could not provide evenly.",
+  "credibleOpposition": "Complete separation can be impossible on a 200-mile mass-participation course with daylight, permits, volunteers, aid stations, and thousands of customers. The 2024 Unbound start gaps produced a nine-rider women's sprint and kept the lead women clear of amateur men, suggesting geometry was already improving the race. A severe bright-line penalty also creates a strong deterrent, and concessions for singletrack, climbs, and congestion acknowledge unavoidable contact.",
+  "whatHappened": "On April 2, Life Time president Kimo Seymour said cross-category drafting had a huge impact on elite women's races and that the series had debated the problem since 2022. The week before the April 10 Sea Otter opener, riders learned that elite women could not draft elite men or amateurs, elite men could not draft women or amateurs, and a prohibited draft meant staying within roughly 15 feet for more than 15 seconds. Enforcement could use motos, marshals, staff, drones, live cameras, or helicopters, but a competitor's accusation alone would not count; one verified violation meant relegation to last place in the event and its Grand Prix scoring. Sea Otter separated elites from amateurs by day and the elite fields by 20 minutes, so the rule's debut produced no observed violation. The unresolved test was Unbound, where staggered starts still put the categories on the same 200-mile course.",
+  "take": "Model draft, not Matti's approved view: Life Time finally admitted that a man's wheel could decide a woman's prize money, then solved the problem with an invisible 15-foot rectangle, a 15-second egg timer, and the possibility of helicopter court. Progress? Absolutely. Also an incredible confession. If the organizer's start design manufactures the advantage, fairness cannot depend on whether a moto happens to be filming when somebody drifts into it. Mass participation is a feature for customers, not a moral exemption for race design. Keep the giant festival. Keep the amateurs. But the professional women's race should not have to carry its own moving exclusion zone through 200 miles of an event built to mix people together.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "No reviewed source identified a 2025 rider actually relegated under the policy, and Sea Otter's separate-day format did not stress the rule. The available reporting does not establish complete course-wide observation, the internal jury standard, or whether an unreported incident changed a result. Contemporary reports differ slightly on the women's buffer before amateurs at 2024 Unbound, and the rule was described as both 15 seconds in April reporting and 20 seconds in the final Unbound technical guide; the draft should preserve that evolution rather than pretend the first email was the final specification.",
+  "editorialScore": 94,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_lifetime_drafting_huge_impact_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/guidelines-to-eliminate-huge-impact-of-drafting-in-womens-races-coming-to-life-time-grand-prix-series/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-04-02T00:00:00Z",
+      "quoteExcerpt": "drafting has a huge impact",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_enforcement_acknowledged_hard_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/guidelines-to-eliminate-huge-impact-of-drafting-in-womens-races-coming-to-life-time-grand-prix-series/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-04-02T00:00:00Z",
+      "quoteExcerpt": "You just can't watch an entire race on these courses",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_cross_category_drafting_ban_announced_2025",
+      "canonicalUrl": "https://www.cyclingweekly.com/news/new-rule-bans-cross-category-drafting-to-ensure-fair-competition-in-the-life-time-grand-prix",
+      "publisher": "Cycling Weekly",
+      "publishedAt": "2025-04-03T00:00:00Z",
+      "quoteExcerpt": "prevent race outcomes from being influenced by riders from other categories",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_2024_gap_left_some_mixing_2025",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/life-time-grand-prix-banning-drafting-outside-race-category/",
+      "publisher": "Velo",
+      "publishedAt": "2025-04-03T00:00:00Z",
+      "quoteExcerpt": "some intermixing did occur behind the lead group of women",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_sea_otter_rule_soft_launch_result_2025",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/results-sea-otter-classic-gravel-race-pro-life-time-grand-prix-2025",
+      "publisher": "Velo",
+      "publishedAt": "2025-04-11T01:30:00Z",
+      "quoteExcerpt": "Haley Batten and Keegan Swenson won Sea Otter Classic Gravel Race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_draft_zone_and_penalty_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/features/drawing-a-line-in-the-gravel-will-anti-drafting-rules-create-structure-or-friction-in-life-time-grand-prix-competitions/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-04-16T00:00:00Z",
+      "quoteExcerpt": "within 15 feet (or two bike lengths), and 3 feet to either side, for longer than 15 seconds",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_rule_objective_observation_only_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/features/drawing-a-line-in-the-gravel-will-anti-drafting-rules-create-structure-or-friction-in-life-time-grand-prix-competitions/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-04-16T00:00:00Z",
+      "quoteExcerpt": "Rider input as verifiable evidence to determine the validity of a violation will NOT be accepted",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_traka_2026_women_navigated_amateur_traffic",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/let-us-have-our-race-geerike-schreurs-and-lauren-de-crescenzo-share-stories-from-the-traka-360-as-pro-women-navigate-around-all-the-chaos-of-the-amateurs/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-08T00:00:00Z",
+      "quoteExcerpt": "a wave of age-group men sent ahead of the pro women",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_lifetime_drafting_huge_impact_2025",
+        "claim_lifetime_enforcement_acknowledged_hard_2025",
+        "claim_cross_category_drafting_ban_announced_2025",
+        "claim_unbound_2024_gap_left_some_mixing_2025",
+        "claim_lifetime_draft_zone_and_penalty_2025"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T04:35:00Z",
+  "contentHash": "7ddff7a0882861baeb04e852f72825d890889fabb26ab46caf479b13a7f285c2"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -610,8 +610,8 @@ def test_2025_backfill_ledger_preserves_the_complete_census_without_claiming_rev
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 255
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 5
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 46
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 43
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 5
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add an evidence-grounded 2025 Gravel Weekly history draft about Life Time cross-category drafting ban
- preserve contemporary versus later evidence and route any Unbound impact to editorial review only
- resolve three additional 2025 backfill windows without exposing the model draft publicly

## Verification
- history validator passed
- Gravel Weekly tests: 30 passed
- full suite: 7,831 passed, 331 skipped
- diff check passed

## Safety
- status remains draft
- human approval required
- auto publish disabled
- race impact auto-fix disabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial data and backfill metadata only; draft history is excluded from public loaders and does not auto-apply race field changes.
> 
> **Overview**
> Adds a new **draft** Gravel Weekly history entry (`history-life-time-cross-category-drafting-2025`) covering Life Time’s 2025 cross-category anti-drafting policy, with contemporary receipts, later evidence, and explicit uncertainty (including 15s vs 20s rule wording). The take stays `model_draft`; publishing gates remain on (`humanApprovalRequired`, no auto-publish).
> 
> The **2025 backfill ledger** marks three late-March through mid-April windows as `covered_by_draft` (linked to that entry) with week-specific reasons, replacing `pending_review` placeholders—ledger `complete` stays false.
> 
> **Tests** update expected 2025 disposition counts: `pending_review` 46→43, `covered_by_draft` 2→5. Unbound race impact is flagged for **editorial review only** on `race.biased_opinion` with `autoFixAllowed: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 869e02d377f7776c8e2ea3b81fc4e4f98a60317e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->