### PR TITLE
Gravel Weekly: trace the world title announced before its rules

### DIFF
--- a/data/gravel-weekly/backfill/2021.json
+++ b/data/gravel-weekly/backfill/2021.json
@@ -322,9 +322,11 @@
       "periodStartedAt": "2021-09-18",
       "periodEndedAt": "2021-09-24",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-uci-world-title-before-rules-2021"
+      ],
+      "reason": "The UCI created a mass-participation qualification lane and official world title before revealing its rules or events; the shoe review in the same window does not survive the story gate."
     },
     {
       "periodStartedAt": "2021-09-25",
@@ -443,5 +445,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T10:12:52Z"
+  "updatedAt": "2026-08-28T10:20:04Z"
 }

--- a/data/gravel-weekly/history/2021-uci-world-title-before-rules.json
+++ b/data/gravel-weekly/history/2021-uci-world-title-before-rules.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-uci-world-title-before-rules-2021",
+  "activeFrom": "2021-09-22",
+  "activeThrough": "2021-09-24",
+  "status": "draft",
+  "headline": "Gravel Asked for Rules and Got a World Championship",
+  "point": "Nineteen days after leading athletes argued that gravel promoters needed to define their own rules, the UCI announced a World Series and World Championships without yet naming the qualifying events or publishing the governing rules. It did not settle gravel's local disputes; it created a parallel lane in which Golazo-operated mass-participation qualifiers would lead to an official rainbow jersey. Gravel acquired top-down legitimacy before the new institution had an operational bottom.",
+  "priorJudgment": "UCI recognition meant gravel had matured into a normal cycling discipline: a governing body would standardize competition, organize qualification, and resolve the ambiguity independent promoters had tolerated.",
+  "changedJudgment": "The UCI initially standardized prestige, not gravel itself. Independent events retained their own formats while the federation and a private operator built a separate qualification market whose authority came from the world title even before its calendar, rules, and destination were public.",
+  "stakes": "The announcement would shape which events counted as qualifiers, who could pursue age-group and elite rainbow jerseys, what equipment and categories were permitted, how athletes planned travel, and whether a federation-operated title displaced or merely competed with prestige created by independent races.",
+  "credibleOpposition": "A new international discipline cannot publish every operational detail in its first announcement. The UCI preserved mass participation, created an age-group pathway alongside elite racing, partnered with an experienced Cycling for All operator, and ultimately delivered a global series and World Championships in 2022. Independent races remained free to ignore sanctioning, so recognition expanded athlete choice rather than immediately imposing one rulebook on the sport.",
+  "whatHappened": "On September 22, 2021, the UCI Management Committee added gravel to its Cycling for All calendar for 2022. The federation said it would work with Belgian event company Golazo on a World Series of mass-participation races that qualified athletes for a new UCI Gravel World Championships. Contemporary reporting described gravel as the UCI's tenth discipline but noted that no rules or series events had been revealed. The announcement arrived less than three weeks after Lauren Stephens argued that high-prize races might need separate starts while local races could preserve mixed fields and promoter-specific rules. The UCI did not answer that dispute; it offered another jurisdiction. In 2022, the missing details became consequential: qualifying opened while the championship date and location were still unannounced, Veneto was named only after early rounds, one planned American qualifier cited the compressed timeline and uncertainty when it canceled, and the championship route arrived 32 days before racing.",
+  "take": "Model draft, not Matti's approved view: Gravel spent August trying to decide whether a bottle handoff violated its soul. In September, the UCI announced who would be world champion. This is cycling governance in one exquisite jump cut. The rules were not public. The qualifying races were not public. The championship did not have a public address. But the rainbow jersey existed conceptually, which is apparently enough infrastructure to begin selling legitimacy. The funny part is that the UCI did not actually seize gravel's republic of vibes. Unbound, SBT, and every local promoter could keep inventing their own constitutions. The federation built a second country beside them: mass-participation qualifiers operated with Golazo, a world title at the border, and paperwork to follow. That plural system eventually created real opportunity. Amateurs could qualify, elites got a jersey that sponsors understood, and independent prestige survived. But the sequence revealed what was being standardized first. Not safety. Not team support. Not women's start design. Prestige. Gravel asked who should write the rules and received the more institutionally useful answer: whoever owns the rainbow jersey gets to write at least one set of them.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The September 2021 record establishes the UCI decision, Golazo partnership, mass-participation qualification concept, and absence of announced rules and events. It does not establish what draft regulations, bids, contracts, or venues the UCI and Golazo had privately developed. The later 2022 evidence demonstrates operational uncertainty and one organizer's stated reasons for cancellation, but does not prove the initial sequencing caused every delay or that the World Series invalidated independent gravel. The comparison to the August rules dispute is chronological and institutional, not evidence that the dispute caused the UCI announcement.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_uci_adds_gravel_cycling_for_all_2021",
+      "canonicalUrl": "https://www.uci.org/pressrelease/the-uci-innovates-in-the-off-road-disciplines/269FNQQIXzxRQGY5eaGbd6",
+      "publisher": "UCI",
+      "publishedAt": "2021-09-22T00:00:00Z",
+      "quoteExcerpt": "gravel, will join the UCI Cycling for All International Calendar in 2022",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_uci_golazo_mass_participation_qualifiers_2021",
+      "canonicalUrl": "https://www.uci.org/pressrelease/the-uci-innovates-in-the-off-road-disciplines/269FNQQIXzxRQGY5eaGbd6",
+      "publisher": "UCI",
+      "publishedAt": "2021-09-22T00:00:00Z",
+      "quoteExcerpt": "Races in the UCI World Series will be mass participation events",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_uci_announcement_lacked_rules_and_events_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/uci-announces-gravel-series-and-official-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-09-22T00:00:00Z",
+      "quoteExcerpt": "No details of the rules ... or which events ... have yet been revealed",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_uci_qualifying_opened_without_destination_2022",
+      "canonicalUrl": "https://www.uci.org/article/2022-trek-uci-gravel-world-series-the-ultimate-cycling-for-all/5QhVQCAjsdByY8BVJhtOf1",
+      "publisher": "UCI",
+      "publishedAt": "2022-04-01T00:00:00Z",
+      "quoteExcerpt": "with date and location yet to be announced",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_uci_qualifier_cites_compressed_timeline_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/lions-den-crit-postponed-no-jingle-gx-gravel-north-american-roundup/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-08-02T20:52:25Z",
+      "quoteExcerpt": "shortened our timeline and ability to promote as a UCI World Championship qualifier",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_uci_first_worlds_route_released_2022",
+      "canonicalUrl": "https://www.uci.org/pressrelease/the-uci-reveals-race-routes-for-first-uci-gravel-world-championships/iPrgqQjdvHWlQN0dyzxXW",
+      "publisher": "UCI",
+      "publishedAt": "2022-09-06T00:00:00Z",
+      "quoteExcerpt": "The races for the different categories will start in Vicenza",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-worlds",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_uci_adds_gravel_cycling_for_all_2021",
+        "claim_uci_golazo_mass_participation_qualifiers_2021",
+        "claim_uci_announcement_lacked_rules_and_events_2021",
+        "claim_uci_qualifying_opened_without_destination_2022",
+        "claim_uci_qualifier_cites_compressed_timeline_2022",
+        "claim_uci_first_worlds_route_released_2022"
+      ],
+      "confidence": 0.99,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T10:20:04Z",
+  "contentHash": "276dbb99d1a460969ccd13e2002632b4e926f988fa768050ba8122f3cd554280"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -671,8 +671,8 @@ def test_2021_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 130
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 11
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 4
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 38
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 5
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 37
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a draft 2021 chapter on the UCI’s first gravel World Series and World Championship announcement
- distinguish UCI recognition from a takeover of independent gravel
- show that a Golazo-operated mass-participation qualification lane was announced before its rules or events
- connect the announcement to the bounded 2022 operational consequences already established in the timeline
- add a review-only UCI Gravel Worlds race impact and account for the relevant 2021 census window

## Editorial gate
- party: pass — gravel debated one bottle handoff, then got a world championship
- point: pass — prestige was standardized before operations or local governance
- friend: pass — the jump cut and parallel-country frame make the institutional point legible
- craft: pass — chronology moves from rule dispute to jurisdiction to consequence
- hostile editor: pass — mass participation, athlete choice, successful delivery, and private unknowns are preserved

## Verification
- `python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2021-uci-world-title-before-rules.json`
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2021.json`
- `python3 -m pytest -q tests/test_gravel_weekly.py`
- both slop detectors: zero violations
- `git diff --check`

Draft only. Human approval remains required; auto-publish and race auto-fix remain disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON, backfill accounting, and test expectations only; no runtime auth, deploy, or automated race-field mutation.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history entry for September 2021: the UCI announced a Golazo-operated mass-participation World Series and gravel World Championships while rules and qualifying events were still undisclosed, framed against the prior month’s local-rules debate and tied to bounded 2022 follow-on receipts.
> 
> The **2021 backfill ledger** reclassifies the week of **2021-09-18–2021-09-24** from `pending_review` to **`covered_by_draft`**, linking `history-uci-world-title-before-rules-2021` and noting the co-located shoe review does not pass the story gate. **`tests/test_gravel_weekly.py`** updates expected draft vs pending week counts (5 / 37).
> 
> The entry flags a **review-only** `raceImpacts` hook on `gravel:uci-gravel-worlds` (`race.biased_opinion`); human approval, no auto-publish, and no race auto-fix remain explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c5d76d25df3b7d2acd058487231b525e0abe878. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->