### PR TITLE
Add 2024 Team USA privateer history

### DIFF
--- a/data/gravel-weekly/backfill/2024.json
+++ b/data/gravel-weekly/backfill/2024.json
@@ -326,17 +326,21 @@
       "periodStartedAt": "2024-09-21",
       "periodEndedAt": "2024-09-27",
       "sourceCardCount": 9,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-team-usa-invitation-bill-2024"
+      ],
+      "reason": "The reported withdrawal of prominent US specialists exposed the direct trade between a self-funded Worlds place and sponsor-visible domestic series earnings."
     },
     {
       "periodStartedAt": "2024-09-28",
       "periodEndedAt": "2024-10-04",
       "sourceCardCount": 18,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-team-usa-invitation-bill-2024"
+      ],
+      "reason": "De Crescenzo's first-person privateer accounting and the pre-race funding analysis established the systemic filter before Worlds began."
     },
     {
       "periodStartedAt": "2024-10-05",
@@ -447,5 +451,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T07:35:00Z"
+  "updatedAt": "2026-08-28T08:05:00Z"
 }

--- a/data/gravel-weekly/history/2024-team-usa-invitation-bill.json
+++ b/data/gravel-weekly/history/2024-team-usa-invitation-bill.json
@@ -1,0 +1,134 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-team-usa-invitation-bill-2024",
+  "activeFrom": "2024-09-25",
+  "activeThrough": "2024-10-03",
+  "status": "draft",
+  "headline": "Team USA Sent Gravel Riders an Invitation and a Bill",
+  "point": "The 2024 US gravel team exposed the gap between national selection and national support. USA Cycling could identify medal-capable riders while requiring them to finance the entire attempt, so privateers compared an unpaid world title trip with sponsor-visible domestic races and a $300,000 series purse. Worlds was not selecting only the best available Americans; it was selecting the best who could also make the uncertainty pencil out.",
+  "priorJudgment": "A world-championship selection is the obvious peak of an athlete's season, and being named to a national team implies enough institutional support that qualified contenders can reasonably accept.",
+  "changedJudgment": "For a privateer, selection without funding is permission rather than support. Prestige can lose rationally to course fit, sponsor exposure, recovery, and races that keep the career solvent, even when the athlete genuinely values the national jersey.",
+  "stakes": "The funding model affected which athletes represented the United States, whether Gravel Worlds could claim the strongest specialist field, which careers benefited from federation selection, and whether personal wealth or sponsor backing became an unofficial final selection criterion.",
+  "credibleOpposition": "USA Cycling disclosed the financial terms, faced exceptional Olympic-year costs without government funding, and could not fund every athlete qualifying through gravel's unusually open pathways. Some riders considered self-funding a worthwhile career investment or national-team duty, while course suitability and the crowded calendar—not money alone—also drove withdrawals.",
+  "whatHappened": "USA Cycling's 2024 elite selection criteria said its primary objective was a cohesive, medal-capable team, then stated that automatically invited and discretionary athletes were responsible for the event's full expense and that the federation would assume no financial responsibility. Keegan Swenson, Paige Onweller, Russell Finsterwald, Lauren De Crescenzo, Alexis Skarda, and Argentina's US-based Sofia Gomez Villafañe were among prominent North American specialists reported as skipping Belgium. Worlds offered no prize money; riders faced airfare, lodging, bike transport, national kit, ground logistics, and limited on-site support. The timing put Worlds one week after The Rad Dirt Fest and two weeks before Big Sugar, the final events deciding a $300,000 Life Time Grand Prix purse. Onweller, second in the series, said a 20th at Worlds would do little for her or her sponsors compared with winning the Grand Prix. De Crescenzo wrote that the unsupported point-to-point trip did not make financial or competitive sense and chose domestic series points instead. USA Cycling said Olympic-year costs and insufficient offsetting revenue constrained support. John Borstelmann and Andy Lydic made the opposite choice, treating the trip as duty, content, or an investment and setting aside or redirecting money to attend.",
+  "take": "Model draft, not Matti's approved view: Team USA picked a gravel team and then slid the dinner check across the table. Congratulations on being medal-capable. Airfare is over there. Your bike is enormous luggage. You may need to buy the national kit. Also, Worlds pays nothing, Life Time has $300,000 across the ocean, and your sponsors know where the cameras are. The privateers who stayed home did not disrespect the rainbow jersey; they respected arithmetic. USA Cycling's Olympic-year constraints were real and disclosed, but transparency does not make the sporting filter disappear. A self-funded World Championship does not assemble only the best riders. It assembles the best riders who can afford to treat international uncertainty as a career investment—and then acts surprised when a domestic paycheck wins the sprint.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed sources do not provide itemized budgets for each rider, and no athlete described cost as the sole reason for declining. Course fit, UCI starting position, recovery, existing sponsor obligations, and the Life Time calendar were material. Some athletes reached Worlds through UCI automatic qualification rather than federation discretion, although the published USA Cycling criteria assigned both groups full financial responsibility. The evidence cannot establish how the absent riders would have performed or whether additional funding would have changed every decision. Later 2025 evidence shows recurrence, not that the 2024 controversy caused subsequent choices.",
+  "editorialScore": 97,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_usac_worlds_full_financial_responsibility_2024",
+      "canonicalUrl": "https://assets.usacycling.org/prod/documents/Selection-Criteria/2024-UCI-GRAVEL-WORLD-CHAMPIONSHIPS-ELITE-MEN-WOMEN.pdf",
+      "publisher": "USA Cycling",
+      "publishedAt": "2024-04-03T14:03:11Z",
+      "quoteExcerpt": "USA Cycling will not assume any financial responsibility for athletes",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_us_specialists_declined_worlds_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/onweller-de-crescenzo-among-us-riders-skipping-uci-gravel-worlds-to-earn-a-living-and-support-life-time-grand-prix/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-09-25T18:23:34Z",
+      "quoteExcerpt": "Multiple US riders skip Gravel Worlds as team members asked to cover extensive costs",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_no_prize_or_us_travel_support_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/onweller-de-crescenzo-among-us-riders-skipping-uci-gravel-worlds-to-earn-a-living-and-support-life-time-grand-prix/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-09-25T18:23:34Z",
+      "quoteExcerpt": "there is no prize money, there is no travel support from USA Cycling",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_onweller_sponsor_series_tradeoff_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/onweller-de-crescenzo-among-us-riders-skipping-uci-gravel-worlds-to-earn-a-living-and-support-life-time-grand-prix/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-09-25T18:23:34Z",
+      "quoteExcerpt": "if I finish 20th at Worlds, that doesn't really do a lot for me and my sponsors",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_usac_olympic_year_constraint_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/onweller-de-crescenzo-among-us-riders-skipping-uci-gravel-worlds-to-earn-a-living-and-support-life-time-grand-prix/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-09-25T18:23:34Z",
+      "quoteExcerpt": "we can't spend money we don't have",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_decrescenzo_privateer_math_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/blogs/lauren-de-crescenzo/lauren-de-crescenzo-and-her-tough-decision-to-miss-uci-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-10-02T11:45:12Z",
+      "quoteExcerpt": "Being an independent athlete means that races need to make financial sense",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_absences_funding_complication_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/features/funding-complications-absent-greats-and-tactical-quandaries-gravel-world-championships-talking-points/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-10-03T10:46:50Z",
+      "quoteExcerpt": "some of the best have decided that they can't afford the luxury of chasing rainbows",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_usac_worlds_self_funded_again_2025",
+      "canonicalUrl": "https://assets.usacycling.org/prod/documents/Selection-Criteria/2025-UCI-GRAVEL-WORLD-CHAMPIONSHIPS-ELITE-MEN-WOMEN-June-26.pdf",
+      "publisher": "USA Cycling",
+      "publishedAt": "2025-06-27T16:09:55Z",
+      "quoteExcerpt": "USA Cycling will not assume any financial responsibility for athletes",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_us_womens_podium_declined_worlds_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/features/logistics-money-and-career-sustainability-why-some-us-riders-are-saying-no-to-uci-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-10-07T20:41:25Z",
+      "quoteExcerpt": "all three women on the US Gravel National Championships podium opted not to accept roster spots",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-world-championships",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_usac_worlds_full_financial_responsibility_2024",
+        "claim_us_specialists_declined_worlds_2024",
+        "claim_worlds_no_prize_or_us_travel_support_2024",
+        "claim_onweller_sponsor_series_tradeoff_2024",
+        "claim_decrescenzo_privateer_math_2024",
+        "claim_us_womens_podium_declined_worlds_2025"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T08:05:00Z",
+  "contentHash": "105dcea1543820301dd0bfe9f82f1003a153c2260e8b15d33fc2a48e211426ca"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -626,8 +626,8 @@ def test_2024_backfill_ledger_accounts_for_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 239
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 2
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 6
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 45
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 8
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 43
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a focused 2024 chapter on national-team selection without national-team funding
- use official USA Cycling criteria, rider accounting, federation constraints, and riders who chose to attend
- distinguish the 2024 privateer funding filter from the later 2025 calendar-conflict sequel
- move two 2024 weekly windows from pending review to covered by draft
- keep the take private, model-authored, human-approval-required, and race impacts review-only

## Verification
- history and backfill validators pass
- 33 focused Gravel Weekly tests pass
- 7,834 passed, 331 skipped, 26 warnings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill bookkeeping only; draft content is gated from public load and does not auto-modify race data.
> 
> **Overview**
> Adds a new **draft** Gravel Weekly history entry (`history-team-usa-invitation-bill-2024`) covering late September–early October 2024: USA Cycling’s self-funded Gravel Worlds selection, prominent US withdrawals, and the tradeoff against the Life Time Grand Prix purse. The piece is receipt-backed (USAC criteria, Cyclingnews), keeps a **model_draft** take with **human approval** required, and flags **review-only** race impacts on `gravel:uci-gravel-world-championships`—no auto-publish.
> 
> The **2024 backfill ledger** reclassifies two weekly windows (2024-09-21–09-27 and 2024-09-28–10-04) from `pending_review` to `covered_by_draft`, pointing at that entry with week-specific reasons; `updatedAt` is bumped. **`test_gravel_weekly`** expectation counts shift to **8** `covered_by_draft` and **43** `pending_review` weeks (ledger still `complete: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce92c6cc5bd087a8680378b23cc3c86990c3e235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->