### PR TITLE
Gravel Weekly: add 2022 broadcast infrastructure chapter

### DIFF
--- a/data/gravel-weekly/backfill/2022.json
+++ b/data/gravel-weekly/backfill/2022.json
@@ -122,9 +122,11 @@
       "periodStartedAt": "2022-04-02",
       "periodEndedAt": "2022-04-08",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-tv-series-2022"
+      ],
+      "reason": "The Grand Prix launch promised that all six events and its $250,000 season-long contest would be visible through live worldwide coverage."
     },
     {
       "periodStartedAt": "2022-04-09",
@@ -274,9 +276,11 @@
       "periodStartedAt": "2022-08-06",
       "periodEndedAt": "2022-08-12",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-life-time-tv-series-2022"
+      ],
+      "reason": "Ending live production before Leadville severed the media connective tissue halfway through the first season and exposed broadcasting as core series infrastructure."
     },
     {
       "periodStartedAt": "2022-08-13",
@@ -453,5 +457,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T16:00:00Z"
+  "updatedAt": "2026-08-28T16:35:00Z"
 }

--- a/data/gravel-weekly/history/2022-life-time-tv-series.json
+++ b/data/gravel-weekly/history/2022-life-time-tv-series.json
@@ -1,0 +1,139 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-life-time-tv-series-2022",
+  "activeFrom": "2022-04-07",
+  "activeThrough": "2022-08-07",
+  "status": "draft",
+  "headline": "Life Time Built a TV Series and Turned Off the TV",
+  "point": "The inaugural Life Time Grand Prix professionalized athlete selection and prize money before it could reliably make the competition visible. Live coverage was not a decorative extra to a six-race series; it was the infrastructure that allowed separate events, disciplines, and standings to become one public story. When technical limits ended the broadcast halfway through the season, the athletes kept racing for $250,000 but most of the audience lost the thing that made a series exist outside a spreadsheet.",
+  "priorJudgment": "A large equal prize purse, invitation-only field, and season standings were sufficient to turn established gravel and mountain-bike events into a coherent professional series; live video was an ambitious promotional bonus.",
+  "changedJudgment": "Prize money can create a competition, but media creates the shared season. Without reliable coverage, athlete performance becomes less legible to fans and sponsors, each race collapses back into its local event, and a series has professional obligations without a durable public product.",
+  "stakes": "The failure affected athlete and sponsor visibility, audience understanding of cross-discipline standings, the value of being selected into the series, whether remote gravel could support real-time fandom, and how much technical production an organizer had to treat as core infrastructure rather than launch marketing.",
+  "credibleOpposition": "Live production across 100-to-200-mile remote courses was genuinely difficult, expensive, and largely unprecedented. Life Time and FloSports said terrain, weather, course conditions, connectivity, and quality standards made the remaining broadcasts untenable; stopping a bad product can be more honest than selling an unusable stream. The races, equal purse, and standings continued, while later productions proved that the first failure generated useful technical learning rather than permanent abandonment.",
+  "whatHappened": "On April 7, Life Time introduced a six-event invitation-only Grand Prix with 30 women, 30 men, three gravel races, three mountain-bike races, and a $250,000 season purse split equally between the top ten women and men. FloSports was announced as the broadcast partner, with all six events promised live and on demand worldwide. Fuego 80K and Unbound received live productions. Crusher in the Tushar was reduced to interviews, on-course clips, and post-race highlights because of technical limits. On August 7, one week before Leadville, Life Time announced that it and FloSports had ended live production for the final three events; Leadville, Chequamegon, and Big Sugar would receive social updates instead. The stated reason was that remote locations, environmental conditions, and course demands prevented a broadcast at the quality athletes and fans deserved. The announcement surprised athletes who had entered a series advertised with international coverage. Life Time later treated the attempt as an aggressive first-year experiment. In 2025 it returned with a free seven-hour Unbound production using eight cameras and reported more than 332,000 weekend views across 50 countries; Big Sugar added extended finish coverage. In 2026 Unbound moved to start-to-finish coverage and Leadville again carried full elite-race video.",
+  "take": "Model draft, not Matti's approved view: Life Time launched the Grand Prix like Netflix for people who say they do not watch television: 60 selected athletes, six episodes, equal prize money, and every race live. By episode three, the television series was an Instagram Story. The mountains had defeated the media plan. That is funny until you remember the athletes were still traveling across the country, changing disciplines, satisfying sponsors, and racing for a quarter-million dollars inside a season the audience could no longer watch become a season. A leaderboard is not a narrative. Prize money professionalizes the pressure; coverage professionalizes the memory. Life Time was right not to keep charging people for helicopter static and one frozen pixel crossing Kansas, and remote gravel television really was a nasty technical problem. But the failure clarified the job. If you sell a series, broadcasting is not garnish. It is the connective tissue between Fuego, Unbound, Leadville, and Big Sugar. The later free productions mattered because Life Time eventually stopped asking whether gravel deserved television and started learning how to televise gravel.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed reporting establishes the six-race promise, purse, selection model, partial productions, cancellation, stated technical rationale, and later broadcast expansion. It does not disclose production budgets, contractual allocation of responsibility, subscriber counts, stream quality metrics, sponsor losses, or whether athlete applications materially depended on coverage. Audience figures for later broadcasts came from Life Time and platform measures are not equivalent to sustained unique viewers. The evidence supports a broken media promise and later capability growth, not bad faith or proof that live production alone made the series economically viable.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_lifetime_grand_prix_launch_and_broadcast_promise_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/fuego-80k-lights-up-life-time-grand-prix-on-saturday/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-04-07T20:28:19Z",
+      "quoteExcerpt": "All six off-road events in new US series with $250,000 purse to be broadcast live",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_broadcasts_ended_midseason_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/live-broadcasts-cancelled-for-final-three-life-time-grand-prix-events-in-2022/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-08-07T22:32:39Z",
+      "quoteExcerpt": "Live streaming has abruptly ended for the inaugural LifeTime Grand Prix",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_broadcast_technical_limits_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/live-broadcasts-cancelled-for-final-three-life-time-grand-prix-events-in-2022/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-08-07T22:32:39Z",
+      "quoteExcerpt": "technical limitations, course conditions and remote locations proved insurmountable",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_unbound_broadcast_audience_and_cameras_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/unbound-gravel-200-live-coverage-draws-more-than-300-000-views-in-50-countries/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-06-13T00:00:00Z",
+      "quoteExcerpt": "185,000 unique viewers tuned in",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_big_sugar_extended_finish_broadcast_2025",
+      "canonicalUrl": "https://www.cyclingweekly.com/gravel/watch-live-as-life-time-grand-prix-titles-are-decided-at-big-sugar-finale",
+      "publisher": "Cycling Weekly",
+      "publishedAt": "2025-10-02T00:00:00Z",
+      "quoteExcerpt": "finish line camera that will remain rolling through the 12-hour mark",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_start_to_finish_broadcast_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/profound-shakeups-spills-splashes-and-wild-wheel-changes-at-unbound-gravel-2026-conclusions-on-what-unravelled-and-what-worked/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-06-01T16:24:11Z",
+      "quoteExcerpt": "Going from an already extensive seven hours of coverage last year to the whole lot in 2026",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_leadville_full_broadcast_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/how-to-watch-gravel-races-around-the-world-a-guide-to-livestreams-and-free-broadcasts-for-the-biggest-events-including-the-traka-unbound-gravel-and-more/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-08-13T13:48:53Z",
+      "quoteExcerpt": "Leadville will have a full start-to-finish broadcast for elite men and women",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_lifetime_grand_prix_launch_and_broadcast_promise_2022",
+        "claim_lifetime_broadcasts_ended_midseason_2022",
+        "claim_unbound_broadcast_audience_and_cameras_2025",
+        "claim_unbound_start_to_finish_broadcast_2026"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:leadville-100",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_lifetime_broadcasts_ended_midseason_2022",
+        "claim_lifetime_broadcast_technical_limits_2022",
+        "claim_leadville_full_broadcast_2026"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:big-sugar-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_lifetime_broadcasts_ended_midseason_2022",
+        "claim_big_sugar_extended_finish_broadcast_2025"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T16:35:00Z",
+  "contentHash": "52c6a4ee3f2de5f3d538d36b0d0d8c645a5ab603fbfca8db2896ba8a5227df8e"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -656,8 +656,8 @@ def test_2022_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 173
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 6
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 9
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 38
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 11
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 36
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a private historical chapter about the Life Time Grand Prix launching as a televised season before its broadcast infrastructure could sustain the promise
- connect the 2022 failure to the later 2025–2026 capability curve without rewriting the contemporary record
- mark the two corresponding 2022 ledger weeks as covered and keep all race effects editorial-review-only

## Validation
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2022-life-time-tv-series.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2022.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q -k "history or backfill"`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and ledger metadata only; the chapter is draft and gated from public publish or automatic race updates.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history chapter (`history-life-time-tv-series-2022`) on the inaugural Life Time Grand Prix: the April 2022 promise of live worldwide coverage for all six races and the August cancellation of broadcasts for the final three events, framed as media as series infrastructure rather than marketing. The entry stays unpublished (`model_draft` take, `humanApprovalRequired`), cites contemporary and later (2025–2026) receipts, and records **editorial-review-only** race impacts for Unbound, Leadville, and Big Sugar—no auto race-field changes.
> 
> The **2022 backfill ledger** reclassifies two weeks (early April launch, early August cancellation) from `pending_review` to `covered_by_draft` with reasons tied to that story; ledger `updatedAt` bumps accordingly. **Tests** expect two more `covered_by_draft` weeks and two fewer `pending_review` on the 2022 ledger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 676f3a86c6350e67b03caa89dc947ffc5f214eb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->