### PR TITLE
Gravel Weekly: complete the 2021 narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2021.json
+++ b/data/gravel-weekly/backfill/2021.json
@@ -6,7 +6,7 @@
   "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33161461936",
   "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
   "sourceCardCount": 130,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -54,9 +54,9 @@
       "periodStartedAt": "2021-01-30",
       "periodEndedAt": "2021-02-05",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "The Flanders Gravel launch announced a promising event but supplied no completed race, conflict, or season consequence; the tyre review is product coverage. Preserve the launch as a searchable receipt, not a forced story."
     },
     {
       "periodStartedAt": "2021-02-06",
@@ -94,9 +94,9 @@
       "periodStartedAt": "2021-03-06",
       "periodEndedAt": "2021-03-12",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Cromwell's planned road-and-gravel calendar was a meaningful precursor, but the executed August program already anchors the stronger transfer-window chapter; the Rapha shoe launch adds no independent consequence."
     },
     {
       "periodStartedAt": "2021-03-13",
@@ -174,9 +174,11 @@
       "periodStartedAt": "2021-05-15",
       "periodEndedAt": "2021-05-21",
       "sourceCardCount": 7,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-giro-put-mountain-biker-in-pink-2021"
+      ],
+      "reason": "Five Giro reports and the stage result show gravel rewarding a repeatable mix of climbing, handling, positioning, and preparation as Bernal took and extended pink; the two U.S. event previews do not need separate chapters."
     },
     {
       "periodStartedAt": "2021-05-22",
@@ -220,9 +222,11 @@
       "periodStartedAt": "2021-06-19",
       "periodEndedAt": "2021-06-25",
       "sourceCardCount": 6,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-migration-changed-direction-of-access-2021"
+      ],
+      "reason": "Migration Gravel brought international competition to East African riders, attached U.S. opportunities to local performance, and produced durable development consequences; Oregon Trail's preview and partial results do not outrank that point."
     },
     {
       "periodStartedAt": "2021-06-26",

--- a/data/gravel-weekly/history/2021-giro-put-mountain-biker-in-pink.json
+++ b/data/gravel-weekly/history/2021-giro-put-mountain-biker-in-pink.json
@@ -1,0 +1,90 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-giro-put-mountain-biker-in-pink-2021",
+  "activeFrom": "2021-05-15",
+  "activeThrough": "2021-05-21",
+  "status": "draft",
+  "headline": "The Giro Put a Mountain Biker in Pink",
+  "point": "The 2021 Giro used gravel twice in four days and produced something more interesting than random spectacle: a coherent advantage for Egan Bernal, whose cycling career began on a mountain bike. He took the race lead with a gravel-finish attack at Campo Felice, then extended it across four Tuscan dirt sectors while key rivals lost contact. Gravel did not merely interrupt the general classification; it revealed a broader definition of the complete stage racer.",
+  "priorJudgment": "Loose surfaces in a Grand Tour were primarily an organizer's stunt: good for suspense, dangerous for equipment, and too random to say much about the best rider over three weeks.",
+  "changedJudgment": "Puncture risk remained real, but positioning, handling, preparation, team execution, and off-road experience could turn gravel into a repeatable competitive advantage. The same rider did not luck into one moment: Bernal took pink on the first gravel finish and strengthened it on the second dirt stage.",
+  "stakes": "The episodes changed which skills a Grand Tour could reward, how teams prepared for nontraditional terrain, whether multidisciplinary riders carried a real advantage, and whether gravel should be understood as a lottery ticket or as another surface on which the race's strongest all-around rider could make the difference.",
+  "credibleOpposition": "Campo Felice contained only 1.6 kilometers of gravel at the end of a steep mountain stage, so climbing power mattered at least as much as off-road handling. At Montalcino, Ineos used superior team positioning and Filippo Ganna's pace before Bernal finished the work. Remco Evenepoel was returning from an eight-month racing absence, and Bernal himself would not claim that his mountain-bike background explained the result. No clean comparison can isolate dirt skill from form, team strength, climbing, or tactics, and the feared puncture lottery remained possible even though it did not decide these stages.",
+  "whatHappened": "Before stage 9, Cyclingnews called the 1.6-kilometer gravel summit finish at Campo Felice uncharted terrain. Evenepoel warned that a puncture there could seriously damage a rider's Giro. On May 16, Bernal attacked with 550 meters remaining, won the stage, and took pink with Evenepoel 15 seconds behind. Two days later the race previewed four Tuscan gravel sectors on the road to Montalcino. Ineos had reconnoitered the route, and Bernal's third place at Strade Bianche plus his mountain-bike origins made the matchup conspicuous. During stage 11, Ganna's pressure split the favorites on the first dirt sector. Evenepoel eventually lost contact and finished 2:08 behind Bernal; other contenders lost more. Bernal increased his overall lead to 45 seconds and later won the Giro by 1:29. Across two different uses of dirt—one explosive finish and one extended tactical stage—the same rider gained authority rather than merely surviving chaos.",
+  "take": "Model draft, not Matti's approved view: Road racing loves calling gravel random when the road stops obeying the team meeting. Then Egan Bernal used it like a résumé. Stage 9 gave the Giro 1.6 kilometers of dirt at the top of a mountain; he attacked, won, and took pink. Stage 11 gave it four Tuscan sectors; Ineos put Filippo Ganna on the front, Bernal stayed upright and correctly located, and Remco Evenepoel lost more than two minutes. That is not proof that mountain biking was the secret ingredient—Bernal would not even claim that—but it is an awkward result for the idea that gravel only identifies the luckiest tyre. The former mountain biker took the lead on dirt, widened it on dirt, and won the Giro. The surface asked for power, handling, positioning, equipment judgment, and a team that had done its homework. In other words, it asked who could ride a bicycle while the spreadsheet was being shaken. Gravel did not corrupt the general classification. For four days, it expanded the job description. The jump-scare era would come next, when organizers learned to rent dirt for television. This was the better version: the strange terrain made the eventual winner look more complete, not merely more fortunate.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources establish Bernal's results, background, team reconnaissance, and the time gaps, but they do not quantify how much of his advantage came from off-road skill. Stage 9 was a steep mountain finish with a short gravel section, and stage 11 combined dirt, team tactics, positioning, and climbing. The final 1:29 Giro winning margin does not mean the gravel stages alone decided the race. The chapter treats the two stages as evidence that gravel can reward a broad skill set, not as proof that it always produces a fair or deterministic result.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_giro_campo_felice_gravel_risk_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/features/preview-giro-ditalia-enters-uncharted-terrain-on-the-gravel-of-campo-felice/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-05-15T19:50:56Z",
+      "quoteExcerpt": "the last mile of racing takes place on gravel roads ... a puncture there can have serious consequences",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_bernal_takes_pink_campo_felice_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/races/giro-d-italia-2021/stage-9/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-05-16T16:30:00Z",
+      "quoteExcerpt": "attacks with 550 metres to the finish ... defending the pink jersey",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_giro_montalcino_gravel_gc_preview_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/features/preview-montalcino-gravel-stage-to-shake-loose-giro-ditalia-gc-battle/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-05-18T19:52:28Z",
+      "quoteExcerpt": "four sectors of white gravel roads ... set to shake up the general classification",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_bernal_extends_giro_lead_on_gravel_2021",
+      "canonicalUrl": "https://www.giroditalia.it/news/mauro-schmid-vince-la-tappa-11-del-giro-ditalia",
+      "publisher": "Giro d'Italia",
+      "publishedAt": "2021-05-19T18:00:00Z",
+      "quoteExcerpt": "Mauro Schmid wins stage 11, Egan Bernal increases his lead in the general classification",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_evenepoel_loses_208_to_bernal_gravel_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/races/giro-d-italia-2021/stage-11/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-05-19T18:15:00Z",
+      "quoteExcerpt": "Evenepoel, 2:08 behind Bernal ... Bernal leads Vlasov by 45 seconds",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_bernal_wins_giro_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/races/giro-d-italia-2021/stage-21/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-05-30T18:00:00Z",
+      "quoteExcerpt": "Egan Bernal was crowned winner of the Giro d'Italia",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T15:10:00Z",
+  "contentHash": "d428fed7c5ab552780b3b2ce5a7f97add72d2f11accde8c5c185ed8e5f9f466a"
+}

--- a/data/gravel-weekly/history/2021-migration-changed-direction-of-access.json
+++ b/data/gravel-weekly/history/2021-migration-changed-direction-of-access.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-migration-changed-direction-of-access-2021",
+  "activeFrom": "2021-06-22",
+  "activeThrough": "2021-06-25",
+  "status": "draft",
+  "headline": "Migration Gravel Changed the Direction of Access",
+  "point": "The inaugural Migration Gravel Race did not wait for East African riders to overcome the cost, visa, equipment, and network barriers required to become visible in Europe or the United States. It brought established international gravel racers to Kenya, put them directly against local athletes, and attached outbound opportunities to what happened on home roads. Gravel briefly made the scouts and stars migrate before asking the talent to do so.",
+  "priorJudgment": "African riders could enter international cycling only by first leaving home, solving the logistics of another continent, and proving themselves inside a European or American system built without them.",
+  "changedJudgment": "A race could reverse the discovery pipeline: bring international competition and media attention to East Africa, let local riders compete on familiar terrain, then fund selected athletes to race abroad as contenders rather than symbolic invitees.",
+  "stakes": "The model affected who could be discovered, who paid the cost of exposure, whether sponsorship followed demonstrated performance, whether East African riders could build professional pathways outside road cycling's traditional gatekeepers, and whether an event in Kenya became a durable part of global gravel rather than adventure tourism for visiting athletes.",
+  "credibleOpposition": "The 2021 field was small and the early men's stages were still won by famous visitors. Travel to the United States did not remove visa, equipment, language, financial, or cultural barriers, and a sponsored race trip is not the same as a stable professional career. The project depended on foreign sponsors and media as well as local leadership. Its later success cannot be attributed to one race alone, and the unequal time gaps in the first women's stage show that creating a start line did not instantly create equal preparation or depth.",
+  "whatHappened": "On June 22, Unbound winner Ian Boswell described a 600-kilometer, four-day Kenyan stage race built to match European and American riders against leading African athletes and open routes into U.S. gravel. Wahoo had already supplied Team Amani with equipment and sports-science support, and the top performers were promised starts at SBT GRVL and Belgian Waffle Ride Asheville. Laurens ten Dam won stage 1, but Kenyan Suleman Kangangi finished second; Kenneth Karaya was fourth. American Betsy Welch won the women's stage while Kenyan Nancie Akinyi placed second, then Akinyi won the 174-kilometer stage 2. A September follow-up reported that four East African riders had been selected and sponsored for four U.S. events, explicitly rejecting charity framing in favor of equal competition. The pathway did not resolve quickly or cleanly, but it endured. In 2026, Migration's Black Mambas development riders occupied the first five men's positions, Team Amani's Claudette Nyirarukundo finished second among women, and the women's UCI Continental team was racing a European calendar while still confronting visa and experience barriers.",
+  "take": "Model draft, not Matti's approved view: Migration Gravel changed the shipping label. Cycling's normal talent-identification plan asks the talent to acquire a visa, buy the equipment, learn the airport system, survive somebody else's roads, and somehow look employable before anyone important agrees to notice the legs. In 2021, Boswell, ten Dam, and company did the 36-hour travel and raced East African riders in Kenya. The result was not charity tourism. Suleman Kangangi finished second on stage 1. Nancie Akinyi finished second, then won stage 2. Four riders earned sponsored U.S. racing. Five years later, the Black Mambas development squad occupied the first five men's places at Migration and an Amani rider finished second in the women's race. That does not mean the access problem is solved; Team Amani still reports visas, equipment, and European peloton experience as active barriers. It means the original idea survived contact with reality. If your development system can recognize African talent only after the athlete reaches your continent, it is not talent detection. It is baggage claim. Migration's better question was brutally simple: what if the famous riders had to travel first?",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources establish the race design, named support, stage results, selected U.S. opportunities, and later Team Amani outcomes. They do not disclose the complete 2021 selection criteria, travel completion for every selected rider, sponsor spending, contract terms, or the causal share of Migration Gravel in each later career. The 2026 results demonstrate a durable local development program and stronger home-road performance, not equality across global cycling. The chapter uses 'changed the direction of access' to describe the event model, not a claim that international mobility barriers disappeared.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_migration_brings_global_field_to_kenya_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/ian-boswell-migration-gravel-race-is-about-opening-doors-to-african-riders/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-06-22T15:36:42Z",
+      "quoteExcerpt": "competing against a field of European riders and some of the best African athletes",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_migration_support_and_us_pathway_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/news/ian-boswell-migration-gravel-race-is-about-opening-doors-to-african-riders/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-06-22T15:36:42Z",
+      "quoteExcerpt": "bring the top three athletes from this race to the States for SBT Gravel and Belgian Waffle Ride",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_kangangi_second_migration_stage_one_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/races/migration-gravel-race-2021/stage-1/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-06-23T20:48:59Z",
+      "quoteExcerpt": "Laurens Ten Dam ... Suleman Kangangi ... Kenneth Karaya",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_akinyi_wins_migration_stage_two_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/races/migration-gravel-race-2021/stage-2/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-06-24T20:52:33Z",
+      "quoteExcerpt": "Kenyan Nancie Akinyi wins 174km stage 2 for women",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_migration_selects_four_east_african_riders_2021",
+      "canonicalUrl": "https://gravelunion.cc/article/fursa",
+      "publisher": "Gravel Union",
+      "publishedAt": "2021-09-08T00:00:00Z",
+      "quoteExcerpt": "four East African gravel riders have been chosen ... sponsored to travel to the USA",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_black_mambas_sweep_migration_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/gravel-earth-series-kenyan-riders-sweep-mens-podium-while-swedish-national-champion-nathalie-eklund-earns-womens-title-at-migration-gravel-race/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-06-23T00:00:00Z",
+      "quoteExcerpt": "Black Mambas Development Squad completed a remarkable sweep of the men's overall podium",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_team_amani_women_race_europe_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/pedalling-hard-to-realise-the-african-dream-team-amanis-two-year-plan-for-tour-de-france-femmes-start/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-08-27T08:35:57Z",
+      "quoteExcerpt": "Team Amani's two-year plan for a Tour de France Femmes start",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:migration-gravel-race",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_migration_brings_global_field_to_kenya_2021",
+        "claim_migration_support_and_us_pathway_2021",
+        "claim_kangangi_second_migration_stage_one_2021",
+        "claim_akinyi_wins_migration_stage_two_2021",
+        "claim_migration_selects_four_east_african_riders_2021",
+        "claim_black_mambas_sweep_migration_2026",
+        "claim_team_amani_women_race_europe_2026"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T15:15:00Z",
+  "contentHash": "a7e63443a143dba1cc2b8b73a20590497b1a965d2e58b40f88f3d7fe3a9322bf"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -671,10 +671,10 @@ def test_2021_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 130
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 11
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 16
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 22
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 4
-    assert validated["complete"] is False
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 18
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 24
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
 
 
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():


### PR DESCRIPTION
## Summary
- add the Giro chapter showing gravel reward Bernal with a repeatable competitive advantage, not only random spectacle
- add the Migration Gravel chapter showing an access model that brought international competition to East African riders before asking them to travel
- reject the remaining weak and duplicative windows and mark all 53 weeks / 130 source cards in the 2021 ledger complete
- preserve human approval, publication, and race-impact safety boundaries

## Verification
- `python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2021-giro-put-mountain-biker-in-pink.json data/gravel-weekly/history/2021-migration-changed-direction-of-access.json`
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2021.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q`
- both slop detectors: zero findings on both takes
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and ledger metadata only; drafts cannot auto-publish, and the Migration race impact is review-only with auto-fix disabled.
> 
> **Overview**
> **Finishes the 2021 Gravel Weekly backfill ledger** by flipping `complete` to true once every week has a final disposition—no `pending_review` windows remain across all 53 weeks and 130 source cards.
> 
> Adds two **draft history chapters** and wires them in the ledger: **Giro gravel / Bernal in pink** (May 15–21) and **Migration Gravel / reversed talent access** (June 19–25). Several former `pending_review` weeks are now **`rejected`** with explicit assigning-desk reasons (weak product coverage, duplicative arcs), and the two new weeks are **`covered_by_draft`** with linked `entryIds`.
> 
> Both entries stay **`status: draft`**, **`humanApprovalRequired`**, and **`autoPublishAllowed: false`**. The Migration chapter records a **`editorial_review` race impact** on `gravel:migration-gravel-race` with **`autoFixAllowed: false`**. Contract tests in `test_gravel_weekly.py` are updated for the new disposition totals and `complete: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfc88307d9b7731ab1eeadc3f0c013d5859e8636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->