### PR TITLE
Reconcile remaining 2024 history auditions

### DIFF
--- a/data/gravel-weekly/backfill/2024.json
+++ b/data/gravel-weekly/backfill/2024.json
@@ -14,9 +14,11 @@
       "periodStartedAt": "2023-12-30",
       "periodEndedAt": "2024-01-05",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-qualifier-access-2024"
+      ],
+      "reason": "The ordinary random-entry process and accepted-rider fees establish the access system that the first qualifier announcements subsequently changed."
     },
     {
       "periodStartedAt": "2024-01-06",
@@ -64,9 +66,11 @@
       "periodStartedAt": "2024-02-10",
       "periodEndedAt": "2024-02-16",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-qualifier-access-2024"
+      ],
+      "reason": "The first Belgian qualifier created 50 early entries divided between performance and a post-finish random draw."
     },
     {
       "periodStartedAt": "2024-02-17",
@@ -136,9 +140,11 @@
       "periodStartedAt": "2024-04-13",
       "periodEndedAt": "2024-04-19",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-womens-start-gap-2024"
+      ],
+      "reason": "Life Time's separate-start commitment and De Crescenzo's athlete-advisory account establish that the later Unbound buffer was deliberate competitive governance, not incidental scheduling."
     },
     {
       "periodStartedAt": "2024-04-20",
@@ -160,9 +166,11 @@
       "periodStartedAt": "2024-05-04",
       "periodEndedAt": "2024-05-10",
       "sourceCardCount": 13,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-qualifier-access-2024"
+      ],
+      "reason": "Unbound's own athlete guide preserved the random-selection mechanics against which the emerging qualifier lane offered an alternate route."
     },
     {
       "periodStartedAt": "2024-05-11",
@@ -188,9 +196,10 @@
       "sourceCardCount": 14,
       "disposition": "covered_by_draft",
       "entryIds": [
-        "history-unbound-womens-start-gap-2024"
+        "history-unbound-womens-start-gap-2024",
+        "history-unbound-qualifier-access-2024"
       ],
-      "reason": "The official 15-minute men-to-women and 25-minute women-to-amateur start sequence made the proposed intervention concrete before race day."
+      "reason": "The official start sequence made the women's-race intervention concrete, while the European qualifier partnership framed scarce Unbound entry as an exportable access product."
     },
     {
       "periodStartedAt": "2024-06-01",
@@ -206,9 +215,11 @@
       "periodStartedAt": "2024-06-08",
       "periodEndedAt": "2024-06-14",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-qualifier-access-2024"
+      ],
+      "reason": "Rad Dirt's 100 coins completed a 150-entry qualifier lane whose slots were split evenly between performance and random selection."
     },
     {
       "periodStartedAt": "2024-06-15",
@@ -238,9 +249,9 @@
       "periodStartedAt": "2024-07-06",
       "periodEndedAt": "2024-07-12",
       "sourceCardCount": 14,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Tour gravel stage produced a strong route-trust hypothesis, but rider and team claims that raced sectors differed from reconnaissance still lack organizer-side documentation of what changed, when, and why."
     },
     {
       "periodStartedAt": "2024-07-13",
@@ -455,5 +466,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T09:10:00Z"
+  "updatedAt": "2026-08-28T10:05:00Z"
 }

--- a/data/gravel-weekly/history/2024-unbound-qualifier-access.json
+++ b/data/gravel-weekly/history/2024-unbound-qualifier-access.json
@@ -1,0 +1,126 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-unbound-qualifier-access-2024",
+  "activeFrom": "2024-01-05",
+  "activeThrough": "2024-06-11",
+  "status": "draft",
+  "headline": "Unbound Let Riders Escape One Lottery by Entering Another",
+  "point": "Unbound's first qualifiers did not replace its lottery with a merit system. They created a second access lane through partner races: 150 early entries across Belgium and Colorado, half awarded by performance and half randomly drawn from finishers. The model broadened geographic access and rewarded commitment, but certainty now favored riders able to travel to and finish another 70- to 100-mile event before paying for and traveling to Unbound itself.",
+  "priorJudgment": "Unbound's oversubscribed lottery was blunt but broadly egalitarian because ordinary applicants encountered the same random selection gate, apart from invited elites and limited allocations.",
+  "changedJudgment": "Qualifiers can broaden access without making it neutral. They convert money, travel flexibility, endurance, and performance into additional chances, while retaining randomness for many of the riders who make the extra investment.",
+  "stakes": "The access design influences who reaches gravel's most valuable amateur start line, the real time and travel cost of improving one's odds, how international riders enter a Kansas event, and how partner promoters convert Unbound's scarcity into demand for their own races.",
+  "credibleOpposition": "The ordinary lottery remained available and free to enter, qualifier coins represented only a small share of a roughly 4,000-rider event, and random allocation of half the coins kept the new path from serving only the fastest athletes. A European qualifier reduced one major geographic barrier, and every oversubscribed event must ration finite permits, roads, staff, and participant capacity somehow.",
+  "whatHappened": "In January 2024, Unbound opened random selection for its 25-, 50-, 100-, and 200-mile distances. Applying was free, accepted riders would pay between $55 and $295, and invited Life Time Grand Prix athletes bypassed the process. In February, Life Time and Flanders Classics announced the first Unbound qualifier: Belgium's 100-mile Heathland Gravel would distribute 50 entries for 2025, 25 by performance and 25 by a drawing among finishers. The announcement did not yet specify gender or age-group allocations. In June, Life Time added Colorado's Rad Dirt Fest, where finishers of the 70- and 110-mile races would compete for 100 early entries, again split evenly between results and random selection. Those two events therefore created 150 early routes around Unbound's main lottery. By November, after the next Unbound lottery results were released, Life Time announced a five-race qualifier network for future editions, confirming that the experiment had become an expanding access channel rather than a one-season promotion.",
+  "take": "Model draft, not Matti's approved view: Unbound solved the lottery by inventing a side quest. Did the email robot reject you? Excellent news: fly to Belgium or Colorado, race up to 100 miles, and half the golden tickets will go to fast people. The other half will be awarded by—please enjoy this—another random drawing. It is Willy Wonka for adults who own bike bags. This is not automatically evil. Unbound cannot fit everybody, Europe deserved a route in, and performance should probably count somewhere in a race application. But let us call the innovation what it was. Access did not become fair; scarcity became a product other races could borrow. The new system rewarded speed, disposable weekends, travel money, and the willingness to gamble twice. Gravel's most famous start line became slightly more reachable and considerably more franchisable at the same time.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed 2024 announcements establish the 50/50 allocation methods and 150 available qualifier entries, but they do not disclose the total applications, acceptance rate, demographic distribution, exact 2024 qualifier entry fees, travel costs, no-show rate, or how many coin winners ultimately registered for Unbound. The comparison with roughly 4,000 participants spans all event distances and does not establish what share of Unbound 200 places qualifiers consumed. Partner events may have offered value independent of their coins, so travel cannot be treated solely as an access surcharge.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_unbound_main_lottery_and_fees_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/lottery-open-for-2024-unbound-gravel-entries-through-january-20/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-01-05T00:00:00Z",
+      "quoteExcerpt": "the price range set from $55 for the 25-mile distance to $295 for Unbound 200",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_heathland_first_unbound_qualifier_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/unbound-gravel-schedules-first-ever-qualifier-event-in-belgium-august-11/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-02-16T00:00:00Z",
+      "quoteExcerpt": "50 qualifier spots for next year's Unbound Gravel",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_heathland_half_performance_half_random_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/unbound-gravel-schedules-first-ever-qualifier-event-in-belgium-august-11/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-02-16T00:00:00Z",
+      "quoteExcerpt": "Half of those entries will be awarded to riders based on performance",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_heathland_access_partnership_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/the-original-spirit-of-gravel-heads-to-europe-with-flanders-classics-unbound-qualifier-in-belgium/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-05-28T00:00:00Z",
+      "quoteExcerpt": "a qualifier for the 2025 Unbound Gravel in Emporia, Kansas",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_official_random_selection_2024",
+      "canonicalUrl": "https://www.unboundgravel.com/wp-content/uploads/2024/05/2024UNBOUNDGravelAthleteGuides_200_100_5_8.pdf",
+      "publisher": "UNBOUND Gravel",
+      "publishedAt": "2024-05-10T13:32:23Z",
+      "quoteExcerpt": "The individuals whose names were drawn were awarded entry in the 2024 UNBOUND GRAVEL",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_rad_dirt_hundred_qualifier_coins_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/bypassing-the-unbound-gravel-lottery-rad-dirt-fest-added-as-qualifier/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-06-11T00:00:00Z",
+      "quoteExcerpt": "A hundred qualifier coins will be up for grabs",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_rad_dirt_half_performance_half_random_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/bypassing-the-unbound-gravel-lottery-rad-dirt-fest-added-as-qualifier/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-06-11T00:00:00Z",
+      "quoteExcerpt": "half going to those who deliver top results among their category and the other half randomly distributed",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_unbound_five_qualifiers_announced_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/whos-going-to-kansas-life-time-confirms-lottery-winners-for-unbound-gravel-reveal-five-qualifier-events/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-11-22T00:00:00Z",
+      "quoteExcerpt": "Life Time revealed five gravel races that will serve as qualifying events for Unbound Gravel",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_unbound_main_lottery_and_fees_2024",
+        "claim_unbound_official_random_selection_2024",
+        "claim_heathland_first_unbound_qualifier_2024",
+        "claim_heathland_half_performance_half_random_2024",
+        "claim_rad_dirt_hundred_qualifier_coins_2024",
+        "claim_rad_dirt_half_performance_half_random_2024",
+        "claim_unbound_five_qualifiers_announced_2024"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T10:05:00Z",
+  "contentHash": "1c62aa697dda2d2c6cf4f15b31f648c72f4f8577a3b58fd302a723827bf2e4a0"
+}

--- a/data/gravel-weekly/history/2024-unbound-womens-start-gap.json
+++ b/data/gravel-weekly/history/2024-unbound-womens-start-gap.json
@@ -10,7 +10,7 @@
   "changedJudgment": "Start design is competitive governance. A sufficiently large buffer can preserve tactical agency for the decisive part of an elite women's race even when a complete drafting ban is impractical, but organizers still own the interference their field geometry creates behind the leaders.",
   "stakes": "The start sequence affected who could shape the race, whether a mechanical or attack was answered by women or by unrelated men, whether viewers could understand a coherent competition, and whether elite women's results and Grand Prix points reflected a distinct sporting contest.",
   "credibleOpposition": "The dry 2024 conditions helped the gaps survive; the 2023 mud walk had erased smaller intervals almost immediately. A nine-rider sprint is not inherently fairer than a solo win, and the deeper women's groups still mixed with elite and amateur men. Separate race days would protect the field more completely but impose major daylight, permit, staffing, broadcast, and participant-experience costs on a mass event.",
-  "whatHappened": "In January, leading women told Life Time that Unbound's 2023 experiment had stopped feeling like a separate race after roughly 90 minutes. That year the women had started two minutes behind the elite men and eight minutes before amateurs; mud and a hike-a-bike erased the geometry. Life Time explored a cross-category drafting prohibition for 2024 but declined to impose a one-hour penalty without a precise definition, video proof, and an appeal mechanism. Instead, the final technical guide scheduled elite men at 5:50, elite women at 6:05, and amateurs at 6:30: a 15-minute rear gap and 25 minutes of clear road ahead. On dry roads, the lead women remained separate from men, raced attacks and counters among themselves, and finished with the first women's bunch sprint in Unbound 200 history. Rosa Klöser won from nine. The fix was incomplete: Lauren De Crescenzo encountered elite men during her solo move, and riders farther back reported amateur men disrupting and accelerating chase groups.",
+  "whatHappened": "In January, leading women told Life Time that Unbound's 2023 experiment had stopped feeling like a separate race after roughly 90 minutes. That year the women had started two minutes behind the elite men and eight minutes before amateurs; mud and a hike-a-bike erased the geometry. An athlete advisory group pushed Life Time on start protocols and cross-category drafting, and in April the organizer committed to separate elite starts with larger buffers across all seven Grand Prix events. Life Time explored a cross-category drafting prohibition for Unbound but declined to impose a one-hour penalty without a precise definition, video proof, and an appeal mechanism. Instead, the final technical guide scheduled elite men at 5:50, elite women at 6:05, and amateurs at 6:30: a 15-minute rear gap and 25 minutes of clear road ahead. On dry roads, the lead women remained separate from men, raced attacks and counters among themselves, and finished with the first women's bunch sprint in Unbound 200 history. Rosa Klöser won from nine. The fix was incomplete: Lauren De Crescenzo encountered elite men during her solo move, and riders farther back reported amateur men disrupting and accelerating chase groups.",
   "take": "Model draft, not Matti's approved view: Gravel spent months asking whether drafting violated the spirit of gravel, as though the spirit were going to descend from the Flint Hills with a clipboard. Life Time tried something much less spiritual: it moved the clocks. Eight minutes of air in 2023 became 25 in 2024, and suddenly the front of the women's race was recognizably a race—attacks, counters, a nine-up sprint, and no random aerobars deciding who got dragged home. That is the useful lesson. Race design is governance even when organizers call it logistics. The caveat matters too: women farther back still got blended into the customer base, so this was not equality achieved. It was proof of concept with a very long tail. Give the women empty road first; then stop pretending the remaining interference is gravel magic.",
   "takeProvenance": "model_draft",
   "uncertainty": "The evidence supports a protected lead contest, not a completely independent women's field. Weather and course conditions differed radically between 2023 and 2024, so the larger buffer cannot be isolated as the sole cause of the sprint or presumed to work in mud. Rider accounts establish incidents behind the lead group but do not reconstruct every cross-category interaction or quantify its effect on final placings. Contemporary descriptions sometimes call the finish a nine-woman or nine-rider sprint while Lauren De Crescenzo, who attacked earlier, described sprinting with nine other women; the official and race-report result is treated here as a nine-rider lead finish.",
@@ -38,6 +38,24 @@
       "publisher": "Cyclingnews",
       "publishedAt": "2024-05-11T23:22:02Z",
       "quoteExcerpt": "lack of drafting rule change for Unbound Gravel",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_2024_separate_elite_starts",
+      "canonicalUrl": "https://www.cyclingnews.com/news/decluttering-mass-starts-rewarding-podium-riders-top-changes-to-2024-life-time-grand-prix/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-04-17T00:00:00Z",
+      "quoteExcerpt": "For all of our events, the elite men and women will have separate starts",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_athlete_advisory_start_protocol_work_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/blogs/lauren-de-crescenzo/road-prep-and-adapting-to-new-rules-as-life-time-grand-prix-begins-at-fuego-xl-mountain-bike-event/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-04-19T00:00:00Z",
+      "quoteExcerpt": "Our focus is refining the start protocols and drafting rules for the Life Time series",
       "transcriptStartSeconds": null,
       "transcriptEndSeconds": null
     },
@@ -123,6 +141,8 @@
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_unbound_2023_gap_failed_2024",
+        "claim_lifetime_2024_separate_elite_starts",
+        "claim_athlete_advisory_start_protocol_work_2024",
         "claim_unbound_2024_declined_drafting_rule",
         "claim_unbound_2024_official_start_times",
         "claim_unbound_2024_first_womens_sprint",
@@ -137,6 +157,6 @@
   "autoPublishAllowed": false,
   "editorialApproval": null,
   "publishedAt": null,
-  "updatedAt": "2026-08-28T07:00:00Z",
-  "contentHash": "77233102cec8f43d4f86811393f4e0d9ca93fc945c7aa99da0a2ba217f81f5fe"
+  "updatedAt": "2026-08-28T10:05:00Z",
+  "contentHash": "dee9c20190f62fb82d618fa4a83c65930e5eee9a7979e88edaa54a4601f1583a"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -626,8 +626,9 @@ def test_2024_backfill_ledger_accounts_for_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 239
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 2
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 9
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 42
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 14
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 36
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
Summary:
- Adds a private historical chapter on Unbound qualifier access using Cyclingnews evidence plus Unbound own 2024 athlete guide.
- Enriches the existing Unbound women start-gap chapter with the April athlete-advisory and series-wide separate-start evidence.
- Holds the Tour gravel route-trust premise for organizer-side documentation instead of promoting an allegation.
- Moves the 2024 ledger to 14 covered, 36 pending, 1 held, and 2 explicit gaps.

Safety:
- All narrative remains model draft and requires human approval.
- Automatic publication is disabled.
- Race impacts are review-only with autofix disabled.

Verification:
- Focused history and backfill validators pass.
- Gravel Weekly tests: 33 passed.
- Full suite: 7,834 passed, 331 skipped, 26 warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill metadata only; drafts stay non-publishable with autofix disabled on race impacts.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history chapter on **Unbound qualifier access** (lottery vs. partner-race “coins,” 50/50 performance/random splits) and wires five more 2024 backfill weeks to it via `covered_by_draft`.
> 
> **Enriches** the existing **women’s start-gap** draft with April Life Time separate-start and athlete-advisory receipts, updates the narrative and `raceImpacts` claim set, and refreshes content hashes.
> 
> **Reclassifies** the mid-July 2024 week from `pending_review` to **`held_for_evidence`** so Tour gravel route-trust stays a hypothesis until organizer documentation exists; ledger totals move to **14 covered / 36 pending / 1 held** (tests updated). All new copy remains **model draft** with human approval and review-only race impacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d020be9475776e01efbc51f5b729b63297625b9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->