### PR TITLE
Gravel Weekly: complete the 2022 backfill ledger

### DIFF
--- a/data/gravel-weekly/backfill/2022.json
+++ b/data/gravel-weekly/backfill/2022.json
@@ -6,7 +6,7 @@
   "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33155339385",
   "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
   "sourceCardCount": 173,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -14,25 +14,25 @@
       "periodStartedAt": "2022-01-01",
       "periodEndedAt": "2022-01-07",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The sole source was a titanium bike review; it documents a product, not a season-level change, conflict, or consequence worth narrating."
     },
     {
       "periodStartedAt": "2022-01-08",
       "periodEndedAt": "2022-01-14",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Utah race announcement may mark a durable event origin, but a single launch story cannot establish the event's eventual identity, field, or consequence."
     },
     {
       "periodStartedAt": "2022-01-15",
       "periodEndedAt": "2022-01-21",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The sole source was a wheelset review with no demonstrated effect on the season's competitive or cultural story."
     },
     {
       "periodStartedAt": "2022-01-22",
@@ -46,9 +46,9 @@
       "periodStartedAt": "2022-01-29",
       "periodEndedAt": "2022-02-04",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A new Spanish pro race and Haas's move from the WorldTour signal geographic and career migration, but launch announcements alone do not establish what either changed."
     },
     {
       "periodStartedAt": "2022-02-05",
@@ -84,9 +84,9 @@
       "periodStartedAt": "2022-02-26",
       "periodEndedAt": "2022-03-04",
       "sourceCardCount": 6,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Three product stories and the familiar road-racing gravel debate add no distinct consequence beyond the dedicated road-risk chapter."
     },
     {
       "periodStartedAt": "2022-03-05",
@@ -102,9 +102,9 @@
       "periodStartedAt": "2022-03-12",
       "periodEndedAt": "2022-03-18",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A WorldTour descent report and a frameset review do not establish an independent gravel narrative for this window."
     },
     {
       "periodStartedAt": "2022-03-19",
@@ -148,25 +148,25 @@
       "periodStartedAt": "2022-04-16",
       "periodEndedAt": "2022-04-22",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The sole source was a wheelset review; technical novelty without verified sporting consequence does not clear the editorial gate."
     },
     {
       "periodStartedAt": "2022-04-23",
       "periodEndedAt": "2022-04-29",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The sole source was a first-look wheel story with no evidence of a broader season-level change."
     },
     {
       "periodStartedAt": "2022-04-30",
       "periodEndedAt": "2022-05-06",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two component reviews provided buying information but no conflict, changed judgment, or durable race consequence."
     },
     {
       "periodStartedAt": "2022-05-07",
@@ -243,25 +243,25 @@
       "periodStartedAt": "2022-06-25",
       "periodEndedAt": "2022-07-01",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two isolated result cards and a budget bike review do not combine into a defensible Current Thing."
     },
     {
       "periodStartedAt": "2022-07-02",
       "periodEndedAt": "2022-07-08",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The sole source was a shoe review; it carries no verified consequence for the historical narrative."
     },
     {
       "periodStartedAt": "2022-07-09",
       "periodEndedAt": "2022-07-15",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The sole source was a handlebar review; product coverage alone does not justify a historical chapter."
     },
     {
       "periodStartedAt": "2022-07-16",
@@ -306,25 +306,25 @@
       "periodStartedAt": "2022-08-13",
       "periodEndedAt": "2022-08-19",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The SBT GRVL equipment gallery is a useful snapshot but has no point or consequence beyond cataloging what riders used."
     },
     {
       "periodStartedAt": "2022-08-20",
       "periodEndedAt": "2022-08-26",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Four standalone result cards record winners without establishing a cross-event shift or a story with a point."
     },
     {
       "periodStartedAt": "2022-08-27",
       "periodEndedAt": "2022-09-02",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Regional results plus a generic gravel-racing explainer preserve facts but do not clear the party, point, or hostile-editor gates."
     },
     {
       "periodStartedAt": "2022-09-03",
@@ -340,17 +340,17 @@
       "periodStartedAt": "2022-09-10",
       "periodEndedAt": "2022-09-16",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The sole source was a tire review with no demonstrated season-level consequence."
     },
     {
       "periodStartedAt": "2022-09-17",
       "periodEndedAt": "2022-09-23",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A Chequamegon result and a bike launch do not establish a distinct point beyond the existing Grand Prix and product records."
     },
     {
       "periodStartedAt": "2022-09-24",
@@ -405,41 +405,41 @@
       "periodStartedAt": "2022-10-29",
       "periodEndedAt": "2022-11-04",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Dirty Warrny's launch may support a race-origin and longevity story, but the announcement needs longitudinal evidence covering its interruptions and promised return."
     },
     {
       "periodStartedAt": "2022-11-05",
       "periodEndedAt": "2022-11-11",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Fahringer's concussion recovery could support a careful health and career-transition chapter, but it needs primary corroboration; the Wilson legal update is not a standalone gravel story."
     },
     {
       "periodStartedAt": "2022-11-12",
       "periodEndedAt": "2022-11-18",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Grand Prix expansion from six to seven races and 60 to 70 riders is a useful scale marker, but not a story until linked to athlete access, media, or competitive outcomes."
     },
     {
       "periodStartedAt": "2022-11-19",
       "periodEndedAt": "2022-11-25",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The early 2024 Worlds start-and-finish announcement is valuable longitudinal evidence for institutional lead time, but the update alone does not support another chapter."
     },
     {
       "periodStartedAt": "2022-11-26",
       "periodEndedAt": "2022-12-02",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Gravel Earth Series launch may mark an independent global counterweight, while Smith's recommitment may illuminate the Grand Prix labor market; both require outcome evidence."
     },
     {
       "periodStartedAt": "2022-12-03",
@@ -455,17 +455,17 @@
       "periodStartedAt": "2022-12-10",
       "periodEndedAt": "2022-12-16",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Cyclocross survival and the 2023 Grand Prix roster suggest a cross-discipline calendar story, but the two announcements do not yet establish a consequence or changed judgment."
     },
     {
       "periodStartedAt": "2022-12-17",
       "periodEndedAt": "2022-12-23",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "held_for_evidence",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Expansion to 17 World Series rounds is a meaningful scale marker retained for a later growth-versus-quality analysis, not a sufficient story by itself."
     },
     {
       "periodStartedAt": "2022-12-24",
@@ -484,5 +484,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T18:30:00Z"
+  "updatedAt": "2026-08-28T20:30:00Z"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -657,8 +657,10 @@ def test_2022_backfill_ledger_starts_from_the_complete_source_census():
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 173
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 6
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 23
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 24
-    assert validated["complete"] is False
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 9
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 15
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
 
 
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():


### PR DESCRIPTION
## Summary
- disposition every remaining 2022 source window with no ambiguous pending reviews
- retain nine evidence-worthy leads for later development and explicitly reject fifteen product/result-only windows
- mark the year complete with 23 covered weeks, six quiet gaps, nine holds, and fifteen rejections

## Validation
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2022.json`
- `python3 -m pytest -q tests/test_gravel_weekly.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and test assertions only; no runtime auth, publish, or automation behavior changes.
> 
> **Overview**
> **Finishes the 2022 Gravel Weekly backfill ledger** by resolving every week that was still `pending_review`, with per-window editorial `reason` text explaining the call.
> 
> Fifteen windows move to **`rejected`** (mostly product reviews, isolated results, or overlap with existing history drafts). Nine move to **`held_for_evidence`** for possible later chapters (race launches, scale markers, health/calendar leads that need more corroboration). **`complete`** is set to **`true`** and **`updatedAt`** is bumped; **`covered_by_draft`**, **`explicit_gap`**, and the 173-card census are unchanged.
> 
> The **`test_2022_backfill_ledger_starts_from_the_complete_source_census`** contract now expects **0** `pending_review`, the new held/rejected counts, and **`complete: true`**, matching other finished year ledgers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b3a8f5bd3d45132dd667bedfe31b4a6cb865347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->