### PR TITLE
Add 2024 Unbound women start-gap history

### DIFF
--- a/data/gravel-weekly/backfill/2024.json
+++ b/data/gravel-weekly/backfill/2024.json
@@ -38,9 +38,11 @@
       "periodStartedAt": "2024-01-20",
       "periodEndedAt": "2024-01-26",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-womens-start-gap-2024"
+      ],
+      "reason": "Elite women publicly defined the 2023 start experiment's failure and opened the arc that led to Unbound's larger 2024 timing envelope."
     },
     {
       "periodStartedAt": "2024-01-27",
@@ -166,9 +168,11 @@
       "periodStartedAt": "2024-05-11",
       "periodEndedAt": "2024-05-17",
       "sourceCardCount": 7,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-womens-start-gap-2024"
+      ],
+      "reason": "Life Time's decision not to deploy an insufficiently defined drafting penalty clarified why the start geometry, rather than a rule alone, would carry the fairness test."
     },
     {
       "periodStartedAt": "2024-05-18",
@@ -182,17 +186,21 @@
       "periodStartedAt": "2024-05-25",
       "periodEndedAt": "2024-05-31",
       "sourceCardCount": 14,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-womens-start-gap-2024"
+      ],
+      "reason": "The official 15-minute men-to-women and 25-minute women-to-amateur start sequence made the proposed intervention concrete before race day."
     },
     {
       "periodStartedAt": "2024-06-01",
       "periodEndedAt": "2024-06-07",
       "sourceCardCount": 24,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-womens-start-gap-2024"
+      ],
+      "reason": "The protected lead contest, first women's bunch sprint, participant testimony, and documented interference behind the leaders establish both the start gap's consequence and its limit."
     },
     {
       "periodStartedAt": "2024-06-08",
@@ -435,5 +443,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T06:30:00Z"
+  "updatedAt": "2026-08-28T07:00:00Z"
 }

--- a/data/gravel-weekly/history/2024-unbound-womens-start-gap.json
+++ b/data/gravel-weekly/history/2024-unbound-womens-start-gap.json
@@ -1,0 +1,142 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-unbound-womens-start-gap-2024",
+  "activeFrom": "2024-01-25",
+  "activeThrough": "2024-06-05",
+  "status": "draft",
+  "headline": "A 25-Minute Head Start Gave Unbound's Women Their Race Back",
+  "point": "Unbound's breakthrough was not a stirring statement about equality or a perfectly policed drafting rule. It was course geometry: put enough empty road around the elite women and they could make tactical decisions about one another instead of scavenging men's wheels. The 2024 buffer protected the lead race well enough to produce Unbound's first women's bunch sprint, while the interference that persisted farther back showed that a better start is a practical intervention, not absolution.",
+  "priorJudgment": "Mixed categories were an unavoidable expression of gravel's mass-participation character, and changing start times could tidy the opening without materially altering a 200-mile race that would eventually recombine.",
+  "changedJudgment": "Start design is competitive governance. A sufficiently large buffer can preserve tactical agency for the decisive part of an elite women's race even when a complete drafting ban is impractical, but organizers still own the interference their field geometry creates behind the leaders.",
+  "stakes": "The start sequence affected who could shape the race, whether a mechanical or attack was answered by women or by unrelated men, whether viewers could understand a coherent competition, and whether elite women's results and Grand Prix points reflected a distinct sporting contest.",
+  "credibleOpposition": "The dry 2024 conditions helped the gaps survive; the 2023 mud walk had erased smaller intervals almost immediately. A nine-rider sprint is not inherently fairer than a solo win, and the deeper women's groups still mixed with elite and amateur men. Separate race days would protect the field more completely but impose major daylight, permit, staffing, broadcast, and participant-experience costs on a mass event.",
+  "whatHappened": "In January, leading women told Life Time that Unbound's 2023 experiment had stopped feeling like a separate race after roughly 90 minutes. That year the women had started two minutes behind the elite men and eight minutes before amateurs; mud and a hike-a-bike erased the geometry. Life Time explored a cross-category drafting prohibition for 2024 but declined to impose a one-hour penalty without a precise definition, video proof, and an appeal mechanism. Instead, the final technical guide scheduled elite men at 5:50, elite women at 6:05, and amateurs at 6:30: a 15-minute rear gap and 25 minutes of clear road ahead. On dry roads, the lead women remained separate from men, raced attacks and counters among themselves, and finished with the first women's bunch sprint in Unbound 200 history. Rosa Klöser won from nine. The fix was incomplete: Lauren De Crescenzo encountered elite men during her solo move, and riders farther back reported amateur men disrupting and accelerating chase groups.",
+  "take": "Model draft, not Matti's approved view: Gravel spent months asking whether drafting violated the spirit of gravel, as though the spirit were going to descend from the Flint Hills with a clipboard. Life Time tried something much less spiritual: it moved the clocks. Eight minutes of air in 2023 became 25 in 2024, and suddenly the front of the women's race was recognizably a race—attacks, counters, a nine-up sprint, and no random aerobars deciding who got dragged home. That is the useful lesson. Race design is governance even when organizers call it logistics. The caveat matters too: women farther back still got blended into the customer base, so this was not equality achieved. It was proof of concept with a very long tail. Give the women empty road first; then stop pretending the remaining interference is gravel magic.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The evidence supports a protected lead contest, not a completely independent women's field. Weather and course conditions differed radically between 2023 and 2024, so the larger buffer cannot be isolated as the sole cause of the sprint or presumed to work in mud. Rider accounts establish incidents behind the lead group but do not reconstruct every cross-category interaction or quantify its effect on final placings. Contemporary descriptions sometimes call the finish a nine-woman or nine-rider sprint while Lauren De Crescenzo, who attacked earlier, described sprinting with nine other women; the official and race-report result is treated here as a nine-rider lead finish.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_unbound_2023_gap_failed_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/does-drafting-ruin-the-spirit-of-gravel-top-women-to-discuss-with-unbound-organisers/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-01-25T20:35:48Z",
+      "quoteExcerpt": "Then 90 minutes in, we're back to where we were the year before",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_2024_declined_drafting_rule",
+      "canonicalUrl": "https://www.cyclingnews.com/news/breaks-my-heart-villafane-laments-lack-of-drafting-rule-change-for-unbound-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-05-11T23:22:02Z",
+      "quoteExcerpt": "lack of drafting rule change for Unbound Gravel",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_2024_official_start_times",
+      "canonicalUrl": "https://www.unboundgravel.com/wp-content/uploads/2024/05/2024LTGPTechGuideUNBOUND_FINALv3.pdf",
+      "publisher": "UNBOUND Gravel",
+      "publishedAt": "2024-05-24T18:15:42Z",
+      "quoteExcerpt": "5:50 AM – Elite Men's Start; 6:05 AM – Elite Women's Start; 6:30 AM – Mass Start",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_2024_gap_pre_race_doubt",
+      "canonicalUrl": "https://www.cyclingnews.com/news/bigger-start-gap-for-unbound-200-pro-women-nice-but-in-the-end-the-fields-will-be-mixed/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-05-31T20:01:15Z",
+      "quoteExcerpt": "nice but in the end the fields will be mixed",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_2024_timing_envelope",
+      "canonicalUrl": "https://www.lifetimegrandprix.com/2024/06/03/unbound-gravel/",
+      "publisher": "Life Time Grand Prix",
+      "publishedAt": "2024-06-03T00:00:00Z",
+      "quoteExcerpt": "a timing envelope between the Elite Men and the rest of the amateur field",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_2024_first_womens_sprint",
+      "canonicalUrl": "https://www.cyclingnews.com/features/unbound-gravel-2024-conclusions-the-spirit-of-gravel-closes-the-gender-gap/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-06-03T15:51:52Z",
+      "quoteExcerpt": "a sprint finish on Commercial Street for the first time",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_2024_gap_changed_dynamic",
+      "canonicalUrl": "https://www.cyclingnews.com/features/unbound-gravel-2024-conclusions-the-spirit-of-gravel-closes-the-gender-gap/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-06-03T15:51:52Z",
+      "quoteExcerpt": "It completely changed the dynamic of the race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_2024_deeper_field_interference",
+      "canonicalUrl": "https://www.cyclingnews.com/blogs/lauren-de-crescenzo/a-proper-womens-race-historic-day-in-emporia-at-unbound-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-06-05T09:44:26Z",
+      "quoteExcerpt": "Some pro women still affected by men's groups",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_unbound_start_model_spread_2024",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/gravel-racing/womens-gravel-race-unbound/",
+      "publisher": "Velo",
+      "publishedAt": "2024-07-02T16:54:00Z",
+      "quoteExcerpt": "Gravel Worlds decided to follow Unbound's model",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_formalized_cross_category_rule_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/guidelines-to-eliminate-huge-impact-of-drafting-in-womens-races-coming-to-life-time-grand-prix-series/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-04-02T00:00:00Z",
+      "quoteExcerpt": "drafting has a huge impact",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_unbound_2023_gap_failed_2024",
+        "claim_unbound_2024_declined_drafting_rule",
+        "claim_unbound_2024_official_start_times",
+        "claim_unbound_2024_first_womens_sprint",
+        "claim_unbound_2024_deeper_field_interference"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T07:00:00Z",
+  "contentHash": "77233102cec8f43d4f86811393f4e0d9ca93fc945c7aa99da0a2ba217f81f5fe"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -626,7 +626,8 @@ def test_2024_backfill_ledger_accounts_for_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 239
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 2
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 51
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 4
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 47
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add the first evidence-adjudicated 2024 Gravel Weekly history chapter
- reconstruct the 2023 failure, 2024 start geometry, first women’s bunch sprint, and deeper-field limitation
- preserve contemporary official and participant receipts plus later evidence
- move four 2024 weekly windows from pending review to covered by draft
- keep the take private, model-authored, human-approval-required, and race impacts review-only

## Verification
- history and backfill validators pass
- 33 focused Gravel Weekly tests pass
- 7,834 passed, 331 skipped, 26 warnings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill bookkeeping only; draft content is not public and race impacts are review-only with auto-publish disabled.
> 
> **Overview**
> Introduces the first **2024 Gravel Weekly history chapter** as a **draft** entry (`history-unbound-womens-start-gap-2024`) covering Unbound’s 2023 start-gap failure, Life Time’s 2024 timing envelope (no drafting penalty), the first women’s bunch sprint, and remaining cross-category interference—with contemporary receipts, later evidence, and a **model-authored take** that still requires human approval.
> 
> Updates the **2024 backfill ledger** so **four weekly windows** (late Jan through early Jun 2024) move from `pending_review` to **`covered_by_draft`**, each pointing at that entry with week-specific reasons; bumps `updatedAt`.
> 
> Adjusts **`test_2024_backfill_ledger_accounts_for_the_complete_source_census`** to expect **4** `covered_by_draft` and **47** `pending_review` weeks (ledger still **`complete: false`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b304bc4e6188efad5554d71f77b9e7e0c3d392a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->