### PR TITLE
Gravel Weekly: add 2022 professionalization chapter

### DIFF
--- a/data/gravel-weekly/backfill/2022.json
+++ b/data/gravel-weekly/backfill/2022.json
@@ -194,25 +194,31 @@
       "periodStartedAt": "2022-06-04",
       "periodEndedAt": "2022-06-10",
       "sourceCardCount": 15,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-spirit-hr-job-2022"
+      ],
+      "reason": "The Unbound aerobar email chain exposed professional incentives, sponsor obligations, safety externalities, and the failure mode of voluntary consensus."
     },
     {
       "periodStartedAt": "2022-06-11",
       "periodEndedAt": "2022-06-17",
       "sourceCardCount": 12,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-spirit-hr-job-2022"
+      ],
+      "reason": "Women riders turned the equipment argument into the larger governance point: safety, drafting, and a separate race require organizer rules, not a men's agreement."
     },
     {
       "periodStartedAt": "2022-06-18",
       "periodEndedAt": "2022-06-24",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-spirit-hr-job-2022"
+      ],
+      "reason": "De Boer and Haas established the consequence: careers and life-changing wins made more money, investment, opportunity, pressure, and formal governance inseparable."
     },
     {
       "periodStartedAt": "2022-06-25",
@@ -447,5 +453,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T15:25:00Z"
+  "updatedAt": "2026-08-28T16:00:00Z"
 }

--- a/data/gravel-weekly/history/2022-gravel-spirit-hr-job.json
+++ b/data/gravel-weekly/history/2022-gravel-spirit-hr-job.json
@@ -1,0 +1,136 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-spirit-hr-job-2022",
+  "activeFrom": "2022-06-04",
+  "activeThrough": "2022-06-22",
+  "status": "draft",
+  "headline": "Gravel Asked a Vibe to Do HR's Job",
+  "point": "Unbound's 2022 aerobar fight exposed a broader governance failure: gravel had become paid work while still asking shared culture to regulate professional incentives. Once victories could change careers, sponsors supplied equipment obligations, and large packs made individual choices affect other riders, a private email chain and the spirit of gravel could no longer provide safety, fairness, or equal participation. Professionalization did not require making every rider a pro; it required organizers to write the rules that their growing event had previously outsourced to vibes.",
+  "priorJudgment": "Gravel's light rulebooks and self-policing preserved the sport's accessible, countercultural character, while formal regulation would import road cycling's bureaucracy and drain away the fun.",
+  "changedJudgment": "Informal culture works only while incentives remain compatible and consequences remain mostly personal. When racing becomes a livelihood and one rider's equipment, drafting, or support structure changes another rider's contest, refusing to govern does not preserve neutrality; it rewards whoever can exploit ambiguity most effectively.",
+  "stakes": "The boundary affected pack safety, equipment cost, sponsor influence, women's ability to contest their own race, whether privateers could compete with supported programs, who gained career opportunities, and whether amateur participation could coexist with an elite event without pretending both needed identical rules.",
+  "credibleOpposition": "Aerobars had legitimate roots as a comfort position for riders spending long hours alone, and a universal ban would burden amateurs who were not racing in a front pack. More rules, separate fields, and elite infrastructure can raise costs, fragment the communal mass start, and reproduce the less friendly parts of professional road and cyclocross. Sophie de Boer nevertheless argued that professionalization had created careers and opportunities for women in cyclocross, while Haas still considered Unbound extraordinary and worth winning. The choice was not purity or corruption; it was which parts of growth to govern and which traditions to protect.",
+  "whatHappened": "Before the 2022 Unbound 200, leading men circulated an email seeking a voluntary agreement not to use aerobars in the front group. Riders described a collective-action problem: most preferred not to use them in packs, but one rider's aerodynamic advantage pushed others to follow, while some contenders had sponsor obligations involving unreleased equipment. Ian Boswell and Kiel Reijnen emphasized braking and control risks; Peter Stetina argued that the extensions still made sense for solitary ultra-endurance riders but not for the increasingly competitive lead pack. The agreement did not include the same organized discussion among elite women. After the race, Amanda Nauman and winner Sofia Gomez Villafañe said self-policing was insufficient: if organizers wanted to restrict equipment, protect a separate women's race, or regulate drafting, they needed clear rules and different treatment for elite and amateur fields. Days later Sophie de Boer connected those debates to money and careers, arguing that professional sport creates pressure for fair conditions but can also create opportunities, especially for women. Nathan Haas described Unbound as a standalone commercial and competitive tidal wave where winning could change a life and serious investment followed naturally, even while less industrial events retained the relaxed gravel atmosphere. In 2023 Unbound prohibited aerobars for elite fields and created separate starts; racers immediately adapted legal handlebar tops into padded forearm rests. In 2024 a 25-minute envelope protected the front women's race well enough to produce its first bunch sprint, while interference persisted deeper in the field.",
+  "take": "Model draft, not Matti's approved view: Gravel spent 2022 asking a vibe to do HR's job. The front men at Unbound opened an email chain about aerobars because nobody wanted to be the only honorable employee in a department where the bonus went to whoever found the fastest loophole. Sponsors had unreleased cockpit obligations. Riders without brakes under their hands were sitting inside growing packs. The elite women were largely outside the gentleman's agreement, a name that was becoming less metaphorical by the minute. Then Sofia Gomez Villafañe supplied the adult sentence: if you do not want us using the bars, make a rule. This is what professionalization actually means. Not matching team buses and a LinkedIn page for the spirit of gravel. It means winning can change a life, money creates rational pressure, and organizers must stop treating ambiguity as authenticity. Keep aerobars for the person riding alone for fourteen hours. Give elite women enough empty road to have their own race. Write down what the pointy end may do, then let everybody else enjoy the party. Gravel did not need road cycling's entire employee handbook. It needed management to admit there were employees.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reporting documents rider statements, the email effort, sponsor pressure described by participants, and later organizer changes; it does not provide the full email chain, prove that aerobars caused a 2022 crash, quantify their competitive advantage, or establish every sponsor obligation. De Boer's cyclocross comparison is experiential rather than causal evidence that the same governance would produce equal benefits in gravel. Later aerobar workarounds show that formal rules create edge cases, while the 2024 women's start shows one operational benefit under different weather and race conditions. Neither proves that a single professional rulebook should govern all gravel events or amateur fields.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_unbound_aerobar_collective_action_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/should-aero-bars-be-used-in-gravel-unbound-racers-debate/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-06-04T14:43:33Z",
+      "quoteExcerpt": "All it takes is one person in the front to use them",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_aerobar_sponsor_and_cost_pressure_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/should-aero-bars-be-used-in-gravel-unbound-racers-debate/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-06-04T14:43:33Z",
+      "quoteExcerpt": "some top contenders have sponsorship obligations with yet-to-be-released bars",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_gentlemans_agreement_insufficient_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/aero-bars-in-gravel-gentlemans-agreement-is-not-enough/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-06-15T20:41:11Z",
+      "quoteExcerpt": "It can't be a gentleman's agreement or an agreement between just the pro men, and it has to be a rule",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_womens_race_rules_priority_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/aero-bars-in-gravel-gentlemans-agreement-is-not-enough/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-06-15T20:41:11Z",
+      "quoteExcerpt": "I'd rather talk about getting our own women's start, or drafting rules, or our own race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_professionalization_opportunity_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/features/money-rules-and-going-pro-in-gravel-not-all-change-is-bad-says-sophie-de-boer/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-06-19T19:01:50Z",
+      "quoteExcerpt": "more races, more money, and more rules",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_career_changing_professionalization_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/blogs/nathan-haas/nathan-haas-blog-unbound-the-pro-ification-of-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-06-22T21:07:10Z",
+      "quoteExcerpt": "winning this race can actually change a rider's life",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_unbound_elite_aerobar_ban_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/unbound-gravel-200-bans-aerobars-and-adds-start-groups-for-elite-racers/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-01-04T12:00:00Z",
+      "quoteExcerpt": "Aerobars or bar extensions will no longer be permitted for competitors in the elite field",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_aerobar_workaround_2023",
+      "canonicalUrl": "https://www.bikeradar.com/features/tech/unbound-2023-gravel-tech-gallery",
+      "publisher": "BikeRadar",
+      "publishedAt": "2023-06-05T14:00:00Z",
+      "quoteExcerpt": "some riders found a workaround",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_womens_start_gap_consequence_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/features/unbound-gravel-2024-conclusions-the-spirit-of-gravel-closes-the-gender-gap/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-06-03T15:51:52Z",
+      "quoteExcerpt": "a sprint finish on Commercial Street for the first time",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_unbound_aerobar_collective_action_2022",
+        "claim_unbound_aerobar_sponsor_and_cost_pressure_2022",
+        "claim_unbound_gentlemans_agreement_insufficient_2022",
+        "claim_unbound_womens_race_rules_priority_2022",
+        "claim_unbound_career_changing_professionalization_2022",
+        "claim_unbound_elite_aerobar_ban_2023",
+        "claim_unbound_aerobar_workaround_2023",
+        "claim_unbound_womens_start_gap_consequence_2024"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T16:00:00Z",
+  "contentHash": "54a1bb74759de687d1905e96e1042e52f4ac6dd9df7945bb9fec7ea67d3719f9"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -656,8 +656,8 @@ def test_2022_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 173
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 6
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 6
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 41
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 9
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 38
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a private 2022 chapter showing why professional incentives outgrew self-policing and the spirit-of-gravel governance model
- connect the Unbound aerobar dispute to later elite rules, immediate equipment workarounds, and women’s start design
- link three more 2022 census weeks while keeping publication and race-data changes behind human review

## Verification
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2022-gravel-spirit-hr-job.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2022.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q -k "history or backfill"`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill metadata only; the new chapter stays draft with human approval and no auto-publish or race-data auto-fix.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history chapter (`history-gravel-spirit-hr-job-2022`) covering mid-June 2022 Unbound aerobar governance: voluntary men’s agreements vs sponsor pressure, women riders calling for organizer rules, and De Boer/Haas on money and career stakes. It includes contemporary Cyclingnews receipts, later evidence (2023 elite aerobar ban/workarounds, 2024 women’s start), and a **non-auto** `editorial_review` race impact on `gravel:unbound-gravel-200`—still `humanApprovalRequired` / not published.
> 
> The **2022 backfill ledger** reclassifies three census weeks (2022-06-04 through 2022-06-24) from `pending_review` to `covered_by_draft` with week-specific reasons pointing at that entry; `updatedAt` bumps accordingly. **`test_gravel_weekly.py`** updates expected `covered_by_draft` (9) and `pending_review` (38) counts for the incomplete 2022 ledger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921e39cb6c3b9e92236b5e392853e050f3099f3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->