### PR TITLE
Add 2025 Worlds host rescue history

### DIFF
--- a/data/gravel-weekly/backfill/2025.json
+++ b/data/gravel-weekly/backfill/2025.json
@@ -78,9 +78,11 @@
       "periodStartedAt": "2025-02-22",
       "periodEndedAt": "2025-02-28",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-worlds-host-rescue-2025"
+      ],
+      "reason": "Nice's withdrawal eight months before race day opened the host-collapse arc and made the championship's organizer, venue, and date unsettled."
     },
     {
       "periodStartedAt": "2025-03-01",
@@ -114,9 +116,11 @@
       "periodStartedAt": "2025-03-22",
       "periodEndedAt": "2025-03-28",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-worlds-host-rescue-2025"
+      ],
+      "reason": "Carinthia's public bid and the leaked Limburg account exposed the compressed replacement contest one month after Nice withdrew."
     },
     {
       "periodStartedAt": "2025-03-29",
@@ -134,9 +138,10 @@
       "sourceCardCount": 8,
       "disposition": "covered_by_draft",
       "entryIds": [
-        "history-life-time-cross-category-drafting-2025"
+        "history-life-time-cross-category-drafting-2025",
+        "history-worlds-host-rescue-2025"
       ],
-      "reason": "Sea Otter's separate-day soft launch exposed the central tradeoff: geometry could prevent the interference more reliably than policing it after the fields mixed."
+      "reason": "Sea Otter exposed the drafting-rule tradeoff, while the April 11 Limburg award completed the Worlds rescue and revealed Golazo as the championship's portable institutional core."
     },
     {
       "periodStartedAt": "2025-04-12",

--- a/data/gravel-weekly/history/2025-worlds-host-rescue.json
+++ b/data/gravel-weekly/history/2025-worlds-host-rescue.json
@@ -1,0 +1,127 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-worlds-host-rescue-2025",
+  "activeFrom": "2025-02-25",
+  "activeThrough": "2025-04-11",
+  "status": "draft",
+  "headline": "Gravel Worlds Lost Its Host. Golazo Was the Plan B.",
+  "point": "The 2025 Gravel World Championships survived a host collapse because the event's real continuity did not reside in Nice. It resided with Golazo, the private operator already managing the UCI Gravel World Series and fresh from organizing the previous Worlds. That portability made the young championship resilient, but it also revealed how much of gravel's international institution was concentrated in one event company.",
+  "priorJudgment": "A world championship awarded three years in advance is anchored by its host city, while the governing body and event contractor support a venue-led plan.",
+  "changedJudgment": "The fourth Gravel Worlds behaved more like a portable event product than a place-bound institution. Its experienced operator could move the package and save the title, but the same rescue showed that the series, expertise, and championship delivery were unusually dependent on one commercial organization.",
+  "stakes": "Thousands of qualified age-group riders and elite selections needed a date, venue, travel plan, and course; municipalities were asked to accept a major event on a compressed timetable; and the UCI's world-title credibility depended on an operator being able to rebuild the championship after its announced host disappeared.",
+  "credibleOpposition": "The rescue worked. Zuid-Limburg had deep cycling infrastructure, three participating municipalities, and an organizer with current championship experience. The UCI confirmed a replacement within 45 days, moved the event only one week earlier, and ultimately awarded the rainbow jerseys. A young discipline using an experienced repeat operator can be sensible resilience rather than institutional weakness, and the public record does not prove Nice's confidential constraints or that the UCI lacked other viable bids.",
+  "whatHappened": "The UCI awarded the 2025 Gravel World Championships to Nice in September 2022. On February 25, 2025, with roughly eight months remaining, the UCI and city abandoned the October event because of unspecified technical and calendar constraints; the governing body said it was searching for a new organizer, venue, and possibly date. By March 27, Carinthia's Wörthersee organizer publicly confirmed an Austrian bid backed by government, tourism, mayors, suppliers, and proposed courses, while a South Limburg location had already leaked through an event Instagram account. On April 11, the UCI awarded October 11-12 to Zuid-Limburg and named Golazo as organizer. The province said Golazo, holder of the organizing rights, had initiated the Limburg plan on short notice. Golazo was not an emergency stranger: it had managed the Gravel World Series since 2022, renewed that role through 2030, and organized the 2024 Worlds. The replacement championship was subsequently delivered in Beek, Beekdaelen, and Maastricht.",
+  "take": "Model draft, not Matti's approved view: Gravel Worlds spent two and a half years engaged to Nice, got dumped eight months before the wedding, and was remarried in Limburg 45 days later by the same company carrying the folding chairs. That is impressive. It is also revealing. The UCI supplied the rainbow jerseys and Golazo supplied almost everything that made the championship portable: the series, organizer knowledge, recent Worlds experience, and apparently the ability to call three Dutch municipalities before lunch. The event going ahead is not evidence that the system was sturdy. It is evidence that Golazo was sturdy. Gravel's world championship was saved, but the rescue exposed the actual institution hiding underneath it: not a city, and perhaps not entirely the federation, but one very useful events company with the whole circus already packed in trucks.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The UCI and Nice described only broad technical and calendar constraints, so the evidence does not establish the precise failure, financial responsibility, contractual penalties, or whether either party could have prevented the withdrawal. Public reporting confirms an Austrian application but not the UCI's full candidate list or selection scoring. The provincial phrase translated as holder of the organizing rights does not disclose the complete contract between the UCI and Golazo. The championship's successful delivery demonstrates operational resilience but does not quantify additional costs or disruption borne by riders, federations, municipalities, or suppliers.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_nice_awarded_gravel_worlds_2022",
+      "canonicalUrl": "https://www.uci.org/pressrelease/the-uci-congress-approves-the-institutions-agenda-2030-the-second-edition-of/bp2YBwmGGnYDLLxPAzlx8",
+      "publisher": "UCI",
+      "publishedAt": "2022-09-22T00:00:00Z",
+      "quoteExcerpt": "2025 UCI Gravel World Championships: Nice (France)",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_nice_withdrew_gravel_worlds_2025",
+      "canonicalUrl": "https://www.uci.org/pressrelease/the-2025-uci-gravel-world-championships-will-not-take-place-in-nice/5GO38XEc6qHThPJGlL8MnW",
+      "publisher": "UCI",
+      "publishedAt": "2025-02-25T00:00:00Z",
+      "quoteExcerpt": "various constraints, technical and regarding the calendar",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_needed_host_eight_months_out_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/2025-gravel-world-championships-up-in-the-air-after-uci-confirms-nice-unable-to-host-major-event-in-october/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-02-25T14:50:57Z",
+      "quoteExcerpt": "with the Championships just eight months away",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_carinthia_submitted_worlds_bid_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/southern-austria-region-more-than-ready-to-host-uci-gravel-world-championships-and-confirms-application-with-proposed-courses/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-03-27T20:58:36Z",
+      "quoteExcerpt": "we applied for the UCI Gravel World Championships 2025",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_limburg_replaced_nice_2025",
+      "canonicalUrl": "https://www.uci.org/pressrelease/2025-uci-gravel-world-championships-to-be-held-in-zuid-limburg-the/3X4pSQWNMQHO44eCNEoYOv",
+      "publisher": "UCI",
+      "publishedAt": "2025-04-11T00:00:00Z",
+      "quoteExcerpt": "will finally take place in the Zuid-Limburg region",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_golazo_managed_series_and_prior_worlds_2025",
+      "canonicalUrl": "https://www.uci.org/pressrelease/2025-uci-gravel-world-championships-to-be-held-in-zuid-limburg-the/3X4pSQWNMQHO44eCNEoYOv",
+      "publisher": "UCI",
+      "publishedAt": "2025-04-11T00:00:00Z",
+      "quoteExcerpt": "managing the UCI Gravel World Series on behalf of the UCI since 2022",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_golazo_initiated_limburg_rescue_2025",
+      "canonicalUrl": "https://limburg.bestuurlijkeinformatie.nl/Document/View/4d5fcf5e-e9a4-4ea7-b055-190444076908",
+      "publisher": "Province of Limburg",
+      "publishedAt": "2025-04-11T00:00:00Z",
+      "quoteExcerpt": "op korte termijn het initiatief genomen",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_limburg_delivered_mens_worlds_2025",
+      "canonicalUrl": "https://www.uci.org/article/2025-bolero-uci-gravel-world-championships-vermeersch-steps-up-to-the/5ZA5c1vr7I20SLcM2fWCDF",
+      "publisher": "UCI",
+      "publishedAt": "2025-10-12T00:00:00Z",
+      "quoteExcerpt": "came to a spectacular end on Sunday",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-world-championships",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_nice_awarded_gravel_worlds_2022",
+        "claim_nice_withdrew_gravel_worlds_2025",
+        "claim_worlds_needed_host_eight_months_out_2025",
+        "claim_carinthia_submitted_worlds_bid_2025",
+        "claim_limburg_replaced_nice_2025",
+        "claim_golazo_managed_series_and_prior_worlds_2025",
+        "claim_golazo_initiated_limburg_rescue_2025",
+        "claim_limburg_delivered_mens_worlds_2025"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T05:00:00Z",
+  "contentHash": "6283d6d68c8f0fddc0affe56d7f98bb23721c64baff9f052c5f9363b6f0f9846"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -610,8 +610,8 @@ def test_2025_backfill_ledger_preserves_the_complete_census_without_claiming_rev
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 255
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 5
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 36
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 12
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 34
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 14
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add the Nice-withdrawal-to-Limburg-rescue historical chapter
- center the editorial argument on Golazo as the portable institutional core while preserving the successful delivery as opposition
- resolve the February 25 and March 27 evidence windows and connect the April 11 announcement week
- keep the entry private, model-draft, human-approval-required, and race impacts review-only

## Verification
- historical entry validator: pass
- 2025 backfill validator: pass
- Gravel Weekly tests: 30 passed
- full repository suite: 7,831 passed, 331 skipped
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill metadata only; no auth, deploy, or auto-publish paths change, and the new history remains draft with review-only race impacts.
> 
> **Overview**
> Adds a new Gravel Weekly history entry **`history-worlds-host-rescue-2025`** covering Nice’s February 2025 withdrawal through the April Limburg/Golazo rescue, with sourced receipts and a **review-only** race impact on `gravel:uci-gravel-world-championships` (`race.biased_opinion`). The entry stays **`draft`**, **`model_draft` take**, and **human-approval-required** (not publishable).
> 
> Updates the **2025 backfill ledger** so three evidence windows (late Feb, late Mar, and the week of the Apr 11 award) are **`covered_by_draft`** and point at that entry; the Apr 5–11 week now ties both the cross-category drafting draft and the Worlds rescue draft, with revised week reasons.
> 
> **Tests** bump expected 2025 ledger counts: **`pending_review` 36→34**, **`covered_by_draft` 12→14**, with overall census unchanged and **`complete` still false**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9398d768dd1709f3142086d523c20eb6891d800b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->