### PR TITLE
Add 2025 Gravel Worlds cost history

### DIFF
--- a/data/gravel-weekly/backfill/2025.json
+++ b/data/gravel-weekly/backfill/2025.json
@@ -352,17 +352,21 @@
       "periodStartedAt": "2025-10-04",
       "periodEndedAt": "2025-10-10",
       "sourceCardCount": 12,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-worlds-cost-of-showing-up-2025"
+      ],
+      "reason": "Rider accounts, official self-funding terms, the start list, and Cole Davis's prize-funded path established that qualification did not make Worlds economically accessible."
     },
     {
       "periodStartedAt": "2025-10-11",
       "periodEndedAt": "2025-10-17",
       "sourceCardCount": 17,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-worlds-cost-of-showing-up-2025"
+      ],
+      "reason": "The championship-weekend defense of Worlds as the highest level and the post-race accounting of absent specialists supplied the fair opposition and consequence."
     },
     {
       "periodStartedAt": "2025-10-18",

--- a/data/gravel-weekly/history/2025-worlds-cost-of-showing-up.json
+++ b/data/gravel-weekly/history/2025-worlds-cost-of-showing-up.json
@@ -1,0 +1,116 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-worlds-cost-of-showing-up-2025",
+  "activeFrom": "2025-10-07",
+  "activeThrough": "2025-10-13",
+  "status": "draft",
+  "headline": "Team USA Invited Its Gravel Riders to Pay for Team USA",
+  "point": "Qualification did not create an economically viable path to the 2025 Gravel World Championships. USA Cycling explicitly transferred the event expense to athletes, while a calendar collision made attendance compete with domestic prize money, sponsor visibility, work obligations, and an entire season's livelihood. The rainbow jersey remained real; the start list was also a financial selection.",
+  "priorJudgment": "A place at a world championship is an opportunity a top gravel professional naturally accepts because national representation and a possible rainbow jersey outweigh ordinary calendar and travel considerations.",
+  "changedJudgment": "For independent professionals, an unfunded nomination can be a bill rather than support. Declining Worlds may be the more professional decision when attending creates a guaranteed loss, hides personal sponsors, and jeopardizes the domestic results that finance the next season.",
+  "stakes": "The funding model affected which specialists could appear at the nominal highest level, whether national-team selection meant meaningful support, how privateers protected sponsor value and outside employment, and whether a world championship assembled the best gravel racers or the best qualified riders who could make attendance rational.",
+  "credibleOpposition": "USA Cycling published the financial terms rather than surprising athletes, limited federation resources tend to prioritize Olympic disciplines, and a world championship cannot be scheduled around every commercial series. The Limburg fields still contained exceptional WorldTour, cyclocross, and international gravel talent, so absent US specialists did not make the champions undeserving. Riders who attended could reasonably argue that the highest title demands sacrifice.",
+  "whatHappened": "USA Cycling's June selection criteria said automatically invited and discretionary riders were responsible for their own event expenses and that the federation would assume no financial responsibility. By October, the relocated Worlds dates overlapped Little Sugar and sat one week before mandatory Big Sugar, where individual purses and $200,000 in Grand Prix series money made staying in the United States financially consequential. Lauren De Crescenzo reported that the entire 2025 US Gravel Nationals women's podium declined Worlds places; riders cited airfare, a required national kit, lodging, sponsor exposure, work schedules, course fit, and recovery. Cole Davis took the opposite path: a $1,500 Nationals silver-medal payout helped fund the race that earned his wildcard, extending an unexpected trip to the Netherlands. Published start lists paired dense WorldTour talent with conspicuous specialist absences. Dutch gravel veteran Jasper Ockeloen defended Worlds as the sport's highest level while acknowledging the conflict, and post-race analysis confirmed that marquee US matchups never materialized.",
+  "take": "Model draft, not Matti's approved view: Congratulations, you made Team USA. Please proceed to checkout. USA Cycling's 2025 gravel selection document had the energy of a wedding invitation whose registry was your own airfare, hotel, mechanic, food, and mandatory national kit. Qualification was not a ticket; it was permission to buy the ticket. Meanwhile, the racing that paid US privateers, displayed their actual sponsors, and determined their next season was happening in Arkansas. Of course many stayed home. That is not a patriotism problem or proof the rainbow jersey is fake. It is proof that Gravel Worlds selected twice: first by results, then by who could make the spreadsheet stop screaming. If a federation wants the strongest team, nomination has to mean more than official permission to lose money in matching clothes.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "Individual expenses and sponsor effects were reported by riders and were not independently audited. The evidence does not establish the federation's total gravel budget, what in-kind logistical support may have existed, whether every declined rider would otherwise have started, or whether any absence changed a medal. Cole Davis's article establishes that prize money financed the qualifying sequence, but does not provide a complete accounting of his Worlds trip. Strong road and cyclocross fields complicate any claim that missing US specialists reduced the absolute competitive level.",
+  "editorialScore": 97,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_usac_gravel_worlds_self_funded_2025",
+      "canonicalUrl": "https://assets.usacycling.org/prod/documents/Selection-Criteria/2025-UCI-GRAVEL-WORLD-CHAMPIONSHIPS-ELITE-MEN-WOMEN-June-26.pdf",
+      "publisher": "USA Cycling",
+      "publishedAt": "2025-06-27T16:09:55Z",
+      "quoteExcerpt": "USA Cycling will not assume any financial responsibility for athletes",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_us_womens_nationals_podium_declined_worlds_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/features/logistics-money-and-career-sustainability-why-some-us-riders-are-saying-no-to-uci-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-10-07T20:41:25Z",
+      "quoteExcerpt": "all three women on the US Gravel National Championships podium opted not to accept roster spots",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_vs_livelihood_choice_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/features/logistics-money-and-career-sustainability-why-some-us-riders-are-saying-no-to-uci-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-10-07T20:41:25Z",
+      "quoteExcerpt": "For my sponsors and my livelihood, the U.S. races",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_cole_davis_prize_funded_worlds_path_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/former-us-junior-road-champion-cole-davis-uses-late-season-gravel-prize-money-to-fund-wildcard-spot-at-uci-gravel-worlds/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-10-08T01:20:51Z",
+      "quoteExcerpt": "earned a silver medal and deposited $1,500 in prize money",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_road_talent_and_specialist_absence_2025",
+      "canonicalUrl": "https://www.cyclingweekly.com/racing/tom-pidcock-marianne-vos-lorena-wiebes-but-no-mathieu-van-der-poel-uci-gravel-world-championships-2025-start-lists-confirmed",
+      "publisher": "Cycling Weekly",
+      "publishedAt": "2025-10-08T00:00:00Z",
+      "quoteExcerpt": "start lists packed full of road WorldTour talent",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_ockeloen_worlds_highest_level_objection_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/to-race-the-highest-level-of-the-year-they-should-come-here-dutch-rider-jasper-ockeloen-disappointed-by-absence-of-top-us-racers-at-uci-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-10-11T10:36:05Z",
+      "quoteExcerpt": "if they want to race the highest level of the year, they should come here",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_marquee_matchups_never_happened_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/features/perplexing-tactics-questionable-wildcards-and-classics-revisited-a-cavalcade-of-conclusions-from-2025-uci-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-10-13T00:00:00Z",
+      "quoteExcerpt": "those matchups never materialised",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-world-championships",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_usac_gravel_worlds_self_funded_2025",
+        "claim_us_womens_nationals_podium_declined_worlds_2025",
+        "claim_worlds_vs_livelihood_choice_2025",
+        "claim_cole_davis_prize_funded_worlds_path_2025",
+        "claim_worlds_road_talent_and_specialist_absence_2025",
+        "claim_ockeloen_worlds_highest_level_objection_2025",
+        "claim_worlds_marquee_matchups_never_happened_2025"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T04:40:00Z",
+  "contentHash": "1f9383cabdb49a59a3569da3a6a949b663f25413708334c24831645420391f47"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -610,8 +610,8 @@ def test_2025_backfill_ledger_preserves_the_complete_census_without_claiming_rev
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 255
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 5
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 39
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 9
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 37
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 11
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add an evidence-grounded 2025 Gravel Weekly history draft about the economic filter behind Gravel Worlds attendance
- ground the central claim in USA Cycling official self-funding terms and rider accounts
- preserve the legitimacy of the champions and the strongest fair objection
- resolve two more 2025 backfill windows

## Verification
- official selection PDF extracted and visually checked
- history validator passed
- Gravel Weekly tests: 30 passed
- full suite: 7,831 passed, 331 skipped
- diff check passed

## Safety
- status remains draft
- human approval required
- auto publish disabled
- race impact auto-fix disabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and ledger bookkeeping only; draft gating and disabled auto-publish/auto-fix prevent automated production changes.
> 
> **Overview**
> Adds a new **draft** Gravel Weekly history entry (`history-worlds-cost-of-showing-up-2025`) arguing that 2025 UCI Gravel Worlds attendance was shaped by economics—USA Cycling’s self-funded selection terms, calendar clashes with US prize races, podium declines, and counterexamples like Cole Davis’s prize-funded path—with seven contemporary receipts and explicit uncertainty.
> 
> The **2025 backfill ledger** marks the Oct 4–10 and Oct 11–17 windows as `covered_by_draft` (instead of `pending_review`) and links them to that entry. **Tests** update expected `pending_review` / `covered_by_draft` week counts accordingly.
> 
> The entry stays non-publishable: `status: draft`, `humanApprovalRequired`, `autoPublishAllowed: false`, and a `raceImpacts` hook for manual editorial review of `gravel:uci-gravel-world-championships` with **auto-fix disabled**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cece8fff63f131d80ce746afc4e205e3062c2439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->