### PR TITLE
feat(gravel-weekly): complete 2023 source disposition

### DIFF
--- a/data/gravel-weekly/backfill/2023.json
+++ b/data/gravel-weekly/backfill/2023.json
@@ -6,7 +6,7 @@
   "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33149522994",
   "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
   "sourceCardCount": 218,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -24,73 +24,73 @@
       "periodStartedAt": "2023-01-07",
       "periodEndedAt": "2023-01-13",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Hold the Dirt RAD Fest wildcard as an access-pathway lead until selection mechanics, athlete conversion, and race delivery can show whether the invitation changed opportunity rather than launch publicity."
     },
     {
       "periodStartedAt": "2023-01-14",
       "periodEndedAt": "2023-01-20",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The first Canadian gravel-championship announcement is a meaningful institutional lead, but it needs delivered fields, results, qualification effects, and continuity before it can support a narrative."
     },
     {
       "periodStartedAt": "2023-01-21",
       "periodEndedAt": "2023-01-27",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Boonen's conditional interest was personality speculation without an entry, program, result, or changed institution; it would be celebrity-name aggregation rather than a story."
     },
     {
       "periodStartedAt": "2023-01-28",
       "periodEndedAt": "2023-02-03",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Floyd's of Leadville-ButcherBox private team could anchor a gravel-labor story, but contract terms, operating support, sponsor durability, and athlete outcomes remain necessary evidence."
     },
     {
       "periodStartedAt": "2023-02-04",
       "periodEndedAt": "2023-02-10",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A bike launch and a novelty item about cowboys controlling cattle are amusing observations, not a consequential change with a durable point."
     },
     {
       "periodStartedAt": "2023-02-11",
       "periodEndedAt": "2023-02-17",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "One product launch and an interim Transcordilleras leaderboard do not change a judgment or support a party-worthy narrative."
     },
     {
       "periodStartedAt": "2023-02-18",
       "periodEndedAt": "2023-02-24",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The window is dominated by product launches, reviews, and a mid-race standings update; compiling them would recreate a gear feed rather than historical narrative."
     },
     {
       "periodStartedAt": "2023-02-25",
       "periodEndedAt": "2023-03-03",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Hold the inaugural European Gravel Championships announcement for delivered field quality, course identity, broadcast, title legitimacy, and subsequent continuity."
     },
     {
       "periodStartedAt": "2023-03-04",
       "periodEndedAt": "2023-03-10",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A Strade Bianche tech gallery and weather-heavy race gallery are visual texture without a changed gravel judgment."
     },
     {
       "periodStartedAt": "2023-03-11",
@@ -106,9 +106,9 @@
       "periodStartedAt": "2023-03-18",
       "periodEndedAt": "2023-03-24",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The start-grid rule change is useful precursor evidence, but the later operational effects are already incorporated into the championship-in-beta chapter; the remaining shoe launch and preview add no second point."
     },
     {
       "periodStartedAt": "2023-03-25",
@@ -122,57 +122,57 @@
       "periodStartedAt": "2023-04-01",
       "periodEndedAt": "2023-04-07",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Valverde's return with a gravel squad was a recognizable name and a start announcement, but this window supplies no distinct career mechanism or consequence beyond the later second-act chapter."
     },
     {
       "periodStartedAt": "2023-04-08",
       "periodEndedAt": "2023-04-14",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A wheel launch is product coverage without cultural, competitive, access, or race-database consequence."
     },
     {
       "periodStartedAt": "2023-04-15",
       "periodEndedAt": "2023-04-21",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Series landing pages and a contender profile are useful season orientation but do not establish a decision, conflict, or outcome worth retelling."
     },
     {
       "periodStartedAt": "2023-04-22",
       "periodEndedAt": "2023-04-28",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two bare result cards preserve outcomes but offer no reported mechanism, dispute, or changed judgment for a narrative chapter."
     },
     {
       "periodStartedAt": "2023-04-29",
       "periodEndedAt": "2023-05-05",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Routine results, course-record language, and a championship roundup report what happened without revealing a durable point beyond the result sheet."
     },
     {
       "periodStartedAt": "2023-05-06",
       "periodEndedAt": "2023-05-12",
       "sourceCardCount": 7,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Race-home scaffolding, maps, previews, and individual profiles are assigning-desk inputs, but this window contains no completed conflict or institutional change that clears the story gate."
     },
     {
       "periodStartedAt": "2023-05-13",
       "periodEndedAt": "2023-05-19",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Results, one resilience profile, and Unbound preparation coverage remain event buildup and human interest without a distinct historical thesis."
     },
     {
       "periodStartedAt": "2023-05-20",
@@ -239,49 +239,49 @@
       "periodStartedAt": "2023-07-01",
       "periodEndedAt": "2023-07-07",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The only card is a result page with no additional reporting from which to derive a responsible narrative."
     },
     {
       "periodStartedAt": "2023-07-08",
       "periodEndedAt": "2023-07-14",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A result, two wheel stories, and a series-finale announcement are catalog material; none supplies a consequence or argument strong enough to retain."
     },
     {
       "periodStartedAt": "2023-07-15",
       "periodEndedAt": "2023-07-21",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A single result card is preserved by the source census but fails the point, stakes, and craft gates."
     },
     {
       "periodStartedAt": "2023-07-22",
       "periodEndedAt": "2023-07-28",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Race results plus generic bike-testing lessons are useful reference material, not a specific Current Thing with an opinionated point."
     },
     {
       "periodStartedAt": "2023-07-29",
       "periodEndedAt": "2023-08-04",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Stigmata launch is a product-positioning story without evidence of a broader competitive or cultural shift in this window."
     },
     {
       "periodStartedAt": "2023-08-05",
       "periodEndedAt": "2023-08-11",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Worlds-Leadville doubleheader is a credible calendar-conflict lead; hold for actual athlete choices, travel burden, series consequences, and whether the clash altered later scheduling."
     },
     {
       "periodStartedAt": "2023-08-12",
@@ -307,9 +307,9 @@
       "periodStartedAt": "2023-08-26",
       "periodEndedAt": "2023-09-01",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A routine result, novelty crit title, and GRX launch do not combine into a coherent point and should not be forced into one."
     },
     {
       "periodStartedAt": "2023-09-02",
@@ -345,9 +345,9 @@
       "periodStartedAt": "2023-09-23",
       "periodEndedAt": "2023-09-29",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Roster forecasts, speculative Team USA tactics, a product launch, and a pre-race illness are transient buildup; the championship's institutional identity and delivered consequences are covered elsewhere."
     },
     {
       "periodStartedAt": "2023-09-30",
@@ -374,33 +374,33 @@
       "periodStartedAt": "2023-10-14",
       "periodEndedAt": "2023-10-20",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Hold the new Australian $10,000-purse race as a regional professionalization lead until delivery, field depth, payout, continuity, and athlete impact are verified."
     },
     {
       "periodStartedAt": "2023-10-21",
       "periodEndedAt": "2023-10-27",
       "sourceCardCount": 10,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Tour de France gravel-stage argument is a high-signal risk-versus-spectacle lead; hold the announcement, team objections, organizer rationale, and eventual stage outcome for a dedicated chapter rather than mixing them with weekly results."
     },
     {
       "periodStartedAt": "2023-10-28",
       "periodEndedAt": "2023-11-03",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Mohorič's gravel-world-champion reaction extends the Tour-stage debate and should remain linked to that held chapter pending full delivery and consequence review."
     },
     {
       "periodStartedAt": "2023-11-04",
       "periodEndedAt": "2023-11-10",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Life Time Grand Prix expansion to 60 athletes and a $300,000 purse is a material labor-and-access lead; hold for admissions, support distribution, athlete economics, and delivered outcomes."
     },
     {
       "periodStartedAt": "2023-11-11",
@@ -416,33 +416,33 @@
       "periodStartedAt": "2023-11-18",
       "periodEndedAt": "2023-11-24",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Project Echelon treating gravel as North America's classics and Pidcock reconning the Tour stage suggest road-gravel institutional convergence, but the plans require delivered programs and outcomes."
     },
     {
       "periodStartedAt": "2023-11-25",
       "periodEndedAt": "2023-12-01",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The World Series expansion to 25 races and year-end money analysis form a global-growth lead; hold for participation, travel cost, regional access, calendar load, and series sustainability evidence."
     },
     {
       "periodStartedAt": "2023-12-02",
       "periodEndedAt": "2023-12-08",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two athlete profiles supply personality and offseason texture but no new mechanism, dispute, or institutional shift."
     },
     {
       "periodStartedAt": "2023-12-09",
       "periodEndedAt": "2023-12-15",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Gravel Earth's announced expansion to 20 events is a second global-growth signal; hold for delivered races, field quality, geographic access, financial continuity, and relationship to competing series."
     },
     {
       "periodStartedAt": "2023-12-16",

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -642,8 +642,10 @@ def test_2023_backfill_ledger_starts_from_the_complete_source_census():
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 218
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 4
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 16
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 33
-    assert validated["complete"] is False
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 12
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 21
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
 
 
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():


### PR DESCRIPTION
## Summary
- account for every 2023 source window with an explicit editorial disposition
- retain 12 high-signal unresolved leads as evidence holds with named missing evidence
- reject 21 low-signal windows with specific party/point/consequence reasons
- mark the 218-card, 53-week assigning-desk census complete with zero pending-review buckets

## Final 2023 census
- 16 covered by private drafts
- 12 held for evidence
- 21 rejected
- 4 explicit source gaps
- 0 pending review

## Verification
- 2023 backfill validator
- focused 2023 ledger test
- full suite: 7,835 passed, 331 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and test expectations only; no runtime publish or validation rule changes beyond reflecting an already-supported complete ledger state.
> 
> **Overview**
> **Finishes the 2023 gravel-weekly backfill ledger** by replacing every `pending_review` week with an explicit editorial outcome and setting **`complete`: true** on the 218-card, 53-week census.
> 
> Thirty-three previously open windows are now **`held_for_evidence`** (12 high-signal leads with named missing proof) or **`rejected`** (21 low-signal windows with story-gate rationales). Generic “census complete; disposition pending” reasons are swapped for week-specific explanations (e.g. Tour gravel stage, Grand Prix expansion, product-only weeks). Unchanged buckets remain **16** `covered_by_draft` and **4** `explicit_gap`.
> 
> **`test_2023_backfill_ledger_starts_from_the_complete_source_census`** is updated to assert the new disposition counts, zero `pending_review`, and `complete` is true after validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b723be3685f4cb486639295678ea55bfa975a7e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->