### PR TITLE
Stage 2023 US gravel nationals pathway

### DIFF
--- a/data/gravel-weekly/backfill/2023.json
+++ b/data/gravel-weekly/backfill/2023.json
@@ -96,9 +96,11 @@
       "periodStartedAt": "2023-03-11",
       "periodEndedAt": "2023-03-17",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-us-gravel-nationals-material-jersey-2023"
+      ],
+      "reason": "USA Cycling's launch attached a $60,000 equal elite purse and Worlds qualification to the first national title, opening the material-jersey story."
     },
     {
       "periodStartedAt": "2023-03-18",
@@ -300,17 +302,21 @@
       "periodStartedAt": "2023-09-02",
       "periodEndedAt": "2023-09-08",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-us-gravel-nationals-material-jersey-2023"
+      ],
+      "reason": "Race-week reporting confirmed equal course distance, equal field-level purse totals, automatic top-three qualification, and fully funded support for the winners."
     },
     {
       "periodStartedAt": "2023-09-09",
       "periodEndedAt": "2023-09-15",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-us-gravel-nationals-material-jersey-2023"
+      ],
+      "reason": "Swenson and Stephens won the inaugural titles, converting the announced purse and Worlds pathway into actual results rather than launch copy."
     },
     {
       "periodStartedAt": "2023-09-16",
@@ -443,5 +449,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T07:25:00Z"
+  "updatedAt": "2026-08-28T07:40:00Z"
 }

--- a/data/gravel-weekly/history/2023-us-gravel-nationals-material-jersey.json
+++ b/data/gravel-weekly/history/2023-us-gravel-nationals-material-jersey.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-us-gravel-nationals-material-jersey-2023",
+  "activeFrom": "2023-03-16",
+  "activeThrough": "2023-09-09",
+  "status": "draft",
+  "headline": "USA Cycling Put Cash and a Plane Ticket Behind the Jersey",
+  "point": "The first U.S. gravel national championship mattered because USA Cycling made the title materially useful. A $60,000 elite purse was split equally between men and women, the winners received fully funded World Championship support, and second and third place received partially funded nominations. The federation did not make itself relevant to gravel by declaring jurisdiction; it attached money, travel, and international access to the jersey.",
+  "priorJudgment": "American gravel's meaningful hierarchy belonged to independent monuments and private series; a federation jersey would be ceremonial prestige layered onto a scene that had already built its own stakes.",
+  "changedJudgment": "A national championship becomes consequential when its result changes what a rider can afford and where that rider can race next. The useful part of federation authority was not the title itself but the funded pathway attached to it.",
+  "stakes": "Prize access, equal pay, Worlds travel, national-team selection, licensing costs, privateer opportunity, and whether a federation can add value to a discipline that became important largely outside its structure.",
+  "credibleOpposition": "The prize purse was funded by entry fees and sponsorship rather than membership dues, riders needed USA Cycling licenses, and one race in western Nebraska did not displace Unbound or the Life Time Grand Prix. Its elite winners were already established professionals, second- and third-place riders still owed a $1,000 service fee plus airfare, and the evidence does not show that the event created a new career for anyone. A large first-year purse and a Worlds nomination made the jersey useful without proving the federation had become gravel's center.",
+  "whatHappened": "On March 16, USA Cycling announced the first U.S. Gravel National Championships for September 9 in Gering, Nebraska. It promised $60,000 for the elite races, divided equally between men and women, and described that total as the largest single-day cash prize in American gravel. The federation said entry fees and sponsorship would fund the purse rather than member dues. Its finalized Worlds criteria made the national champions Level 1 funded athletes: economy airfare, bike baggage, lodging, food, local transportation, clothing, mechanical support, and insurance were included. Second- and third-place finishers were Level 2: nominated, but responsible for airfare, baggage, and a $1,000 service fee. Race-week reporting counted 62 elite men and 22 elite women and confirmed equal 131.4-mile courses as well as the purse and Worlds opportunity. Keegan Swenson and Lauren Stephens won the inaugural elite titles; official reporting counted 544 participants from 42 states across the event. One month later, the two national champions were the leading U.S. finishers at Gravel Worlds, fifth and sixth respectively.",
+  "take": "Model draft, not Matti's approved view: USA Cycling arrived late to gravel wearing a lanyard and, in a minor bureaucratic miracle, did the useful thing. It put $60,000 behind the first national championship, split it equally, and gave each winner a funded trip to Worlds. The jersey was no longer commemorative spandex. It was a check, a plane ticket, bike baggage, lodging, food, a mechanic, and permission to wear the national kit somewhere that mattered. Second and third still got the federation special—a nomination, a $1,000 fee, and instructions to buy their own flight—so let us not confuse this with public transit. But gravel had spent years proving it did not need a federation. The federation's best answer was not authority. It was receipts.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed evidence does not establish the net economics after entry, license, training, equipment, and travel costs, or show how the advertised purse was distributed beyond the equal $30,000 field totals. It does not prove that automatic nomination caused the champions to attend Worlds or that either athlete needed the funding to go. The March announcement said the top three would be supported, but the later selection document defines materially different Level 1 and Level 2 obligations; this entry follows the finalized criteria. The evidence supports a funded pathway for the winners and partial support for second and third, not a broadly accessible or durable career system.",
+  "editorialScore": 95,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_usac_announced_first_gravel_nationals_purse_2023",
+      "canonicalUrl": "https://usacycling.org/article/inaugural-usa-cycling-gravel-national-championship-heads-to-nebraska",
+      "publisher": "USA Cycling",
+      "publishedAt": "2023-03-16T09:55:00Z",
+      "quoteExcerpt": "first-ever 2023 USA Cycling Gravel National Championships",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_usac_equal_purse_entry_sponsor_funding_2023",
+      "canonicalUrl": "https://usacycling.org/article/inaugural-usa-cycling-gravel-national-championship-heads-to-nebraska",
+      "publisher": "USA Cycling",
+      "publishedAt": "2023-03-16T09:55:00Z",
+      "quoteExcerpt": "$60,000 prize purse for the Elite races, with an equal pay out for Men and Women",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_usac_worlds_funding_levels_2023",
+      "canonicalUrl": "https://s3.amazonaws.com/usac-craft-uploads-production/documents/Selection-Criteria/2023-UCI-GRAVEL-WORLD-CHAMPIONSHIPS-ELITE-MEN-WOMEN.pdf",
+      "publisher": "USA Cycling",
+      "publishedAt": "2023-09-01T00:00:00Z",
+      "quoteExcerpt": "winner of the 2023 USA Cycling Gravel National Championships",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_us_gravel_nationals_equal_fields_and_worlds_support_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/elite-riders-vie-for-dollar60000-worlds-entry-at-us-gravel-nationals/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-09-07T21:05:01Z",
+      "quoteExcerpt": "$60,000 - equally split between the two fields",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_swenson_stephens_first_us_gravel_champions_2023",
+      "canonicalUrl": "https://usacycling.org/article/swenson-and-stephens-win-first-ever-elite-gravel-national-titles",
+      "publisher": "USA Cycling",
+      "publishedAt": "2023-09-09T17:00:00Z",
+      "quoteExcerpt": "Swenson and Stephens Win First-Ever Elite Gravel National Titles",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_us_gravel_nationals_results_and_worlds_support_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/races/usa-cycling-gravel-national-championships-2023/elite-open-men/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-09-09T18:00:00Z",
+      "quoteExcerpt": "USA Cycling will also fully support the elite winners for the trip to Italy",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_us_national_champions_top_american_worlds_finishers_2023",
+      "canonicalUrl": "https://www.endurancesportswire.com/swenson-and-stephens-secure-fifth-and-sixth-at-2023-uci-gravel-world-championships/",
+      "publisher": "USA Cycling via Endurance Sportswire",
+      "publishedAt": "2023-10-09T00:00:00Z",
+      "quoteExcerpt": "National Champions Lauren Stephens and Keegan Swenson were the top American finishers",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:usa-cycling-gravel-national-championships",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_usac_announced_first_gravel_nationals_purse_2023",
+        "claim_usac_equal_purse_entry_sponsor_funding_2023",
+        "claim_usac_worlds_funding_levels_2023",
+        "claim_us_gravel_nationals_equal_fields_and_worlds_support_2023",
+        "claim_swenson_stephens_first_us_gravel_champions_2023",
+        "claim_us_gravel_nationals_results_and_worlds_support_2023",
+        "claim_us_national_champions_top_american_worlds_finishers_2023"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T07:40:00Z",
+  "contentHash": "1b618b874031fbdcdd69e911f85d60aac2b8bb1690b4394f0e96a74a65c04a9e"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -641,8 +641,8 @@ def test_2023_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 218
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 4
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 4
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 45
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 7
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 42
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- stage a private 2023 Current Thing chapter about the first US gravel national championship making its jersey materially useful through prize money and Worlds support
- distinguish fully funded winners from partially funded second- and third-place finishers
- preserve the limits of a licensed, sponsor-and-entry-funded inaugural event that did not replace independent gravel monuments
- link launch, race-week, and result windows; reduce pending 2023 evidence-bearing weeks from 45 to 42
- keep the model take approval-gated and the race impact review-only

## Verification
- history validator
- backfill validator
- 34 focused Gravel Weekly tests
- public-loader exclusion assertion
- git diff --check
- full repository suite: 7,835 passed, 331 skipped

No public publication or race-database write is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill metadata only; draft status blocks public load and auto-publish per existing validators.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history entry (`history-us-gravel-nationals-material-jersey-2023`) covering the first U.S. gravel national championship as materially useful via the equal $60k elite purse and differentiated Worlds funding (Level 1 winners vs Level 2 second/third). The piece is receipt-backed, keeps a model-draft take with **human approval required**, and registers a **review-only** race impact on `gravel:usa-cycling-gravel-national-championships` with no auto-fix.
> 
> The **2023 backfill ledger** marks three evidence windows (March launch, September race week, September results) as `covered_by_draft` instead of `pending_review`, cutting open weeks from 45 to 42. **`test_2023_backfill_ledger_starts_from_the_complete_source_census`** expectations are updated to match (`covered_by_draft` 4→7).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c526f64ac0ac438179708c03f4024476ec579bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->