### PR TITLE
Gravel Weekly: add 2022 teamification warning

### DIFF
--- a/data/gravel-weekly/backfill/2022.json
+++ b/data/gravel-weekly/backfill/2022.json
@@ -275,9 +275,10 @@
       "sourceCardCount": 5,
       "disposition": "covered_by_draft",
       "entryIds": [
-        "history-road-racing-gravel-jump-scare-2022"
+        "history-road-racing-gravel-jump-scare-2022",
+        "history-haas-saw-teams-coming-2022"
       ],
-      "reason": "The Tour de France Femmes gravel stage supplied the experiment: equipment and handling rewarded Ewers while mechanicals and a frantic team-car recovery compounded Garcia's loss."
+      "reason": "The Tour de France Femmes gravel stage exposed road-racing risk, while The Rift gave Haas the tactical evidence for his later warning that organized gravel teams were already changing the competitive field."
     },
     {
       "periodStartedAt": "2022-07-30",
@@ -441,9 +442,11 @@
       "periodStartedAt": "2022-12-03",
       "periodEndedAt": "2022-12-09",
       "sourceCardCount": 6,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-haas-saw-teams-coming-2022"
+      ],
+      "reason": "Haas used his The Rift win to identify teamification as an incentive problem and called for roster or rulebook limits four years before team tactics became an explicit Unbound issue."
     },
     {
       "periodStartedAt": "2022-12-10",

--- a/data/gravel-weekly/history/2022-haas-saw-teams-coming.json
+++ b/data/gravel-weekly/history/2022-haas-saw-teams-coming.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-haas-saw-teams-coming-2022",
+  "activeFrom": "2022-07-25",
+  "activeThrough": "2022-12-08",
+  "status": "draft",
+  "headline": "Nathan Haas Saw Gravel Teams Coming Four Years Early",
+  "point": "At The Rift in 2022, Nathan Haas watched organized riders control positioning, decline chase work, and use numbers around feeds while he raced alone. He won anyway, then made the prediction gravel preferred not to hear: teams were inevitable, and organizers needed to regulate the advantage rather than defend individualism as a vibe. By 2026, team structures filled elite fields and a teammate's wheel sacrifice decided Unbound. Haas had not imported the future from road racing. He had recognized incentives already operating in gravel.",
+  "priorJudgment": "Early gravel teams were mostly shared branding and support. The terrain was too selective, the fields too fluid, and the culture too individualistic for organized tactics to become decisive in the way they were on the road.",
+  "changedJudgment": "The relevant question was never whether gravel terrain allowed a Tour de France lead-out. Shared objectives already changed positioning, chasing, feeding, equipment access, and which riders spent energy. Teamification did not require gravel to become road racing; it only required professional rewards large enough for cooperation to be rational.",
+  "stakes": "Whether independent riders compete on a legible field, how many athletes one sponsor can deploy, whether teammates may exchange equipment or withhold chase work, what support organizers must equalize, whether team riders receive labor protections, and whether gravel can professionalize without hiding the structure of its competition.",
+  "credibleOpposition": "Haas brought a decade of WorldTour experience and was predisposed to interpret matching jerseys tactically. Cooperation among friends and sponsors predates formal teams, The Rift's selective terrain limited what numbers could accomplish, and Haas's solo victory showed that the strongest individual could still win. The 2026 Unbound result does not prove every race is now controlled by teams. It does show that Haas's rulemaking question was substantive rather than speculative.",
+  "whatHappened": "Haas entered The Rift as a privateer in July 2022. The published results listed multiple riders from Mazda Lauf and Café du Cycliste, while Haas won the 200-kilometer men's race in a sprint. In a December account, he explained what the results page could not: Mazda Lauf moved five riders toward the first technical section, declined to chase when a teammate was ahead, and used numbers around a feed-zone interruption. Haas and other individuals had to decide whether to cooperate against organized interests. He still won, but concluded that teams were already present, would grow with industry investment, and should face roster or rulebook limits to preserve a fair field. By May 2024, Haas reported that elite starts were roughly split between team riders and privateers and raised the absence of employment standards and governing oversight. In 2026, a surge of named teams revived the competitive and community questions he had identified. At Unbound, Keegan Swenson gave his wheel and his own winning chance to Specialized teammate Mads Würtz Schmidt, Matt Beers did not help chase, and the team finished first, second, and fifth.",
+  "take": "Model draft, not Matti's approved view: Gravel treated teams in 2022 like teenagers treat the smell of weed in their parents' basement. Everybody knew what was happening; nobody wanted to be the adult who named it. Nathan Haas had spent a decade in the WorldTour, so when five Mazda Lauf riders moved together before The Rift's first technical section, he did not assume they had independently developed the same urgent interest in road position. He watched teammates stop chasing teammates, watched numbers change the feed-zone math, won the race alone anyway, and still reached the non-romantic conclusion: the teams are coming. Gravel heard the victory and ignored the warning. See, the privateer won. Spirit preserved. Haas's actual point was that a team advantage does not need to guarantee victory before it deserves rules. It only needs to change who works, who waits, who gets fed, who receives a wheel, and who absorbs the cost of racing alone. Four years later, Swenson handed Würtz Schmidt a wheel and effectively transferred his own Unbound candidacy to the team's strongest remaining asset. Specialized went 1-2-5. Haas was not a roadie trying to make gravel boring. He was the smoke alarm. The funny part is that gravel spent four years objecting to the noise while the basement filled with matching jerseys.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The 2022 result and Haas's detailed first-person account establish the observed teams, tactics, his win, and his prediction. His account is one participant's interpretation and does not disclose formal instructions, team contracts, budgets, or the intent of every rider he described. Later reporting establishes growth in team participation and the 2026 Unbound wheel exchange, but not that The Rift caused those developments or that team tactics decide most races. The exact comparison 'four years early' refers to the visible 2026 surge and Unbound example, not the first existence of collaboration in gravel. The argument concerns transparent rules for organized advantage, not a claim that cooperation is inherently illegitimate.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_haas_wins_the_rift_against_team_riders_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/races/the-rift-gravel-race-iceland-2022/200k-pro-elite/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-07-25T00:51:36Z",
+      "quoteExcerpt": "Haas out-kicked Zavyalov to take the victory",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haas_identifies_team_tactics_and_calls_for_rules_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/blogs/nathan-haas/nathan-haas-blog-the-inevitable-rise-of-teamwork-in-gravel-racing/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-12-08T14:06:29Z",
+      "quoteExcerpt": "for the benefit of all riders, individuals and teams, it would be great to see the 'gravel commissaires' ensure a fair battleground",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_haas_reports_team_privateer_split_and_governance_gap_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/features/nathan-haas-blog-who-is-responsible-if-sht-hits-the-fan-in-gravel-teams/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-05-31T00:00:00Z",
+      "quoteExcerpt": "the norm is as much to be on a gravel team as it is to be a privateer",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haas_team_warning_becomes_2026_field_debate",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/a-loss-of-community-two-tier-finances-and-a-tactical-conundrum-are-professional-teams-reshaping-the-gravel-scene/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-26T00:00:00Z",
+      "quoteExcerpt": "You can't just say you're for community; you have to be for community",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_swenson_wheel_sacrifice_confirms_team_unit_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/if-i-give-him-the-wheel-he-can-win-the-story-of-keegan-swensons-sacrifice-to-help-mads-wurtz-schmidt-triumph-at-unbound-gravel-200/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-31T00:00:00Z",
+      "quoteExcerpt": "the goal was that one of us had to win the race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:the-rift",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_haas_wins_the_rift_against_team_riders_2022",
+        "claim_haas_identifies_team_tactics_and_calls_for_rules_2022",
+        "claim_haas_reports_team_privateer_split_and_governance_gap_2024",
+        "claim_haas_team_warning_becomes_2026_field_debate",
+        "claim_swenson_wheel_sacrifice_confirms_team_unit_2026"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T19:35:00Z",
+  "contentHash": "8659a133d7c8caa855bbb76307992a2b98cd36246d8e689185533aa48a66a8bb"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -656,8 +656,8 @@ def test_2022_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 173
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 6
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 21
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 26
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 22
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 25
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a held historical chapter tracing Nathan Haas’s 2022 The Rift observations to gravel teamification
- ground the point in his win, first-person tactical account, 2024 governance follow-up, and the 2026 Unbound wheel sacrifice
- cover the December teamwork window and enrich the already-covered Rift week without publishing or changing race data

## Validation
- `python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2022-haas-saw-teams-coming.json`
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2022.json`
- `python3 -m pytest -q tests/test_gravel_weekly.py`
- `wordpress/slop_rules.py` checks on editorial fields
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill metadata only; no publish path or automated race-data changes.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history entry (`history-haas-saw-teams-coming-2022`) that frames Nathan Haas’s 2022 The Rift win and December Cyclingnews account as an early warning on gravel team tactics and governance, with later receipts through 2024–2026 (including Unbound wheel sacrifice). The entry stays unpublished (`status: draft`, `humanApprovalRequired`, model-draft take) and flags an editorial-review race impact on `gravel:the-rift` without auto-fix.
> 
> The **2022 backfill ledger** now maps that draft to two windows: the late-July Rift week (alongside the existing road-racing gravel chapter) and early December (Haas’s teamwork blog), shifting one week from `pending_review` to `covered_by_draft`. **Tests** bump the expected 2022 ledger counts for `covered_by_draft` (22) and `pending_review` (25).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ed3d31965ede997298a5cb82e00a25ab270e10c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->