### PR TITLE
Add 2020 gravel championship governance chapter

### DIFF
--- a/data/gravel-weekly/backfill/2020.json
+++ b/data/gravel-weekly/backfill/2020.json
@@ -38,17 +38,21 @@
       "periodStartedAt": "2020-01-18",
       "periodEndedAt": "2020-01-24",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-world-championship-before-government-2020"
+      ],
+      "reason": "The January 24 UCI governance proposal begins the draft chapter about institutional and participant-made championship legitimacy."
     },
     {
       "periodStartedAt": "2020-01-25",
       "periodEndedAt": "2020-01-31",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-world-championship-before-government-2020"
+      ],
+      "reason": "Morton's Dirty Kanza argument and Haas's qualified support supply the draft chapter's central conflict and credible counterposition."
     },
     {
       "periodStartedAt": "2020-02-01",
@@ -62,9 +66,11 @@
       "periodStartedAt": "2020-02-08",
       "periodEndedAt": "2020-02-14",
       "sourceCardCount": 5,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-world-championship-before-government-2020"
+      ],
+      "reason": "The UCI's road-gravel rules and Eroica's hosting offer show what governance could do and why official championship status attracted institutional demand."
     },
     {
       "periodStartedAt": "2020-02-15",

--- a/data/gravel-weekly/history/2020-gravel-world-championship-before-government.json
+++ b/data/gravel-weekly/history/2020-gravel-world-championship-before-government.json
@@ -1,0 +1,140 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-world-championship-before-government-2020",
+  "activeFrom": "2020-01-24",
+  "activeThrough": "2020-02-13",
+  "status": "draft",
+  "headline": "Gravel Had a World Championship Before It Had a Government",
+  "point": "The UCI did not discover a sport waiting for a championship. It discovered a sport whose participants had already granted that status to Dirty Kanza, then proposed a different kind of authority: a formal title that could travel across borders, federations, categories, sponsors, and eventually a global qualifying system. The argument was not rules versus no rules. It was who had earned the right to make prestige official without stripping away the shared experience that made the prestige matter.",
+  "priorJudgment": "Gravel was a young, loosely organized discipline that needed a recognized federation to decide what counted as its World Championships and supply the rules, legitimacy, and international reach an independent scene could not create for itself.",
+  "changedJudgment": "By January 2020, gravel already had promoter-made rules and a participant-recognized championship in Dirty Kanza. The UCI could add portable institutional legitimacy, consistent categories, safety oversight, and global reach, but it could not simply manufacture the cultural authority the scene had already assigned. The durable model became competing forms of legitimacy rather than a clean federation takeover.",
+  "stakes": "The answer determined whose title athletes and sponsors valued, whether amateurs could share the same event as elites, how safety and eligibility were governed, which promoters controlled access to championship status, and whether gravel's expansion preserved or monetized away its mass-participation identity.",
+  "credibleOpposition": "Cultural prestige is not a substitute for international governance. A federation title can cross national boundaries, create consistent eligibility and anti-doping expectations, support national-team pathways, and give athletes a rainbow jersey that media and sponsors understand. Nathan Haas welcomed that legitimacy while warning that the format mattered, and Eroica's offer showed that formal sanctioning did not necessarily require abandoning gravel history or participant experience.",
+  "whatHappened": "On January 24, UCI president David Lappartient said the federation was developing a gravel strategy, wanted to become the recognized international governing body, and considered a Gravel World Championships possible. The next day, Lachlan Morton answered that riders in the scene would say they already had one in Dirty Kanza. His objection was not merely anti-rule sentiment: he described gravel as a grassroots movement and argued that mass participation let the winner and a rider finishing six hours later share the same experience. Nathan Haas then supplied the useful middle position. He wanted to race for a rainbow jersey and said UCI legitimacy could help cycling, but warned against taking over a scene that might want to govern itself. In February, two things happened side by side. The UCI added detailed notice, surface, safety, vehicle, and veto requirements for unpaved sectors in road races, demonstrating what formal governance could concretely do. Eroica founder Giancarlo Brocci offered Tuscany as the site of an inaugural sanctioned Gravel World Championships, demonstrating that the institutional title already had would-be hosts. Gravel did not lack rules, events, or prestige. It lacked agreement about which institution could make those things universal.",
+  "take": "Model draft, not Matti's approved view: The UCI did not discover a sport without a world championship. It discovered a world championship without paperwork. Dirty Kanza already had the field, the mythology, and the extremely gravel-specific miracle of letting the winner and some exhausted dentist finish the same story six hours apart. What it did not have was a rainbow jersey, a national-federation pipeline, or a governing body capable of turning local prestige into a product that traveled cleanly through sponsors and borders. That is why the 2020 argument was more interesting than the usual gravel cosplay about freedom. Morton was right that legitimacy had already been earned from the bottom up. Haas was right that official legitimacy could still add something. Even the UCI had a point: someone eventually has to define eligibility, safety, and what counts when the vibes file a protest. The live question was ownership. Could the federation certify the championship without converting the shared experience into another fenced elite paddock? Gravel's eventual answer was gloriously inefficient: keep Unbound as the championship people chose, add UCI Worlds as the championship the rulebook recognized, and make athletes care about both.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The contemporary record establishes what Lappartient, Morton, Haas, and Brocci publicly argued and what the UCI required for unpaved sectors in road races. Morton's description of Dirty Kanza as gravel's existing World Championships records a culturally influential judgment, not a formal vote of every rider or promoter. The road-race regulations demonstrate the UCI's governance capacity but were not themselves rules for a standalone gravel discipline. The later coexistence of Unbound and UCI Worlds supports the two-legitimacies interpretation, but does not prove that outcome was designed in 2020 or accepted uniformly across the sport.",
+  "editorialScore": 97,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_uci_seeks_gravel_governance_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/features/uci-president-keen-to-create-gravel-world-championship/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-01-24T02:53:36Z",
+      "quoteExcerpt": "The UCI wants to be the recognised international governing body for gravel racing",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_morton_dirty_kanza_existing_worlds_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/lachlan-morton-gravel-racers-already-have-a-world-championships-in-dirty-kanza/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-01-25T22:42:22Z",
+      "quoteExcerpt": "they already have a world championships in the Dirty Kanza",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_morton_mass_participation_shared_experience_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/lachlan-morton-gravel-racers-already-have-a-world-championships-in-dirty-kanza/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-01-25T22:42:22Z",
+      "quoteExcerpt": "they're mass participation events",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_haas_wants_title_without_takeover_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/nathan-haas-id-love-to-ride-a-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-01-26T11:57:17Z",
+      "quoteExcerpt": "It'll be important not to lose or take over what is a scene in it's own right",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_uci_road_gravel_safety_requirements_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/uci-sets-rules-on-use-of-gravel-in-road-races/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-02-12T17:06:39Z",
+      "quoteExcerpt": "length, type of surface, difficulty and width of any unpaved sections",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_eroica_offers_gravel_worlds_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/eroica-offers-to-organise-inaugural-gravel-world-championships-in-tuscany/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-02-13T16:42:42Z",
+      "quoteExcerpt": "We'd love to organise a Gravel World Championships",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_uci_announces_gravel_world_series_2021",
+      "canonicalUrl": "https://www.uci.org/pressrelease/the-uci-innovates-in-the-off-road-disciplines/269FNQQIXzxRQGY5eaGbd6",
+      "publisher": "UCI",
+      "publishedAt": "2021-09-22T00:00:00Z",
+      "quoteExcerpt": "gravel, will join the UCI Cycling for All International Calendar in 2022",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_uci_first_gravel_worlds_route_2022",
+      "canonicalUrl": "https://www.uci.org/pressrelease/the-uci-reveals-race-routes-for-first-uci-gravel-world-championships/iPrgqQjdvHWlQN0dyzxXW",
+      "publisher": "UCI",
+      "publishedAt": "2022-09-06T00:00:00Z",
+      "quoteExcerpt": "The races for the different categories will start in Vicenza",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_morton_dirty_kanza_existing_worlds_2020",
+        "claim_morton_mass_participation_shared_experience_2020",
+        "claim_haas_wants_title_without_takeover_2020",
+        "claim_uci_announces_gravel_world_series_2021",
+        "claim_uci_first_gravel_worlds_route_2022"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-worlds",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_uci_seeks_gravel_governance_2020",
+        "claim_haas_wants_title_without_takeover_2020",
+        "claim_uci_road_gravel_safety_requirements_2020",
+        "claim_eroica_offers_gravel_worlds_2020",
+        "claim_uci_announces_gravel_world_series_2021",
+        "claim_uci_first_gravel_worlds_route_2022"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T19:00:00Z",
+  "contentHash": "dd688bd0aa076416b95f57ab3913f16b002c9abbe68bb79c59dedef2c25a2a4f"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -685,10 +685,10 @@ def test_2020_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 88
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 16
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 3
     assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
     assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 20
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 17
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 14
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a draft 2020 Gravel Weekly history chapter on grassroots versus institutional championship legitimacy
- connect the January 24, January 25, and February 8 source windows to the evidence-backed narrative
- preserve human approval, editorial-review-only race impacts, and complete ledger accounting

## Verification
- `python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2020-gravel-world-championship-before-government.json`
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2020.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q`
- both Gravel Weekly slop detectors: zero findings
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill accounting only; draft content cannot auto-publish and race impacts are review-only with no auto-fix.
> 
> **Overview**
> Introduces a **draft** Gravel Weekly history entry (`history-gravel-world-championship-before-government-2020`) on grassroots vs UCI championship legitimacy (Jan–Feb 2020), with contemporary receipts, later UCI gravel-worlds evidence, and **editorial-review-only** race impacts for Unbound and UCI Gravel Worlds. The entry stays unpublished (`humanApprovalRequired`, `model_draft` take).
> 
> The **2020 backfill ledger** reclassifies three weekly windows (Jan 18–24, Jan 25–31, Feb 8–14) from `pending_review` to `covered_by_draft`, each pointing at that entry with narrative reasons tied to the source weeks.
> 
> **Tests** update expected 2020 ledger disposition counts: `covered_by_draft` 0→3, `pending_review` 17→14.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09d14a054f45a14820c83ad45dd4464d88c5ceeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->