### PR TITLE
Gravel Weekly: add 2022 Worlds launch chapter

### DIFF
--- a/data/gravel-weekly/backfill/2022.json
+++ b/data/gravel-weekly/backfill/2022.json
@@ -74,9 +74,11 @@
       "periodStartedAt": "2022-02-19",
       "periodEndedAt": "2022-02-25",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-worlds-qualifying-before-address-2022"
+      ],
+      "reason": "The leaked World Series calendar and premature Tuscany report opened the gap between the qualification product and the still-unsettled championship."
     },
     {
       "periodStartedAt": "2022-02-26",
@@ -106,17 +108,21 @@
       "periodStartedAt": "2022-03-19",
       "periodEndedAt": "2022-03-25",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-worlds-qualifying-before-address-2022"
+      ],
+      "reason": "The official 12-event series promised access to a World Championship whose venue was still deferred to a later announcement."
     },
     {
       "periodStartedAt": "2022-03-26",
       "periodEndedAt": "2022-04-01",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-worlds-qualifying-before-address-2022"
+      ],
+      "reason": "The UCI's opening-weekend preview confirmed that qualifying would begin with the championship date and location still unannounced."
     },
     {
       "periodStartedAt": "2022-04-02",
@@ -208,9 +214,10 @@
       "sourceCardCount": 12,
       "disposition": "covered_by_draft",
       "entryIds": [
-        "history-gravel-spirit-hr-job-2022"
+        "history-gravel-spirit-hr-job-2022",
+        "history-worlds-qualifying-before-address-2022"
       ],
-      "reason": "Women riders turned the equipment argument into the larger governance point: safety, drafting, and a separate race require organizer rules, not a men's agreement."
+      "reason": "Women riders showed why professional gravel needed organizer rules, while the official Veneto award showed that World Championship qualifiers had already begun before the destination was settled."
     },
     {
       "periodStartedAt": "2022-06-18",
@@ -310,9 +317,11 @@
       "periodStartedAt": "2022-09-03",
       "periodEndedAt": "2022-09-09",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-worlds-qualifying-before-address-2022"
+      ],
+      "reason": "The September 6 route release finally defined the championship test 32 days before the first race."
     },
     {
       "periodStartedAt": "2022-09-10",
@@ -457,5 +466,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T16:35:00Z"
+  "updatedAt": "2026-08-28T17:15:00Z"
 }

--- a/data/gravel-weekly/history/2022-worlds-qualifying-before-address.json
+++ b/data/gravel-weekly/history/2022-worlds-qualifying-before-address.json
@@ -1,0 +1,127 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-worlds-qualifying-before-address-2022",
+  "activeFrom": "2022-03-25",
+  "activeThrough": "2022-09-06",
+  "status": "draft",
+  "headline": "The UCI Opened Qualifying for a World Championship With No Address",
+  "point": "The UCI made gravel globally official in the wrong operational order: it created a qualification market before it had publicly settled the championship athletes were qualifying for. Early reporting put Worlds in Tuscany, the official series opened with the date and location still unannounced, the UCI named Veneto only after qualifiers had begun, and it released the route 32 days before the first race. The institution got to learn by shipping; riders became the staging environment.",
+  "priorJudgment": "The first UCI Gravel World Series gave an exploding discipline a legitimate global pathway to rainbow jerseys, and the incomplete details were normal teething problems for an inaugural event.",
+  "changedJudgment": "The global pathway was real and valuable, but its sequencing transferred uncertainty downward. A qualifier is not merely a race result; it can trigger travel, lodging, equipment, training, and national-federation decisions. Launching the credential before defining its destination and test made athletes absorb the institution's product-development risk.",
+  "stakes": "Age-group riders and privateers had to decide whether to pursue qualification, budget international travel, preserve calendar space, select equipment, and prepare for a championship whose host moved in public reporting and whose route arrived barely a month before racing. The sequence also established whether a new governing body would treat participant certainty as infrastructure or a nice-to-have.",
+  "credibleOpposition": "The UCI assembled a new worldwide series quickly, preserved broad equipment access, created age-group championship opportunities, and ultimately delivered eleven qualifiers and a championship in the same season. Early Tuscany reporting was not an official UCI award, so it cannot prove the governing body changed a confirmed venue. Athletes knew the event would be in Europe in autumn, many could qualify close to home, and new events necessarily launch with less lead time than mature championships. The evidence supports a public-certainty failure, not a claim that every rider suffered measurable financial harm or that the championship was illegitimate.",
+  "whatHappened": "On February 22, Cyclingnews reported a leaked 14-round calendar beginning in the Philippines on April 3. The next day it reported that the inaugural World Championships would be held on Tuscany's L'Eroica roads, while noting that final series details were still being agreed. On March 25, the official calendar contained 12 qualifiers and said the championship venue would be announced shortly. In its preview immediately before the April 3 opener, the UCI said the series would culminate in a World Championships whose date and location were still to be announced. Qualifying therefore began before athletes had an official destination. On June 16, after rounds in the Philippines, Australia, and France, the UCI awarded the October 8-9 championship to Italy's Veneto region while leaving the host cities for later. On September 6, 32 days before the women's race, it finally released the Vicenza-to-Cittadella routes, distances, elevation, category waves, and equipment rules. Eleven qualifier rounds ultimately fed the championship. In November 2022, Belgium could already name the start and finish of its 2024 edition, showing that long lead time was possible even if full distances remained pending. The 2023 championship then repeated the late-certainty problem with an organizer change and a full route released seventeen days before the women's race.",
+  "take": "Model draft, not Matti's approved view: Gravel became an official world sport in 2022 the way a restaurant appears on a delivery app while the kitchen is still receiving drywall. First came the leaked global calendar. Then Cyclingnews confidently sent everybody to Tuscany. Then the official series started in the Philippines with the UCI saying the World Championship's date and location would be announced later. This is an incredible product sequence: earn your invitation now; ask where the party is after checkout. Veneto arrived in June. The actual route arrived September 6, 32 days before racing. By then, amateurs and privateers were supposed to have converted a percentile finish into flights, lodging, equipment, training, and the calm certainty that international travel famously provides. The series was still a genuine achievement. Eleven qualifiers happened, people from around the world earned rainbow-jersey starts, and the championship existed by October. But the institution got to iterate in public because the riders absorbed the ambiguity in private. The UCI was not merely building gravel's front door. For most of 2022, it was handing out keys before it had posted the address.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The February Tuscany report described Cyclingnews's understanding, not a confirmed UCI award; the evidence does not establish whether Tuscany lost a finalized contract or whether negotiations simply changed. The reviewed sources establish public announcement timing, not what selected organizers, federations, or individual athletes knew privately. No audited participant-cost data ties the late details to specific losses, and the September route release was 32 days before the women's race and 33 before the men's. The Belgian 2024 announcement named start and finish nearly two years early but did not yet provide every distance or route detail. The claim is about institutional sequencing and transferred uncertainty, not secret intent or invalid results.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_world_series_calendar_leaked_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/new-uci-gravel-world-series-calendar-leaked-with-start-april-3-in-philippines/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-02-22T17:37:27Z",
+      "quoteExcerpt": "start on April 3 with a 14-event calendar",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_tuscany_early_report_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/first-edition-of-uci-gravel-world-championships-to-be-held-in-tuscany/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-02-23T18:03:12Z",
+      "quoteExcerpt": "inaugural edition of the UCI Gravel World Championships will be held in Tuscany",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_world_series_official_calendar_venue_later_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/uci-launches-12-event-2022-gravel-world-series/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-03-25T13:50:56Z",
+      "quoteExcerpt": "venue due to be announced shortly",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_qualifying_opens_without_worlds_destination_2022",
+      "canonicalUrl": "https://www.uci.org/article/2022-trek-uci-gravel-world-series-the-ultimate-cycling-for-all/5QhVQCAjsdByY8BVJhtOf1",
+      "publisher": "UCI",
+      "publishedAt": "2022-04-01T00:00:00Z",
+      "quoteExcerpt": "with date and location yet to be announced",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_veneto_host_cities_later_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/2022-uci-gravel-world-championships-to-be-held-in-veneto-region-of-italy/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-06-16T18:02:19Z",
+      "quoteExcerpt": "The host cities will be announced later",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_route_released_32_days_out_2022",
+      "canonicalUrl": "https://www.uci.org/pressrelease/the-uci-reveals-race-routes-for-first-uci-gravel-world-championships/iPrgqQjdvHWlQN0dyzxXW",
+      "publisher": "UCI",
+      "publishedAt": "2022-09-06T00:00:00Z",
+      "quoteExcerpt": "The races for the different categories will start in Vicenza",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_belgium_2024_start_finish_announced_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/belgium-reveals-2024-gravel-world-championship-course/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-11-23T10:21:13Z",
+      "quoteExcerpt": "Halle start and Leuven finish for 2024 rainbow jersey race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_worlds_2023_late_course_repeat",
+      "canonicalUrl": "https://www.cyclingnews.com/features/2023-uci-gravel-world-championships-conclusions/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-10-09T12:00:00Z",
+      "quoteExcerpt": "arguably improvised test events for the years to come",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-world-championships",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_world_series_calendar_leaked_2022",
+        "claim_worlds_tuscany_early_report_2022",
+        "claim_world_series_official_calendar_venue_later_2022",
+        "claim_qualifying_opens_without_worlds_destination_2022",
+        "claim_worlds_veneto_host_cities_later_2022",
+        "claim_worlds_route_released_32_days_out_2022",
+        "claim_belgium_2024_start_finish_announced_2022",
+        "claim_worlds_2023_late_course_repeat"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T17:15:00Z",
+  "contentHash": "45c14d5a77e310c4f7471d01d4b2984967bcf571e0582496b662fe556081ddd0"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -656,8 +656,8 @@ def test_2022_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 173
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 6
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 11
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 36
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 15
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 32
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a private historical chapter about the UCI opening World Championship qualification before publicly settling the destination and course
- distinguish early Tuscany reporting from an official award and preserve the strongest supported claim: uncertainty was transferred to riders
- account for four additional 2022 weeks while keeping the chapter and its race impact human-review-only

## Validation
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2022-worlds-qualifying-before-address.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2022.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q -k "history or backfill"`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill metadata only; no runtime or publish path changes, and the new chapter stays draft with human approval required.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history chapter (`history-worlds-qualifying-before-address-2022`) arguing the UCI launched Gravel World Series qualification before publicly fixing the championship host and course, with receipts, uncertainty bounds (Tuscany as reporting vs official award), and a **human-review-only** race impact on `gravel:uci-gravel-world-championships` `race.biased_opinion`.
> 
> The **2022 backfill ledger** marks four additional weeks as `covered_by_draft` for that entry (Feb leak/Tuscany reporting, March official calendar, April opener preview, September route release) and ties the June Veneto week to the same chapter alongside the existing aerobar draft. Ledger `updatedAt` and test expectations shift to **15** draft-covered weeks and **32** still `pending_review`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add605a11eb9cd22835040ef99187603a03c421c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->