### PR TITLE
Gravel Weekly: trace the rules gravel made women discover

### DIFF
--- a/data/gravel-weekly/backfill/2021.json
+++ b/data/gravel-weekly/backfill/2021.json
@@ -286,17 +286,21 @@
       "periodStartedAt": "2021-08-21",
       "periodEndedAt": "2021-08-27",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unwritten-rules-failed-women-2021"
+      ],
+      "reason": "The Cinch dispute exposed how legal male-team support could reshape the women's race while an unwritten spirit supplied no enforceable answer; the same window's Gravel Worlds result is supporting evidence and the COVID cancellation is not a separate chapter."
     },
     {
       "periodStartedAt": "2021-08-28",
       "periodEndedAt": "2021-09-03",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unwritten-rules-failed-women-2021"
+      ],
+      "reason": "De Crescenzo and Stephens supplied the competing cases for athlete strength, mixed-start inclusion, prize-race separation, and explicit promoter rules; the product review does not survive the gate."
     },
     {
       "periodStartedAt": "2021-09-04",
@@ -439,5 +443,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T10:05:50Z"
+  "updatedAt": "2026-08-28T10:12:52Z"
 }

--- a/data/gravel-weekly/history/2021-unwritten-rules-failed-women.json
+++ b/data/gravel-weekly/history/2021-unwritten-rules-failed-women.json
@@ -1,0 +1,141 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-unwritten-rules-failed-women-2021",
+  "activeFrom": "2021-08-18",
+  "activeThrough": "2021-09-03",
+  "status": "draft",
+  "headline": "Gravel's Unwritten Rules Failed Women First",
+  "point": "The 2021 Cinch controversy exposed the cost of governing elite gravel through vibes. Male teammates could legally feed, pace, and help position a woman in the same mass start while rivals without that infrastructure raced a different problem. The rulebook did not prohibit the advantage, and the sport's appeal to a shared spirit could only punish it after the fact through outrage. Gravel's absence of rules was not neutral once money, teams, and unequal resources arrived.",
+  "priorJudgment": "Mixed starts, minimal rules, and self-policing made gravel unusually equal: everybody faced the same course together, support emerged organically, and a shared community ethic could handle behavior that organizers did not need to legislate.",
+  "changedJudgment": "At the elite level, freedom from explicit rules gave the best-resourced program more room to define fair play for itself. Women bore the contradiction first because male teammates could materially affect a women's race without facing an equivalent competitive problem in the men's category.",
+  "stakes": "The dispute affected women's prize money, sponsor value, access to team support, confidence in results, the survival of mixed mass starts, and whether promoters—not Instagram outrage—would define legal feeding, pacing, drafting, and category separation before athletes raced.",
+  "credibleOpposition": "The tactics were legal, mixed-field drafting and assistance were already common, and Lauren De Crescenzo still had to produce the winning ride. Cinch disputed that she had dedicated domestiques and argued that critics were discrediting a strong athlete; De Crescenzo then won Gravel Worlds without male teammates. Lauren Stephens also defended the training value and inclusivity of mixed starts and argued that local promoters should retain different formats. The lesson is not that every gravel race needs a federation-sized rulebook or that De Crescenzo's wins were fraudulent.",
+  "whatHappened": "Lauren De Crescenzo won the 2021 Unbound 200 and SBT GRVL. After SBT, Velo reported that her Cinch teammates helped bring her back to Lauren Stephens after the QOM and that a male teammate delivered a bottle while other leading women stopped at the fourth aid station; once De Crescenzo gained separation while riding with men, she held it to the finish. The strategy violated no SBT rule. Rivals nevertheless argued that requiring women to recruit several men for feeding, pacing, mechanical help, and gap control would make an already expensive sport less accessible. Cinch co-founder Kourtney Danielson denied that De Crescenzo had dedicated domestiques and disputed how the winning gap formed. De Crescenzo defended her strength, then won Gravel Worlds without male teammates. Stephens supplied the useful distinction: a local hundred-person race could preserve a shared start, while a high-prize event such as SBT might need separate fields and explicit promoter rules. The conflict therefore was not rules versus freedom. It was whether professional stakes could remain governed by etiquette that participants did not share.",
+  "take": "Model draft, not Matti's approved view: Gravel's founding document was a shrug. Start together, help each other, do not be a dick, and trust several thousand exhausted adults to discover constitutional law somewhere around aid station four. Charming—until women's prize money met a men's support squad. Cinch found an advantage the rules allowed: keep bottles moving, keep the right wheel moving, and make every rival decide whether fairness now required recruiting her own collection of male domestiques. Lauren De Crescenzo was strong enough to win; she proved that again without them. That is exactly why this story matters. The argument was never whether she could pedal. It was whether women should need an auxiliary men's roster to compete on equal terms. Calling the tactic legal did not make the field equal. Calling it against the spirit did not produce an enforceable rule. It just installed a jury in every Instagram comment and called that freedom. Lauren Stephens had the adult answer: keep mixed starts where they make a race fun, separate categories where money and professional results make interference consequential, and force promoters to say what kind of race they are selling before everybody reaches the feed zone. Gravel did not need more rules everywhere. It needed to stop making women discover the missing ones during the race.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "Contemporary reporting establishes De Crescenzo's wins, the legal status of the described tactics, the bottle handoff and mixed-field dynamics reported at SBT, rival concerns, Cinch's denial of dedicated domestiques, and competing proposals for event rules. The reviewed evidence does not reconstruct every teammate instruction, GPS position, draft duration, feed, mechanical assist, or the counterfactual result without support. Public accusations and defenses were participant accounts, not a formal protest finding. Later start and drafting rules respond to the same structural problem but do not prove this single controversy caused each policy change.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_cinch_tactics_legal_and_changed_sbt_field_2021",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/gravel-racing/de-crescenzos-sbt-grvl-win-was-a-team-effort-and-the-gravel-scene-is-divided-on-what-that-means/",
+      "publisher": "Velo",
+      "publishedAt": "2021-08-18T11:07:00Z",
+      "quoteExcerpt": "totally legal at SBT GRVL ... changed the playing field",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_allison_says_rules_allowed_unequal_male_support_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/features/tom-danielson-wants-your-sympathy-for-breaking-the-spirit-of-gravel-racing-dont-give-it-to-him/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-08-25T00:00:00Z",
+      "quoteExcerpt": "not against the 2021 rules ... not something male competitors have to face",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_cinch_denies_dedicated_domestiques_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/features/tom-danielson-wants-your-sympathy-for-breaking-the-spirit-of-gravel-racing-dont-give-it-to-him/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-08-25T00:00:00Z",
+      "quoteExcerpt": "Lauren did not have any dedicated domestiques at SBT",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_de_crescenzo_defends_2021_wins_and_strength",
+      "canonicalUrl": "https://www.cyclingnews.com/features/lauren-de-crescenzo-you-cant-fake-gravel-racing/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-08-30T00:00:00Z",
+      "quoteExcerpt": "You can't fake gravel racing",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_stephens_distinguishes_prize_races_from_local_mixed_starts_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/features/lauren-stephens-the-spirit-of-gravel-is-to-allow-promoters-to-create-their-own-rules/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-09-03T00:00:00Z",
+      "quoteExcerpt": "offers a lot of prize money, then they probably need separate starts",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_lifetime_adopts_separate_elite_starts_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/decluttering-mass-starts-rewarding-podium-riders-top-changes-to-2024-life-time-grand-prix/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-04-17T00:00:00Z",
+      "quoteExcerpt": "elite men and women will have separate starts",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lifetime_formalizes_cross_category_drafting_rule_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/guidelines-to-eliminate-huge-impact-of-drafting-in-womens-races-coming-to-life-time-grand-prix-series/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-04-02T00:00:00Z",
+      "quoteExcerpt": "drafting has a huge impact",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_de_crescenzo_says_us_addressed_womens_race_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/teams-riders/let-us-have-our-race-geerike-schreurs-and-lauren-de-crescenzo-share-stories-from-the-traka-360-as-pro-women-navigate-around-all-the-chaos-of-the-amateurs/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-05-08T00:00:00Z",
+      "quoteExcerpt": "We figured that out like five years ago in the US",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_allison_says_rules_allowed_unequal_male_support_2021",
+        "claim_cinch_denies_dedicated_domestiques_2021",
+        "claim_de_crescenzo_defends_2021_wins_and_strength",
+        "claim_stephens_distinguishes_prize_races_from_local_mixed_starts_2021",
+        "claim_lifetime_adopts_separate_elite_starts_2024",
+        "claim_lifetime_formalizes_cross_category_drafting_rule_2025",
+        "claim_de_crescenzo_says_us_addressed_womens_race_2026"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:sbt-grvl",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_cinch_tactics_legal_and_changed_sbt_field_2021",
+        "claim_allison_says_rules_allowed_unequal_male_support_2021",
+        "claim_cinch_denies_dedicated_domestiques_2021",
+        "claim_de_crescenzo_defends_2021_wins_and_strength",
+        "claim_stephens_distinguishes_prize_races_from_local_mixed_starts_2021"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T10:12:52Z",
+  "contentHash": "ff9b3cc1fa82075a40b1342fa2cf5325559622d51f1737a3ffe7004fa6744d77"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -671,8 +671,8 @@ def test_2021_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 130
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 11
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 40
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 4
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 38
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a draft 2021 chapter on the Cinch support controversy at Unbound and SBT GRVL
- separate De Crescenzo’s demonstrated strength from the structural question of male-team support in a women’s prize race
- ground both the criticism and the winning side’s denial in contemporary reporting
- preserve Lauren Stephens’s distinction between local mixed starts and high-stakes events needing explicit rules
- connect the dispute to 2024 separate starts, the 2025 cross-category drafting rule, and two review-only race impacts
- account for both relevant 2021 source windows without promoting unrelated product or cancellation items

## Editorial gate
- party: pass — legal team support versus an unwritten spirit is an immediate conflict
- point: pass — rulelessness stopped being neutral once unequal infrastructure affected women’s results
- friend: pass — the Instagram-jury and aid-station-constitution mechanics make the point memorable
- craft: pass — the story moves from advantage, to backlash, to the practical rule distinction
- hostile editor: pass — legality, athlete strength, Cinch’s denial, and mixed-start benefits are all preserved

## Verification
- `python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2021-unwritten-rules-failed-women.json`
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2021.json`
- `python3 -m pytest -q tests/test_gravel_weekly.py`
- both slop detectors: zero violations
- `git diff --check`

Draft only. Human approval remains required; auto-publish and race auto-fix remain disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are editorial JSON and test expectations only; no runtime auth, payment, or auto-publish paths.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history entry (`history-unwritten-rules-failed-women-2021`) covering the late-August 2021 Cinch / De Crescenzo controversy at Unbound and SBT GRVL—legal male-team support in a mixed mass start, backlash over “spirit” vs enforceable rules, and Stephens’s prize-race vs local mixed-start distinction—with contemporary receipts and later Life Time start/drafting policy as supporting context.
> 
> The **2021 backfill ledger** marks the weeks **2021-08-21–08-27** and **2021-08-28–09-03** as `covered_by_draft` (both point at that entry) instead of `pending_review`, with reasons that fold Gravel Worlds into the same chapter and exclude unrelated product/cancellation stories. **`tests/test_gravel_weekly.py`** updates expected counts: four `covered_by_draft` weeks and 38 still `pending_review`; the year ledger stays incomplete.
> 
> The entry remains **draft-only** (`humanApprovalRequired`, no auto-publish) and registers **review-only** race impacts on Unbound and SBT `race.biased_opinion` without auto-fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb2beb5c62c82e276cb87fefe752451344f275a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->