### PR TITLE
Gravel Weekly: add Nannup's 2022 Worlds origin

### DIFF
--- a/data/gravel-weekly/backfill/2022.json
+++ b/data/gravel-weekly/backfill/2022.json
@@ -172,9 +172,11 @@
       "periodStartedAt": "2022-05-07",
       "periodEndedAt": "2022-05-13",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-nannup-built-worlds-2022"
+      ],
+      "reason": "SEVEN entered the inaugural World Series with four editions, a thousand-rider local base, and explicit World Championship ambition already built in Nannup."
     },
     {
       "periodStartedAt": "2022-05-14",
@@ -364,9 +366,10 @@
       "sourceCardCount": 7,
       "disposition": "covered_by_draft",
       "entryIds": [
-        "history-gravel-worlds-road-settings-2022"
+        "history-gravel-worlds-road-settings-2022",
+        "history-nannup-built-worlds-2022"
       ],
-      "reason": "The entry list, road-bike selections, and course design exposed how much of road cycling's status and equipment logic the inaugural championship imported."
+      "reason": "The inaugural championship imported road cycling's status and equipment logic, while the Nannup award showed a locally built World Series race becoming the first future Worlds venue outside Europe."
     },
     {
       "periodStartedAt": "2022-10-08",

--- a/data/gravel-weekly/history/2022-nannup-built-worlds.json
+++ b/data/gravel-weekly/history/2022-nannup-built-worlds.json
@@ -1,0 +1,120 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-nannup-built-worlds-2022",
+  "activeFrom": "2022-05-13",
+  "activeThrough": "2022-10-01",
+  "status": "draft",
+  "headline": "Nannup Built a World Championship While the UCI Was Still Looking for One",
+  "point": "The UCI's most credible act of gravel globalization in 2022 was recognizing infrastructure it did not create. While the inaugural championship's location remained unresolved, Nannup's SEVEN entered the World Series with four editions, more than a thousand riders, an established local base, and a course severe enough to expose unknown talent. Four months after the race, the UCI awarded that small Western Australian town the 2026 Worlds—the first outside Europe. Global gravel worked when the governing body followed a local event that had already proved the place.",
+  "priorJudgment": "The UCI World Series created an international gravel circuit by extending a global credential, qualification rules, and championship pathway to otherwise regional races.",
+  "changedJudgment": "The strongest early round reversed that authorship. SEVEN's terrain, community participation, event operations, and ambition existed before the UCI label; the series amplified a locally built race and then adopted its home as a World Championship venue. The global institution added reach, but Nannup supplied the proof.",
+  "stakes": "What 'global' means outside Europe and North America, whether host selection preserves local race character, how international status changes a small community and organizer's costs, whether established mass participation remains central, and whether governing bodies reward durable local capability or merely relocate a branded product.",
+  "credibleOpposition": "UCI recognition, qualification access, federation support, tourism funding, and the World Championship award materially expanded SEVEN's reach; the local race did not become a global event alone. Host awards also depend on bids, government backing, logistics, finance, and federation politics that a race result cannot prove. Nannup's remoteness creates large travel costs, and a strong local event does not guarantee that every championship decision will preserve its culture or course. The claim is that local capability preceded and justified the credential, not that the institution contributed nothing.",
+  "whatHappened": "SEVEN began in Nannup in 2018 with 237 riders and exceeded one thousand by 2021 despite Western Australia's border closure. The town sits about 250 kilometers south of Perth, had roughly 1,300 shire residents, and advertised 387 unsealed kilometers among 536 kilometers of roads. Organizers built a 125-kilometer course with more than 3,000 meters of climbing, gradients touching 20 percent, and only a few paved kilometers. On May 15, 2022, it hosted the second round of the inaugural UCI Gravel World Series. Twenty-three-year-old Adam Blazevic dropped WorldTour veteran Nathan Haas to win, while Maria Madigan took her third SEVEN victory. In September, the UCI awarded Nannup the 2026 Gravel World Championships; Cyclingnews reported the decision October 1, before the first Worlds had even occurred. Nannup would become the championship's first host outside Europe. The 2026 routes retained SEVEN's Blackwood Valley terrain, exceeded 80 percent gravel, and carried more than 3,000 meters of climbing. More than 2,000 riders entered the May 2026 SEVEN preview event.",
+  "take": "Model draft, not Matti's approved view: The UCI spent spring 2022 trying to locate its first Gravel World Championship. Nannup spent it running one in everything but jersey color. This was a Western Australian town whose shire website could advertise 387 kilometers of unsealed road, which is either tourism copy or a municipal confession. SEVEN had started with 237 riders in 2018, cleared a thousand during closed-border pandemic years, and built a 125-kilometer course with 3,000 meters of climbing and gradients that touched 20 percent. Then the new World Series arrived and discovered the venue was already ready for a global championship. A 23-year-old local multi-discipline rider dropped Nathan Haas. The mass-participation field filled the roads. Four months later, the UCI awarded Nannup the 2026 World Championships, the first edition outside Europe. This is what globalization looks like when it is not a blazer parachuting into a postcode with a logo pack. The institution did not manufacture gravel in Nannup. It noticed that organizers, riders, terrain, and a small town had already done the expensive part. The UCI brought the rainbow jerseys. Nannup had built the race they deserved to land on.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources establish SEVEN's growth, course, 2022 World Series role and results, the 2026 award, and the later championship route. Participation figures vary slightly by source and stage of registration: contemporary reporting described 237 inaugural riders and more than 1,000 in 2021, while a later organizer filing reported 235 and 1,052. This entry uses the contemporary rounded figures. The evidence does not disclose the full bid evaluation, public subsidy, host contract, economic impact, or every factor in the UCI award. 'Ready for a global championship' and 'supplied the proof' are editorial judgments grounded in the event's demonstrated scale and subsequent selection, not a claim that race quality alone secured the championship.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_seven_local_scale_course_and_worlds_ambition_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/features/gravel-world-series-nannup-finding-gravel-gold-in-western-australia/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-05-13T01:34:02Z",
+      "quoteExcerpt": "The competitors thought so too, with the 237 that turned up in the first year, 2018, quickly growing to over 1,000",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_blazevic_madigan_win_seven_2022",
+      "canonicalUrl": "https://ucigravelworldseries.com/en/blazevic-and-madigan-to-win-seven/",
+      "publisher": "UCI Gravel World Series",
+      "publishedAt": "2022-05-16T00:00:00Z",
+      "quoteExcerpt": "The second UCI Gravel World Series event took place this past weekend in Nannup, Western Australia",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_nannup_awarded_2026_worlds_2022",
+      "canonicalUrl": "https://ucigravelworldseries.com/en/next-4-uci-gravel-world-championships-awarded/",
+      "publisher": "UCI Gravel World Series",
+      "publishedAt": "2022-09-22T00:00:00Z",
+      "quoteExcerpt": "Nannup in Western Australia has been awarded the UCI Gravel World Championships in 2026",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_nannup_first_worlds_outside_europe_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/australia-farewells-one-world-championships-and-gains-another/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-10-01T21:04:51Z",
+      "quoteExcerpt": "the first UCI Gravel World Championships outside Europe",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_nannup_worlds_route_preserves_seven_terrain_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/uci-gravel-world-championships-2026-route/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-04-16T01:07:06Z",
+      "quoteExcerpt": "many of the features that have become familiar to riders of the SEVEN Gravel Race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_seven_preview_draws_two_thousand_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/more-than-2-000-riders-to-line-up-for-a-taste-of-uci-gravel-world-championships-course-at-seven-in-nannup/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-15T04:51:08Z",
+      "quoteExcerpt": "more than 2,000 riders keen to test out a course",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:seven",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_seven_local_scale_course_and_worlds_ambition_2022",
+        "claim_blazevic_madigan_win_seven_2022",
+        "claim_nannup_awarded_2026_worlds_2022",
+        "claim_nannup_first_worlds_outside_europe_2022",
+        "claim_nannup_worlds_route_preserves_seven_terrain_2026",
+        "claim_seven_preview_draws_two_thousand_2026"
+      ],
+      "confidence": 0.99,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-world-championships",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_nannup_awarded_2026_worlds_2022",
+        "claim_nannup_first_worlds_outside_europe_2022",
+        "claim_nannup_worlds_route_preserves_seven_terrain_2026"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T20:05:00Z",
+  "contentHash": "5a8da75f8bbe2e3955d55b2be3a6c28caa917be38b97e2e0e5e3a0fe880d9547"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -656,8 +656,8 @@ def test_2022_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 173
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 6
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 22
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 25
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 23
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 24
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a held historical chapter showing how locally built SEVEN infrastructure preceded the UCI credential
- trace the 2018–2022 event growth to Nannup’s 2026 Worlds award and the preserved championship terrain
- cover the May discovery window and enrich the October award window with review-only race impacts

## Validation
- `python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2022-nannup-built-worlds.json`
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2022.json`
- `python3 -m pytest -q tests/test_gravel_weekly.py`
- `wordpress/slop_rules.py` checks on editorial fields
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill metadata only; draft status blocks public publish, and race impacts are editorial-review flags with `autoFixAllowed: false`.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history entry (`history-nannup-built-worlds-2022`) arguing that locally built SEVEN in Nannup preceded and justified UCI recognition, the 2022 World Series round, and the 2026 Worlds award (first outside Europe), with contemporary receipts, later 2026 route/preview evidence, and **review-only** `raceImpacts` on `gravel:seven` and `gravel:uci-gravel-world-championships`.
> 
> The **2022 backfill ledger** moves the May 7–13 window from `pending_review` to `covered_by_draft` linked to that entry, and attaches the same entry to the Oct 1–7 week alongside the existing inaugural-Worlds draft while updating the week’s reason text.
> 
> **Tests** bump expected 2022 ledger counts: 23 `covered_by_draft` weeks and 24 `pending_review` (ledger still `complete: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f59d0a6834dcbfe9955c02e746a044dd2b7efb82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->