### PR TITLE
Gravel Weekly: trace Life Time's admissions gate to 2021

### DIFF
--- a/data/gravel-weekly/backfill/2021.json
+++ b/data/gravel-weekly/backfill/2021.json
@@ -390,9 +390,11 @@
       "periodStartedAt": "2021-11-20",
       "periodEndedAt": "2021-11-26",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-lifetime-invented-admissions-2021"
+      ],
+      "reason": "Life Time paired the largest domestic off-road season purse with a privately selected scoring field inside otherwise open events."
     },
     {
       "periodStartedAt": "2021-11-27",
@@ -406,9 +408,11 @@
       "periodStartedAt": "2021-12-04",
       "periodEndedAt": "2021-12-10",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-lifetime-invented-admissions-2021"
+      ],
+      "reason": "More than 200 applications pushed the invitation-only roster from 40 to 60; the wheel review in the same window did not survive the story gate."
     },
     {
       "periodStartedAt": "2021-12-11",
@@ -435,5 +439,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T09:59:01Z"
+  "updatedAt": "2026-08-28T10:05:50Z"
 }

--- a/data/gravel-weekly/history/2021-lifetime-invented-admissions.json
+++ b/data/gravel-weekly/history/2021-lifetime-invented-admissions.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-lifetime-invented-admissions-2021",
+  "activeFrom": "2021-11-22",
+  "activeThrough": "2021-12-17",
+  "status": "draft",
+  "headline": "Gravel Found $250,000 and Immediately Invented Admissions",
+  "point": "Life Time's first Grand Prix did more than add a large, gender-equal purse. It created a private selection layer inside six mostly open events: thousands could enter the races, but only a handpicked field could score for the season and its money. Professional gravel's first coherent league therefore arrived with two products on the same course—an open participation spectacle and a closed career opportunity—and made the promoter's guest list part of competition.",
+  "priorJudgment": "The 2022 Life Time Grand Prix was simply a generous prize series that linked six existing off-road races and gave elite athletes a domestic season worth following.",
+  "changedJudgment": "The purse and the gate were inseparable. A trackable cast helped Life Time sell a season, sponsors follow protagonists, and athletes pursue meaningful money, but it also gave one private promoter authority to decide whose results counted toward the richest storyline.",
+  "stakes": "Selection determined access to season points, $250,000 in prize money, recurring media attention, sponsor value, and a dependable six-race platform. The structure also determined whether an athlete's performance on the same course counted as part of the professional season or only as an individual race result.",
+  "credibleOpposition": "The underlying races remained open to thousands, individual event purses remained available, the Grand Prix reserved only a tiny number of places, and a curated field made standings and media storytelling legible. Life Time doubled down on gender parity, expanded the planned roster from 40 to 60 when applications exceeded 200, and attempted to fund a domestic professional pathway that American off-road cycling did not otherwise provide. Selection was a practical league design, not proof that gravel itself had become closed.",
+  "whatHappened": "On November 22, 2021, Life Time announced that six races it owned—including Unbound, Crusher in the Tushar, and Big Sugar—would form a 2022 Grand Prix with a $250,000 purse split evenly between men and women. The races would continue independently, but only 20 selected women and 20 selected men would score for the series. Applicants would be judged not only on results and résumés but also on their interest in the project and how they helped grow cycling in the United States. More than 200 athletes applied. On December 10, Life Time expanded the invitation-only field to 30 women and 30 men, while preserving the same purse and selection model. Selected rider Pete Stetina described thousands of people contesting each race alongside a handpicked 60-person Grand Prix and openly wondered what would happen if an excluded rider raced all six and beat the invited field. The answer was structural: that rider could win an event, but not the season inside it.",
+  "take": "Model draft, not Matti's approved view: Gravel spent years bragging that anybody could line up, then found $250,000 and immediately invented admissions. Life Time did not close Unbound. Thousands of people could still purchase the same dust, panic, and gastrointestinal negotiations. It created a second race floating inside the open one, visible to the standings only if your application had cleared the velvet rope. Beat every selected rider without being selected and congratulations: you won the race the Grand Prix was using while remaining metaphysically absent from the Grand Prix. This was not just hypocrisy. A season fans can follow needs a cast. A purse large enough to matter needs eligibility. Sponsors prefer protagonists who will appear in episode two. But when the same private promoter owns the marquee races, writes the application, judges your results and your usefulness to cycling, and awards the money, the guest list becomes part of athletic performance. Gravel did not stop being open in 2021. It discovered that an open event and a closed professional league could occupy the same start line while living under different constitutions.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The public record establishes the announced criteria, application count, selected rosters, purse, scoring boundary, and the fact that the underlying events remained independently open. It does not provide the complete applicant list, internal selection deliberations, contracts, sponsor values, or evidence that a specific excluded athlete lost a sustainable career. Stetina's column is one selected athlete's analysis, not an organizer rulebook or population survey. Later wildcard and performance pathways show that admission remained consequential and evolved, but do not prove the 2021 design caused every later policy or competitive outcome.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_lifetime_launches_selected_250k_series_2021",
+      "canonicalUrl": "https://ir.lifetime.life/news-events/press-releases/detail/902/life-time-announces-new-national-grand-prix-cycling-race-series-for-elite-cyclists-in-2022-with-250000-prize-purse",
+      "publisher": "Life Time",
+      "publishedAt": "2021-11-22T00:00:00Z",
+      "quoteExcerpt": "20 men and 20 women selected to compete",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_selection_included_growth_criteria_2021",
+      "canonicalUrl": "https://ir.lifetime.life/news-events/press-releases/detail/902/life-time-announces-new-national-grand-prix-cycling-race-series-for-elite-cyclists-in-2022-with-250000-prize-purse",
+      "publisher": "Life Time",
+      "publishedAt": "2021-11-22T00:00:00Z",
+      "quoteExcerpt": "helping to grow cycling in the U.S. through their activities",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_expands_field_after_200_applicants_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/field-expanded-to-60-riders-for-inaugural-life-time-grand-prix-series/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-12-10T00:00:00Z",
+      "quoteExcerpt": "over 200 applicants ... increase from 40 to 60 total riders",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_stetina_describes_handpicked_series_inside_open_races_2021",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/groad-trip-rating-my-odds-and-my-competition-for-the-life-time-grand-prix/",
+      "publisher": "Velo",
+      "publishedAt": "2021-12-17T06:58:00Z",
+      "quoteExcerpt": "thousands of contestants ... handpicked selection of 60 riders",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_jones_wildcard_won_series_after_initial_exclusion_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/i-was-just-trying-to-think-about-what-was-on-the-line-cameron-jones-charges-from-wildcard-entry-to-life-time-grand-prix-series-winner/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-10-18T00:00:00Z",
+      "quoteExcerpt": "charges from wildcard entry to Life Time Grand Prix series winner",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_moves_toward_performance_admission_2026",
+      "canonicalUrl": "https://www.lifetimegrandprix.com/2026/08/12/life-time-announces-2027-life-time-grand-prix-structure/",
+      "publisher": "Life Time Grand Prix",
+      "publishedAt": "2026-08-12T00:00:00Z",
+      "quoteExcerpt": "entry ... will be determined primarily through performance",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_lifetime_launches_selected_250k_series_2021",
+        "claim_lifetime_selection_included_growth_criteria_2021",
+        "claim_lifetime_expands_field_after_200_applicants_2021",
+        "claim_stetina_describes_handpicked_series_inside_open_races_2021",
+        "claim_jones_wildcard_won_series_after_initial_exclusion_2025",
+        "claim_lifetime_moves_toward_performance_admission_2026"
+      ],
+      "confidence": 0.99,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T10:05:50Z",
+  "contentHash": "3ffe81da09a098c98f41efa78fe9237bb20fcc5952a03bd8f628d17338297efd"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -671,7 +671,8 @@ def test_2021_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 130
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 11
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 42
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 40
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a draft 2021 origin chapter for the Life Time Grand Prix selection layer
- distinguish the open underlying events from the handpicked field eligible for the $250,000 season purse
- ground the chapter in Life Time’s launch, the 200-plus applicant expansion, and Pete Stetina’s contemporary analysis
- connect the origin to later wildcard and performance-based admission reforms without collapsing later evidence into contemporary knowledge
- add a review-only Unbound race impact and account for both relevant 2021 census windows

## Editorial gate
- party: pass — an open race containing a closed league is immediately legible
- point: pass — selection became part of competition
- friend: pass — the draft has a quotable governing metaphor, not a recap
- craft: pass — admissions/velvet-rope mechanics carry the argument
- hostile editor: pass — the strongest defense and evidentiary limits are explicit

## Verification
- `python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2021-lifetime-invented-admissions.json`
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2021.json`
- `python3 -m pytest -q tests/test_gravel_weekly.py`
- both slop detectors: zero violations
- `git diff --check`

Draft only. Human approval remains required; auto-publish and race auto-fix remain disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill accounting only; draft content cannot auto-publish or auto-fix race data without human approval.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history chapter (`history-lifetime-invented-admissions-2021`) framing the Nov–Dec 2021 Life Time Grand Prix launch as an **admissions layer** on top of open events: a $250k gender-equal season purse with a handpicked scoring field, 200+ applicants, expansion to 60 riders, and contemporary receipts (plus later evidence kept separate). The entry stays **model-draft**, requires human approval, and flags a **review-only** Unbound `race.biased_opinion` impact with auto-fix disabled.
> 
> Updates the **2021 backfill ledger** so two late-2021 census windows (Grand Prix announcement and field expansion) move from `pending_review` to **`covered_by_draft`** with reasons tied to that entry; ledger remains incomplete. **Tests** now expect 2 `covered_by_draft` and 40 `pending_review` weeks for 2021.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8089d0d6c26b0aca69ee4fdb40627f6afdbb8179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->