### PR TITLE
Add 2024 Gravel Worlds format history

### DIFF
--- a/data/gravel-weekly/backfill/2024.json
+++ b/data/gravel-weekly/backfill/2024.json
@@ -318,9 +318,11 @@
       "periodStartedAt": "2024-09-14",
       "periodEndedAt": "2024-09-20",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-worlds-road-skill-test-2024"
+      ],
+      "reason": "Mohorič's description of the Worlds route as essentially a one-day Classic opened the format question before the championship field assembled."
     },
     {
       "periodStartedAt": "2024-09-21",
@@ -338,9 +340,10 @@
       "sourceCardCount": 18,
       "disposition": "covered_by_draft",
       "entryIds": [
-        "history-team-usa-invitation-bill-2024"
+        "history-team-usa-invitation-bill-2024",
+        "history-gravel-worlds-road-skill-test-2024"
       ],
-      "reason": "De Crescenzo's first-person privateer accounting and the pre-race funding analysis established the systemic filter before Worlds began."
+      "reason": "De Crescenzo's privateer accounting established the funding filter, while Stephens and Nutt made the cross-discipline seeding and Classics-shaped course advantages explicit before Worlds began."
     },
     {
       "periodStartedAt": "2024-10-05",
@@ -348,9 +351,10 @@
       "sourceCardCount": 17,
       "disposition": "covered_by_draft",
       "entryIds": [
-        "history-vos-gravaa-proof-market-2024"
+        "history-vos-gravaa-proof-market-2024",
+        "history-gravel-worlds-road-skill-test-2024"
       ],
-      "reason": "Vos's Gravel Worlds win converted Gravaa from a returned experiment into a race-proven technology story while leaving causality and consumer value unproved."
+      "reason": "Vos's win validated Gravaa as race-ready without proving causality, while the Dutch multidiscipline sweep and Van der Poel's sole men's wildcard completed the format story."
     },
     {
       "periodStartedAt": "2024-10-12",
@@ -451,5 +455,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T08:05:00Z"
+  "updatedAt": "2026-08-28T09:10:00Z"
 }

--- a/data/gravel-weekly/history/2024-gravel-worlds-road-skill-test.json
+++ b/data/gravel-weekly/history/2024-gravel-worlds-road-skill-test.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-worlds-road-skill-test-2024",
+  "activeFrom": "2024-09-19",
+  "activeThrough": "2024-10-06",
+  "status": "draft",
+  "headline": "Gravel Worlds Invited Road Racers to Their Own Skill Test",
+  "point": "Road stars did not invade an untouched gravel championship in 2024. The UCI staged a fast Belgian course that riders compared with a one-day Classic, counted half of riders' road, mountain-bike, and cyclocross ranking points toward the start grid, and admitted Mathieu van der Poel with the Dutch men's only wildcard. His victory was extraordinary, but the format made a multidiscipline road-and-cross champion the sport's most predictable conqueror.",
+  "priorJudgment": "The arrival and success of major road professionals showed that road racing's larger talent pool could simply overpower gravel specialists once its best athletes took the newer discipline seriously.",
+  "changedJudgment": "Championship results measure the test the organizer actually built. When course design, seeding, selection, and race length transfer road and cyclocross advantages efficiently, road-star dominance says as much about the institution's definition of gravel as it does about either athlete population.",
+  "stakes": "The format determined who received clean starts, whose preparation translated, which specialists appeared world-class, and what fans were taught a gravel champion should be. It also shaped the tension between Europe's short, fast UCI product and the longer, self-supported North American races around which many privateer careers were built.",
+  "credibleOpposition": "Gravel is a surface and a discipline, not an American distance formula. Flanders offered legitimate dirt, cobbles, technical turns, and repeated accelerations, while Vos and Van der Poel brought deep cyclocross skill rather than road résumés alone. A world championship should attract the best all-around cyclists, and specialists remain responsible for adapting to the published course and rules.",
+  "whatHappened": "The organizer announced a Halle-to-Leuven course using a city that had hosted the 2021 Road World Championships finish, with 133 kilometres for elite women, 179 initially announced for elite men, and repeated 47-kilometre finishing circuits. Defending champion Matej Mohorič called the men's route basically a big one-day Classic and said it changed little from a hard WorldTour Classic. Before racing, US champion Lauren Stephens described the women's event as a four-hour cyclocross race; the published start procedure combined Gravel World Series and prior Worlds points with 50 percent of riders' UCI points from road, XCO, XCM, and cyclocross. Gravel specialist Maddy Nutt said the course suited a road Classics rider more than a gravel racer and expected to start around 60th despite winning a Gravel World Series qualifier. The elite races then became a Dutch multidiscipline sweep: Marianne Vos beat newly crowned road champion Lotte Kopecky, and Van der Poel arrived one week after road Worlds bronze through the Dutch men's sole wildcard. He attacked with Florian Vermeersch and went solo inside the final 13 kilometres to win his first gravel rainbow jersey.",
+  "take": "Model draft, not Matti's approved view: The UCI invited road racers to Gravel Worlds, handed them their own exam, and then seemed delighted when they knew the answers. The course was a Belgian one-day Classic in gravel cosplay. The grid counted road and cyclocross points. The Dutch men's wildcard policy was apparently Mathieu van der Poel, singular, which is less a selection process than entering the final boss with a cheat code. None of this makes Mathieu's win fake; he is preposterously good at bikes, and his six elite cyclocross world titles made him rather more than a road tourist. It does make the invasion story backwards. Road stars did not kick down gravel's door. The championship held it open, moved the furniture into Classics formation, and put their names on the good seats. If specialists want a different world champion, they first need a championship that tests more of what makes them specialists.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed evidence does not provide an independently audited surface breakdown or prove that each feature favored road riders. The course included genuine off-road and technical demands, and both winners had exceptional cyclocross experience. Grid rules advantaged riders with points from several disciplines but did not guarantee results; Nutt's exact final grid position is reported from her pre-race estimate. National federations controlled discretionary wildcards, so Van der Poel's selection was Dutch policy within the event rules rather than a UCI invitation addressed to him personally. This entry intentionally excludes an unproved post-race allegation about trade-team tactics.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_worlds_course_road_finish_2024",
+      "canonicalUrl": "https://ucigravelworldseries.com/en/uci-gravel-world-championships-course-details-revealed/",
+      "publisher": "UCI Gravel World Series",
+      "publishedAt": "2024-03-20T00:00:00Z",
+      "quoteExcerpt": "finish in Leuven, which also hosted the finish of the road races at the centenary edition of the 2021 UCI Road World Championships",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_mohoric_worlds_one_day_classic_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/basically-a-big-one-day-classic-matej-mohoric-eager-to-defend-gravel-world-title-weekend-after-road-worlds/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-09-19T00:00:00Z",
+      "quoteExcerpt": "It's basically like a big one-day Classic",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_grid_cross_discipline_points_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/im-envisioning-a-4-hour-cyclocross-race-lauren-stephens-says-uci-gravel-worlds-field-is-stronger-than-ever/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-10-04T00:00:00Z",
+      "quoteExcerpt": "50% of the points in the UCI rankings road, mountain bike cross-country (XCO), mountain bike marathon (XCM) and cyclocross",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_nutt_course_and_grid_disadvantage_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/gravel-racers-have-to-step-it-up-briton-maddy-nutt-assesses-influx-of-road-pros-at-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-10-04T00:00:00Z",
+      "quoteExcerpt": "it actually suits a road Classics rider more than it would suit a gravel racer",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_van_der_poel_only_dutch_mens_wildcard_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/from-wildcard-to-winner-mathieu-van-der-poel-earns-first-title-at-gravel-world-championships-in-leuven/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-10-06T00:00:00Z",
+      "quoteExcerpt": "With the men's team I gave away only one wildcard, and it's to Mathieu",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_vos_van_der_poel_worlds_results_2024",
+      "canonicalUrl": "https://www.uci.org/article/bolero-uci-gravel-world-championships-vos-and-van-der-poel-reign-in-flanders/3RV4oYoEaHDeGUsLSBSjV8",
+      "publisher": "UCI",
+      "publishedAt": "2024-10-06T23:00:00Z",
+      "quoteExcerpt": "Rainbow jerseys for Dutch multi-discipline stars",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-world-championships",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_worlds_course_road_finish_2024",
+        "claim_mohoric_worlds_one_day_classic_2024",
+        "claim_worlds_grid_cross_discipline_points_2024",
+        "claim_nutt_course_and_grid_disadvantage_2024",
+        "claim_van_der_poel_only_dutch_mens_wildcard_2024",
+        "claim_vos_van_der_poel_worlds_results_2024"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T09:10:00Z",
+  "contentHash": "34031ac2b5e729d78c038ad65aa164dbb505825b6a479f518f6f3aad7448a32b"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -626,8 +626,8 @@ def test_2024_backfill_ledger_accounts_for_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 239
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 2
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 8
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 43
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 9
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 42
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
Summary:
- Adds a private historical Gravel Weekly chapter about how the 2024 Gravel Worlds course, grid rules, and Dutch wildcard selection favored transferable road/cyclocross strengths.
- Preserves the legitimate counterargument and explicitly excludes the unproved trade-team tactics allegation.
- Links three evidence-bearing weeks and moves the 2024 ledger to 9 covered, 42 pending, and 2 explicit gaps.

Safety:
- Model draft requiring human approval.
- Automatic publication disabled.
- Race impact is review-only with autofix disabled.

Verification:
- Focused history and backfill validators pass.
- Gravel Weekly tests: 33 passed.
- Full suite: 7,834 passed, 331 skipped, 26 warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are editorial JSON and ledger bookkeeping under existing validators; publication and race-field changes remain gated behind human approval and review-only impacts.
> 
> **Overview**
> Adds a new **draft** Gravel Weekly history entry (`history-gravel-worlds-road-skill-test-2024`) arguing that 2024 UCI Gravel Worlds course design, cross-discipline seeding, and wildcard selection shaped “road star invasion” outcomes more than a pure talent mismatch. The piece includes contemporary receipts, a stated counterargument, explicit uncertainty, and **excludes** an unproved post-race tactics allegation; it stays **model draft** with human approval required and auto-publish off.
> 
> The **2024 backfill ledger** is updated so three late-September/October weeks move from pending (or gain the new entry alongside existing drafts) to **`covered_by_draft`**, with revised week-level reasons tying Mohorič, Stephens/Nutt, and the Vos/VDP results to that chapter. Ledger **`updatedAt`** bumps accordingly; tests now expect **9** draft-covered weeks and **42** pending (still **`complete: false`**).
> 
> A **`raceImpacts`** block proposes **review-only** updates to `race.biased_opinion` for UCI Gravel Worlds (no autofix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3938b3f6ab40302ad443e5327af3ea00d17d56bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->