### PR TITLE
Add 2024 Vos Gravaa history

### DIFF
--- a/data/gravel-weekly/backfill/2024.json
+++ b/data/gravel-weekly/backfill/2024.json
@@ -342,9 +342,11 @@
       "periodStartedAt": "2024-10-05",
       "periodEndedAt": "2024-10-11",
       "sourceCardCount": 17,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-vos-gravaa-proof-market-2024"
+      ],
+      "reason": "Vos's Gravel Worlds win converted Gravaa from a returned experiment into a race-proven technology story while leaving causality and consumer value unproved."
     },
     {
       "periodStartedAt": "2024-10-12",
@@ -398,9 +400,11 @@
       "periodStartedAt": "2024-11-23",
       "periodEndedAt": "2024-11-29",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-vos-gravaa-proof-market-2024"
+      ],
+      "reason": "Visma's post-title testing expanded a successful one-race demonstration into a Classics arms-race question that later commercial evidence sharply qualified."
     },
     {
       "periodStartedAt": "2024-11-30",
@@ -443,5 +447,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T07:00:00Z"
+  "updatedAt": "2026-08-28T07:35:00Z"
 }

--- a/data/gravel-weekly/history/2024-vos-gravaa-proof-market.json
+++ b/data/gravel-weekly/history/2024-vos-gravaa-proof-market.json
@@ -1,0 +1,115 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-vos-gravaa-proof-market-2024",
+  "activeFrom": "2024-10-05",
+  "activeThrough": "2024-11-26",
+  "status": "draft",
+  "headline": "Vos Won Worlds on €3,898 Hubs. The Company Still Died.",
+  "point": "Marianne Vos's gravel world title proved that adjustable tyre pressure could survive and help in elite mixed-surface racing; it did not prove that the equipment caused her win, that rivals needed it, or that enough customers would buy it. The jump from podium to product verdict turned one champion's successful experiment into an arms-race narrative, while the company's later bankruptcy separated technical validity from commercial viability.",
+  "priorJudgment": "A major victory on conspicuous new equipment is practical validation: if the technology works for a world champion and spreads to Classics contenders, a broader competitive and consumer breakthrough is probably beginning.",
+  "changedJudgment": "A podium can validate race readiness and create attention, but it is an uncontrolled product demonstration. Even repeated elite wins cannot isolate the equipment's contribution or manufacture a mass market for a costly, specialised system.",
+  "stakes": "The story shaped what racers thought they needed to test, how cycling media translated correlation into product confidence, whether unsponsored riders faced a new equipment tax, and whether a small manufacturer could convert elite exposure into a sustainable customer base.",
+  "credibleOpposition": "Mixed courses genuinely impose incompatible tyre-pressure demands, Vos said she used the system frequently and that it helped, and Pauline Ferrand-Prévot later described a clear comfort and traction benefit while winning Paris–Roubaix. Gravaa's failure to scale does not invalidate the engineering, and another manufacturer could commercialise the underlying idea more successfully.",
+  "whatHappened": "The UCI had authorised built-in tyre-pressure management systems in 2022, but Gravaa disappeared from top-level racing after an unsuccessful 2023 Paris–Roubaix appearance. On October 5, 2024, Marianne Vos raced the renewed KAPS system at Gravel Worlds in Leuven. Hub-driven compressors let her lower pressure for rough sectors and raise it for pavement; the wheelset retailed for €3,898 and Gravaa said it added less than 250 grams per wheel. Vos beat Lotte Kopecky in a two-rider sprint and told Cyclingnews the system helped on both the rough track and the high-pressure finish. The win made her the first rider reported to win using self-inflating tyres. By November, Visma teammates Wout van Aert and Matteo Jorgenson were testing it while coverage asked whether it would sweep the 2025 Classics. It did deliver another spectacular demonstration when Ferrand-Prévot won Paris–Roubaix in April 2025. In January 2026, however, Gravaa was declared bankrupt; its commercial director said the company could not secure the capital and volume commitments needed to scale, with price and tubeless compatibility reported as obstacles.",
+  "take": "Model draft, not Matti's approved view: Cycling's favorite laboratory is a podium. Marianne Vos put a four-thousand-euro compressor in her hubs, won a fourteenth world title, and by Thanksgiving the question was whether everybody would need one for the Classics. Scientific controls included: none. The subject was Marianne fucking Vos. To be fair, she said it helped, and Pauline Ferrand-Prévot later won Roubaix on the same system. That is about as good a product demo as two wheels can receive. Gravaa still went bankrupt. A rainbow jersey can prove your gadget survives racing; it cannot tell us how much of the win belonged to the gadget, make normal riders tolerate hundreds of grams of extra machinery, or personally create a market. The only thing more cycling than buying speed is mistaking a trophy cabinet for a balance sheet.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "No reviewed independent test isolates the KAPS system's contribution to Vos's result, and her sprint, positioning, physiology, tyres, and team context remain confounders. The quoted €3,898 price and sub-250-gram-per-wheel weight came from contemporary BikeRadar reporting and manufacturer claims rather than an independent retail audit. November testing demonstrated interest within Visma, not a rival-team arms race, so the audition's original framing has been explicitly narrowed. Bankruptcy does not prove the technology lacked value or that its intellectual property will disappear; administrators were assessing whether parts of the company, brand, or technology could continue under new ownership.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_uci_authorized_pressure_management_2022",
+      "canonicalUrl": "https://www.uci.org/pressrelease/uci-authorises-built-in-management-systems-for-tyre-pressure/6snRuAREqGyGeJ4dFZZcRb",
+      "publisher": "UCI",
+      "publishedAt": "2022-03-29T00:00:00Z",
+      "quoteExcerpt": "as of 1 April 2022, built-in management systems for tyre pressure are authorised",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravaa_returned_at_worlds_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/self-inflating-tyres-make-bold-return-to-pro-cycling-as-marianne-vos-uses-system-at-the-gravel-world-champs/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-10-05T09:56:04Z",
+      "quoteExcerpt": "Gravaa returns to the elite level of cycling",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravaa_price_weight_2024",
+      "canonicalUrl": "https://www.bikeradar.com/features/pro-bike/vos-gravaa-gravel-world-championships",
+      "publisher": "BikeRadar",
+      "publishedAt": "2024-10-05T13:42:00Z",
+      "quoteExcerpt": "€3,898 Gravaa KAPS hub system",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_vos_used_and_credited_gravaa_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/handling-the-pressure-self-inflating-tyres-and-decisive-late-sprint-helped-marianne-vos-take-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-10-05T17:03:14Z",
+      "quoteExcerpt": "It helped with higher pressure at the finish but also with lowering the pressure on rougher track",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravaa_visma_classics_tests_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/will-self-inflating-tyres-sweep-the-classics-in-2025-van-aert-and-jorgenson-trial-the-technology-in-training-following-vos-gravel-worlds-victory/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-11-26T14:35:06Z",
+      "quoteExcerpt": "Van Aert and Jorgenson trial the technology in training",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_gravaa_roubaix_win_2025",
+      "canonicalUrl": "https://www.teamvismaleaseabike.com/race-report/winningtogether/after-impressive-team-effort-ferrand-pr%C3%A9vot-solos-to-victory-in-first-paris-roubaix-appearance/",
+      "publisher": "Team Visma | Lease a Bike",
+      "publishedAt": "2025-04-12T18:20:00Z",
+      "quoteExcerpt": "riding on a new tire system from Gravaa",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravaa_bankruptcy_2026",
+      "canonicalUrl": "https://www.cyclingweekly.com/products/brand-behind-visma-lease-a-bikes-adjustable-tyre-pressure-system-declared-bankrupt",
+      "publisher": "Cycling Weekly",
+      "publishedAt": "2026-01-23T11:48:55Z",
+      "quoteExcerpt": "never reached commercial success",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-world-championships",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_gravaa_returned_at_worlds_2024",
+        "claim_gravaa_price_weight_2024",
+        "claim_vos_used_and_credited_gravaa_2024",
+        "claim_gravaa_roubaix_win_2025",
+        "claim_gravaa_bankruptcy_2026"
+      ],
+      "confidence": 0.95,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T07:35:00Z",
+  "contentHash": "3a06d2d2d97211a0be852f539b70589b9e92104377518fabe743548131b2c8ad"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -626,8 +626,8 @@ def test_2024_backfill_ledger_accounts_for_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 239
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 2
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 4
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 47
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 6
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 45
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- reframe the unsupported rival arms-race hypothesis into a sourced podium-versus-product-market story
- preserve Vos’s 2024 Worlds use and testimony, contemporary price and weight reporting, and Visma’s later testing
- use the 2025 Roubaix win and 2026 bankruptcy as later evidence without claiming the technology caused either victory
- move two 2024 weekly windows from pending review to covered by draft
- keep the take private, model-authored, human-approval-required, and race impacts review-only

## Verification
- history and backfill validators pass
- 33 focused Gravel Weekly tests pass
- 7,834 passed, 331 skipped, 26 warnings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill accounting only; draft content cannot publish without human approval and race impacts are review-only.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history entry (`history-vos-gravaa-proof-market-2024`) spanning Oct–Nov 2024 that reframes Marianne Vos’s Gravel Worlds win on Gravaa KAPS as race-ready validation without proving causality, mass adoption, or commercial success—using contemporary receipts (UCI rules, Cyclingnews, BikeRadar pricing) and **later evidence** (2025 Roubaix, 2026 bankruptcy) with explicit uncertainty.
> 
> The entry stays **model-authored**, requires human approval, blocks auto-publish, and registers a **review-only** race impact on UCI Gravel Worlds `biased_opinion` (no auto-fix).
> 
> The **2024 backfill ledger** marks two weekly windows (2024-10-05–11 and 2024-11-23–29) as `covered_by_draft` with tailored reasons instead of `pending_review`, and bumps `updatedAt`. **`test_gravel_weekly`** expectation shifts from 4→6 `covered_by_draft` weeks and 47→45 `pending_review` for the 2024 census.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7dfbd2813a58dd5f8b419c5559005f7ce447159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->