### PR TITLE
Gravel Weekly: reconstruct Unbound's 2021 media gravity

### DIFF
--- a/data/gravel-weekly/backfill/2021.json
+++ b/data/gravel-weekly/backfill/2021.json
@@ -182,25 +182,31 @@
       "periodStartedAt": "2021-05-22",
       "periodEndedAt": "2021-05-28",
       "sourceCardCount": 10,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-became-super-bowl-2021"
+      ],
+      "reason": "Unbound's dedicated race hub and first national live-stream announcement began the media tentpole; Gravel Locos results and the Paydirt purse in the same window are not needed to manufacture extra chapters."
     },
     {
       "periodStartedAt": "2021-05-29",
       "periodEndedAt": "2021-06-04",
       "sourceCardCount": 14,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-became-super-bowl-2021"
+      ],
+      "reason": "Fourteen source cards turned one race into a complete media week spanning service journalism, contenders, elite and amateur profiles, preparation, disability, age, teams, and equipment."
     },
     {
       "periodStartedAt": "2021-06-05",
       "periodEndedAt": "2021-06-11",
       "sourceCardCount": 13,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-unbound-became-super-bowl-2021"
+      ],
+      "reason": "Four distance results, winner follow-ups, a WorldTour crash, participant reaction, and post-race bike launches kept Unbound at the center of the archive after the finish."
     },
     {
       "periodStartedAt": "2021-06-12",
@@ -453,5 +459,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T12:42:00Z"
+  "updatedAt": "2026-08-28T13:15:00Z"
 }

--- a/data/gravel-weekly/history/2021-unbound-became-super-bowl.json
+++ b/data/gravel-weekly/history/2021-unbound-became-super-bowl.json
@@ -1,0 +1,134 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-unbound-became-super-bowl-2021",
+  "activeFrom": "2021-05-22",
+  "activeThrough": "2021-06-11",
+  "status": "draft",
+  "headline": "Unbound Became Gravel's Super Bowl Before Gravel Had a League",
+  "point": "The 2021 Unbound return became the week when one open participation event made the whole young sport publicly legible. Before gravel had a national professional series or world championship, Unbound supported a race hub, history, map, contender analysis, athlete profiles, equipment coverage, four sets of results, and the first national live stream of a U.S. gravel race. It did not merely sit atop the calendar; it became the calendar's media center of gravity.",
+  "priorJudgment": "Unbound was the biggest and hardest version of the same participant-led gravel product: a famous 200-mile race whose meaning came primarily from riding it, finishing it, and swapping stories afterward.",
+  "changedJudgment": "A mass event could also function as gravel's annual public convention. One weekend could concentrate professional ambition, amateur mythology, sponsor launches, human-interest stories, live spectatorship, and arguments about what the sport was becoming—even without a league connecting it to the rest of the season.",
+  "stakes": "The concentration determined which athletes and products sponsors could make visible, which race results defined gravel status, whether fans could follow the sport without entering it, how one promoter shaped the public memory of a decentralized scene, and whether other worthy events became supporting acts in Unbound's story.",
+  "credibleOpposition": "The source concentration is measured from one publisher's archive and includes service pages, results, and equipment pieces rather than 32 independent investigations. A large event returning after a pandemic cancellation reasonably deserved extensive coverage, and Unbound's multiple distances, elite field, amateur scale, long history, and remote challenge supplied more story types than a normal race. Media dominance does not prove every rider or region considered it the only important event.",
+  "whatHappened": "Unbound returned on June 5, 2021 after its 2020 pandemic cancellation and the replacement of the Dirty Kanza name. Cyclingnews built a dedicated race home with history, map, preview, and results for the 100, 200, and 350-mile fields. Its reporting previewed WorldTour riders, established gravel privateers, an 88-year-old attempting 200 miles, a Paralympic champion, an XL specialist, teams, bike setups, and defending champions. Life Time and FloSports announced a two-year exclusive media partnership and seven hours of coverage, described as the first U.S. gravel race streamed live for a national audience. In the completed 2021 source census, 32 of the 37 gravel cards published from May 22 through June 11 were explicitly tied to Unbound. Ian Boswell beat Laurens ten Dam in the men's 200 after a front group featuring former WorldTour riders and leading privateers; Lauren De Crescenzo won the women's race. Four days after the results, the archive was still publishing bikes used at Unbound. The sport did not yet have a coherent league, but it already had Super Bowl week.",
+  "take": "Model draft, not Matti's approved view: Gravel did not have a league in 2021. It had a capital city, and for three weeks everybody moved to Emporia. Cyclingnews needed a race hub, map, history, preview, ten riders to watch, an 88-year-old, a Paralympic champion, four results pages, two new bikes, and enough individual profiles to cast a prestige drama where most characters eventually drink pickle juice in a gas-station parking lot. Then FloBikes put seven hours on television. This is how Unbound became gravel's Super Bowl before gravel had regular season games. If you won there, you were somebody. If you launched equipment there, it counted. If you wanted to explain privateering, endurance, community, road-star migration, or uncomplicated terror, Kansas supplied the example. That focus made the sport understandable and flattened it at the same time. Gravel sold decentralization, local weirdness, and choose-your-own-adventure, then built a Vatican in Emporia. The useful truth is that every messy young sport needs a day when casual people know where to look. The dangerous truth is that eventually everyone starts confusing the place with the religion.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The 32-of-37 count comes from the controlled Cyclingnews archive census used by this backfill and classifies a card as Unbound-linked when its title or canonical URL explicitly names the event. It is a measure of one publication's attention, not total media share or audience demand, and the denominator includes five non-Unbound gravel cards. Available sources establish the announced broadcast duration and scope but do not provide 2021 viewer totals, retention, production cost, or sponsor return. 'Super Bowl' and 'capital city' are editorial descriptions of concentrated status and coverage, not claims that Unbound matched another sport's audience or represented every gravel community.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_unbound_first_us_national_gravel_stream_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/unbound-gravel-confirms-live-broadcast-of-june-5-races/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-05-28T20:49:55Z",
+      "quoteExcerpt": "first time that a US gravel race has been streamed live for a national audience",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_biggest_race_and_mixed_elite_field_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/features/unbound-gravel-10-riders-to-watch/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-06-01T15:24:28Z",
+      "quoteExcerpt": "the biggest gravel race of the year ... a strong WorldTour contingent",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_six_distance_return_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/races/unbound-gravel-2021/preview/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-06-02T12:59:19Z",
+      "quoteExcerpt": "regrouped for its 15th edition in 2021 with six racing distances",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_88_year_old_participant_story_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/200-miles-at-88-years-old-frederic-schmid-gears-up-for-unbound-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-06-04T10:38:32Z",
+      "quoteExcerpt": "200 miles at 88 years old",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_boswell_beats_ten_dam_unbound_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/races/unbound-gravel-2021/unbound-gravel-200-men/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-06-05T21:24:08Z",
+      "quoteExcerpt": "Ian Boswell used a locomotive-like power surge ... to win the Unbound Gravel 200",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_decrescenzo_wins_unbound_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/races/unbound-gravel-2021/unbound-gravel-200-women/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-06-05T23:19:35Z",
+      "quoteExcerpt": "Lauren De Crescenzo claimed the elite women's title",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_controlled_census_counts_unbound_attention_2026",
+      "canonicalUrl": "https://github.com/wattgod/race-intelligence-control-plane/issues/55",
+      "publisher": "Gravel Race Intelligence Control Plane",
+      "publishedAt": "2026-08-28T00:00:00Z",
+      "quoteExcerpt": "complete 2021 source census with weekly accounting",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_cyclingnews_declares_gravel_week_for_unbound_2025",
+      "canonicalUrl": "https://www.cyclingnews.com/news/its-gravel-week/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2025-05-26T00:00:00Z",
+      "quoteExcerpt": "designated this week as 'gravel week' ... Unbound will undoubtedly take a lot of the airtime",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_unbound_status_essential_stop_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/profound-shakeups-spills-splashes-and-wild-wheel-changes-at-unbound-gravel-2026-conclusions-on-what-unravelled-and-what-worked/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-06-01T16:24:11Z",
+      "quoteExcerpt": "if you want to truly be taken seriously in gravel its almost an essential stop",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_unbound_first_us_national_gravel_stream_2021",
+        "claim_unbound_biggest_race_and_mixed_elite_field_2021",
+        "claim_unbound_six_distance_return_2021",
+        "claim_controlled_census_counts_unbound_attention_2026",
+        "claim_cyclingnews_declares_gravel_week_for_unbound_2025",
+        "claim_unbound_status_essential_stop_2026"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T13:15:00Z",
+  "contentHash": "1ada8531f92235d54c34215f8edaa93aae45858b4c709e27020f294ca841f493"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -671,9 +671,9 @@ def test_2021_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 130
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 11
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 9
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 12
     assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 22
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 11
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 8
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a draft-only 2021 historical Current Thing explaining how Unbound became gravel's media center before the sport had a coherent league
- quantify the controlled archive concentration, preserve its methodological caveat, and separate later confirmation
- account for three more source-heavy archive windows, reducing unresolved 2021 weeks from 11 to 8

## Safety
- draft only; human approval required; automatic publication disabled
- Unbound race impact is editorial review only; automatic fixes disabled

## Verification
- historical-entry validator passed
- 2021 backfill-ledger validator passed
- `python3 -m pytest tests/test_gravel_weekly.py -q` (36 passed)
- both slop detectors: zero findings
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill accounting only; draft status and human-approval gates prevent publication or automated race-field changes.
> 
> **Overview**
> Adds a **draft** historical Current Thing (`history-unbound-became-super-bowl-2021`) spanning **2021-05-22 through 2021-06-11**, arguing that Unbound’s return became gravel’s concentrated media week—race hub, profiles, results, and the first nationally streamed U.S. gravel broadcast—before the sport had a coherent league. The entry carries contemporary Cyclingnews receipts, later corroboration, census caveats in **uncertainty**, and a **race.biased_opinion** impact flagged for editorial review only (no auto-fix, no auto-publish).
> 
> The **2021 backfill ledger** reclassifies three source-heavy weeks (May 22–June 11) from **pending_review** to **covered_by_draft**, each pointing at that single entry with week-specific reasons; ledger **updatedAt** moves forward. Tests expect **covered_by_draft** 9→12 and **pending_review** 11→8 while the year stays **complete: false**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a74b539aece9e138f83d062b99959a8d7d23ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->