### PR TITLE
Gravel Weekly: add 2022 Mo Wilson remembrance chapter

### DIFF
--- a/data/gravel-weekly/backfill/2022.json
+++ b/data/gravel-weekly/backfill/2022.json
@@ -92,9 +92,11 @@
       "periodStartedAt": "2022-03-05",
       "periodEndedAt": "2022-03-11",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-season-stops-for-mo-wilson-2022"
+      ],
+      "reason": "Wilson's third victory in three covered 2022 starts established the sporting trajectory that later memorial coverage must remember without turning it into a counterfactual résumé."
     },
     {
       "periodStartedAt": "2022-03-12",
@@ -178,25 +180,31 @@
       "periodStartedAt": "2022-05-14",
       "periodEndedAt": "2022-05-20",
       "sourceCardCount": 6,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-season-stops-for-mo-wilson-2022"
+      ],
+      "reason": "The report of Wilson's murder and the community's remembrance made the season stop being an ordinary sequence of competitive results."
     },
     {
       "periodStartedAt": "2022-05-21",
       "periodEndedAt": "2022-05-27",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-season-stops-for-mo-wilson-2022"
+      ],
+      "reason": "Wilson's family directed mourning toward youth access and joy, while a fellow racer redirected part of her prize money into that memorial work."
     },
     {
       "periodStartedAt": "2022-05-28",
       "periodEndedAt": "2022-06-03",
       "sourceCardCount": 12,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-season-stops-for-mo-wilson-2022"
+      ],
+      "reason": "Grief remained inside Unbound week, culminating in a pre-dawn tribute where elite and amateur riders listened to Wilson's words and stopped together."
     },
     {
       "periodStartedAt": "2022-06-04",
@@ -466,5 +474,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T17:15:00Z"
+  "updatedAt": "2026-08-28T18:00:00Z"
 }

--- a/data/gravel-weekly/history/2022-season-stops-for-mo-wilson.json
+++ b/data/gravel-weekly/history/2022-season-stops-for-mo-wilson.json
@@ -1,0 +1,131 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-season-stops-for-mo-wilson-2022",
+  "activeFrom": "2022-03-07",
+  "activeThrough": "2022-06-03",
+  "status": "draft",
+  "headline": "The Season Has to Stop Here for Mo Wilson",
+  "point": "A 2022 timeline that treats Moriah 'Mo' Wilson's murder as another news card fails both its subject and the season. Wilson was winning, leading the inaugural Life Time Grand Prix, preparing to race full-time, and favored for Unbound when she was killed. The meaningful gravel story is not a counterfactual trophy count or a true-crime recap. It is that the sport's claim to community became observable behavior when her family, riders, and organizers made room for grief inside a calendar that still had to continue.",
+  "priorJudgment": "The defining 2022 gravel narrative was the sport's rapid professionalization: new series, bigger purses, international governance, and the athletes who won the landmark races.",
+  "changedJudgment": "Professionalization explains the season's machinery but not its center of gravity. Wilson's death changed how races felt and what the community asked racing to hold. Any honest history of 2022 has to pause the competitive story, remember a person rather than an unrealized résumé, and document how mourning became collective action.",
+  "stakes": "Wilson's dignity, her family's stated wishes, the historical record of women's gravel, whether memorial coverage preserves a life rather than exploiting a murder, and whether 'community' means anything when a sport is forced to respond to violence and loss.",
+  "credibleOpposition": "Wilson's family expressly said they wanted events to carry on and hoped riders would feel her support while chasing their own dreams. Continuing to race was therefore not evidence of indifference, and no single tragedy should be used to claim that every athlete experienced the season identically. Competitive results still belong in the record. The editorial obligation is to give this event proportion and humanity, not to make all of 2022 about grief, infer private feelings, sensationalize the criminal case, or convert Wilson into a symbol she did not choose.",
+  "whatHappened": "On March 5, Wilson won the Shasta Gravel Hugger, her third victory in three 2022 starts covered by Cyclingnews. By May she had also won Fuego 80K, taken the first women's lead in the inaugural Life Time Grand Prix, and won Belgian Waffle Ride California. She was preparing for Gravel Locos and Unbound and planned to move from her Specialized job into full-time racing in June. Wilson was murdered in Austin on May 11; Cyclingnews reported the homicide on May 14. She was 25. Her family asked people to celebrate her life and said the racing should continue. Gravel Locos began with a moment of silence, riders described struggling to race through grief, and Flavia Oliveira Parks later donated part of her Paydirt winnings to the memorial fundraiser. Wilson's family directed that fund toward youth confidence, strength, and joy through cycling, skiing, and other activities she loved. Ahead of Unbound, riders described the loss as having a profound effect on the community. On June 3, more than 100 elite and amateur riders joined a pre-dawn tribute ride in Emporia, carried Ride Like Mo stickers and ribbons, listened to Wilson's own words, and stopped for silence. In August, Kingdom Trails dedicated Moriah's Ascent, built with youth and women volunteers, in her memory. In November 2023, a Travis County jury convicted Kaitlin Armstrong of Wilson's murder and assessed a 90-year prison sentence; the verdict established legal responsibility but did not turn the loss into a finished story.",
+  "take": "Model draft, not Matti's approved view: There is no joke in this one, and there should not be. In March, Mo Wilson was winning everything in front of her. By May, she led the first Life Time Grand Prix, was the favorite for Unbound, and was preparing to become a full-time professional. Then she was murdered. A worse version of sportswriting turns that into the theft of a championship arc: imagine what she would have won. That is not the loss. The loss is Mo Wilson—the skier, cyclist, friend, daughter, sister, and 25-year-old person whose future belonged to her, not to our projected results page. The calendar did what calendars do and kept moving. Her family said it should. But gravel did not pretend the next starting gun reset the world. People cried at Gravel Locos. Flavia Oliveira Parks gave away part of her winnings. Wilson's family began turning grief toward youth access and joy. Before Unbound, more than 100 people rode into the Kansas sunrise, stopped, listened to Mo's words, and were quiet together. 'Community' is usually sponsor copy until something terrible happens and people have to prove it. In 2022, gravel proved it by making room for grief inside the race itself. A historical timeline should do the same: stop, say her name, remember who she was, and refuse to turn her unrealized future into a statistic.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The evidence establishes Wilson's results, planned move to full-time racing, community tributes, family fundraiser, trail dedication, and the later conviction and sentence. It cannot establish what Wilson would have won, how every rider experienced the loss, or whether every public tribute matched her family's private wishes. 'Favorite for Unbound' is contemporary journalistic assessment, not a prediction that can be audited. The later verdict establishes criminal responsibility under the adjudicated case; this entry intentionally omits disputed or sensational details that are unnecessary to the gravel history. The foundation and memorial work continue beyond the active period, so they are evidence of legacy rather than proof that grief was resolved.",
+  "editorialScore": 100,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_wilson_third_2022_win_shasta",
+      "canonicalUrl": "https://www.cyclingnews.com/news/wilson-and-wurtz-continue-winning-streaks-at-shasta-gravel-hugger/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-03-07T15:20:54Z",
+      "quoteExcerpt": "Moriah Wilson races to her third win of 2022",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_wilson_murder_reported_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/us-gravel-star-moriah-wilson-killed-in-texas/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-05-14T14:22:30Z",
+      "quoteExcerpt": "Police rule death of 25-year-old a homicide",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_wilson_rise_full_time_plan_and_tributes_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/all-light-and-laughter-remembering-moriah-wilson/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-05-16T00:00:00Z",
+      "quoteExcerpt": "ready to progress to full-time racing in June ahead of Unbound Gravel",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_wilson_family_youth_fund_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/family-launch-moriah-wilson-fund-to-honour-her-memory/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-05-23T00:00:00Z",
+      "quoteExcerpt": "help youth find self-confidence, strength, and joy",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_parks_donates_winnings_to_wilson_fund_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/oliveira-parks-wins-womens-payout-at-stetinas-carson-city-paydirt/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-05-23T00:00:00Z",
+      "quoteExcerpt": "donates part of winnings to Moriah 'Mo' Wilson fundraiser",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_community_grieves_before_unbound_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/gravel-racers-flock-to-unbound-as-community-grieves-for-mo-wilson/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-06-01T14:15:30Z",
+      "quoteExcerpt": "It has had a profound effect",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_sunrise_tribute_for_wilson_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/sunrise-tribute-spin-for-mo-day-before-unbound-gravel-gallery/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-06-03T18:41:32Z",
+      "quoteExcerpt": "More than a hundred elite and amateur riders turned out",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_moriahs_ascent_trail_dedication_2022",
+      "canonicalUrl": "https://www.kingdomtrails.org/new-trail-moriah-s-ascent-now-open",
+      "publisher": "Kingdom Trails",
+      "publishedAt": "2022-08-11T00:00:00Z",
+      "quoteExcerpt": "create a lasting memory for Moriah",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_armstrong_conviction_and_sentence_2023",
+      "canonicalUrl": "https://districtattorney.traviscountytx.gov/travis-county-das-office-secures-guilty-verdict-for-woman-charged-with-murder/",
+      "publisher": "Travis County District Attorney",
+      "publishedAt": "2023-11-16T00:00:00Z",
+      "quoteExcerpt": "jury convicted Kaitlin Armstrong, 35, of Murder",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_wilson_rise_full_time_plan_and_tributes_2022",
+        "claim_gravel_community_grieves_before_unbound_2022",
+        "claim_unbound_sunrise_tribute_for_wilson_2022"
+      ],
+      "confidence": 0.99,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T18:00:00Z",
+  "contentHash": "a89bb248324f02b9b3e2ba6b29f620ca946835314f8aae89bd0c37b8c3a75dc6"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -656,8 +656,8 @@ def test_2022_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 173
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 6
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 15
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 32
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 19
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 28
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a private, restrained historical chapter that pauses the 2022 competitive narrative for Moriah Wilson
- center Wilson as a person and document the community response without speculative career projections or sensational criminal detail
- connect the Unbound sunrise tribute to review-only race history and account for four additional 2022 windows

## Safety
- model draft only; human approval remains required
- no automatic publication or race-profile write
- later legal outcome is sourced to the Travis County District Attorney

## Validation
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2022-season-stops-for-mo-wilson.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2022.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q -k "history or backfill"`
- `PYTHONPATH=wordpress python3 -c "...slop_rules.check_text..."` (headline, point, facts, take, uncertainty: clean)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sensitive memorial and homicide content with editorial guardrails, but mis-handling could harm dignity or imply publication; race-profile impacts are review-only and still need human sign-off.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history entry (`history-season-stops-for-mo-wilson-2022`) that reframes 2022 around Moriah Wilson’s competitive rise, her death, and how the community grieved—explicitly avoiding counterfactual results pages and sensational crime detail. The entry is sourced with contemporary Cyclingnews receipts plus bounded later evidence (trail dedication, Travis County conviction), stays `model_draft` with **human approval required** and **no auto-publish**, and registers a **review-only** `raceImpacts` hook on `gravel:unbound-gravel-200` (`race.biased_opinion`, `autoFixAllowed: false`).
> 
> The **2022 backfill ledger** reclassifies **four** weekly windows (early March through Unbound week) from `pending_review` to `covered_by_draft`, each pointing at that entry with week-specific reasons; `updatedAt` is bumped. **`test_2022_backfill_ledger_starts_from_the_complete_source_census`** expectations move to **19** `covered_by_draft` and **28** `pending_review` weeks (ledger still `complete: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df7cfe0cb9416b385395d07deace861a587f4284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->