### PR TITLE
Gravel Weekly: reject 2021 archive noise

### DIFF
--- a/data/gravel-weekly/backfill/2021.json
+++ b/data/gravel-weekly/backfill/2021.json
@@ -22,33 +22,33 @@
       "periodStartedAt": "2021-01-02",
       "periodEndedAt": "2021-01-08",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two standalone wheel and bike reviews establish no season-level change, conflict, consequence, or point beyond product evaluation."
     },
     {
       "periodStartedAt": "2021-01-09",
       "periodEndedAt": "2021-01-15",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "An e-gravel launch and a bike review are category inventory, not evidence that e-gravel altered racing, participation, or the season's governing argument."
     },
     {
       "periodStartedAt": "2021-01-16",
       "periodEndedAt": "2021-01-22",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "George Bennett's one-off return to a New Zealand gravel race and a handlebar review do not establish a durable career shift or distinct historical point."
     },
     {
       "periodStartedAt": "2021-01-23",
       "periodEndedAt": "2021-01-29",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two bare Gravel and Tar results pages plus a value-wheel launch supply neither a conflict nor a consequence worth narrating."
     },
     {
       "periodStartedAt": "2021-01-30",
@@ -62,9 +62,9 @@
       "periodStartedAt": "2021-02-06",
       "periodEndedAt": "2021-02-12",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two reviews, tan-sidewall news, and Morton's Old Man Winter bike setup are equipment coverage without a demonstrated competitive or cultural consequence."
     },
     {
       "periodStartedAt": "2021-02-13",
@@ -86,9 +86,9 @@
       "periodStartedAt": "2021-02-27",
       "periodEndedAt": "2021-03-05",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A bike review and one Oregon event preview do not show that the announced field or Strade Bianche comparison changed the event or the wider season."
     },
     {
       "periodStartedAt": "2021-03-06",
@@ -110,41 +110,41 @@
       "periodStartedAt": "2021-03-20",
       "periodEndedAt": "2021-03-26",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A single e-gravel range launch is commercial category news without a story-level consequence."
     },
     {
       "periodStartedAt": "2021-03-27",
       "periodEndedAt": "2021-04-02",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A multi-material bike range and chainring review are product aggregation; neither source identifies a change in how gravel was raced or understood."
     },
     {
       "periodStartedAt": "2021-04-03",
       "periodEndedAt": "2021-04-09",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Stetina's van-life trip to Gorge Gravel Grinder is colorful profile material but lacks a conflict, changed judgment, or later consequence."
     },
     {
       "periodStartedAt": "2021-04-10",
       "periodEndedAt": "2021-04-16",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two Gorge Gravel Grinder results pages record winners but do not themselves make a story."
     },
     {
       "periodStartedAt": "2021-04-17",
       "periodEndedAt": "2021-04-23",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Cervelo Aspero-5 launch is a product event without evidence of a season-level consequence."
     },
     {
       "periodStartedAt": "2021-04-24",
@@ -158,17 +158,17 @@
       "periodStartedAt": "2021-05-01",
       "periodEndedAt": "2021-05-07",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A Grasshopper preview promising a tweaked format and familiar spirit does not establish what changed after the race."
     },
     {
       "periodStartedAt": "2021-05-08",
       "periodEndedAt": "2021-05-14",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Canyon Grizl launch is commercially relevant but supplies no independent historical point."
     },
     {
       "periodStartedAt": "2021-05-15",
@@ -206,9 +206,9 @@
       "periodStartedAt": "2021-06-12",
       "periodEndedAt": "2021-06-18",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A wheelset launch immediately after Unbound is product follow-up, not a distinct Current Thing."
     },
     {
       "periodStartedAt": "2021-06-19",
@@ -230,17 +230,17 @@
       "periodStartedAt": "2021-07-03",
       "periodEndedAt": "2021-07-09",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The redesigned Scott Addict is a product launch with no demonstrated historical consequence in this source window."
     },
     {
       "periodStartedAt": "2021-07-10",
       "periodEndedAt": "2021-07-16",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A generic women's gravel-bike buying guide is evergreen commerce content, not season narrative evidence."
     },
     {
       "periodStartedAt": "2021-07-17",
@@ -254,9 +254,9 @@
       "periodStartedAt": "2021-07-24",
       "periodEndedAt": "2021-07-30",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Rift results and gallery plus a Rooted Vermont culture feature are vivid event coverage but do not establish a distinct consequence beyond later, better-evidenced teamification records."
     },
     {
       "periodStartedAt": "2021-07-31",
@@ -332,9 +332,9 @@
       "periodStartedAt": "2021-09-25",
       "periodEndedAt": "2021-10-01",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A shoe review and Trek Checkpoint overhaul are product coverage without a story-level consequence."
     },
     {
       "periodStartedAt": "2021-10-02",
@@ -364,17 +364,17 @@
       "periodStartedAt": "2021-10-23",
       "periodEndedAt": "2021-10-29",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Bare Big Sugar men's and women's results pages identify winners but contain no independent point beyond the surrounding professionalization arc."
     },
     {
       "periodStartedAt": "2021-10-30",
       "periodEndedAt": "2021-11-05",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Evenepoel's one-off BWR top ten and a Giant Revolt launch are celebrity-result and product items without a durable gravel consequence."
     },
     {
       "periodStartedAt": "2021-11-06",
@@ -424,9 +424,9 @@
       "periodStartedAt": "2021-12-11",
       "periodEndedAt": "2021-12-17",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A helmet review is commerce content and does not become a historical chapter because the week is otherwise quiet."
     },
     {
       "periodStartedAt": "2021-12-18",
@@ -445,5 +445,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T10:20:04Z"
+  "updatedAt": "2026-08-28T10:27:13Z"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -672,7 +672,8 @@ def test_2021_backfill_ledger_starts_from_the_complete_source_census():
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 130
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 11
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 5
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 37
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 21
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 16
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- explicitly reject 21 populated 2021 windows that contain only product coverage, generic results, isolated celebrity appearances, or previews without demonstrated consequences
- preserve a specific hostile-editor reason for every rejection
- reduce unresolved 2021 windows from 37 to 16 without manufacturing a story for a quiet week
- update regression coverage for the new disposition counts

## Gate
Each rejected window fails at least one required condition: no defensible point, no changed judgment, no consequence, or no evidence beyond an announcement/result/product item. Potential career, governance, media, access, and professional-lane arcs remain pending for research.

## Verification
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2021.json`
- `python3 -m pytest -q tests/test_gravel_weekly.py`
- `git diff --check`

No draft was promoted, no race record changed, and publication remains prohibited.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial metadata and test assertions only; no publication, race records, or runtime behavior changes.
> 
> **Overview**
> This PR advances the **2021 Gravel Weekly backfill ledger** by moving **21 weekly windows** from **`pending_review`** to **`rejected`**, each with a specific hostile-editor **`reason`** (gear reviews, bare results, one-off celebrity runs, previews without post-race consequence, commerce, etc.) instead of the generic census-complete placeholder.
> 
> **Unresolved work** drops from **37** to **16** `pending_review` weeks; **`explicit_gap`**, **`covered_by_draft`**, and **`complete: false`** are unchanged—no drafts promoted and no new history entries. The regression test **`test_2021_backfill_ledger_starts_from_the_complete_source_census`** now asserts **21 rejected** and **16 pending_review**, and **`updatedAt`** on the ledger file is bumped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 734a7571e42456106e810232e74f213e2cc00e69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->