### PR TITLE
Gravel Weekly: reject 2020 archive noise

### DIFF
--- a/data/gravel-weekly/backfill/2020.json
+++ b/data/gravel-weekly/backfill/2020.json
@@ -78,9 +78,9 @@
       "periodStartedAt": "2020-02-22",
       "periodEndedAt": "2020-02-28",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A shoe launch and two bike galleries are equipment coverage without evidence of a competitive, cultural, or season-level consequence."
     },
     {
       "periodStartedAt": "2020-02-29",
@@ -110,9 +110,9 @@
       "periodStartedAt": "2020-03-21",
       "periodEndedAt": "2020-03-27",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A single oversized-handlebar launch supplies no conflict, changed judgment, or consequence beyond the product itself."
     },
     {
       "periodStartedAt": "2020-03-28",
@@ -150,17 +150,17 @@
       "periodStartedAt": "2020-04-25",
       "periodEndedAt": "2020-05-01",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two standalone bike updates during an otherwise quiet archive period are product inventory, not a Current Thing."
     },
     {
       "periodStartedAt": "2020-05-02",
       "periodEndedAt": "2020-05-08",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two tyre items and a flat-bar bike launch show category breadth but establish no independent season narrative."
     },
     {
       "periodStartedAt": "2020-05-09",
@@ -214,41 +214,41 @@
       "periodStartedAt": "2020-06-20",
       "periodEndedAt": "2020-06-26",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A clothing guide and nutrition checklist are useful service journalism but neither changes the season's governing argument."
     },
     {
       "periodStartedAt": "2020-06-27",
       "periodEndedAt": "2020-07-03",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A gravel-bike conversion guide is evergreen service content without a historical conflict or consequence."
     },
     {
       "periodStartedAt": "2020-07-04",
       "periodEndedAt": "2020-07-10",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A single monster-cross bike launch is product coverage, not evidence of a wider change in racing or participation."
     },
     {
       "periodStartedAt": "2020-07-11",
       "periodEndedAt": "2020-07-17",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A mixed product roundup containing gravel tyres does not survive the story gate."
     },
     {
       "periodStartedAt": "2020-07-18",
       "periodEndedAt": "2020-07-24",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "An e-gravel bike launch records category expansion but no demonstrated consequence for the 2020 season."
     },
     {
       "periodStartedAt": "2020-07-25",
@@ -262,17 +262,17 @@
       "periodStartedAt": "2020-08-01",
       "periodEndedAt": "2020-08-07",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A standalone gravel-shoe review supplies no point beyond product evaluation."
     },
     {
       "periodStartedAt": "2020-08-08",
       "periodEndedAt": "2020-08-14",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A bike review and dropper-post launch are equipment coverage without evidence that either changed gravel competition or culture."
     },
     {
       "periodStartedAt": "2020-08-15",
@@ -286,9 +286,9 @@
       "periodStartedAt": "2020-08-22",
       "periodEndedAt": "2020-08-28",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A single electric-gravel-bike review is commercial category coverage, not a story."
     },
     {
       "periodStartedAt": "2020-08-29",
@@ -318,9 +318,9 @@
       "periodStartedAt": "2020-09-19",
       "periodEndedAt": "2020-09-25",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A bike-category explainer and 13-speed groupset launch are technically notable but lack a demonstrated season-level consequence."
     },
     {
       "periodStartedAt": "2020-09-26",
@@ -334,9 +334,9 @@
       "periodStartedAt": "2020-10-03",
       "periodEndedAt": "2020-10-09",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A standalone tyre review supplies no conflict, changed judgment, or later consequence."
     },
     {
       "periodStartedAt": "2020-10-10",
@@ -366,17 +366,17 @@
       "periodStartedAt": "2020-10-31",
       "periodEndedAt": "2020-11-06",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A standalone tyre review is product evaluation, not a historical Current Thing."
     },
     {
       "periodStartedAt": "2020-11-07",
       "periodEndedAt": "2020-11-13",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A single bike-range overhaul is product news without evidence of a broader competitive or cultural change."
     },
     {
       "periodStartedAt": "2020-11-14",
@@ -398,25 +398,25 @@
       "periodStartedAt": "2020-11-28",
       "periodEndedAt": "2020-12-04",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A standalone shoe review is product evaluation, not a historical Current Thing."
     },
     {
       "periodStartedAt": "2020-12-05",
       "periodEndedAt": "2020-12-11",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A standalone wheelset review supplies no independent narrative consequence."
     },
     {
       "periodStartedAt": "2020-12-12",
       "periodEndedAt": "2020-12-18",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A standalone wheel review supplies no independent narrative consequence."
     },
     {
       "periodStartedAt": "2020-12-19",
@@ -430,9 +430,9 @@
       "periodStartedAt": "2020-12-26",
       "periodEndedAt": "2021-01-01",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A standalone bike review closes the archive as product evaluation, not a season-level story."
     }
   ],
   "updatedAt": "2026-08-28T15:30:00Z"

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -687,8 +687,8 @@ def test_2020_backfill_ledger_starts_from_the_complete_source_census():
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 16
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 0
     assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 37
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 20
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 17
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- reject 20 product-only and service-only 2020 archive windows
- keep 17 potentially consequential windows pending evidence review
- preserve all 53 weeks and 88 source cards in the fail-closed ledger

## Verification
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2020.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial disposition metadata and test expectations only; no runtime, auth, or publish-path changes.
> 
> **Overview**
> Updates the **2020 Gravel Weekly backfill ledger** by moving **20 weekly windows** from `pending_review` to `rejected`, each with a specific reason that the source cards are product reviews, equipment launches, or service journalism without competitive, cultural, or season-level consequence.
> 
> **17 windows** with potentially consequential coverage stay `pending_review`; **53 weeks** and **88 source cards** are unchanged, and the ledger remains **incomplete** (`complete: false`). The **2020 backfill contract test** now expects 20 rejected and 17 pending_review weeks instead of 0 and 37.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77dd0b4a80c0cf91121d601d289c015969381c33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->