### PR TITLE
Add 2024 gravel career market history

### DIFF
--- a/data/gravel-weekly/backfill/2024.json
+++ b/data/gravel-weekly/backfill/2024.json
@@ -24,9 +24,11 @@
       "periodStartedAt": "2024-01-06",
       "periodEndedAt": "2024-01-12",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-career-market-2024"
+      ],
+      "reason": "Naesen's sponsor-built privateer program showed gravel absorbing a WorldTour rider whom the road market had left without a contract."
     },
     {
       "periodStartedAt": "2024-01-13",
@@ -50,9 +52,11 @@
       "periodStartedAt": "2024-01-27",
       "periodEndedAt": "2024-02-02",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-career-market-2024"
+      ],
+      "reason": "Lydic described gravel as a platform toward professional road racing, establishing that career traffic could move out as well as in."
     },
     {
       "periodStartedAt": "2024-02-03",
@@ -217,17 +221,20 @@
       "sourceCardCount": 3,
       "disposition": "covered_by_draft",
       "entryIds": [
-        "history-unbound-qualifier-access-2024"
+        "history-unbound-qualifier-access-2024",
+        "history-gravel-career-market-2024"
       ],
-      "reason": "Rad Dirt's 100 coins completed a 150-entry qualifier lane whose slots were split evenly between performance and random selection."
+      "reason": "Rad Dirt completed the qualifier lane, while Haga's Unbound result and insistence that gravel was a new career supplied the labor-market proof point."
     },
     {
       "periodStartedAt": "2024-06-15",
       "periodEndedAt": "2024-06-21",
       "sourceCardCount": 6,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-career-market-2024"
+      ],
+      "reason": "Bardet's planned post-road gravel campaign made the discipline a deliberate competitive destination rather than an improvised retirement fallback."
     },
     {
       "periodStartedAt": "2024-06-22",
@@ -466,5 +473,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T10:05:00Z"
+  "updatedAt": "2026-08-28T10:45:00Z"
 }

--- a/data/gravel-weekly/history/2024-gravel-career-market.json
+++ b/data/gravel-weekly/history/2024-gravel-career-market.json
@@ -1,0 +1,113 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-career-market-2024",
+  "activeFrom": "2024-01-10",
+  "activeThrough": "2024-06-21",
+  "status": "draft",
+  "headline": "Gravel Stopped Being Road Racing's Retirement Home",
+  "point": "In 2024, gravel became a bidirectional career market rather than a soft landing for ex-road professionals. It absorbed riders the road system had discarded, gave young riders a platform from which to pursue road contracts, supported a genuine second career after road retirement, and became a planned competitive destination for riders who still had WorldTour value.",
+  "priorJudgment": "Professional gravel was where recognizable road riders prolonged their visibility after the contracts, pressure, or performance of top-level road racing had ended.",
+  "changedJudgment": "Gravel could now function as refuge, proving ground, independent career, and route back into a WorldTour team. The traffic moved both directions, even though income and support remained far less standardized than on a salaried road team.",
+  "stakes": "The shift changed how young riders could build résumés, how displaced veterans could preserve careers, what sponsors bought when backing a privateer, and whether gravel specialists were athletes in a durable profession or participants in road cycling's afterlife.",
+  "credibleOpposition": "The examples were unusually talented and do not prove a stable labor market for the median rider. Road fame still made sponsorship easier, young riders such as Andy Lydic described an ambition rather than a completed promotion, and privateering transferred logistics and financial risk from teams to athletes. Romain Bardet's planned move also retained support from his road organization rather than demonstrating independent viability.",
+  "whatHappened": "In January, Lawrence Naesen lost his Decathlon AG2R contract, joined roughly two dozen WorldTour professionals reported without 2024 teams, and assembled sponsor support for a private gravel program. In February, 22-year-old Colorado rider Andy Lydic described gravel in the opposite direction: a platform for results he hoped would lead to a professional or WorldTour team after a poor experience in the amateur road pipeline. In June, former Giro stage winner Chad Haga finished second in his first Unbound 200 and said the result helped prove he was not a road rider using gravel as retirement; he called it the start of a new career. Ten days later, DSM announced that Tour de France podium finisher Romain Bardet would end his road career in 2025 but continue with team support in gravel, targeting the UCI Gravel World Championships. Later in 2024, Unbound winner and full-time PhD student Rosa Klöser signed a two-year Canyon-SRAM road deal while retaining gravel privateering, Peter Stetina left the Life Time Grand Prix without leaving professional gravel, and Haga committed to a full privateer operation for 2025.",
+  "take": "Model draft, not Matti's approved view: Road racing used to send riders to gravel with a cardboard box and a euphemism. Congratulations on your retirement; here is a flannel shirt and an Instagram deliverable. Then 2024 broke the conveyor belt. Lawrence Naesen came in because the WorldTour had no chair for him. Andy Lydic tried to use gravel as the staircase back up. Chad Haga finished second at Unbound and informed everybody that he was starting a career, not embalming one. Romain Bardet planned his road retirement around a gravel world title, while Rosa Klöser won Unbound during a PhD and somehow left with both a WorldTour contract and her privateer identity. That is not a retirement home. It is a labor market—an unstable, sponsor-dependent, assemble-your-own-health-insurance labor market, but one with doors on both sides. The sport became real when riders could enter it for different reasons and still argue about which job was better.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed sources do not disclose salaries, sponsorship values, benefits, contract guarantees, or the share of riders who could support themselves through gravel. Lydic's WorldTour pathway was an expressed goal, not a documented contract outcome. Naesen's ability to secure several recognizable sponsors may reflect prior WorldTour visibility. Haga's results validated competitiveness but did not remove family-income risk, and Bardet's planned transition had not occurred during the active period. The later cases show additional career structures, not that gravel had achieved broad economic stability.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_naesen_gravel_after_road_contract_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/lawrence-naesen-turns-gravel-privateer-after-not-finding-a-team-for-2024/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-01-10T00:00:00Z",
+      "quoteExcerpt": "without a road team for 2024, the Belgian got creative",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lydic_gravel_worldtour_pathway_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/gravel-racing-becomes-pathway-to-worldtour-for-usas-andy-lydic/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-02-02T00:00:00Z",
+      "quoteExcerpt": "My whole mission is to use gravel as a platform to professional cycling",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haga_gravel_new_career_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/features/chad-haga-gravel-racing-isnt-a-transition-from-road-its-the-start-of-a-new-career/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-06-11T00:00:00Z",
+      "quoteExcerpt": "It's not really a transition from road – this is the start of a new career",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_bardet_planned_gravel_transition_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/romain-bardet-set-to-switch-to-gravel-racing-in-summer-2025/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-06-21T00:00:00Z",
+      "quoteExcerpt": "retiring from road racing next summer and turning his focus to gravel racing",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_kloser_gravel_privateer_worldtour_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/unbound-gravel-winner-rosa-kloser-to-combine-privateering-with-worldtour-racing-in-2025-for-canyon-sram/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-10-21T00:00:00Z",
+      "quoteExcerpt": "combine privateering with WorldTour racing in 2025",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_stetina_left_series_not_gravel_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/peter-stetina-passes-on-fourth-year-in-life-time-grand-prix-to-seek-races-that-truly-suit-me/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-11-05T00:00:00Z",
+      "quoteExcerpt": "The Grand Prix is awesome ... but for me, the series doesn't make sense",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haga_full_privateer_2025_plan",
+      "canonicalUrl": "https://www.cyclingnews.com/news/chad-haga-gambles-as-full-on-privateer-in-2025-after-pas-racing-gravel-success-at-unbound-the-traka/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-12-20T00:00:00Z",
+      "quoteExcerpt": "I will be a full-on privateer in 2025",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_haga_gravel_new_career_2024",
+        "claim_kloser_gravel_privateer_worldtour_2024",
+        "claim_haga_full_privateer_2025_plan"
+      ],
+      "confidence": 0.94,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T10:45:00Z",
+  "contentHash": "b1e6f5c47094cab09dd093b00b4fc1bc4f61f7f458585dae3dfcec6e12913ce0"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -626,9 +626,9 @@ def test_2024_backfill_ledger_accounts_for_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 239
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 2
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 14
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 17
     assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 1
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 36
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 33
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
Summary:
- Adds a private historical chapter on gravel becoming a bidirectional career market rather than only a retirement destination for road professionals.
- Grounds the active arc in Naesen, Lydic, Haga, and Bardet, with Klöser, Stetina, and Haga privateering as later evidence.
- Links four evidence-bearing weeks and moves the 2024 ledger to 17 covered, 33 pending, 1 held, and 2 explicit gaps.

Safety:
- Model draft requiring human approval.
- Automatic publication disabled.
- Unbound race impact is review-only with autofix disabled.

Verification:
- Focused history and backfill validators pass.
- Gravel Weekly tests: 33 passed.
- Full suite: 7,834 passed, 331 skipped, 26 warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill accounting only; draft content cannot auto-publish and race changes require human review.
> 
> **Overview**
> Adds a new **draft** Gravel Weekly history entry (`history-gravel-career-market-2024`) arguing that 2024 gravel became a **bidirectional career market** (refuge, proving ground, independent career, and route back to WorldTour), anchored on Naesen, Lydic, Haga, and Bardet with Cyclingnews receipts and later evidence for Klöser, Stetina, and Haga’s 2025 privateer plan.
> 
> The **2024 backfill ledger** now marks **four additional weeks** as `covered_by_draft` for that entry (Jan 6–12, Jan 27–Feb 2, Jun 8–14 alongside the qualifier story, Jun 15–21), shifting totals to **17 covered / 33 pending**. Tests in `test_gravel_weekly.py` are updated to match those disposition counts.
> 
> The entry stays **non-publishable** (`status: draft`, `humanApprovalRequired`, `autoPublishAllowed: false`) and flags a **review-only** Unbound `race.biased_opinion` impact with autofix disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62663adb0e31d9610d259edd7fe7930440b0fe98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->