### PR TITLE
Add 2025 Unbound live broadcast history

### DIFF
--- a/data/gravel-weekly/backfill/2025.json
+++ b/data/gravel-weekly/backfill/2025.json
@@ -184,33 +184,41 @@
       "periodStartedAt": "2025-05-17",
       "periodEndedAt": "2025-05-23",
       "sourceCardCount": 17,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-live-broadcast-2025"
+      ],
+      "reason": "Life Time's May 21 announcement established the free, global live-broadcast experiment and its explicit real-time storytelling ambition."
     },
     {
       "periodStartedAt": "2025-05-24",
       "periodEndedAt": "2025-05-30",
       "sourceCardCount": 22,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-live-broadcast-2025"
+      ],
+      "reason": "The final preview specified nearly seven free hours for both elite races while Cyclingnews added a start-to-finish live report."
     },
     {
       "periodStartedAt": "2025-05-31",
       "periodEndedAt": "2025-06-06",
       "sourceCardCount": 19,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-live-broadcast-2025"
+      ],
+      "reason": "The official May 31 stream converted the announcement into an observable seven-hour product rather than a promised media initiative."
     },
     {
       "periodStartedAt": "2025-06-07",
       "periodEndedAt": "2025-06-13",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-live-broadcast-2025"
+      ],
+      "reason": "Reported audience and production figures supplied the first evidence that real-time gravel storytelling had a material global audience."
     },
     {
       "periodStartedAt": "2025-06-14",

--- a/data/gravel-weekly/history/2025-unbound-live-broadcast.json
+++ b/data/gravel-weekly/history/2025-unbound-live-broadcast.json
@@ -1,0 +1,125 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-unbound-live-broadcast-2025",
+  "activeFrom": "2025-05-21",
+  "activeThrough": "2025-06-13",
+  "status": "draft",
+  "headline": "Gravel Finally Discovered the Race Was Happening During the Race",
+  "point": "Unbound's free 2025 broadcast did more than add pictures to a famous event. It moved gravel's public story from organizer highlights and delayed rider testimony into a shared present where tactics, failures, media effects, and race-management choices could be watched and argued about before post-production decided what mattered.",
+  "priorJudgment": "Gravel was a participation business whose remoteness, duration, and dispersed fields made conventional live coverage economically unnecessary and technically unrealistic; dot-watching, social posts, and polished recaps were adequate for the audience the sport actually had.",
+  "changedJudgment": "The natural gravel audience is still made largely of riders, crews, families, and people who want to participate, but that is precisely why live coverage has value. It can turn experience into fandom without imitating road television, while making the professional race and the organizer's execution more legible and accountable.",
+  "stakes": "A credible live product affects athlete visibility and sponsorship, whether the women's race receives equal narrative space, how new viewers learn tactics, whether families can follow participants, and whether organizer decisions can be scrutinized as they occur rather than explained later through a controlled highlight package.",
+  "credibleOpposition": "Remote gravel production is expensive, intrusive vehicles can affect racing and safety, a seven-hour stream still missed roughly the first four hours, views do not prove a durable non-participant fan base, and professional spectacle is not the economic center of a mass event. The 2022 broadcast attempt also showed that one marquee production does not make an entire dispersed series technically sustainable.",
+  "whatHappened": "Life Time and FloSports attempted live Grand Prix coverage in 2022, but stopped after Sea Otter and Unbound when remote terrain, course conditions, and production limits proved unsustainable. On May 21, 2025, Life Time announced a free YouTube broadcast of both elite Unbound 200 races, positioning the seven-hour show as real-time storytelling for a global audience. Cyclingnews added a start-to-finish live report. The May 31 production began around four hours after the elite starts and used eight cameras, including a helicopter, drone, course units, and a finish camera that also showed amateur riders. On June 13, Life Time reported 185,000 unique viewers and more than 332,000 weekend views in 50 countries; Cyclingnews reported another 164,000 views for its live report. The numbers did not prove gravel had become television, but they disproved the idea that nobody wanted to watch it happen.",
+  "take": "Model draft, not Matti's approved view: For years, Unbound's live media product was a blue dot, an Instagram story filmed through somebody's dirty thumb, and a 47-minute GoPro confession uploaded on Tuesday. In 2025 gravel discovered the race was also happening on Saturday. That does not mean we need Tour de France cosplay, six hours of château history, or a helicopter teaching Cameron Jones what a draft feels like. It means the sport finally had witnesses. Eight cameras could show tactics, feed-zone mistakes, both elite fields, and hundreds of regular people finishing after the stars were gone. Once that exists, the organizer no longer owns the only usable memory of its event. Build broadcasts for the people gravel actually has—riders, families, bike nerds, and future entrants—and let visibility make the race more accountable than the recap video.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The audience totals were supplied by Life Time and platform view definitions are not equivalent to unique people or sustained watch time. Contemporary coverage sometimes called 2025 Unbound's first live broadcast without distinguishing it from the paid 2022 FloBikes production; this entry treats 2025 as the first free, global, sustained broadcast of both elite races, not the first live moving image from Unbound. Available evidence does not quantify production cost, sponsor return, audience retention, gender allocation of airtime, or any media-vehicle effect on the 2025 result.",
+  "editorialScore": 95,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_2022_grand_prix_broadcast_ended_early",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/plug-pulled-on-live-broadcasts-for-remainder-of-life-time-grand-prix-series/",
+      "publisher": "Velo",
+      "publishedAt": "2022-08-11T08:31:00Z",
+      "quoteExcerpt": "technical limitations, course conditions and remote locations proved insurmountable",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_free_broadcast_announced_2025",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/gravel-racing/unbound-gravel-to-be-live-streamed-for-first-time-in-2025/",
+      "publisher": "Velo",
+      "publishedAt": "2025-05-21T01:48:00Z",
+      "quoteExcerpt": "live, free-to-stream coverage",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_global_free_access_and_live_report_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/how-to-watch-and-follow-unbound-gravel-2025-life-time-streaming-and-live-report-on-cyclingnews/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-05-30T00:00:00Z",
+      "quoteExcerpt": "introducing free live streaming for the first time",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_official_live_stream_2025",
+      "canonicalUrl": "https://www.youtube.com/watch?v=5jS6uf1_KlU",
+      "publisher": "Life Time Grand Prix",
+      "publishedAt": "2025-05-31T00:00:00Z",
+      "quoteExcerpt": "The toughest day in gravel is going LIVE",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_broadcast_audience_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/unbound-gravel-200-live-coverage-draws-more-than-300-000-views-in-50-countries/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-06-13T00:00:00Z",
+      "quoteExcerpt": "185,000 unique viewers tuned in",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_broadcast_eight_cameras_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/unbound-gravel-200-live-coverage-draws-more-than-300-000-views-in-50-countries/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-06-13T00:00:00Z",
+      "quoteExcerpt": "a total of eight cameras along the course",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_big_sugar_extended_live_model_2025",
+      "canonicalUrl": "https://www.cyclingweekly.com/gravel/watch-live-as-life-time-grand-prix-titles-are-decided-at-big-sugar-finale",
+      "publisher": "Cycling Weekly",
+      "publishedAt": "2025-10-02T00:00:00Z",
+      "quoteExcerpt": "finish line camera that will remain rolling through the 12-hour mark",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_start_to_finish_broadcast_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/profound-shakeups-spills-splashes-and-wild-wheel-changes-at-unbound-gravel-2026-conclusions-on-what-unravelled-and-what-worked/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-06-01T16:24:11Z",
+      "quoteExcerpt": "Going from an already extensive seven hours of coverage last year to the whole lot in 2026",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_2022_grand_prix_broadcast_ended_early",
+        "claim_unbound_free_broadcast_announced_2025",
+        "claim_unbound_global_free_access_and_live_report_2025",
+        "claim_unbound_official_live_stream_2025",
+        "claim_unbound_broadcast_audience_2025",
+        "claim_unbound_broadcast_eight_cameras_2025"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T04:24:00Z",
+  "contentHash": "cecf8a8e5da21dbe7e5a3e7d125f6f3b5f38442c44b8618a7850b89f62735824"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -610,8 +610,8 @@ def test_2025_backfill_ledger_preserves_the_complete_census_without_claiming_rev
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 255
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 5
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 43
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 5
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 39
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 9
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add an evidence-grounded 2025 Gravel Weekly history draft about Unbound live coverage
- distinguish the failed 2022 paid experiment from the 2025 free global broadcast
- connect live storytelling to athlete visibility and organizer accountability without claiming conventional TV fandom
- resolve four more 2025 backfill windows

## Verification
- history validator passed
- Gravel Weekly tests: 30 passed
- full suite: 7,831 passed, 331 skipped
- diff check passed

## Safety
- status remains draft
- human approval required
- auto publish disabled
- race impact auto-fix disabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill metadata only; draft status blocks public exposure and race auto-fix remains off.
> 
> **Overview**
> Adds a new **Gravel Weekly history draft** (`history-unbound-live-broadcast-2025`) covering Life Time’s free 2025 Unbound elite live stream—contrasted with the aborted 2022 FloSports experiment—and frames it as real-time storytelling, accountability, and audience evidence, with receipts, later evidence, and a flagged **editorial review** on `gravel:unbound-gravel-200` (`race.biased_opinion`). The entry stays **draft** with human approval required and auto-publish disabled.
> 
> Marks **four May–June 2025 backfill weeks** as `covered_by_draft` (linked to that entry with week-specific reasons) instead of `pending_review`, and updates the **2025 ledger test** expectations (`covered_by_draft` 5→9, `pending_review` 43→39).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca628b38cda5f3d36e25ecb181b865c87b3f0e01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->