### PR TITLE
Add fail-closed 2024 backfill intake

### DIFF
--- a/data/gravel-weekly/backfill/2024.json
+++ b/data/gravel-weekly/backfill/2024.json
@@ -1,0 +1,439 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2024,
+  "asOf": "2024-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/39",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33133544413",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 239,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2023-12-30",
+      "periodEndedAt": "2024-01-05",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-01-06",
+      "periodEndedAt": "2024-01-12",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-01-13",
+      "periodEndedAt": "2024-01-19",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-01-20",
+      "periodEndedAt": "2024-01-26",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-01-27",
+      "periodEndedAt": "2024-02-02",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-02-03",
+      "periodEndedAt": "2024-02-09",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-02-10",
+      "periodEndedAt": "2024-02-16",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-02-17",
+      "periodEndedAt": "2024-02-23",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-02-24",
+      "periodEndedAt": "2024-03-01",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-03-02",
+      "periodEndedAt": "2024-03-08",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-03-09",
+      "periodEndedAt": "2024-03-15",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-03-16",
+      "periodEndedAt": "2024-03-22",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-03-23",
+      "periodEndedAt": "2024-03-29",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-03-30",
+      "periodEndedAt": "2024-04-05",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-04-06",
+      "periodEndedAt": "2024-04-12",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-04-13",
+      "periodEndedAt": "2024-04-19",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-04-20",
+      "periodEndedAt": "2024-04-26",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-04-27",
+      "periodEndedAt": "2024-05-03",
+      "sourceCardCount": 6,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-05-04",
+      "periodEndedAt": "2024-05-10",
+      "sourceCardCount": 13,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-05-11",
+      "periodEndedAt": "2024-05-17",
+      "sourceCardCount": 7,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-05-18",
+      "periodEndedAt": "2024-05-24",
+      "sourceCardCount": 9,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-05-25",
+      "periodEndedAt": "2024-05-31",
+      "sourceCardCount": 14,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-06-01",
+      "periodEndedAt": "2024-06-07",
+      "sourceCardCount": 24,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-06-08",
+      "periodEndedAt": "2024-06-14",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-06-15",
+      "periodEndedAt": "2024-06-21",
+      "sourceCardCount": 6,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-06-22",
+      "periodEndedAt": "2024-06-28",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-06-29",
+      "periodEndedAt": "2024-07-05",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-07-06",
+      "periodEndedAt": "2024-07-12",
+      "sourceCardCount": 14,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-07-13",
+      "periodEndedAt": "2024-07-19",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-07-20",
+      "periodEndedAt": "2024-07-26",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-07-27",
+      "periodEndedAt": "2024-08-02",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-08-03",
+      "periodEndedAt": "2024-08-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2024-08-10",
+      "periodEndedAt": "2024-08-16",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-08-17",
+      "periodEndedAt": "2024-08-23",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-08-24",
+      "periodEndedAt": "2024-08-30",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-08-31",
+      "periodEndedAt": "2024-09-06",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-09-07",
+      "periodEndedAt": "2024-09-13",
+      "sourceCardCount": 6,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-09-14",
+      "periodEndedAt": "2024-09-20",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-09-21",
+      "periodEndedAt": "2024-09-27",
+      "sourceCardCount": 9,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-09-28",
+      "periodEndedAt": "2024-10-04",
+      "sourceCardCount": 18,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-10-05",
+      "periodEndedAt": "2024-10-11",
+      "sourceCardCount": 17,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-10-12",
+      "periodEndedAt": "2024-10-18",
+      "sourceCardCount": 7,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-10-19",
+      "periodEndedAt": "2024-10-25",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-10-26",
+      "periodEndedAt": "2024-11-01",
+      "sourceCardCount": 3,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-11-02",
+      "periodEndedAt": "2024-11-08",
+      "sourceCardCount": 4,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-11-09",
+      "periodEndedAt": "2024-11-15",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-11-16",
+      "periodEndedAt": "2024-11-22",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-11-23",
+      "periodEndedAt": "2024-11-29",
+      "sourceCardCount": 2,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-11-30",
+      "periodEndedAt": "2024-12-06",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-12-07",
+      "periodEndedAt": "2024-12-13",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-12-14",
+      "periodEndedAt": "2024-12-20",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-12-21",
+      "periodEndedAt": "2024-12-27",
+      "sourceCardCount": 1,
+      "disposition": "pending_review",
+      "entryIds": [],
+      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+    },
+    {
+      "periodStartedAt": "2024-12-28",
+      "periodEndedAt": "2025-01-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    }
+  ],
+  "updatedAt": "2026-08-28T06:30:00Z"
+}

--- a/scripts/prepare_gravel_weekly_backfill_ledger.py
+++ b/scripts/prepare_gravel_weekly_backfill_ledger.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Create a fail-closed assigning ledger from a historical source census."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from validate_gravel_weekly import IssueValidationError
+from validate_gravel_weekly_backfill import validate_backfill_ledger
+
+
+def _record(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise IssueValidationError(f"{name} must be an object")
+    return value
+
+
+def _list(value: Any, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise IssueValidationError(f"{name} must be an array")
+    return value
+
+
+def _timestamp_day(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise IssueValidationError(f"{name} must be an ISO-8601 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise IssueValidationError(f"{name} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise IssueValidationError(f"{name} must include a timezone")
+    return parsed.date().isoformat()
+
+
+def build_initial_backfill_ledger(
+    discovery_value: Any,
+    *,
+    source_ledger_issue: str,
+    source_ledger_run: str,
+    program_issue: str,
+    updated_at: str,
+) -> dict[str, Any]:
+    """Convert a complete discovery ledger into an all-accounted initial review ledger."""
+
+    discovery = _record(discovery_value, "historical discovery ledger")
+    if discovery.get("schemaVersion") != "gravel-weekly-historical-ledger/v1":
+        raise IssueValidationError("unsupported historical discovery ledger schema")
+    year = discovery.get("year")
+    if not isinstance(year, int) or isinstance(year, bool):
+        raise IssueValidationError("historical discovery year is invalid")
+
+    requested = discovery.get("archiveMonthsRequested")
+    succeeded = discovery.get("archiveMonthsSucceeded")
+    errors = _list(discovery.get("archiveMonthErrors"), "archiveMonthErrors")
+    if not isinstance(requested, int) or requested <= 0:
+        raise IssueValidationError("archiveMonthsRequested is invalid")
+    if succeeded != requested or errors:
+        raise IssueValidationError("historical discovery ledger is incomplete")
+
+    cards = [_record(card, f"sourceCards[{index}]") for index, card in enumerate(_list(discovery.get("sourceCards"), "sourceCards"))]
+    card_ids: list[str] = []
+    for index, card in enumerate(cards):
+        card_id = card.get("id")
+        if not isinstance(card_id, str) or not card_id:
+            raise IssueValidationError(f"sourceCards[{index}].id is invalid")
+        card_ids.append(card_id)
+    if len(card_ids) != len(set(card_ids)):
+        raise IssueValidationError("historical source card IDs must be unique")
+    source_count = discovery.get("sourceCardCount")
+    if source_count != len(card_ids):
+        raise IssueValidationError("historical sourceCardCount does not match sourceCards")
+
+    assigned_ids: list[str] = []
+    weeks: list[dict[str, Any]] = []
+    for index, week_value in enumerate(_list(discovery.get("weeks"), "weeks")):
+        week = _record(week_value, f"weeks[{index}]")
+        source_ids = _list(week.get("sourceCardIds"), f"weeks[{index}].sourceCardIds")
+        for source_index, source_id in enumerate(source_ids):
+            if not isinstance(source_id, str) or not source_id:
+                raise IssueValidationError(f"weeks[{index}].sourceCardIds[{source_index}] is invalid")
+            assigned_ids.append(source_id)
+        count = len(source_ids)
+        weeks.append({
+            "periodStartedAt": _timestamp_day(week.get("periodStartedAt"), f"weeks[{index}].periodStartedAt"),
+            "periodEndedAt": _timestamp_day(week.get("periodEndedAt"), f"weeks[{index}].periodEndedAt"),
+            "sourceCardCount": count,
+            "disposition": "explicit_gap" if count == 0 else "pending_review",
+            "entryIds": [],
+            "reason": (
+                "Cyclingnews exposed no matching source card; preserve the quiet window."
+                if count == 0
+                else "Source census complete; assigning-desk research and disposition remain pending."
+            ),
+        })
+
+    if len(assigned_ids) != len(set(assigned_ids)):
+        raise IssueValidationError("historical source cards must not be assigned to multiple weeks")
+    if set(assigned_ids) != set(card_ids):
+        missing = sorted(set(card_ids) - set(assigned_ids))
+        unknown = sorted(set(assigned_ids) - set(card_ids))
+        raise IssueValidationError(f"weekly source-card accounting mismatch: missing={missing}, unknown={unknown}")
+
+    result = {
+        "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+        "year": year,
+        "asOf": discovery.get("asOf"),
+        "sourceLedgerIssue": source_ledger_issue,
+        "sourceLedgerRun": source_ledger_run,
+        "programIssue": program_issue,
+        "sourceCardCount": source_count,
+        "complete": not any(week["disposition"] == "pending_review" for week in weeks),
+        "humanApprovalRequired": True,
+        "autoPublishAllowed": False,
+        "weeks": weeks,
+        "updatedAt": updated_at,
+    }
+    return validate_backfill_ledger(result, [])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("ledger", type=Path)
+    parser.add_argument("--source-ledger-issue", required=True)
+    parser.add_argument("--source-ledger-run", required=True)
+    parser.add_argument("--program-issue", required=True)
+    parser.add_argument("--updated-at", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    result = build_initial_backfill_ledger(
+        json.loads(args.ledger.read_text(encoding="utf-8")),
+        source_ledger_issue=args.source_ledger_issue,
+        source_ledger_run=args.source_ledger_run,
+        program_issue=args.program_issue,
+        updated_at=args.updated_at,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"Prepared {args.output} with {len(result['weeks'])} accounted windows")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -25,6 +25,7 @@ from validate_gravel_weekly_history import (  # noqa: E402
     validate_history_entry,
 )
 from validate_gravel_weekly_backfill import validate_backfill_ledger  # noqa: E402
+from prepare_gravel_weekly_backfill_ledger import build_initial_backfill_ledger  # noqa: E402
 from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
 from prepare_gravel_weekly_issue import prepare_issue  # noqa: E402
 from approve_gravel_weekly_issue import approve_issue, build_decision_receipt  # noqa: E402
@@ -615,6 +616,92 @@ def test_2025_backfill_ledger_preserves_the_complete_assigning_desk_review():
     assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 13
     assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 20
     assert validated["complete"] is True
+
+
+def test_2024_backfill_ledger_accounts_for_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2024.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 239
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 51
+    assert validated["complete"] is False
+
+
+def test_initial_backfill_ledger_accounts_for_every_discovery_card():
+    discovery = {
+        "schemaVersion": "gravel-weekly-historical-ledger/v1",
+        "year": 2024,
+        "asOf": "2024-12-31T23:59:59Z",
+        "archiveMonthsRequested": 12,
+        "archiveMonthsSucceeded": 12,
+        "archiveMonthErrors": [],
+        "sourceCardCount": 1,
+        "sourceCards": [{"id": "source-1"}],
+        "weeks": [
+            {
+                "periodStartedAt": "2023-12-30T00:00:00Z",
+                "periodEndedAt": "2024-01-05T23:59:59Z",
+                "sourceCardIds": ["source-1"],
+            },
+            {
+                "periodStartedAt": "2024-01-06T00:00:00Z",
+                "periodEndedAt": "2024-01-12T23:59:59Z",
+                "sourceCardIds": [],
+            },
+        ],
+    }
+    ledger = build_initial_backfill_ledger(
+        discovery,
+        source_ledger_issue="https://github.com/example/project/issues/1",
+        source_ledger_run="https://github.com/example/project/actions/runs/2",
+        program_issue="https://github.com/example/project/issues/3",
+        updated_at="2026-08-28T06:30:00Z",
+    )
+
+    assert ledger["complete"] is False
+    assert [week["disposition"] for week in ledger["weeks"]] == ["pending_review", "explicit_gap"]
+    assert sum(week["sourceCardCount"] for week in ledger["weeks"]) == 1
+
+
+def test_initial_backfill_ledger_rejects_partial_archive_and_bad_card_accounting():
+    discovery = {
+        "schemaVersion": "gravel-weekly-historical-ledger/v1",
+        "year": 2024,
+        "asOf": "2024-12-31T23:59:59Z",
+        "archiveMonthsRequested": 12,
+        "archiveMonthsSucceeded": 11,
+        "archiveMonthErrors": ["December failed"],
+        "sourceCardCount": 1,
+        "sourceCards": [{"id": "source-1"}],
+        "weeks": [{
+            "periodStartedAt": "2023-12-30T00:00:00Z",
+            "periodEndedAt": "2024-01-05T23:59:59Z",
+            "sourceCardIds": ["source-1"],
+        }],
+    }
+    with pytest.raises(IssueValidationError, match="incomplete"):
+        build_initial_backfill_ledger(
+            discovery,
+            source_ledger_issue="https://github.com/example/project/issues/1",
+            source_ledger_run="https://github.com/example/project/actions/runs/2",
+            program_issue="https://github.com/example/project/issues/3",
+            updated_at="2026-08-28T06:30:00Z",
+        )
+
+    discovery["archiveMonthsSucceeded"] = 12
+    discovery["archiveMonthErrors"] = []
+    discovery["weeks"][0]["sourceCardIds"] = ["unknown-source"]
+    with pytest.raises(IssueValidationError, match="accounting mismatch"):
+        build_initial_backfill_ledger(
+            discovery,
+            source_ledger_issue="https://github.com/example/project/issues/1",
+            source_ledger_run="https://github.com/example/project/actions/runs/2",
+            program_issue="https://github.com/example/project/issues/3",
+            updated_at="2026-08-28T06:30:00Z",
+        )
 
 
 def test_2026_backfill_ledger_accounts_for_every_window_without_claiming_completion():


### PR DESCRIPTION
## Summary
- add a reusable fail-closed generator for historical weekly ledgers
- account for all 239 discovered 2024 source cards across 53 contiguous windows
- initialize 51 evidence-review windows and 2 explicit zero-source gaps
- test complete archive requirements and reject bad source-card accounting

## Verification
- 7,834 passed, 331 skipped, 26 warnings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data and tooling for editorial backfill intake with validation gates; no runtime auth or publish-path changes in this diff.
> 
> **Overview**
> Adds **2024 gravel-weekly backfill intake**: a new `data/gravel-weekly/backfill/2024.json` ledger that accounts for all **239** discovered source cards across **53** weekly windows, with **51** windows marked `pending_review`, **2** `explicit_gap` quiet weeks, and `complete: false` so nothing is treated as finished assigning-desk work yet.
> 
> Introduces **`prepare_gravel_weekly_backfill_ledger.py`** with `build_initial_backfill_ledger`, which turns a complete `gravel-weekly-historical-ledger/v1` discovery census into an initial `gravel-weekly-backfill-ledger/v1` review ledger. The generator is **fail-closed**: it requires full archive success, unique source-card IDs, and exact week-level accounting (no missing or duplicate assignments), sets `humanApprovalRequired` / `autoPublishAllowed` to block auto-publish, and runs output through `validate_backfill_ledger`.
> 
> **Tests** lock the 2024 ledger contract (53 weeks, 239 cards, incomplete state) and cover happy-path ledger build plus rejection of incomplete archives and source-card accounting mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d496c4427dbf8696fe85e4087a55a2f083eaf58c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->