### PR TITLE
feat(gravel-weekly): add 2023 retirement-plan chapter

### DIFF
--- a/data/gravel-weekly/backfill/2023.json
+++ b/data/gravel-weekly/backfill/2023.json
@@ -216,17 +216,21 @@
       "periodStartedAt": "2023-06-17",
       "periodEndedAt": "2023-06-23",
       "sourceCardCount": 8,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-retirement-plan-2023"
+      ],
+      "reason": "Porte's low-pressure Devil's Cardigan entry opened the story of gravel as an adjustable second act after elite road racing."
     },
     {
       "periodStartedAt": "2023-06-24",
       "periodEndedAt": "2023-06-30",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-retirement-plan-2023"
+      ],
+      "reason": "Porte's muddy 22nd place and praise for camaraderie showed that a useful post-road sporting life did not require pretending every start was a comeback."
     },
     {
       "periodStartedAt": "2023-07-01",
@@ -280,9 +284,11 @@
       "periodStartedAt": "2023-08-12",
       "periodEndedAt": "2023-08-18",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-retirement-plan-2023"
+      ],
+      "reason": "Haga's announcement converted the retirement-home joke into a full-time second-career proposition rather than a ceremonial exit."
     },
     {
       "periodStartedAt": "2023-08-19",
@@ -397,9 +403,11 @@
       "periodStartedAt": "2023-11-11",
       "periodEndedAt": "2023-11-17",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-retirement-plan-2023"
+      ],
+      "reason": "Specialized building its first gravel team around Oss showed a manufacturer-backed second act with high-level ambitions, not merely occasional ex-pro tourism."
     },
     {
       "periodStartedAt": "2023-11-18",

--- a/data/gravel-weekly/history/2023-gravel-retirement-plan.json
+++ b/data/gravel-weekly/history/2023-gravel-retirement-plan.json
@@ -1,0 +1,116 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-retirement-plan-2023",
+  "activeFrom": "2023-06-23",
+  "activeThrough": "2023-11-15",
+  "status": "draft",
+  "headline": "Gravel Invented a Retirement Home Worth Wanting",
+  "point": "Calling gravel road cycling's retirement home was supposed to diminish it, but 2023 showed why the sport needed one. Elite road racing had no graceful off-ramp between a team contract and disappearance. Gravel offered experienced riders an adjustable second act: Richie Porte could choose local suffering without professional pressure, Chad Haga could build a new full-time racing project, and Specialized could construct a team around Daniel Oss. The insult accidentally identified a useful institution.",
+  "priorJudgment": "When recognizable road veterans moved to gravel, they were prolonging relevance in an easier and less serious version of the sport after their real careers had ended.",
+  "changedJudgment": "Gravel could preserve different parts of an athlete's sporting life without requiring the same commitment from everyone. It let one retired rider ride with friends, another pursue a new privateer career, and another retain manufacturer support and high-level ambitions outside road racing's narrow employment ladder.",
+  "stakes": "Athlete identity after a road contract, sponsor continuity, family and travel pressure, whether veteran visibility crowds out established privateers, and whether gravel can become a durable second-career system rather than a celebrity annex.",
+  "credibleOpposition": "Porte, Haga, and Oss were famous, connected road veterans whose experience and sponsor value were not available to the typical rider. Their arrival could consume attention and commercial support that established gravel specialists had built without WorldTour résumés. Porte was deliberately not pursuing a title, Haga was still searching for the right doors to open, and Specialized's backing of Oss did not establish a stable labor market. These examples prove that gravel offered useful second acts, not that it offered equal or economically secure ones.",
+  "whatHappened": "In June, retired Tour de France podium finisher Richie Porte entered Tasmania's Devil's Cardigan and Australian Gravel National Championships because it was low-stress, local, and something he could enjoy with friends. He finished 22nd after 106 muddy kilometres and 2,300 metres of climbing, called it horrible and brilliant, and praised the camaraderie. In August, Giro stage winner Chad Haga announced that he would end a road career begun in 2011 and race gravel full-time in 2024, describing the move not as quitting bikes but as moving to the next thing. In November, Daniel Oss said road cycling's youth focus had left him choosing between another major team and something else; Specialized would build its first gravel team around him, and he planned to race at a high level while recovering freedom and discovery. Seven months later, Haga finished second by one second in his first Unbound 200 after escaping with Lachlan Morton 77 miles from the finish, evidence that a second act could remain elite competition.",
+  "take": "Model draft, not Matti's approved view: Pro road cycling retires people the way a restaurant clears a table: thanks, here is your jacket, we need this chair. Gravel built the missing retirement plan. It was adjustable. Richie Porte selected the beer-and-mud package, rode with friends, finished 22nd, and described a freezing Tasmanian death march as horrible, beautiful, and brilliant. Chad Haga selected full-time employment and nearly won Unbound on his first try. Daniel Oss got the executive plan where Specialized built the retirement home around him. Cycling invented a place whose residents still race 200 miles and sometimes beat everybody. Calling it a retirement home was supposed to be an insult. The joke is that the old system offered nothing better—and gravel's version let athletes decide which parts of being a bike racer they actually wanted to keep.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed sources do not disclose sponsorship values, salaries, benefits, expenses, or whether any of the three programs produced durable income. Porte explicitly rejected competitive ambition, while Haga and Oss pursued it, so the cases illustrate different uses of gravel rather than one uniform transition model. Haga's later Unbound result establishes competitive relevance but not financial security. The evidence does not measure whether veteran road riders displaced gravel specialists from sponsorships, entries, or coverage.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_porte_low_stress_gravel_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/a-gravel-diversion-for-richie-porte-low-stress-and-low-key-something-to-enjoy/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-06-23T00:00:00Z",
+      "quoteExcerpt": "Low stress and low key and, you know, something to enjoy",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_porte_cardigan_camaraderie_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/a-new-level-of-suck-porte-laughs-off-mud-cold-of-australian-gravel-nationals/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-06-24T00:00:00Z",
+      "quoteExcerpt": "absolutely brilliant, good camaraderie on the road",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haga_next_thing_gravel_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/chad-haga-to-switch-to-gravel-in-2024/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-08-15T00:00:00Z",
+      "quoteExcerpt": "the next thing, which, as it turns out, is still racing bikes",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_oss_specialized_gravel_team_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/daniel-oss-switches-from-road-to-gravel-for-discovery-with-new-specialized-team/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-11-15T00:00:00Z",
+      "quoteExcerpt": "Specialized will build its first gravel team around me",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_haga_unbound_second_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/races/unbound-gravel-2024/ltgp-2-unbound-200-pro-men/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-06-01T00:00:00Z",
+      "quoteExcerpt": "Morton bested Chad Haga in a sprint to the line",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haga_gravel_new_career_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/features/chad-haga-gravel-racing-isnt-a-transition-from-road-its-the-start-of-a-new-career/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-06-11T00:00:00Z",
+      "quoteExcerpt": "It's not really a transition from road – this is the start of a new career",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:devils-cardigan",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_porte_low_stress_gravel_2023",
+        "claim_porte_cardigan_camaraderie_2023"
+      ],
+      "confidence": 0.92,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_haga_next_thing_gravel_2023",
+        "claim_haga_unbound_second_2024",
+        "claim_haga_gravel_new_career_2024"
+      ],
+      "confidence": 0.95,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T12:00:00Z",
+  "contentHash": "a0e3ce6ec556e38de64a16d0818e38f1525bade44f6f003ef1cc3959309e06ba"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -641,8 +641,8 @@ def test_2023_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 218
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 4
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 11
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 38
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 15
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 34
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add the private 2023 historical chapter “Gravel Invented a Retirement Home Worth Wanting”
- ground the argument in Richie Porte, Chad Haga, Daniel Oss, and Haga’s later Unbound result
- connect four 2023 source windows and two race-editorial review targets without enabling publication or automatic race changes

## Safety
- draft/model-draft only
- human approval required
- auto-publish disabled
- race impacts are editorial review with auto-fix disabled

## Verification
- history validator
- 2023 backfill validator
- focused Gravel Weekly tests
- public-history exclusion check
- full suite: 7,835 passed, 331 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill bookkeeping only; draft gates block public load and auto-publish, with no automated race field changes.
> 
> **Overview**
> Adds a **draft** 2023 Gravel Weekly history chapter (`history-gravel-retirement-plan-2023`) arguing that gravel became an adjustable “second act” for road veterans, grounded in Porte, Haga, and Oss reporting plus later Haga/Unbound evidence.
> 
> The **2023 backfill ledger** reclassifies **four** weekly windows (mid-June, late June, mid-August, mid-November) from `pending_review` to `covered_by_draft`, each tied to that entry with narrative reasons. Ledger tests now expect **15** draft-covered weeks and **34** still pending (was 11 / 38).
> 
> The new entry stays **non-publishable**: `status: draft`, `takeProvenance: model_draft`, human approval required, and `raceImpacts` are **editorial_review** only for Devil’s Cardigan and Unbound 200 (`autoFixAllowed: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334a6bb57ee0612482b6354177411f2d1eac9bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->