### PR TITLE
feat(gravel-weekly): add 2023 Unbound mud chapter

### DIFF
--- a/data/gravel-weekly/backfill/2023.json
+++ b/data/gravel-weekly/backfill/2023.json
@@ -200,17 +200,20 @@
       "sourceCardCount": 23,
       "disposition": "covered_by_draft",
       "entryIds": [
-        "history-unbound-aerobar-workaround-2023"
+        "history-unbound-aerobar-workaround-2023",
+        "history-unbound-mud-mythology-2023"
       ],
-      "reason": "The post-race cockpit gallery preserved a compliant forearm-rest workaround without evidence of a penalty, performance effect, or safety incident."
+      "reason": "The week produced two distinct institutional stories: compliant forearm-rest setups tested the aerobar rule, while the known D Hill failure mode and unused backup route turned preventable equipment damage into Unbound mythology."
     },
     {
       "periodStartedAt": "2023-06-10",
       "periodEndedAt": "2023-06-16",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-mud-mythology-2023"
+      ],
+      "reason": "Haas's post-race argument centered paying amateurs and separated unavoidable Kansas weather from an organizer's choice to preserve a known equipment trap."
     },
     {
       "periodStartedAt": "2023-06-17",

--- a/data/gravel-weekly/history/2023-unbound-mud-mythology.json
+++ b/data/gravel-weekly/history/2023-unbound-mud-mythology.json
@@ -1,0 +1,126 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-unbound-mud-mythology-2023",
+  "activeFrom": "2023-06-03",
+  "activeThrough": "2023-06-11",
+  "status": "draft",
+  "headline": "Unbound Branded a Routing Decision as Adversity",
+  "point": "The 2023 Unbound mud pit was not simply weather making gravel unpredictable. Organizers knew D Hill became a bike-destroying mud trap, had removed it after the same problem in 2015, described a simple backup route before the race, received more overnight rain, and kept the section anyway. When predictable equipment damage was then defended as homework, character, and the Unbound experience, a controllable course decision was converted into brand mythology.",
+  "priorJudgment": "Unbound's attrition was the honest product of Kansas weather and self-supported gravel: riders accepted whatever the Flint Hills delivered, and finishing proved preparation and resilience.",
+  "changedJudgment": "Weather remains part of the contest, but organizers own the conditions they knowingly preserve when a practical alternative exists. Adversity tests riders; preventable mechanical roulette tests who can carry a clogged bicycle through a choice somebody made with a route file.",
+  "stakes": "Participant equipment and travel investment, sporting fairness, organizer duty, the line between authentic difficulty and manufactured spectacle, and whether mass-participation gravel can use toughness as a waiver for avoidable decisions.",
+  "credibleOpposition": "Unbound is explicitly difficult, its minimum-maintenance roads and variable weather distinguish it from an ordinary 200-mile ride, and many participants defended keeping D Hill as the wild experience they entered. The section was reportedly considered accessible rather than unsafe, several leading riders survived it, and any last-minute reroute can create navigation, permitting, staffing, or communication problems not fully documented in the reviewed reporting. A promoter should not sanitize every hard condition. The narrower criticism is that this was a known failure mode with a stated backup, not that mud itself was illegitimate.",
+  "whatHappened": "Overnight rain turned D Hill, beginning roughly 10 miles into the June 3 Unbound 200, into several miles of sticky mud. The road had last appeared in 2015, when rain produced similar chaos, and the 2023 race director had told media that an uncomplicated reroute using the prior year's path was available if conditions required it. No change was made. Riders pushed or carried clogged bikes, searched through grass and fencing, broke drivetrains, and began all-day chases before the race was an hour old. Cyclingnews reported that one third of 57 elite women and one quarter of 116 elite men did not finish, roughly double the dropout rates of the wet 2022 edition. Life Time's post-race response said it would reroute only if the course were unsafe or inaccessible, reminded athletes to prepare, and said the event was not intended for everyone to finish. Local coverage described organizers treating the mud as an exciting challenge. Nathan Haas's later argument centered the paying amateurs: Unbound was already one of cycling's hardest days, so a known and avoidable equipment trap did not need to be added to make it epic. In 2026 the race again selected Road D, now calling the section a celebrity and part of a legendary transformation; overnight rain again stopped riders within the first hour.",
+  "take": "Model draft, not Matti's approved view: Mother Nature can take credit for the rain. She did not upload the GPX file. Unbound knew D Hill had previously become artisanal derailleur cement, announced that a basic detour existed, received another night of rain, and sent thousands of people into it anyway. Then the organizer handed the repair bill back to the riders as a lesson in preparation and personal transformation. Kansas did not giveth and Kansas did not taketh away. A person with a route file made a choice, and the marketing department promoted the consequences to character building. Unbound is 200 miles of Flint Hills, sharp rock, weather, navigation, nutrition, and existential negotiation. It does not become gravel Disneyland because the promoter removes one predictable bicycle graveyard. Adventure is what remains after competent people eliminate the stupid parts.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed reporting establishes the known history of D Hill, a publicly described backup path, overnight rain, the decision not to reroute, reported mechanical damage and dropout rates, and Life Time's post-race rationale. It does not disclose the organizer's complete race-morning inspection, permitting constraints, landowner agreements, emergency plan, or internal decision record. Mechanical reports do not isolate mud from every later cause of abandonment. The 2026 return shows continued institutional embrace of Road D and another muddy split, but not that the precise 2023 decision process repeated.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_unbound_dhill_backup_not_used_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/broken-gear-barbed-wire-mud-wreak-havoc-on-unbound-gravel-200-favourites/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-06-05T00:00:00Z",
+      "quoteExcerpt": "a basic re-route could be made",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_mud_dropout_rates_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/broken-gear-barbed-wire-mud-wreak-havoc-on-unbound-gravel-200-favourites/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-06-05T00:00:00Z",
+      "quoteExcerpt": "those numbers were double the dropout rate",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_mud_reroute_editorial_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/features/5-conclusions-from-a-muddy-and-muddled-unbound-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-06-05T00:00:00Z",
+      "quoteExcerpt": "organisers should have followed through on the already known re-route",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_mud_rider_opposition_2023",
+      "canonicalUrl": "https://escapecollective.com/it-was-absolute-madness-peanut-butter-mud-hampers-2023-unbound-gravel/",
+      "publisher": "Escape Collective",
+      "publishedAt": "2023-06-05T00:00:00Z",
+      "quoteExcerpt": "so glad you had the courage to leave this section in",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_organizers_exciting_challenge_2023",
+      "canonicalUrl": "https://kvoe.com/2023/06/06/muddy-momentous-and-memorable-unbound-gravel-administrators-look-back-at-2023-event/",
+      "publisher": "KVOE",
+      "publishedAt": "2023-06-06T18:27:00Z",
+      "quoteExcerpt": "an exciting challenge in addition to the hundreds of miles of gravel riding",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haas_unbound_mass_participant_reroute_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/blogs/nathan-haas/nathan-haas-blog-we-need-to-talk-about-the-unbound-mud-pit/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-06-11T00:00:00Z",
+      "quoteExcerpt": "mass participation events are exactly that, for the masses",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_unbound_road_d_legendary_return_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/rugged-road-d-and-possible-return-of-legendary-peanut-butter-mud-awaits-elites-and-amateurs-in-unbound-200/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-26T00:00:00Z",
+      "quoteExcerpt": "become a bit of a celebrity in their own right",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_road_d_mud_return_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/the-mud-mayhem-arrives-again-early-at-unbound-200-with-fields-shattered-early/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-30T00:00:00Z",
+      "quoteExcerpt": "the muddy chaos has hit",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_unbound_dhill_backup_not_used_2023",
+        "claim_unbound_mud_dropout_rates_2023",
+        "claim_unbound_mud_rider_opposition_2023",
+        "claim_unbound_organizers_exciting_challenge_2023",
+        "claim_haas_unbound_mass_participant_reroute_2023",
+        "claim_unbound_road_d_legendary_return_2026",
+        "claim_unbound_road_d_mud_return_2026"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T13:00:00Z",
+  "contentHash": "de0394f834f6731faddcb391ee5324aa97b3351afb3a5c7f5fafed287876dd2d"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -641,8 +641,8 @@ def test_2023_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 218
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 4
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 15
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 34
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 16
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 33
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add the private historical chapter “Unbound Branded a Routing Decision as Adversity”
- distinguish unavoidable weather from a known D Hill failure mode, unused backup route, and post-race toughness framing
- preserve contemporary opposition and connect 2026 Road D evidence
- update the 2023 ledger and Unbound editorial-review target without enabling publication or automatic race changes

## Safety
- draft/model-draft only
- human approval required
- auto-publish disabled
- race impact is editorial review with auto-fix disabled

## Verification
- history validator
- 2023 backfill validator
- focused Gravel Weekly test
- public-history exclusion check
- full suite: 7,835 passed, 331 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and ledger metadata only; draft status blocks public history and automatic race edits.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history chapter (`history-unbound-mud-mythology-2023`) on the 2023 Unbound D Hill mud pit: known failure mode, unused backup route, post-race toughness framing, Haas’s mass-participant argument, and 2026 Road D follow-on receipts. The take stays **model_draft** with human approval and auto-publish off; race impact is **editorial_review** on `gravel:unbound-gravel-200` (`race.biased_opinion`) with **autoFixAllowed: false**.
> 
> The **2023 backfill ledger** now tags that entry on the June 3–9 week (alongside the aerobar chapter) and moves June 10–16 from `pending_review` to `covered_by_draft`, with updated week reasons. **`test_2023_backfill_ledger_starts_from_the_complete_source_census`** expects 16 `covered_by_draft` and 33 `pending_review` weeks (ledger still incomplete).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae202fd74b44968344aa183b8344bd7096cc1213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->