### PR TITLE
Add 2025 wildcard champion history

### DIFF
--- a/data/gravel-weekly/backfill/2025.json
+++ b/data/gravel-weekly/backfill/2025.json
@@ -206,9 +206,10 @@
       "sourceCardCount": 19,
       "disposition": "covered_by_draft",
       "entryIds": [
-        "history-unbound-live-broadcast-2025"
+        "history-unbound-live-broadcast-2025",
+        "history-wildcard-won-series-2025"
       ],
-      "reason": "The official May 31 stream converted the announcement into an observable seven-hour product rather than a promised media initiative."
+      "reason": "The official stream made the race observable while Cameron Jones's Unbound win converted the new wildcard pathway from a promised access mechanism into a title-eligible result."
     },
     {
       "periodStartedAt": "2025-06-07",
@@ -364,17 +365,20 @@
       "sourceCardCount": 17,
       "disposition": "covered_by_draft",
       "entryIds": [
-        "history-worlds-cost-of-showing-up-2025"
+        "history-worlds-cost-of-showing-up-2025",
+        "history-wildcard-won-series-2025"
       ],
-      "reason": "The championship-weekend defense of Worlds as the highest level and the post-race accounting of absent specialists supplied the fair opposition and consequence."
+      "reason": "Worlds attendance arguments documented the international-versus-domestic economy, while Jones's Little Sugar win moved the initially unselected wildcard within one point of the series lead."
     },
     {
       "periodStartedAt": "2025-10-18",
       "periodEndedAt": "2025-10-24",
       "sourceCardCount": 8,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-wildcard-won-series-2025"
+      ],
+      "reason": "Big Sugar settled the season arc: Jones finished ahead of every relevant rival and became the first men's champion other than Keegan Swenson."
     },
     {
       "periodStartedAt": "2025-10-25",

--- a/data/gravel-weekly/history/2025-wildcard-won-series.json
+++ b/data/gravel-weekly/history/2025-wildcard-won-series.json
@@ -1,0 +1,126 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-wildcard-won-series-2025",
+  "activeFrom": "2025-06-01",
+  "activeThrough": "2025-10-18",
+  "status": "draft",
+  "headline": "Life Time Left Out the Man Who Won Its Series",
+  "point": "The first 2025 wildcard pathway was not a decorative second chance. It functioned as a correction mechanism for preseason selection: Cameron Jones raced the same opening qualifiers, earned admission by winning Unbound, then won Little Sugar and the overall title over every rider chosen ahead of him.",
+  "priorJudgment": "A midseason wildcard gives promising outsiders visibility and fills roster gaps, but the season-long championship remains structurally controlled by athletes selected before round one.",
+  "changedJudgment": "A performance-based wildcard can expose scouting error and improve the championship if candidates must contest the opening events, carry real results into the same scoring structure, and receive full title eligibility rather than guest status.",
+  "stakes": "The pathway affected who could access series points, prize money, sponsor exposure, and a season-defining platform; it also tested whether Life Time's application process selected the strongest field or merely the strongest field it could identify before racing began.",
+  "credibleOpposition": "Jones had applied in advance and was supported by Scott-Shimano, so he was not an unknown amateur arriving from nowhere. The wildcard chase may encourage unusually risky tactics at Unbound, while initial selections must make sponsor and calendar commitments months earlier. One exceptional winner does not prove the mechanism will consistently identify overlooked talent, and a shortened Big Sugar made the final title hinge on a sprint rather than the advertised 100-mile test.",
+  "whatHappened": "Life Time announced in October 2024 that only 22 men and 22 women would receive initial 2025 selection, with the remaining positions awarded after riders contested both Sea Otter Gravel and Unbound. Jones applied but was not initially selected. He finished third among wildcard candidates at Sea Otter, then faced a choice at Unbound between protecting series admission and attacking the race. He chose a breakaway with roughly 150 miles remaining, won in a course-record 8:37:09, and secured wildcard entry on merit. He continued through the series, won Little Sugar on October 12 to move within one point of three-time champion Keegan Swenson, then finished fifth in the weather-shortened Big Sugar finale ahead of every relevant rival. The result made Jones the first men's champion other than Swenson in the series' four seasons.",
+  "take": "Model draft, not Matti's approved view: Life Time asked riders to prove they belonged, then accidentally built a season-long appeals court for its own scouting department. Cameron Jones was not selected. Fine. He applied anyway, raced Sea Otter, then gambled both Unbound and his possible series entry on a 150-mile break. He won Unbound, won Little Sugar, and took the overall from the only men's champion the Grand Prix had ever known. Cinderella did not have to average 23.5 miles per hour for 200 miles before she got into the party. This was better than a Cinderella story: the wildcard was actual competitive governance. Keep the side door, keep the same workload, and let the stopwatch embarrass the résumé committee whenever necessary.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "Life Time has not published the internal reasons Jones missed initial selection, so 'left out' describes the roster result rather than a documented judgment that he lacked ability. Contemporary reports differ on whether three or four men's wildcard places were ultimately available. The evidence does not independently reconstruct every 2025 points calculation, quantify any tactical advantage from wildcard status, or establish that Jones would have followed the same calendar without selection. Big Sugar was shortened from roughly 100 miles to 53.9 miles because of severe weather, materially changing the finale while applying the same altered race to all contenders.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_lifetime_2025_wildcard_structure_announced",
+      "canonicalUrl": "https://ir.lifetime.life/news-events/press-releases/detail/1095/life-time-announces-2025-grand-prix-series-details",
+      "publisher": "Life Time",
+      "publishedAt": "2024-10-09T00:00:00Z",
+      "quoteExcerpt": "three men's and three women's wild card spots confirmed after the Life Time UNBOUND Gravel 200",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_wildcards_raced_both_opening_events_2025",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/gravel-racing/2025-life-time-grand-prix-series/",
+      "publisher": "Velo",
+      "publishedAt": "2024-10-09T19:28:00Z",
+      "quoteExcerpt": "competed at both the Sea Otter Classic gravel race and Unbound",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_jones_not_initially_selected_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/racing-like-there-is-nothing-to-lose-when-its-in-my-best-interests-to-play-it-safe-cameron-jones-takes-the-risk-for-unbound-200-win/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-06-01T00:26:24Z",
+      "quoteExcerpt": "had applied for the 2025 Grand Prix earlier this year but was not initially selected",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_jones_unbound_risk_secured_wildcard_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/racing-like-there-is-nothing-to-lose-when-its-in-my-best-interests-to-play-it-safe-cameron-jones-takes-the-risk-for-unbound-200-win/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-06-01T00:26:24Z",
+      "quoteExcerpt": "the chance to be in the Grand Prix",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_jones_little_sugar_moved_within_one_point_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/early-launches-secure-cameron-jones-and-sofia-gomez-villafane-wins-at-little-sugar-mtb/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-10-13T22:44:56Z",
+      "quoteExcerpt": "one point behind current series leader and three-time series winner Keegan Swenson",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_jones_wildcard_won_series_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/i-was-just-trying-to-think-about-what-was-on-the-line-cameron-jones-charges-from-wildcard-entry-to-life-time-grand-prix-series-winner/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-10-18T00:00:00Z",
+      "quoteExcerpt": "charges from wildcard entry to Life Time Grand Prix series winner",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_jones_first_man_to_beat_swenson_2025",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/gravel-racing/results-big-sugar-gravel-2025-beers-gomez-villafane/",
+      "publisher": "Velo",
+      "publishedAt": "2025-10-18T12:21:00Z",
+      "quoteExcerpt": "the first man to beat Keegan Swenson in the four-year history of the competition",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_lifetime_2025_wildcard_structure_announced",
+        "claim_wildcards_raced_both_opening_events_2025",
+        "claim_jones_not_initially_selected_2025",
+        "claim_jones_unbound_risk_secured_wildcard_2025"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:big-sugar-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_jones_little_sugar_moved_within_one_point_2025",
+        "claim_jones_wildcard_won_series_2025",
+        "claim_jones_first_man_to_beat_swenson_2025"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T04:50:00Z",
+  "contentHash": "8cdd9f93d3bdcc5a12969723b3f4b858646a5d4f686a1e8bc15ebf72b14057ab"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -610,8 +610,8 @@ def test_2025_backfill_ledger_preserves_the_complete_census_without_claiming_rev
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 255
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 5
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 37
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 11
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 36
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 12
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add the Cameron Jones wildcard-to-series-champion historical chapter
- connect the Unbound, Little Sugar, and Big Sugar evidence windows in the 2025 ledger
- keep race impacts review-only and the entry in model-draft status

## Verification
- targeted Gravel Weekly tests: 30 passed
- full repository suite: 7,831 passed, 331 skipped
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill metadata only; draft status blocks public publish, and race impacts are flagged for human review without auto-fix.
> 
> **Overview**
> Adds a new **draft** Gravel Weekly history chapter (`history-wildcard-won-series-2025`) framing Cameron Jones’s 2025 Life Time Grand Prix arc—from missing initial selection, winning Unbound for a wildcard, through Little Sugar and Big Sugar to the first men’s series title not won by Keegan Swenson. The entry stays **model-draft** (`takeProvenance: model_draft`), requires human approval, and records **review-only** `raceImpacts` on Unbound and Big Sugar (`race.biased_opinion`), not auto-fixes.
> 
> The **2025 backfill ledger** now ties that entry to the late-May (Unbound), mid-October (Little Sugar), and Oct 18–24 (Big Sugar finale) windows, updates those weeks’ reasons, and moves the Oct 18–24 week from `pending_review` to `covered_by_draft`. Ledger test expectations shift by one week each for `pending_review` (36) and `covered_by_draft` (12); the year remains incomplete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96463a2f1b25421cabe881f0840b674e157c1cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->