### PR TITLE
Complete 2025 historical assigning review

### DIFF
--- a/data/gravel-weekly/backfill/2025.json
+++ b/data/gravel-weekly/backfill/2025.json
@@ -6,7 +6,7 @@
   "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33138955480",
   "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
   "sourceCardCount": 255,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -22,9 +22,9 @@
       "periodStartedAt": "2025-01-04",
       "periodEndedAt": "2025-01-10",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Michaela Thompson profile may establish a before-and-after for Life Time's U23 pathway, but a retrospective athlete profile alone does not prove the program's access or development consequences."
     },
     {
       "periodStartedAt": "2025-01-11",
@@ -46,33 +46,33 @@
       "periodStartedAt": "2025-01-25",
       "periodEndedAt": "2025-01-31",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The lone roundup combines unrelated Project Echelon results and Gravel Hall of Fame news; it supplies no single changed judgment or consequential gravel narrative."
     },
     {
       "periodStartedAt": "2025-02-01",
       "periodEndedAt": "2025-02-07",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Weather-gallery, product-review, tyre-test, and series-index cards record useful service information but no demonstrated sporting or cultural consequence worth preserving as the Current Thing."
     },
     {
       "periodStartedAt": "2025-02-08",
       "periodEndedAt": "2025-02-14",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Morton's international calendar, Klöser's WorldTour move, PAS's roster, and Van Aert's interest suggest gravel-road convergence, but the cards do not yet establish a shared mechanism or consequence."
     },
     {
       "periodStartedAt": "2025-02-15",
       "periodEndedAt": "2025-02-21",
       "sourceCardCount": 8,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Castelli roster, road-retiree crossover, BMC recall, and new U23 qualifiers expose several possible professionalization arcs, but none clears every story gate from this mixed evidence set."
     },
     {
       "periodStartedAt": "2025-02-22",
@@ -88,9 +88,9 @@
       "periodStartedAt": "2025-03-01",
       "periodEndedAt": "2025-03-07",
       "sourceCardCount": 7,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Unbound and Lauf's 1,000-women commitment may support a participation-and-access story, but registration goals and road-race gravel coverage do not yet prove durable participation or retention."
     },
     {
       "periodStartedAt": "2025-03-08",
@@ -157,33 +157,35 @@
       "periodStartedAt": "2025-04-19",
       "periodEndedAt": "2025-04-25",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The announcement of Australia's first national gravel championship may begin an institutional-growth arc, but a proposed event alone cannot establish delivery, legitimacy, or consequence."
     },
     {
       "periodStartedAt": "2025-04-26",
       "periodEndedAt": "2025-05-02",
       "sourceCardCount": 11,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Australia's first elite national titles and the international race cluster may advance gravel's formalization, but the mixed results and personality pieces lack a focused changed judgment."
     },
     {
       "periodStartedAt": "2025-05-03",
       "periodEndedAt": "2025-05-09",
       "sourceCardCount": 13,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-pit-crews-2025"
+      ],
+      "reason": "Pre-race route reporting documented the planned 200- and 100-mile field overlap near Council Grove that later rider accounts identified as part of Unbound's checkpoint congestion."
     },
     {
       "periodStartedAt": "2025-05-10",
       "periodEndedAt": "2025-05-16",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two routine results and a 2026 Worlds preparation update provide calendar continuity but no 2025 consequence, conflict, or judgment change for a standalone story."
     },
     {
       "periodStartedAt": "2025-05-17",
@@ -232,49 +234,49 @@
       "periodStartedAt": "2025-06-14",
       "periodEndedAt": "2025-06-20",
       "sourceCardCount": 7,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The source set is dominated by routine results and product launches; the Unbound XL chase is a compelling race reconstruction but does not establish a broader changed judgment."
     },
     {
       "periodStartedAt": "2025-06-21",
       "periodEndedAt": "2025-06-27",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two results pages and one bike review document outcomes and equipment without a defensible mechanism, affected party, or consequence beyond the week."
     },
     {
       "periodStartedAt": "2025-06-28",
       "periodEndedAt": "2025-07-04",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two routine results and a product launch do not clear the point, stakes, opposition, or historical-consequence gates."
     },
     {
       "periodStartedAt": "2025-07-05",
       "periodEndedAt": "2025-07-11",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The only card is a UCI Gravel World Series result with no demonstrated consequence beyond the finishing order."
     },
     {
       "periodStartedAt": "2025-07-12",
       "periodEndedAt": "2025-07-18",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The only card is a Gravel One Fifty result with no evidence of a durable sporting, institutional, or cultural change."
     },
     {
       "periodStartedAt": "2025-07-19",
       "periodEndedAt": "2025-07-25",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two bike reviews and one result page are service coverage; product novelty without verified downstream consequence is not a historical Current Thing."
     },
     {
       "periodStartedAt": "2025-07-26",
@@ -296,65 +298,65 @@
       "periodStartedAt": "2025-08-09",
       "periodEndedAt": "2025-08-15",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A tyre-clearance product item plus Worlds race-home, map, and history utility pages contain no new event or judgment to preserve."
     },
     {
       "periodStartedAt": "2025-08-16",
       "periodEndedAt": "2025-08-22",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two race results and a season index are navigational or outcome coverage, not evidence of a consequential change."
     },
     {
       "periodStartedAt": "2025-08-23",
       "periodEndedAt": "2025-08-29",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Carolin Schiff ending her season over bone-density and RED-S concerns may support a professional-gravel health story, but one athlete account cannot establish prevalence, incentives, or systemic responsibility."
     },
     {
       "periodStartedAt": "2025-08-30",
       "periodEndedAt": "2025-09-05",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The lone Houffa Gravel result records a finishing order without a distinct changed judgment or consequence."
     },
     {
       "periodStartedAt": "2025-09-06",
       "periodEndedAt": "2025-09-12",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The lone Graean Cymru result records an outcome but does not support a standalone historical narrative."
     },
     {
       "periodStartedAt": "2025-09-13",
       "periodEndedAt": "2025-09-19",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two results and two bicycle launches are routine coverage; the set demonstrates neither an earned judgment change nor a verified consequence."
     },
     {
       "periodStartedAt": "2025-09-20",
       "periodEndedAt": "2025-09-26",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Championship results and a suspension-bike launch are individually notable but do not form a coherent, consequence-bearing story from the available evidence."
     },
     {
       "periodStartedAt": "2025-09-27",
       "periodEndedAt": "2025-10-03",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Big Sugar broadcast announcement is already later evidence for the Unbound media arc; the remaining result, retirement, and registration items do not create another durable Current Thing."
     },
     {
       "periodStartedAt": "2025-10-04",
@@ -391,82 +393,82 @@
       "periodStartedAt": "2025-10-25",
       "periodEndedAt": "2025-10-31",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Life Time's $590,000 purse expansion and first U23 titles may support a paid-pathway story, but announced money and inaugural titles need recipient, access, and livelihood consequences before publication."
     },
     {
       "periodStartedAt": "2025-11-01",
       "periodEndedAt": "2025-11-07",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The season roundup synthesizes already-auditioned arcs while the remaining cards are results and product coverage; no distinct new judgment survives the duplication gate."
     },
     {
       "periodStartedAt": "2025-11-08",
       "periodEndedAt": "2025-11-14",
       "sourceCardCount": 6,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The top three Gravel Earth women entering Life Time and the public selection reactions may reveal a cross-series talent pipeline, but roster announcements alone do not prove access or competitive effects."
     },
     {
       "periodStartedAt": "2025-11-15",
       "periodEndedAt": "2025-11-21",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "One rider's stated 2026 Worlds target is a personal calendar intention, not a consequential event or changed judgment."
     },
     {
       "periodStartedAt": "2025-11-22",
       "periodEndedAt": "2025-11-28",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The UCI series expansion to 45 events may support a globalization or dilution story, but the announcement does not yet establish participation quality, organizer burden, or championship effects."
     },
     {
       "periodStartedAt": "2025-11-29",
       "periodEndedAt": "2025-12-05",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Oceania's first continental gravel title may extend the institutional-growth arc, but a future-event announcement cannot prove delivery, field quality, or regional consequence."
     },
     {
       "periodStartedAt": "2025-12-06",
       "periodEndedAt": "2025-12-12",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The only card is a gear-of-the-year shopping feature with no verified sporting or cultural consequence."
     },
     {
       "periodStartedAt": "2025-12-13",
       "periodEndedAt": "2025-12-19",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "De Gendt building a gravel team may advance the teamification arc and the Bianchi recall raises safety stakes, but the mixed cards do not yet support one focused 2025 judgment change."
     },
     {
       "periodStartedAt": "2025-12-20",
       "periodEndedAt": "2025-12-26",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The lone year-in-photos retrospective is celebratory recap material and does not introduce a new consequential narrative."
     },
     {
       "periodStartedAt": "2025-12-27",
       "periodEndedAt": "2026-01-02",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Swenson joining Specialized is a credible prelude to 2026 teamification, but the signing itself had not yet produced the tactical or competitive consequence documented the following season."
     }
   ],
-  "updatedAt": "2026-08-28T03:55:00Z"
+  "updatedAt": "2026-08-28T06:15:00Z"
 }

--- a/data/gravel-weekly/history/2025-unbound-pit-crews.json
+++ b/data/gravel-weekly/history/2025-unbound-pit-crews.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "gravel-weekly-history-entry/v1",
   "entryId": "history-unbound-pit-crews-2025",
-  "activeFrom": "2025-06-01",
+  "activeFrom": "2025-05-08",
   "activeThrough": "2025-06-11",
   "status": "draft",
   "headline": "Unbound Was Self-Supported, Provided Your Self Had a Pit Crew",
@@ -10,7 +10,7 @@
   "changedJudgment": "Once a safe feed requires several people handing bottles, packs, food, and ice to riders moving through mixed crowds at race speed, the checkpoint is competitive infrastructure. The organizer must design it for predictable access and equal safety rather than treating every failure as private gravel incompetence.",
   "stakes": "A missed handoff could mean severe dehydration, a ten-mile chase, lost prize money, Grand Prix points, or a crash among riders, volunteers, crews, and age-group participants. At the same time, requiring elaborate private support favored funded teams over independent professionals and strained the event's claim to a shared self-supported experience.",
   "credibleOpposition": "Unbound's 2025 guide clearly limited outside support to official checkpoints, and riders knew that crew planning was part of the race. Cecily Decker called her first-feed problem a critical mistake and still finished second; the evidence does not show that checkpoint design cost her the win. Meticulous logistics are a legitimate endurance skill, drop bags and crew-for-hire reduce some access differences, and separating elites can create a two-tier event that pushes the professional race farther from Unbound's mass-participation identity.",
-  "whatHappened": "The 2025 elite rules allowed outside support only at official checkpoints. At Unbound 200, the front fields treated the two locations like moving pit lanes because stopping for ten or fifteen seconds could require a hard chase. Cecily Decker missed critical supplies at the first feed and rode a long exposed section with two bottles; teammate Karolina Migoń shared water, but Decker said she became horribly dehydrated, hallucinated, and survived to second. Lauren De Crescenzo described tents, volunteers, teams, and riders searching for crews while the 100-mile field merged onto the same route; she argued for marked elite handoff lanes or separate zones. Peter Stetina contrasted the old sandwich-and-stop culture with choreographed feeds, and podium finisher Torbjørn Røed described four crew interactions at one checkpoint. In April 2026, Life Time announced controlled, separate elite feed zones at Unbound and Leadville after feedback from athletes, crews, media, and local partners, explicitly citing safety, congestion, and competitive integrity.",
+  "whatHappened": "On May 8, Unbound confirmed that the 200- and 100-mile routes would overlap near the shared Council Grove checkpoint; the race director expected only a tight window before their fields converged. The 2025 elite rules allowed outside support only at official checkpoints. At Unbound 200, the front fields treated the two locations like moving pit lanes because stopping for ten or fifteen seconds could require a hard chase. Cecily Decker missed critical supplies at the first feed and rode a long exposed section with two bottles; teammate Karolina Migoń shared water, but Decker said she became horribly dehydrated, hallucinated, and survived to second. Lauren De Crescenzo described tents, volunteers, teams, and riders searching for crews while the 100-mile field merged onto the same route; she argued for marked elite handoff lanes or separate zones. Peter Stetina contrasted the old sandwich-and-stop culture with choreographed feeds, and podium finisher Torbjørn Røed described four crew interactions at one checkpoint. In April 2026, Life Time announced controlled, separate elite feed zones at Unbound and Leadville after feedback from athletes, crews, media, and local partners, explicitly citing safety, congestion, and competitive integrity.",
   "take": "Model draft, not Matti's approved view: Unbound remained self-supported in 2025, provided your self included four adults spread across a Kansas checkpoint holding a hydration pack, bottles, gels, an ice sock, and the emotional stability to perform NASCAR choreography in a farmers-market crowd. Miss once and the punishment was not quaint gravel character-building. Cecily Decker spent the next section dehydrated enough to hallucinate and still finished second. This is where the romance has to stop lying about the product. When a ten-second feed can decide a professional race, the feed zone is part of the course. Mark lanes, control access, separate speeds, and let the athletes lose Unbound on the rocks—not because their spouse was hidden behind the wrong pop-up tent.",
   "takeProvenance": "model_draft",
   "uncertainty": "The evidence relies heavily on firsthand rider accounts published by one outlet and does not provide a complete incident log, checkpoint video audit, comparative crew budgets, or proof that support access differed systematically by team. Decker identified her own mistake, and the counterfactual result with a clean feed is unknowable. Life Time's 2026 changes addressed both Unbound and Leadville and should not be read as a formal admission of negligence in 2025. The later rules show that the concern produced an operational response, not that every proposed criticism was accepted.",
@@ -23,6 +23,15 @@
     "hostileEditor": "pass"
   },
   "contemporaryReceipts": [
+    {
+      "claimId": "claim_unbound_routes_shared_checkpoint_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/everything-worked-unbound-gravel-200-north-course-remains-unchanged-with-100-milers-sharing-route-for-final-70-miles/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-05-08T00:00:00Z",
+      "quoteExcerpt": "the overlap of fields will take place a few miles later, closer to the shared checkpoint",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
     {
       "claimId": "claim_unbound_outside_support_checkpoint_only_2025",
       "canonicalUrl": "https://www.unboundgravel.com/wp-content/uploads/2025/05/2025LTGPTechGuideUNBOUNDGravel_FINAL.pdf",
@@ -113,6 +122,7 @@
       "raceId": "gravel:unbound-gravel-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
+        "claim_unbound_routes_shared_checkpoint_2025",
         "claim_unbound_outside_support_checkpoint_only_2025",
         "claim_decker_botched_feed_dehydration_2025",
         "claim_decker_hallucinated_and_finished_second_2025",
@@ -132,6 +142,6 @@
   "autoPublishAllowed": false,
   "editorialApproval": null,
   "publishedAt": null,
-  "updatedAt": "2026-08-28T05:30:00Z",
-  "contentHash": "ce78d32f29ac3dac797756979a9e1c8bf68adc3fff81ce512eaa77f49cab6d63"
+  "updatedAt": "2026-08-28T06:15:00Z",
+  "contentHash": "b0c3d9d6b3da6da55a47f8c9ae706132c65aa5968346d2e4936cf34d428325ee"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -602,7 +602,7 @@ def test_historical_drafts_never_cross_the_public_loader(tmp_path):
     assert [entry["entryId"] for entry in load_public_history_entries(tmp_path)] == [approved["entryId"]]
 
 
-def test_2025_backfill_ledger_preserves_the_complete_census_without_claiming_review():
+def test_2025_backfill_ledger_preserves_the_complete_assigning_desk_review():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2025.json").read_text())
     validated = validate_backfill_ledger(ledger, histories)
@@ -610,9 +610,11 @@ def test_2025_backfill_ledger_preserves_the_complete_census_without_claiming_rev
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 255
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 5
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 34
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 14
-    assert validated["complete"] is False
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 15
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 13
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 20
+    assert validated["complete"] is True
 
 
 def test_2026_backfill_ledger_accounts_for_every_window_without_claiming_completion():


### PR DESCRIPTION
## Summary
- complete the assigning-desk disposition for all 53 weekly windows in the 2025 source census
- preserve 15 evidence-backed draft windows, 13 held evidence queues, 20 explicit editorial rejections, and 5 quiet archive gaps
- eliminate every pending_review placeholder and set complete only because the validator now sees zero pending windows
- extend the Unbound pit-crew chapter to the May 8 route-overlap receipt and connect that pre-race window
- keep every historical entry private and human-approval-required

## Verification
- historical entry validator: pass
- 2025 backfill validator: pass
- no pending_review or placeholder assigning reasons remain in the 2025 ledger
- Gravel Weekly tests: 30 passed
- full repository suite: 7,831 passed, 331 skipped
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and contract tests only; no runtime, auth, or publish-path changes, and historical entries remain draft with human approval required.
> 
> **Overview**
> **Finishes the 2025 gravel-weekly backfill ledger** by replacing every `pending_review` week with explicit assigning-desk outcomes and setting **`complete: true`** once no windows remain pending. The census still covers 53 weeks and 255 source cards; outcomes are now **15** `covered_by_draft`, **13** `held_for_evidence`, **20** `rejected`, and **5** `explicit_gap`, each with editorial reasons instead of placeholders.
> 
> The **2025-05-03** week is newly tied to **`history-unbound-pit-crews-2025`**. That draft entry is extended with a **May 8** Cyclingnews receipt on 200/100-mile route overlap at Council Grove, an earlier **`activeFrom`**, updated narrative, **`raceImpacts`** claim wiring, and a refreshed **`contentHash`**.
> 
> **`test_2025_backfill_ledger_preserves_the_complete_assigning_desk_review`** is updated to assert the new disposition counts and **`complete: true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a1aba3a30bf7b76a78a1f39e3550fb4d12553d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->