### PR TITLE
Gravel Weekly: reconstruct the 2021 transfer window

### DIFF
--- a/data/gravel-weekly/backfill/2021.json
+++ b/data/gravel-weekly/backfill/2021.json
@@ -270,17 +270,21 @@
       "periodStartedAt": "2021-08-07",
       "periodEndedAt": "2021-08-13",
       "sourceCardCount": 7,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-opened-transfer-window-2021"
+      ],
+      "reason": "Haas described a serious hybrid road-and-gravel future while still negotiating a road contract; that transfer-market tension survives the story gate, while equipment and generic race coverage in the same window do not."
     },
     {
       "periodStartedAt": "2021-08-14",
       "periodEndedAt": "2021-08-20",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-opened-transfer-window-2021"
+      ],
+      "reason": "Cromwell executed the delayed crossover at SBT GRVL and discovered that the sponsor-friendly side project was still one of the hardest races of her career."
     },
     {
       "periodStartedAt": "2021-08-21",
@@ -306,9 +310,11 @@
       "periodStartedAt": "2021-09-04",
       "periodEndedAt": "2021-09-10",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-opened-transfer-window-2021"
+      ],
+      "reason": "Reijnen's announced move from WorldTour domestique work to pursuing his own gravel results made the discipline an active competitive transfer rather than a ceremonial retirement ride."
     },
     {
       "periodStartedAt": "2021-09-11",
@@ -406,9 +412,11 @@
       "periodStartedAt": "2021-11-27",
       "periodEndedAt": "2021-12-03",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-opened-transfer-window-2021"
+      ],
+      "reason": "Haas completed the choice he had debated in August and explicitly called full-time gravel a change of discipline, not retirement; named technical-partner planning made the career claim concrete."
     },
     {
       "periodStartedAt": "2021-12-04",
@@ -432,9 +440,9 @@
       "periodStartedAt": "2021-12-18",
       "periodEndedAt": "2021-12-24",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Roberge's 2022 campaign primarily restates the already-covered Life Time selection and career-platform story. Floyd's of Leadville's five-rider announcement is a colorful sponsor and redemption profile, but this census supplies no distinct later consequence that clears the season-level story gate."
     },
     {
       "periodStartedAt": "2021-12-25",
@@ -445,5 +453,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T10:27:13Z"
+  "updatedAt": "2026-08-28T12:42:00Z"
 }

--- a/data/gravel-weekly/history/2021-gravel-opened-transfer-window.json
+++ b/data/gravel-weekly/history/2021-gravel-opened-transfer-window.json
@@ -1,0 +1,102 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-opened-transfer-window-2021",
+  "activeFrom": "2021-08-07",
+  "activeThrough": "2021-12-02",
+  "status": "draft",
+  "headline": "Gravel Opened a Transfer Window",
+  "point": "In the second half of 2021, gravel stopped waiting for road professionals to retire before offering them a serious alternative. Tiffany Cromwell and Canyon-SRAM activated a dual road-and-gravel calendar, Nathan Haas negotiated his future around both disciplines before choosing gravel full-time, and Kiel Reijnen moved from years of WorldTour domestique work toward racing for his own results. Gravel was becoming a parallel career choice while riders still had competitive ambition, not merely a reunion tour after road cycling was finished with them.",
+  "priorJudgment": "Road professionals visited gravel for sponsor appearances, novelty, or an informal post-career encore; their real employment and competitive identity remained on the road.",
+  "changedJudgment": "A rider and a road team could treat gravel as part of an active contract, while another rider could leave the WorldTour, assemble technical partners, and describe the move as a change of discipline rather than retirement. The choice was still economically improvised, but it had become a recognizable transfer rather than an exit.",
+  "stakes": "The shift affected who could call gravel a professional job, how riders extended or redesigned careers, whether road teams and equipment brands funded crossover schedules, which athletes received attention and sponsor access, and whether established privateers would face a growing stream of WorldTour engines with industry relationships already attached.",
+  "credibleOpposition": "Cromwell's gravel program depended on her existing WorldTour team and sponsors, while Reijnen and Haas brought reputations and commercial relationships unavailable to most privateers. Their moves did not create salaries, benefits, roster standards, or a stable labor market for the broader field. Gravel had already attracted former road professionals including Ted King, Peter Stetina, Ian Boswell, and Laurens ten Dam, so 2021 was an acceleration and normalization of the pathway, not its invention.",
+  "whatHappened": "On August 7, Cofidis rider Nathan Haas said his ideal 2022 program would combine serious road objectives with as much gravel as possible, even while he sought another road contract. Eight days later, Canyon-SRAM rider Tiffany Cromwell resumed a gravel program her Olympic selection had delayed, explicitly using SBT GRVL to keep the season fresh while remaining competitive; she finished eighth and called it one of the hardest races of her career. In September, Trek-Segafredo announced that Kiel Reijnen would end his road career and focus on gravel, where he expected to race for his own results after years working as a domestique. By December, Haas had converted his proposed hybrid calendar into a full-time move, insisting that it was a change of discipline rather than retirement and saying he was already planning with technical partners including Castelli. Colnago later supplied five bikes for an international privateer schedule. In July 2022, Haas won The Rift's 200-kilometer race.",
+  "take": "Model draft, not Matti's approved view: Road cycling used to send riders to gravel through the retirement door. In 2021, gravel installed a transfer window. Tiffany Cromwell kept her Canyon-SRAM job and added ten dirt races because the team and its sponsors could see a market. Kiel Reijnen left a WorldTour domestique role because gravel would let him chase his own result again. Nathan Haas spent August asking whether he could keep one foot on the road, then reached December and kicked the door shut: this is not retirement; it is a change of discipline. The paperwork was admittedly gravel paperwork. Instead of one team contract, Haas assembled technical partners, chose his own calendar, budgeted his own travel, and eventually received five differently painted Colnagos, which is either professional infrastructure or the world's most elegant spreadsheet problem. He then won The Rift, so it was not cosplay. Gravel had become a place an active professional could transfer competitive ambition, sponsor value, and identity—not safely, not equally, and not with health insurance magically appearing in the feed zone, but without pretending the athlete had stopped having a career.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources establish the announced calendars, team and sponsor involvement, stated motivations, transition decisions, and Haas's later support and result. They do not disclose contract values, whether gravel income matched WorldTour salaries, which road offers Reijnen or Haas declined, or how much sponsor support depended on prior fame. Cromwell's planned ten-event calendar was disrupted by Olympic selection and travel restrictions, so it demonstrates organizational intent more strongly than a completed 2021 schedule. The chapter identifies a visible cohort and changing career language, not the first road-to-gravel move or a representative outcome for all riders.",
+  "editorialScore": 97,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_cromwell_executes_gravel_debut_2021",
+      "canonicalUrl": "https://wmncycling.com/thats-one-of-the-hardest-things-ive-ever-done/",
+      "publisher": "Canyon-SRAM Racing",
+      "publishedAt": "2021-08-16T00:00:00Z",
+      "quoteExcerpt": "Racing her first gravel event of the year ... one of the toughest racing challenges of her career",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haas_considers_parallel_calendar_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/nathan-haas-eyes-future-combining-gravel-and-road-racing/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-08-07T00:00:00Z",
+      "quoteExcerpt": "I'd love to seriously focus on some parts of the season and then just tie in as much gravel racing as I can",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_reijnen_moves_to_gravel_for_results_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/kiel-reijnen-ends-road-career-will-focus-on-gravel-in-2022/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-09-08T00:00:00Z",
+      "quoteExcerpt": "moving to gravel racing will allow him to race for his own results",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haas_calls_gravel_discipline_change_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/nathan-haas-makes-the-switch-to-gravel-racing-for-2022/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-12-02T00:00:00Z",
+      "quoteExcerpt": "This is not a retirement. It's a change of discipline",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_colnago_supports_haas_privateer_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/nathan-haas-backed-by-colnago-as-he-makes-switch-to-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-02-04T00:00:00Z",
+      "quoteExcerpt": "supported by Colnago in 2022 as he makes the switch from the WorldTour",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haas_wins_rift_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/races/the-rift-gravel-race-iceland-2022/200k-pro-elite/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-07-25T00:00:00Z",
+      "quoteExcerpt": "Haas out-kicked Zavyalov to take the victory",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:sbt-grvl",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_cromwell_executes_gravel_debut_2021"
+      ],
+      "confidence": 0.93,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T12:30:00Z",
+  "contentHash": "31a99187d5a35bde6568f3062cbc1193f321c22bafcfd7e82efb69e749e9821c"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -671,9 +671,9 @@ def test_2021_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 130
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 11
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 5
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 21
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 16
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 9
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 22
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 11
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a draft-only 2021 historical Current Thing on gravel becoming a credible transfer destination for active road professionals
- separate contemporary evidence from later validation and propose only review-gated SBT GRVL context
- disposition four additional archive windows plus reject one redundant late-December bundle, reducing unresolved 2021 weeks from 16 to 11

## Safety
- draft only; human approval required; automatic publication disabled
- race impact is editorial review only; automatic fixes disabled

## Verification
- `python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2021-gravel-opened-transfer-window.json`
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2021.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q` (36 passed)
- both slop detectors: zero findings
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill metadata only; draft status blocks public surfacing, and race impact is editorial review with auto-fix disabled.
> 
> **Overview**
> Adds a **draft** historical chapter (`history-gravel-opened-transfer-window-2021`) arguing that H2 2021 made gravel a parallel career path for active road pros (Haas, Cromwell, Reijnen), with contemporary receipts, later validation, and a review-only SBT GRVL race impact—**human approval required**, no auto-publish.
> 
> Updates the **2021 backfill ledger**: four weeks (Aug 7–13, Aug 14–20, Sep 4–10, Nov 27–Dec 3) move from `pending_review` to `covered_by_draft` tied to that entry; **Dec 18–24** moves from `pending_review` to `rejected` with rationale that the sources restate already-covered stories. Open weeks drop from 16 to 11 (`covered_by_draft` 5→9, `rejected` 21→22).
> 
> **Tests** refresh expected 2021 ledger disposition counts to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f39f944b8df47ba28c672960575c5fef4325cc1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->