### PR TITLE
Gravel Weekly: reconstruct Serenissima's pro experiment

### DIFF
--- a/data/gravel-weekly/backfill/2021.json
+++ b/data/gravel-weekly/backfill/2021.json
@@ -326,9 +326,11 @@
       "periodStartedAt": "2021-09-11",
       "periodEndedAt": "2021-09-17",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-road-racing-entered-gravel-escape-room-2021"
+      ],
+      "reason": "Pozzato's announcement established a deliberately hybrid professional experiment between two road races; generic service features and a wheel launch in the same window do not require separate chapters."
     },
     {
       "periodStartedAt": "2021-09-18",
@@ -352,25 +354,31 @@
       "periodStartedAt": "2021-10-02",
       "periodEndedAt": "2021-10-08",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-road-racing-entered-gravel-escape-room-2021"
+      ],
+      "reason": "The first confirmed riders moved Serenissima from promoter concept to a real professional field; two product launches remain supporting commercial noise."
     },
     {
       "periodStartedAt": "2021-10-09",
       "periodEndedAt": "2021-10-15",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-road-racing-entered-gravel-escape-room-2021"
+      ],
+      "reason": "The technical preview and result exposed the experiment's actual rules and consequence: a pro-only field, limited support, and Lutsenko winning after a long solo move; the Wilier launch is not a second story."
     },
     {
       "periodStartedAt": "2021-10-16",
       "periodEndedAt": "2021-10-22",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-road-racing-entered-gravel-escape-room-2021"
+      ],
+      "reason": "The inside report showed road-team tactics surviving without radios or following team cars and supplied the chapter's point; the two crossover announcements and a bike launch do not outrank that completed experiment."
     },
     {
       "periodStartedAt": "2021-10-23",

--- a/data/gravel-weekly/history/2021-road-racing-entered-gravel-escape-room.json
+++ b/data/gravel-weekly/history/2021-road-racing-entered-gravel-escape-room.json
@@ -1,0 +1,114 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-road-racing-entered-gravel-escape-room-2021",
+  "activeFrom": "2021-09-17",
+  "activeThrough": "2021-10-16",
+  "status": "draft",
+  "headline": "Road Racing Entered Gravel and Lost the Team Car",
+  "point": "Serenissima Gravel did not simply put professional road riders on dirt. Its first edition imported road teams into a race that deliberately removed their normal control room: no radios, no following team cars, small squads, and rider-carried repair tools outside limited assistance zones. The experiment showed that road tactics survived the loss of road infrastructure—and that the resulting race looked more recognizably gravel because the professionals had to solve their own problems.",
+  "priorJudgment": "A gravel race for road teams would either be a road race on brown pavement or an industry stunt whose professional field supplied names without changing how the race worked.",
+  "changedJudgment": "A promoter could preserve teams and serious competition while deleting enough team support to make professional riders improvise. Road squads still controlled attacks and produced the winner, but the decisive rider spent roughly 80 kilometers alone without radio instructions or a following car.",
+  "stakes": "The format tested whether gravel could professionalize without copying every dependency of the WorldTour, whether self-sufficiency could survive team tactics, and whether promoters could create legible elite racing while keeping equipment failure and rider judgment inside the competition rather than outsourcing them to a convoy.",
+  "credibleOpposition": "Serenissima was a short, invitation-only European experiment rather than an open mass-participation gravel race. The field was tiny, road teams supplied most of its tactical structure, and the result favored an established WorldTour rider. A format designed around roughly three dozen men does not prove the same rules would be safe, fair, or watchable with 130 professionals or thousands of amateurs, and the reviewed evidence does not show a women's professional field.",
+  "whatHappened": "On September 17, Filippo Pozzato announced a professional gravel race between the Giro del Veneto and Veneto Classic, with rules developed alongside the Italian federation. The federation later specified teams of two to four, no radios, and rider-carried repair tools outside assistance zones. Cyclingnews confirmed the first riders on October 6, then reported a field of only 34 before the race; the official timing sheet recorded 37 starters and 19 finishers. On October 15, Astana rider Alexey Lutsenko won after attacking with more than 80 kilometers remaining. Reporting from inside the event described riders without following cars or radio contact, Astana and Intermarché still using team tactics, and punctures altering the race. Nathan Haas called it a different model for road teams to enter gravel rather than a threat to the whole discipline. Taco van der Hoorn thought the experiment worked with about 30 riders and warned that 130 would be another problem entirely.",
+  "take": "Model draft, not Matti's approved view: Europe invited road racing into gravel and made it leave the team car at coat check. Serenissima kept the logos, squads, tactical games, and professionally shaved legs, then took away the radio earpieces and rolling bicycle shops. The result was not road racing in a dust filter. It was a gravel escape room: here is your bike, here are two tiny tools, your director cannot whisper the answer, and somewhere ahead Alexey Lutsenko has decided to spend 80 kilometers making this everybody else's administrative problem. The funniest part is that road tactics survived. Astana and Intermarché still chased attacks and arranged the race; they simply had to do it without headquarters narrating every breath. That is the useful blueprint. Professional gravel does not need to pretend teams are impure. It needs rules that keep the rider responsible when the course starts deleting plans. Serenissima proved that you can import the circus and still refuse delivery of the trailer. It also proved the limit: 37 riders started, 19 finished, and even participants warned that multiplying the field by four would change the game. This was a prototype, not a constitution—and a men-only prototype at that.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "Contemporary sources disagree on the field size: Cyclingnews reported 34 starters while the official timing record lists 37 starters and 19 classified finishers. The chapter therefore attributes each count and does not merge them. Cyclingnews reported that Lutsenko attacked with more than 80 kilometers remaining, while the federation described him as alone for almost 100 kilometers; the narrative uses the narrower claim. Available evidence establishes the published format and observed tactics but not whether every rule was enforced uniformly, how team budgets affected access, why each rider abandoned, or whether organizers attempted to recruit a women's field.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_serenissima_announced_between_road_races_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/filippo-pozzato-creates-a-pro-gravel-race-between-the-giro-del-veneto-and-the-veneto-classic/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-09-17T11:28:28Z",
+      "quoteExcerpt": "a first edition of a new pro gravel race, to be held between the Giro del Veneto and Veneto Classic",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_serenissima_small_teams_no_radios_self_repair_2021",
+      "canonicalUrl": "https://www.federciclismo.it/articoli/mountainbike-articoli/serenissima-gravel-linedita-competizione-pronta-a-dare-spettacolo/",
+      "publisher": "Federazione Ciclistica Italiana",
+      "publishedAt": "2021-09-28T00:00:00Z",
+      "quoteExcerpt": "due to four athletes per team and no radio transceivers ... tools to repair the bike",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_serenissima_first_riders_confirmed_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/first-riders-confirmed-for-inaugural-edition-of-serenissima-gravel/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-10-06T12:20:44Z",
+      "quoteExcerpt": "first riders confirmed for inaugural edition of Serenissima Gravel",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_serenissima_pro_only_field_and_format_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/inaugural-serenissima-gravel-presents-a-challenge-more-technical-than-strade-bianche/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-10-14T19:43:44Z",
+      "quoteExcerpt": "the first gravel race expressly for professional riders",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lutsenko_wins_serenissima_after_long_attack_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/races/serenissima-gravel-2021/serenissima-gravel-2021/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-10-15T16:46:37Z",
+      "quoteExcerpt": "attacked with more than 80 kilometres remaining ... claimed the win with a 42-second margin",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_serenissima_road_tactics_without_team_cars_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/features/riding-to-win-not-to-just-take-part-inside-the-pioneering-serenissima-gravel-pro-race/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-10-16T10:47:14Z",
+      "quoteExcerpt": "there were no team cars ... with no radio contact, Lutsenko was left alone",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_serenissima_official_37_started_19_finished_2021",
+      "canonicalUrl": "https://a.storyblok.com/f/120766/x/b8d2b6f370/ordine-d-arrivo-finale-1.pdf",
+      "publisher": "Serenissima Gravel official timing",
+      "publishedAt": "2021-10-15T00:00:00Z",
+      "quoteExcerpt": "37 starters listed; 19 riders recorded with finishing times",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:serenissima-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_serenissima_small_teams_no_radios_self_repair_2021",
+        "claim_serenissima_pro_only_field_and_format_2021",
+        "claim_lutsenko_wins_serenissima_after_long_attack_2021",
+        "claim_serenissima_road_tactics_without_team_cars_2021",
+        "claim_serenissima_official_37_started_19_finished_2021"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T14:10:00Z",
+  "contentHash": "dab51d0b44a9771d795d578f8a5ecffe82ab5426734764574f4800638555f250"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -671,9 +671,9 @@ def test_2021_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 130
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 11
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 12
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 16
     assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 22
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 8
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 4
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a draft historical Current Thing explaining how Serenissima imported road-team tactics while removing radios and following cars
- bind four 2021 archive weeks to one evidence-backed chapter instead of treating announcements and product coverage as separate stories
- preserve human approval, publication, and race-impact safety boundaries

## Verification
- `python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2021-road-racing-entered-gravel-escape-room.json`
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2021.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q`
- both slop detectors: zero findings
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and ledger bookkeeping only; draft status and human-approval flags keep race-impact and publish paths gated.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history entry (`history-road-racing-entered-gravel-escape-room-2021`) that frames Serenissima’s 2021 debut as a pro-gravel experiment: road teams kept, radios and following cars gone, with receipts and a proposed `race.biased_opinion` editorial-review impact that still requires human approval.
> 
> The **2021 backfill ledger** moves four late-September/October weeks from `pending_review` to `covered_by_draft`, all pointing at that single chapter (announcement → field confirmation → race/result → inside report) and documenting why parallel product coverage stays subordinate.
> 
> **Tests** update expected 2021 ledger disposition totals (`covered_by_draft` 12→16, `pending_review` 8→4). Publication and auto-publish remain off for the new entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12b75187d8a78dbef65cc2d11f863b937ff6f7fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->