### PR TITLE
Complete 2024 Gravel Weekly assigning desk

### DIFF
--- a/data/gravel-weekly/backfill/2024.json
+++ b/data/gravel-weekly/backfill/2024.json
@@ -6,7 +6,7 @@
   "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33133544413",
   "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
   "sourceCardCount": 239,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -34,9 +34,9 @@
       "periodStartedAt": "2024-01-13",
       "periodEndedAt": "2024-01-19",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Classified and Ridley announced a factory gravel team, but the launch alone does not establish whether manufacturer-backed teams materially changed rider pay, race tactics, or privateer viability; hold for contracts, operating evidence, and season outcomes."
     },
     {
       "periodStartedAt": "2024-01-20",
@@ -62,9 +62,9 @@
       "periodStartedAt": "2024-02-03",
       "periodEndedAt": "2024-02-09",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Phase II proposed a development path through Unbound and Big Sugar, but the announcement does not yet show who advanced, what support riders received, or whether the program changed access to professional racing; hold for participant and outcome evidence."
     },
     {
       "periodStartedAt": "2024-02-10",
@@ -80,65 +80,65 @@
       "periodStartedAt": "2024-02-17",
       "periodEndedAt": "2024-02-23",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The window contains race results, a race gallery, and an athlete enthusiasm profile; none changes a durable judgment about gravel or survives the party-story and point gates."
     },
     {
       "periodStartedAt": "2024-02-24",
       "periodEndedAt": "2024-03-01",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Strade Bianche and BWR previews plus rider-recon and journey profiles describe upcoming racing, but they do not establish a consequential gravel-system change or a distinct retrospective point."
     },
     {
       "periodStartedAt": "2024-03-02",
       "periodEndedAt": "2024-03-08",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "An electric-bike launch and a rider's Cape Epic preparation are product and training-cycle observations, not a coherent Current Thing with a changed judgment."
     },
     {
       "periodStartedAt": "2024-03-09",
       "periodEndedAt": "2024-03-15",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A single Valley of Tears result and prize report records an event outcome without enough comparative purse, field, or organizer evidence to support an economic story."
     },
     {
       "periodStartedAt": "2024-03-16",
       "periodEndedAt": "2024-03-22",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Mid South and UCI result roundup is useful race-record evidence but offers no independent development, conflict, or consequence worth elevating into the narrative."
     },
     {
       "periodStartedAt": "2024-03-23",
       "periodEndedAt": "2024-03-29",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The only card is a UCI Gravel World Championships race-home shell; it is navigational metadata rather than evidence of a story."
     },
     {
       "periodStartedAt": "2024-03-30",
       "periodEndedAt": "2024-04-05",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Israel-Premier Tech choosing gravel bikes for Paris-Roubaix is an interesting equipment decision, but one road-race setup does not establish a broader gravel narrative."
     },
     {
       "periodStartedAt": "2024-04-06",
       "periodEndedAt": "2024-04-12",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two Paris-Roubaix tech galleries, one results page, and a bike launch are product and race-record material; the shared gravel keyword does not create a story with a point."
     },
     {
       "periodStartedAt": "2024-04-13",
@@ -154,17 +154,17 @@
       "periodStartedAt": "2024-04-20",
       "periodEndedAt": "2024-04-26",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Results, a race-home page, Van Aert's recovery ride, and Roed's career profile are disconnected updates; Roed corroborates the career-market chapter without supplying a distinct turn that merits another story."
     },
     {
       "periodStartedAt": "2024-04-27",
       "periodEndedAt": "2024-05-03",
       "sourceCardCount": 6,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Four result shells and two bike launches are archive and product evidence only; they fail the narrative-point gate."
     },
     {
       "periodStartedAt": "2024-05-04",
@@ -190,9 +190,9 @@
       "periodStartedAt": "2024-05-18",
       "periodEndedAt": "2024-05-24",
       "sourceCardCount": 9,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The mixed buildup combines ordinary results, rider previews, a crash report, and a number-plate rule; none has enough consequence or corroboration to justify a chapter, and the unrelated items do not become a story by proximity."
     },
     {
       "periodStartedAt": "2024-05-25",
@@ -240,17 +240,17 @@
       "periodStartedAt": "2024-06-22",
       "periodEndedAt": "2024-06-28",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Australian title coverage and event results are record material, while the subscriber ticket competition merely promotes a qualifier already explained by the access chapter."
     },
     {
       "periodStartedAt": "2024-06-29",
       "periodEndedAt": "2024-07-05",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Three race reports and a Giant product launch contain no shared structural development or consequence beyond who won and what was released."
     },
     {
       "periodStartedAt": "2024-07-06",
@@ -264,25 +264,25 @@
       "periodStartedAt": "2024-07-13",
       "periodEndedAt": "2024-07-19",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A results page and an all-road bike launch are useful reference material but do not clear the party-attention or point gates."
     },
     {
       "periodStartedAt": "2024-07-20",
       "periodEndedAt": "2024-07-26",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "USA Cycling's ten elite Worlds places could reveal how federation-controlled access reshaped a domestic championship, but the announcement lacks selection, participation, funding, and athlete-outcome evidence; hold rather than infer impact."
     },
     {
       "periodStartedAt": "2024-07-27",
       "periodEndedAt": "2024-08-02",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The SRAM 13-speed launch and same-day review establish a product release, not a consequential season narrative; commercial novelty alone is not a Current Thing."
     },
     {
       "periodStartedAt": "2024-08-03",
@@ -296,41 +296,41 @@
       "periodStartedAt": "2024-08-10",
       "periodEndedAt": "2024-08-16",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Earlier Unbound lottery dates and two bike launches are administrative and product updates; the lottery item adds no new judgment beyond the qualifier-access chapter."
     },
     {
       "periodStartedAt": "2024-08-17",
       "periodEndedAt": "2024-08-23",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The sole source is a result page, which belongs in the race record but supplies no narrative development."
     },
     {
       "periodStartedAt": "2024-08-24",
       "periodEndedAt": "2024-08-30",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two event results and a Worlds race-history page document outcomes and archive context without producing a distinct, consequential point."
     },
     {
       "periodStartedAt": "2024-08-31",
       "periodEndedAt": "2024-09-06",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "British championship results, another result shell, and a rider's altitude-camp profile do not add up to a durable gravel story."
     },
     {
       "periodStartedAt": "2024-09-07",
       "periodEndedAt": "2024-09-13",
       "sourceCardCount": 6,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The week mixes results, one disputed finish, a rider schedule choice, and apparel; the isolated sportsmanship dispute lacks enough independent or systemic evidence to carry a chapter."
     },
     {
       "periodStartedAt": "2024-09-14",
@@ -378,49 +378,49 @@
       "periodStartedAt": "2024-10-12",
       "periodEndedAt": "2024-10-18",
       "sourceCardCount": 7,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Life Time moved money from the series purse to Unbound, Big Sugar, and Leadville, a potentially meaningful incentive redesign; hold until organizer rationale, athlete reaction, field effects, and later purse outcomes can establish the point rather than merely repeat the announcement."
     },
     {
       "periodStartedAt": "2024-10-19",
       "periodEndedAt": "2024-10-25",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Big Sugar results close the sporting record, while Klöser's combined WorldTour-privateer plan corroborates the existing career-market chapter without creating a separate narrative turn."
     },
     {
       "periodStartedAt": "2024-10-26",
       "periodEndedAt": "2024-11-01",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The announced five-race junior series could represent a real youth-access pathway, but the launch supplies no participant, cost, safeguarding, retention, or inaugural-season outcome evidence; hold for delivery rather than treating intent as impact."
     },
     {
       "periodStartedAt": "2024-11-02",
       "periodEndedAt": "2024-11-08",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Team Amani fundraiser may belong to a larger East African access and representation story, but the window otherwise contains career-market corroboration and series announcements; hold the Amani lead for participant voices, program economics, and observed outcomes."
     },
     {
       "periodStartedAt": "2024-11-09",
       "periodEndedAt": "2024-11-15",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Premium shoes and a prototype bike are product-news cards with no demonstrated effect on racing, access, or the season's governing argument."
     },
     {
       "periodStartedAt": "2024-11-16",
       "periodEndedAt": "2024-11-22",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The year-in-review feature is a secondary summary, and the expanded qualifier announcement is later evidence for the existing access chapter; neither warrants a duplicate Current Thing."
     },
     {
       "periodStartedAt": "2024-11-23",
@@ -436,33 +436,33 @@
       "periodStartedAt": "2024-11-30",
       "periodEndedAt": "2024-12-06",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A Cyber Monday fantasy build is commerce content, not historical narrative evidence."
     },
     {
       "periodStartedAt": "2024-12-07",
       "periodEndedAt": "2024-12-13",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Team Amani feature suggests an important East African agency, access, and representation story, but one outsider-led feature cannot establish the program's economics, riders' own framing, or durable consequences; hold for first-party and longitudinal evidence."
     },
     {
       "periodStartedAt": "2024-12-14",
       "periodEndedAt": "2024-12-20",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Haga's full-privateer plan is useful later evidence for the already drafted career-market chapter, but it does not introduce a new point that merits a second story."
     },
     {
       "periodStartedAt": "2024-12-21",
       "periodEndedAt": "2024-12-27",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A gear-of-the-year feature is retrospective product commentary and does not document a consequential Current Thing."
     },
     {
       "periodStartedAt": "2024-12-28",
@@ -473,5 +473,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T10:45:00Z"
+  "updatedAt": "2026-08-28T18:30:00Z"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -627,9 +627,10 @@ def test_2024_backfill_ledger_accounts_for_the_complete_source_census():
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 239
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 2
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 17
-    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 1
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 33
-    assert validated["complete"] is False
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 8
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 26
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
 
 
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():


### PR DESCRIPTION
## Summary
- adjudicate all 33 remaining 2024 source windows with individualized editorial reasons
- preserve 8 evidence holds for structural leads and reject 26 non-stories
- mark the 239-card, 53-week 2024 ledger complete with zero pending windows

## Safety
- historical stories remain private model drafts
- no publication or race-data autofix is enabled
- rejected cards remain preserved in the source census

## Verification
- python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2024.json
- python3 -m pytest -q tests/test_gravel_weekly.py -k '2024_backfill or 2025_backfill'
- python3 -m pytest -q (7,834 passed; 331 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial ledger JSON and contract tests only; no publish, approval, or race-data automation changes.
> 
> **Overview**
> **Finishes the 2024 Gravel Weekly backfill ledger** by adjudicating every week that was still `pending_review`, then marking the 239-card census **complete** with no open windows.
> 
> The 33 former pending weeks now have final dispositions and per-window **reason** text: **26** `rejected` (race records, product launches, or corroboration-only items that fail narrative gates), **8** `held_for_evidence` (e.g. factory team launch, Phase II development path, Tour gravel route-trust, USA Cycling Worlds places, Life Time purse shift, junior series, Team Amani leads), while existing `covered_by_draft` and `explicit_gap` weeks are unchanged. `updatedAt` moves to `2026-08-28T18:30:00Z`.
> 
> `test_2024_backfill_ledger_accounts_for_the_complete_source_census` is updated to expect `complete: true`, zero `pending_review`, and the new disposition totals (8 held, 26 rejected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8781d42ecf9cccb7db8128d67fd223d156a5e113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->