### PR TITLE
Gravel Weekly: begin 2022 historical narrative

### DIFF
--- a/data/gravel-weekly/backfill/2022.json
+++ b/data/gravel-weekly/backfill/2022.json
@@ -54,17 +54,21 @@
       "periodStartedAt": "2022-02-05",
       "periodEndedAt": "2022-02-11",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-road-racing-gravel-jump-scare-2022"
+      ],
+      "reason": "Trentin's objection and Haga's explanation established the conflict between accumulated stage-race risk and organizer demand for viewer-producing spectacle."
     },
     {
       "periodStartedAt": "2022-02-12",
       "periodEndedAt": "2022-02-18",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-road-racing-gravel-jump-scare-2022"
+      ],
+      "reason": "Froome sharpened the sporting point: in a multi-week GC project, gravel's broadcast excitement transfers puncture and crash risk onto accumulated rider and team investment."
     },
     {
       "periodStartedAt": "2022-02-19",
@@ -246,9 +250,11 @@
       "periodStartedAt": "2022-07-23",
       "periodEndedAt": "2022-07-29",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-road-racing-gravel-jump-scare-2022"
+      ],
+      "reason": "The Tour de France Femmes gravel stage supplied the experiment: equipment and handling rewarded Ewers while mechanicals and a frantic team-car recovery compounded Garcia's loss."
     },
     {
       "periodStartedAt": "2022-07-30",
@@ -326,25 +332,31 @@
       "periodStartedAt": "2022-10-01",
       "periodEndedAt": "2022-10-07",
       "sourceCardCount": 7,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-worlds-road-settings-2022"
+      ],
+      "reason": "The entry list, road-bike selections, and course design exposed how much of road cycling's status and equipment logic the inaugural championship imported."
     },
     {
       "periodStartedAt": "2022-10-08",
       "periodEndedAt": "2022-10-14",
       "sourceCardCount": 12,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-worlds-road-settings-2022"
+      ],
+      "reason": "The races supplied the consequence: cross-discipline grid priority, national-team blocking, trade-team loyalty, and a WorldTour sweep of the first nine men's places."
     },
     {
       "periodStartedAt": "2022-10-15",
       "periodEndedAt": "2022-10-21",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-worlds-road-settings-2022"
+      ],
+      "reason": "Haas's post-race audit identified the fix implied by the story: value the Gravel World Series in the grid and constrain national wildcard team size."
     },
     {
       "periodStartedAt": "2022-10-22",
@@ -435,6 +447,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T08:28:00Z"
+  "updatedAt": "2026-08-28T15:25:00Z"
 }
-

--- a/data/gravel-weekly/history/2022-gravel-worlds-road-settings.json
+++ b/data/gravel-weekly/history/2022-gravel-worlds-road-settings.json
@@ -1,0 +1,147 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-worlds-road-settings-2022",
+  "activeFrom": "2022-10-05",
+  "activeThrough": "2022-10-15",
+  "status": "draft",
+  "headline": "Gravel Worlds Shipped With Road Racing Preinstalled",
+  "point": "The inaugural UCI Gravel World Championships did not merely attract road professionals; its institutional design imported road cycling's status, incentives, and alliances. The UCI initially ignored points from its own Gravel World Series while using road, mountain-bike, and cyclocross points for the start grid, national selections favored famous road riders, the fast course rewarded WorldTour speed, and trade-team loyalties shaped the chase. Road riders did not hijack a finished gravel championship. The governing body launched one with road racing already installed.",
+  "priorJudgment": "WorldTour stars overwhelmed gravel specialists at the first world championship because road cycling's deeper talent pool finally showed up and proved it was stronger.",
+  "changedJudgment": "The result measured a test whose rules, grid, selection, course, and tactical incentives already transferred road and multidiscipline advantages. The champions were excellent, but their success cannot be separated from the institution's first attempt to define what championship gravel rewarded.",
+  "stakes": "Start position affected access to an early bottleneck and descent, national selections determined which specialists could race the elite event, team size changed the tactical contest, equipment choice revealed what terrain the title actually valued, and the first champions taught audiences whose version of gravel the UCI considered legitimate.",
+  "credibleOpposition": "The course still contained substantial gravel, singletrack, technical descending, and enough selectivity to reward exceptional all-around riders. Pauline Ferrand-Prévot was a dominant mountain-bike champion, Gianni Vermeersch brought cyclocross skill as well as WorldTour speed, and specialists such as Nathan Haas described the event as hard, fun, and worth improving rather than rejecting. A world championship should invite cycling's best athletes, national teams naturally race tactically, fast courses are valid gravel, and an inaugural event cannot begin with mature gravel rankings that do not yet exist.",
+  "whatHappened": "The inaugural championship in Veneto assembled WorldTour stars, gravel privateers, mountain bikers, and age-group riders on mixed-surface courses reported as 69 percent gravel for elite women and 73 percent for elite men. Riders could use road, gravel, cyclocross, or mountain bikes. Mathieu van der Poel chose his Canyon Ultimate road frame, and several Specialized riders selected Roubaix road bikes; the course's roughly 30 percent asphalt and sustained flat speed made that rational. Before the start, gravel specialists learned that road, mountain-bike, and cyclocross points had been used for grid priority while the UCI Gravel World Series that qualified them carried no ranking points. A compromise moved some specialists into rows two and three, but national wildcards still produced a ten-rider Italian men's team while Italy's established gravel racer Mattia De Marchi raced an age category instead. Ferrand-Prévot won the women's race on her gravel debut after three mountain-bike world titles that season. In the men's race, Vermeersch and Italian Daniel Oss escaped with roughly 150 kilometres remaining; Italian riders disrupted the chase for Oss, and Van der Poel declined to pursue his Belgian Alpecin-Deceuninck trade teammate Vermeersch despite wearing Dutch colors. Vermeersch won, Oss finished second, Van der Poel third, and WorldTour riders occupied the first nine positions. Post-race, Haas called for smaller national wildcard teams and actual Gravel World Series points while still praising the event. Two years later, the Belgian championship again counted half of riders' road, mountain-bike, and cyclocross ranking points for grid order, used a Classics-like course, and crowned Marianne Vos and Van der Poel.",
+  "take": "Model draft, not Matti's approved view: The UCI did not let road racing invade gravel. It did something much more bureaucratically impressive: it created a Gravel World Series, forgot to give that series useful points, then used road, mountain-bike, and cyclocross points to seat famous people at the front of Gravel Worlds. That is not a hostile takeover. That is installing a new app and importing every setting from the old one. Road bikes were fastest. WorldTour riders took the first nine men's places. Italy arrived with ten road pros and used them like ten road pros. Mathieu van der Poel wore Dutch orange but would not chase Belgian Gianni Vermeersch because Belgian Gianni Vermeersch was also Alpecin Gianni Vermeersch. Apparently nationality ended where payroll began. None of this makes Vermeersch or Pauline Ferrand-Prévot counterfeit champions; both were ferociously qualified to ride bicycles over mixed surfaces. It makes the roadies-stole-gravel story lazy. The riders answered the exam they were handed. The UCI wrote an exam in road racing's handwriting, left the gravel specialists' season in the coat check, and called the result a definition of the discipline. The first Gravel Worlds was not proof that gravel had no identity. It was proof that institutions fill an identity vacuum with whatever rules they already have in the drawer.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "Contemporary accounts establish the grid dispute, road-bike selections, course character, national-team tactics, trade-team non-pursuit, and finishing order. Haas's account is a participant's perspective and not an independent audit of every selection decision or team instruction. The reporting does not establish that the UCI intentionally favored road athletes, that Vermeersch would have lost under different rules, or that every WorldTour finisher benefited from team tactics. The course percentages varied by elite field, and fast, less technical gravel remains legitimate gravel. Later 2024 evidence shows related institutional choices recurring, not an unchanged rulebook across every edition.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_worlds_road_privateer_field_and_course_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/euro-pro-roadies-take-on-the-privateers-at-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-10-05T21:49:39Z",
+      "quoteExcerpt": "European-based professionals road riders will take on the privateers and US-based gravel specialists",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_road_bike_choices_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/van-der-poel-is-set-to-ride-a-road-bike-at-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-10-07T13:39:45Z",
+      "quoteExcerpt": "Choosing not to ride the two more gravel-specific bikes available to him",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_grid_cross_discipline_points_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/greg-van-avermaet-road-riders-at-gravel-worlds-can-only-help-make-the-sport-bigger/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-10-08T11:56:57Z",
+      "quoteExcerpt": "UCI points from road and MTB racing in the allocation of grid positions",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_ferrand_prevot_inaugural_gravel_title_2022",
+      "canonicalUrl": "https://www.uci.org/article/pauline-ferrand-prevot-wins-first-ever-uci-gravel-world-champions-rainbow/6h7MuGTfOqKfQPgTC6VHJN",
+      "publisher": "UCI",
+      "publishedAt": "2022-10-08T20:16:31Z",
+      "quoteExcerpt": "the first rider to earn rainbow bands four times in the same calendar year",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_trade_team_rules_worlds_chase_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/van-der-poel-obeys-unspoken-rules-of-road-at-uci-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-10-09T17:52:27Z",
+      "quoteExcerpt": "the unspoken rules of the road were certainly on show",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_vermeersch_inaugural_result_2022",
+      "canonicalUrl": "https://www.uci.org/article/uci-gravel-world-championships-men-elite-title-for-belgiums-vermeersch/6heE9iiV9VxNKTGhNqQ9ge",
+      "publisher": "UCI",
+      "publishedAt": "2022-10-09T19:00:00Z",
+      "quoteExcerpt": "The silver medal went to Daniel Oss with the final spot on the podium taken by Mathieu Van der Poel",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_first_nine_worldtour_and_grid_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/features/like-a-junior-race-with-tour-de-france-riders-inside-the-first-uci-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-10-11T09:29:56Z",
+      "quoteExcerpt": "the first nine places at the finish were occupied by WorldTour riders",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haas_gravel_points_and_team_size_reforms_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/blogs/nathan-haas/nathan-haas-blog-whats-the-points-unpacking-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-10-15T13:32:16Z",
+      "quoteExcerpt": "add in qualifying points for the UCI gravel races",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_worlds_2024_grid_and_course_road_advantage",
+      "canonicalUrl": "https://www.cyclingnews.com/news/gravel-racers-have-to-step-it-up-briton-maddy-nutt-assesses-influx-of-road-pros-at-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-10-04T00:00:00Z",
+      "quoteExcerpt": "it actually suits a road Classics rider more than it would suit a gravel racer",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_multidiscipline_winners_2024",
+      "canonicalUrl": "https://www.uci.org/article/bolero-uci-gravel-world-championships-vos-and-van-der-poel-reign-in-flanders/3RV4oYoEaHDeGUsLSBSjV8",
+      "publisher": "UCI",
+      "publishedAt": "2024-10-06T23:00:00Z",
+      "quoteExcerpt": "Rainbow jerseys for Dutch multi-discipline stars",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-world-championships",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_worlds_road_privateer_field_and_course_2022",
+        "claim_worlds_road_bike_choices_2022",
+        "claim_worlds_grid_cross_discipline_points_2022",
+        "claim_ferrand_prevot_inaugural_gravel_title_2022",
+        "claim_trade_team_rules_worlds_chase_2022",
+        "claim_vermeersch_inaugural_result_2022",
+        "claim_worlds_first_nine_worldtour_and_grid_2022",
+        "claim_haas_gravel_points_and_team_size_reforms_2022",
+        "claim_worlds_2024_grid_and_course_road_advantage",
+        "claim_worlds_multidiscipline_winners_2024"
+      ],
+      "confidence": 0.99,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T15:25:00Z",
+  "contentHash": "57796d3b4c940a2079ac58f43bdf705f5d9f3b3ffbe85f92e98c8766c954491c"
+}

--- a/data/gravel-weekly/history/2022-road-racing-gravel-jump-scare.json
+++ b/data/gravel-weekly/history/2022-road-racing-gravel-jump-scare.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-road-racing-gravel-jump-scare-2022",
+  "activeFrom": "2022-02-05",
+  "activeThrough": "2022-07-27",
+  "status": "draft",
+  "headline": "Road Racing Rented Gravel for the Jump Scare",
+  "point": "Gravel's first major influence on road racing was not a bike, a rider, or a governing body. It was a content format. Organizers could insert a few loose sectors into a stage race and manufacture positioning fights, mechanical suspense, and television drama without turning the event into a gravel race. The spectacle was real, but its upside belonged primarily to the show while riders carried the accumulated-cost risk.",
+  "priorJudgment": "Road riders objected to gravel in stage races because specialists disliked change and wanted Grand Tours protected from a younger discipline's terrain.",
+  "changedJudgment": "The strongest objection was not that loose surfaces were beneath road racing. It was that a one-day race can spend all its luck at once, while a stage race can let one puncture erase months of preparation without necessarily revealing a stronger overall rider. Gravel could make excellent television and remain a disputed sporting test at the same time.",
+  "stakes": "Course design determined whether equipment selection and handling were rewarded, whether accumulated general-classification work could be lost to a mechanical, who absorbed the cost of broadcast spectacle, and whether road racing treated gravel as a real discipline or merely borrowed its most telegenic instability.",
+  "credibleOpposition": "Road racing has always tested versatility through cobbles, wind, descents, narrow roads, equipment choices, and changing weather. Kasia Niewiadoma argued that gravel exposed additional bike skills and created the difficulty spectators wanted to see, while Veronica Ewers's 30 mm tyre choice and confident riding showed that preparation could materially change the outcome. The 2024 Tour stage produced aggressive, widely praised racing without changing the leading general-classification positions. Luck exists on every surface, and removing every unpredictable element would make stage racing safer in one narrow sense but also tactically poorer and less interesting.",
+  "whatHappened": "On February 5, after a rough uphill sector at the Volta a la Comunitat Valenciana, Matteo Trentin called gravel in stage races a spectacle the sport did not need. Remco Evenepoel said the hard climb had not required the added puncture risk, while Chad Haga acknowledged the fun and connective uses of dirt but said organizers were searching for whatever would excite viewers. A week later Chris Froome made the risk allocation explicit: gravel and cobbles could make one-day races, but in a stage race a crash or mechanical could erase months of general-classification preparation. The argument became a live experiment at the inaugural Tour de France Femmes on July 27. Before its 12.9 kilometres of white roads, Annemiek van Vleuten called the chance of GC being decided by bad luck unnecessary; Kasia Niewiadoma welcomed the extra skills and spectacle. During the stage, Veronica Ewers used 30 mm tyres, felt in control, and earned her first WorldTour top five. Mavi Garcia suffered multiple mechanicals, regained the leaders, then lost almost two minutes after her own team car clipped her rear wheel during a frantic chase. Marlen Reusser attacked before the final gravel sector and won solo. In 2024 the men's Tour expanded the formula to 32 kilometres across 14 sectors around Troyes: the race was chaotic and captivating, Jonas Vingegaard punctured and changed onto a teammate's bike, Tadej Pogacar repeatedly attacked, and the leading GC positions did not change.",
+  "take": "Model draft, not Matti's approved view: Road racing did not fall in love with gravel in 2022. It licensed the jump scare. Drop a few dirt sectors into a stage race, put months of GC preparation one puncture from irrelevance, and television gets its trailer shot. Trentin and Froome sounded like old men yelling at a cloud, except the cloud was a dust plume and their boring point was correct: a one-day race can spend all its luck at once; a stage race asks riders to carry the receipt for three weeks. Then the Tour de France Femmes ran the experiment. The show was excellent. Veronica Ewers chose 30 mm tyres and discovered a career-best WorldTour result. Mavi Garcia had multiple mechanicals, got clipped by her own frantic team car, and lost nearly two minutes. Same surface, two stories: skill rewarded, chaos compounded. By 2024 the men's Tour had perfected the product—32 kilometres of white roads, Vingegaard on a teammate's bike, Pogacar attacking everything, no change at the top of GC. Gravel had become hot sauce for road racing: the broadcast tasted more exciting, the meal was still road, and riders absorbed the heartburn. That does not make it illegitimate. It means stop pretending the dirt is there only to identify the best stage racer. It is there because everyone watches.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed reporting does not quantify audience gains attributable to gravel, establish organizers' private motives, or isolate surface-induced incidents from the normal chaos of a road race. Garcia's team car, not the gravel itself, caused her crash, although it occurred during a recovery after repeated mechanical trouble on the stage. Ewers's result demonstrates successful preparation in one case, not that tyre width explains every outcome. The 2024 stage confirms that gravel could create major action without altering the top GC order, but one later stage cannot settle the broader fairness argument.",
+  "editorialScore": 97,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_trentin_stage_racing_gravel_spectacle_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/matteo-trentin-gravel-sectors-have-no-place-in-stage-racing-or-even-paris-tours/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-02-05T00:00:00Z",
+      "quoteExcerpt": "we are going too far, to a spectacle we don't need",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haga_organizers_seek_viewers_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/matteo-trentin-gravel-sectors-have-no-place-in-stage-racing-or-even-paris-tours/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-02-05T00:00:00Z",
+      "quoteExcerpt": "every organiser wants to find the thing that makes race exciting and bring in the viewers",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_froome_stage_race_risk_reward_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/chris-froome-questions-whether-time-trial-bikes-and-gravel-belong-in-road-cycling/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-02-12T00:00:00Z",
+      "quoteExcerpt": "rolling the dice in terms of risk vs reward for the GC guys",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_tdff_gravel_opposing_views_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/should-gravel-be-on-the-menu-at-the-tour-de-france-femmes/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-07-27T00:00:00Z",
+      "quoteExcerpt": "gravel roads allow you to discover more of your abilities or bike skills",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_ewers_wide_tyres_tdff_result_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/ewers-credits-wide-tyres-for-top-tour-de-france-femmes-gravel-stage-placing/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-07-27T17:00:00Z",
+      "quoteExcerpt": "We rode 30mm Vittoria tyres today and that was super beneficial",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_garcia_team_car_gravel_stage_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/mavi-garcia-hit-by-own-team-car-on-hectic-tour-de-france-femmes-gravel-stage/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-07-27T18:00:00Z",
+      "quoteExcerpt": "the vehicle hit the Spanish champion's rear wheel, causing her to crash",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_tdff_stage_four_mechanicals_and_result_2022",
+      "canonicalUrl": "https://www.letourfemmes.fr/en/news/2022/reusser-means-power/1292439",
+      "publisher": "Tour de France Femmes",
+      "publishedAt": "2022-07-27T16:45:00Z",
+      "quoteExcerpt": "Mavi Garcia lost almost 2 minutes as she suffered mechanical incidents and a crash",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_tour_gravel_chaos_no_gc_change_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/races/tour-de-france-2024/stage-9/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-07-07T18:00:00Z",
+      "quoteExcerpt": "chaotic and captivating gravel stage 9",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_tour_gravel_32km_gc_unchanged_2024",
+      "canonicalUrl": "https://www.letour.fr/en/news/2024/stage-9/gravel-masterclass-gives-turgis-troyes-win/1320149",
+      "publisher": "Tour de France",
+      "publishedAt": "2024-07-07T18:16:00Z",
+      "quoteExcerpt": "32km of gravel roads",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T15:00:00Z",
+  "contentHash": "c5c6a4ad2f40cefe6e18977ccff50bf03a5f0089c4f8b9286bac37a094a91774"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -656,7 +656,8 @@ def test_2022_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 173
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 6
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 47
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 6
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 41
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add two private 2022 Gravel Weekly chapters about road racing borrowing gravel as spectacle and the inaugural UCI Gravel Worlds importing road-racing defaults
- link six source-census weeks to their supporting drafts while leaving 41 evidence-bearing weeks pending
- preserve human approval, public exclusion, and review-only race impact controls

## Verification
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2022-road-racing-gravel-jump-scare.json data/gravel-weekly/history/2022-gravel-worlds-road-settings.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2022.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q -k "history or backfill"`
- `python3 -m pytest tests/ -q` (7296 passed, 331 skipped)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill bookkeeping only; drafts are excluded from public loaders and do not auto-apply race field changes.
> 
> **Overview**
> Adds the first **2022 Gravel Weekly history drafts**: one chapter on road stage races using gravel for TV spectacle and GC risk (`history-road-racing-gravel-jump-scare-2022`), and one on inaugural UCI Gravel Worlds inheriting road-racing grid, equipment, and tactics (`history-gravel-worlds-road-settings-2022`). Both stay **`draft`** with **`model_draft`** takes, **`humanApprovalRequired`**, and no **`publishedAt`**.
> 
> Updates **`data/gravel-weekly/backfill/2022.json`** so **six** census weeks move from **`pending_review`** to **`covered_by_draft`**, each pointing at the matching **`entryId`** with week-specific **`reason`** text (Feb gravel debate, July TDFF gravel stage, Oct Worlds buildup/races/Haas follow-up). The ledger remains **`complete: false`** with **41** weeks still pending.
> 
> The Worlds draft registers a **review-only** **`raceImpacts`** hook on `gravel:uci-gravel-world-championships` (`autoFixAllowed: false`). **`test_2022_backfill_ledger_starts_from_the_complete_source_census`** now expects **6** `covered_by_draft` and **41** `pending_review` weeks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 059114ce2ce16984472afa3224ace445d296f8fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->