### PR TITLE
Stage 2023 Unbound aerobar workaround

### DIFF
--- a/data/gravel-weekly/backfill/2023.json
+++ b/data/gravel-weekly/backfill/2023.json
@@ -14,9 +14,11 @@
       "periodStartedAt": "2022-12-31",
       "periodEndedAt": "2023-01-06",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-aerobar-workaround-2023"
+      ],
+      "reason": "Unbound's announced elite aerobar ban and safety rationale opened the component-rule story that riders tested with forearm-rest adaptations at race week."
     },
     {
       "periodStartedAt": "2023-01-07",
@@ -182,17 +184,21 @@
       "periodStartedAt": "2023-05-27",
       "periodEndedAt": "2023-06-02",
       "sourceCardCount": 16,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-aerobar-workaround-2023"
+      ],
+      "reason": "Rider support, explicit opposition, and multiple padded forearm setups exposed the difference between removing extensions and regulating the rewarded posture."
     },
     {
       "periodStartedAt": "2023-06-03",
       "periodEndedAt": "2023-06-09",
       "sourceCardCount": 23,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-aerobar-workaround-2023"
+      ],
+      "reason": "The post-race cockpit gallery preserved a compliant forearm-rest workaround without evidence of a penalty, performance effect, or safety incident."
     },
     {
       "periodStartedAt": "2023-06-10",
@@ -437,5 +443,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T07:10:00Z"
+  "updatedAt": "2026-08-28T07:25:00Z"
 }

--- a/data/gravel-weekly/history/2023-unbound-aerobar-workaround.json
+++ b/data/gravel-weekly/history/2023-unbound-aerobar-workaround.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-unbound-aerobar-workaround-2023",
+  "activeFrom": "2023-01-03",
+  "activeThrough": "2023-06-05",
+  "status": "draft",
+  "headline": "Unbound Banned Aerobars. Racers Brought Elbow Rests.",
+  "point": "Unbound's 2023 elite aerobar ban created a clear, enforceable equipment boundary and removed protruding extensions, but it did not define or prohibit the forearms-on-tops posture that produced part of the same comfort and aerodynamic incentive. Riders immediately adapted ordinary handlebars with padding and a computer grip. The episode shows why safety rules must distinguish the hazardous object from the rewarded behavior instead of assuming that banning one noun settles both.",
+  "priorJudgment": "Once Unbound prohibited aerobars and extensions for the elite 200-mile fields, the safety dispute and the associated aerodynamic arms race would largely be resolved by one simple hardware rule.",
+  "changedJudgment": "The hardware boundary was real and potentially useful, but the incentive remained. Racers could reproduce part of the posture with legal bar tops, turning a clean component ban into an immediate design-and-enforcement edge case.",
+  "stakes": "The distinction affects high-speed group safety, consistent enforcement, equipment equality, the credibility of organizer rules, and whether racers must spend race week reverse-engineering what a policy means rather than preparing for the event.",
+  "credibleOpposition": "Aerobar extensions protrude from the cockpit and can create entanglement, steering, and control concerns distinct from briefly resting forearms on ordinary tops. Removing that hardware can improve safety even when body position remains unrestricted. Unbound also preserved extensions for amateurs who valued an extra comfort position over 200 miles, and the rule never claimed to ban all aerodynamic postures. The workaround therefore demonstrates a limit, not policy failure.",
+  "whatHappened": "On January 3, Life Time president of events Kimo Seymour said increased safety was the foremost reason for separating Unbound's elite starts and prohibiting aerobars, describing the changes as an experiment that could spread across Life Time events. The published 2023 athlete guide gave elite riders a component rule: no aerobars, bar extensions, or clip-on attachments. By race week, leading riders broadly supported the clarity and safety rationale, although defending champion Ivar Slik disputed the claim that skilled riders using extensions in a group were inherently more dangerous. Cyclingnews then photographed at least three elite bikes with extra tape, grips, or shaped tops intended to make the forearms-on-tops puppy-paws posture more comfortable; gravel outside UCI competition did not inherit the UCI's posture ban. A BikeRadar gallery published after the race documented Innokenty Zavyalov's padded tops and long computer mount, describing the setup as a workaround. No reviewed source reported a penalty because the equipment still complied with the written ban.",
+  "take": "Model draft, not Matti's approved view: Unbound wrote a rule against aerobars and the racers responded by inventing artisanal elbows. By race week at least three elite bikes had padded handlebar tops for a posture the UCI had banned in its races; one post-race gallery showed tape for a forearm rest plus a long Garmin to hold like a tiny flight yoke. This is how racers read rules: not as moral literature but as a shopping list of nouns they may no longer use. Unbound was probably right to remove protruding hardware. Extensions can create a different entanglement and control hazard, and amateurs kept them for comfort. But if the behavior is the concern, name the behavior. Ban only the furniture and the incentive does not disappear; you have started a craft fair.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The evidence documents rule language, organizer intent, pre-race adaptations, and at least one adapted cockpit photographed at the finish. It does not establish how long any rider used the forearms-on-tops posture during the race, whether the setup saved measurable time, whether an official reviewed it, or whether aerobars or the workaround caused or prevented any crash. The organizer may have intended only to remove extensions rather than regulate posture. Safety benefits from the hardware ban cannot be isolated from the separate-start changes, weather, field behavior, or other controls.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_unbound_safety_rationale_and_aerobar_ban_2023",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/unbound-gravel-rolls-out-major-changes-for-2023-edition/",
+      "publisher": "Velo",
+      "publishedAt": "2023-01-03T20:00:00Z",
+      "quoteExcerpt": "we're open to rules that will help make things safer",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_elite_start_and_aerobar_rules_announced_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/unbound-gravel-200-bans-aerobars-and-adds-start-groups-for-elite-racers/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-01-04T12:00:00Z",
+      "quoteExcerpt": "Aerobars or bar extensions will no longer be permitted for competitors in the elite field",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_official_component_rule_2023",
+      "canonicalUrl": "https://www.unboundgravel.com/wp-content/uploads/2023/05/2023_Unbound_100-200_AthleteGuideFINAL-1.pdf",
+      "publisher": "Unbound Gravel",
+      "publishedAt": "2023-05-04T19:33:18Z",
+      "quoteExcerpt": "No aerobars, bar extensions, or clip on attachments of any kinds will be permitted",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_rider_support_and_opposition_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/features/good-riddance-to-aero-bars-pros-agree-on-ban-at-unbound-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-06-01T12:00:00Z",
+      "quoteExcerpt": "increased safety, clearer boundaries, less confusion and tension, fairer racing",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_multiple_puppy_paws_adaptations_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/puppy-paws-position-set-for-a-comeback-at-2023-unbound-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-06-02T12:00:00Z",
+      "quoteExcerpt": "adapted so that riders can adopt the puppy paws position more comfortably",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_postrace_forearm_rest_workaround_2023",
+      "canonicalUrl": "https://www.bikeradar.com/features/tech/unbound-2023-gravel-tech-gallery",
+      "publisher": "BikeRadar",
+      "publishedAt": "2023-06-05T14:00:00Z",
+      "quoteExcerpt": "some riders found a workaround",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_unbound_safety_rationale_and_aerobar_ban_2023",
+        "claim_unbound_elite_start_and_aerobar_rules_announced_2023",
+        "claim_unbound_official_component_rule_2023",
+        "claim_unbound_rider_support_and_opposition_2023",
+        "claim_unbound_multiple_puppy_paws_adaptations_2023",
+        "claim_unbound_postrace_forearm_rest_workaround_2023"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T07:25:00Z",
+  "contentHash": "97f8286c2c9d0220680bc0a90d21a64cf1ad47efc7695d9098246147ec39f291"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -641,8 +641,8 @@ def test_2023_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 218
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 4
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 48
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 4
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 45
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- stage a private, evidence-grounded 2023 Current Thing chapter about Unbound banning aerobar hardware while riders preserved part of the posture with padded forearm rests
- preserve the meaningful safety case for removing protruding extensions and avoid claims the evidence cannot establish
- link the announcement, race-week adaptation, and post-race documentation windows; reduce pending 2023 evidence-bearing weeks from 48 to 45
- keep the model take approval-gated and all race impacts review-only

## Verification
- history validator
- backfill validator
- focused Gravel Weekly tests
- public-loader exclusion assertion
- git diff --check
- full repository suite: 7,835 passed, 331 skipped

No public publication or race-database write is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill bookkeeping only; content stays draft, approval-gated, and excluded from public loaders per existing contracts.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history entry (`history-unbound-aerobar-workaround-2023`) covering Unbound’s 2023 elite aerobar ban, race-week “puppy paws” bar adaptations, and post-race forearm-rest workarounds, with six contemporary receipts, explicit uncertainty, a **model_draft** take, and **human-approval / no auto-publish** flags. Race impacts are **editorial_review** only on `gravel:unbound-gravel` (`race.biased_opinion`), with `autoFixAllowed: false`.
> 
> The **2023 backfill ledger** marks three additional weeks (announcement, late-May race week, early-June post-race) as **`covered_by_draft`** linked to that entry, with week-specific reasons—bringing **`covered_by_draft`** from 1→4 and **`pending_review`** from 48→45. Ledger `updatedAt` is bumped.
> 
> **Tests** in `test_2023_backfill_ledger_starts_from_the_complete_source_census` are updated to match the new disposition counts. No publication or automatic race-database writes are implied by the staged data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9fd04954ff80d7d69edc724267505f9c9b76662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->