### PR TITLE
Gravel Weekly: add 2022 Onweller career-market chapter

### DIFF
--- a/data/gravel-weekly/backfill/2022.json
+++ b/data/gravel-weekly/backfill/2022.json
@@ -391,9 +391,11 @@
       "periodStartedAt": "2022-10-22",
       "periodEndedAt": "2022-10-28",
       "sourceCardCount": 11,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-onweller-career-bet-2022"
+      ],
+      "reason": "Onweller's Big Sugar win converted an athlete-funded career bet into prize money, sponsor interest, and a durable professional pathway."
     },
     {
       "periodStartedAt": "2022-10-29",

--- a/data/gravel-weekly/history/2022-onweller-career-bet.json
+++ b/data/gravel-weekly/history/2022-onweller-career-bet.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-onweller-career-bet-2022",
+  "activeFrom": "2022-10-22",
+  "activeThrough": "2022-11-04",
+  "status": "draft",
+  "headline": "Paige Onweller Bet Her ER Career Before Gravel Knew Her Name",
+  "point": "Paige Onweller's 2022 Big Sugar win showed what the inaugural Life Time Grand Prix could do that a normal results calendar could not: turn an unfamiliar rider into legible professional talent in one afternoon. But the sequence matters. Onweller decided to leave an eight-year physician-assistant career before the breakthrough. The win moved her from outside the series money to a $7,000 payout and helped produce sponsor offers, but she had already accepted the career risk that made discovery possible. Gravel built a talent market; the athlete supplied its venture capital.",
+  "priorJudgment": "The inaugural Grand Prix mainly formalized a hierarchy among athletes who were already established, using invitations, standings, and equal prize money to determine which known stars had the best season.",
+  "changedJudgment": "The series also became a discovery and career-conversion mechanism. A single visible result against a selected field could translate raw ability into prize money, sponsor confidence, and a full-time pathway. That was real opportunity, but it arrived after the athlete had funded the learning curve and chosen to bear the downside herself.",
+  "stakes": "Who gets recognized as professional talent, whether late entrants and athletes from outside cycling's normal pipeline can become economically legible, how much personal risk precedes sponsor support, what equal prize money changes materially, and whether a season series creates careers rather than merely ranking them.",
+  "credibleOpposition": "Onweller was not an anonymous lottery winner. She had elite running ability, esports experience, a coach, strong gravel results, and an invitation to the Grand Prix before Big Sugar. She had already decided to leave medicine, so the race did not cause her career change, and her exceptional physical talent makes her a poor template for ordinary riders. A sponsor announcement also cannot prove that one result alone created every offer. The defensible claim is narrower: Big Sugar publicly validated her bet and materially improved the market around it.",
+  "whatHappened": "Onweller had barely ridden before 2020, learned racing through Zwift, and called 2021 Gravel Worlds her first mass-start race. She entered the inaugural 2022 Life Time Grand Prix while still working as a physician assistant in a hospital emergency room and coaching athletes. Knee surgery disrupted the spring, she did not finish Unbound, and she started the Big Sugar finale twelfth in the standings, outside the top-ten payout. On October 22 she attacked alone and won the 104-mile race by more than six minutes. The result lifted her to ninth overall and changed her series earnings from zero to $7,000. Contemporary reporting said she had enough support to race full-time and had submitted notice at the hospital. Her later account clarified the chronology: she had decided before Big Sugar to pause medicine and race full-time, while the win validated that decision and was followed by many offers and opportunities. Trek signed her to its Driftless gravel program for 2023. She remained there through 2026, after finishing third at Unbound and third overall in the 2024 Grand Prix.",
+  "take": "Model draft, not Matti's approved view: Paige Onweller followed gravel's most responsible career plan. Step one: barely ride a bike until 2020. Step two: learn tactics on a video game because riding outside is terrifying. Step three: work hospital ER shifts while teaching yourself to corner. Step four: decide to leave an eight-year medical career before the sport has offered enough evidence that this is sane. Then win Big Sugar by six minutes. Onweller entered the finale twelfth in the Grand Prix, which is a prestigious way to say outside the money. She left ninth, $7,000 richer, and suddenly interesting to sponsors who had apparently discovered that a two-year cyclist capable of detonating a selected pro field might be marketable. The win did not make her brave decision for her. That is the point. She had already made it. Big Sugar converted private conviction into public proof, and the first Grand Prix showed it could function as something more useful than a season-long trophy shelf: a labor market with a finish line. This is the beautiful and slightly deranged promise of professional gravel. The pathway was open enough for an ER physician assistant who learned on Zwift to become a full-time pro. It was also open in the manner of a startup funding round, where the athlete contributes the idea, labor, savings, risk, and proof of concept before the industry arrives holding a branded hat.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources establish Onweller's background, decision to leave medicine, Big Sugar result, movement from twelfth to ninth, $7,000 payout, later sponsor offers, Trek signing, and continued career. They differ slightly in presentation: immediate reporting said she had submitted notice after securing enough support, while her later first-person account said she decided before Big Sugar and that the win validated the choice. The evidence does not identify every sponsor offer, disclose contract values, isolate Big Sugar from her full 2022 results, or show that the Grand Prix offers the same pathway to less-resourced athletes. 'Talent market' is an editorial interpretation of the observed conversion from performance to support, not a formal series promise.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_onweller_big_sugar_win_and_payout_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/big-sugar-gravel-winner-paige-onweller-on-the-radar-for-pro-contract/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-10-23T19:13:43Z",
+      "quoteExcerpt": "moved Onweller from 12th to ninth in the six-race series, which translated from zero dollars to $7,000",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_onweller_solo_margin_big_sugar_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/races/big-sugar-gravel-2022/pro-women/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-10-25T14:34:22Z",
+      "quoteExcerpt": "She finished the race six minutes ahead of runner-up Emily Newsom",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_onweller_support_to_race_full_time_2022",
+      "canonicalUrl": "https://www.cyclingweekly.com/news/one-womans-journey-from-newbie-zwift-rider-to-gravel-pro-in-two-years",
+      "publisher": "Cycling Weekly",
+      "publishedAt": "2022-11-04T19:18:19Z",
+      "quoteExcerpt": "I have enough support to ride full-time now",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_onweller_decided_before_win_and_signed_trek_2023",
+      "canonicalUrl": "https://racing.trekbikes.com/stories/driftless/paige-onweller-is-treks-newest-gravel-rider",
+      "publisher": "Trek Race Shop",
+      "publishedAt": "2023-02-22T16:07:31Z",
+      "quoteExcerpt": "I had a lot of offers and opportunities after the season, and especially after Big Sugar",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_onweller_fourth_trek_year_and_2024_series_third_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/a-team-that-can-thrive-together-paige-onweller-and-toby-roed-anchor-trek-driftless-off-road-team-with-three-new-teammates-and-a-focus-on-us-gravel-races/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-01-29T20:40:17Z",
+      "quoteExcerpt": "entering my fourth year on the team",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:big-sugar-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_onweller_big_sugar_win_and_payout_2022",
+        "claim_onweller_solo_margin_big_sugar_2022",
+        "claim_onweller_support_to_race_full_time_2022",
+        "claim_onweller_decided_before_win_and_signed_trek_2023",
+        "claim_onweller_fourth_trek_year_and_2024_series_third_2026"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T19:05:00Z",
+  "contentHash": "3acfabc749df4f31dc0895470104f1c0b7a94587e61fcc7ac0f6d5c1fb2a4373"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -656,8 +656,8 @@ def test_2022_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 173
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 6
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 20
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 27
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 21
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 26
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a held historical chapter on Paige Onweller’s Big Sugar breakthrough and the athlete-funded risk behind it
- ground the result-to-career conversion in contemporary Cyclingnews/Cycling Weekly reporting and later Trek evidence
- mark the October 22 source window covered while preserving human approval and review-only race impacts

## Validation
- `python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2022-onweller-career-bet.json`
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2022.json`
- `python3 -m pytest -q tests/test_gravel_weekly.py`
- `wordpress/slop_rules.py` checks on headline, point, whatHappened, take, and uncertainty
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill accounting only; no runtime, auth, or auto-publish paths change.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history chapter (`history-onweller-career-bet-2022`) framing Paige Onweller’s 2022 Big Sugar win as career validation after she had already left medicine—not as the cause of that bet. The piece argues the inaugural Life Time Grand Prix could convert a single visible result into prize money and sponsor legibility, with receipts from contemporary Cyclingnews/Cycling Weekly coverage and later Trek/Cyclingnews follow-ups.
> 
> The **2022 backfill ledger** moves the Oct 22–28 source window from `pending_review` to `covered_by_draft` and links that week to the new entry. The chapter stays non-publishable (`status: draft`, `humanApprovalRequired`, `autoPublishAllowed: false`) and only proposes a **review-only** race impact on `gravel:big-sugar-gravel` (`race.biased_opinion`), with no auto-fix.
> 
> **Tests** update expected 2022 ledger disposition counts (`covered_by_draft` 21, `pending_review` 26).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f6d943ab74e76f4b9bc2c6e9363859838ff6b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->