### PR TITLE
Add 2020 pro cycling exit chapter

### DIFF
--- a/data/gravel-weekly/backfill/2020.json
+++ b/data/gravel-weekly/backfill/2020.json
@@ -22,17 +22,21 @@
       "periodStartedAt": "2020-01-04",
       "periodEndedAt": "2020-01-10",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-became-pro-cycling-exit-interview-2020"
+      ],
+      "reason": "Stetina's in-prime WorldTour exit begins the draft chapter about gravel becoming an alternative professional structure."
     },
     {
       "periodStartedAt": "2020-01-11",
       "periodEndedAt": "2020-01-17",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-became-pro-cycling-exit-interview-2020"
+      ],
+      "reason": "Boswell's decision to decline a road contract for gravel, media, and brand work supplies the draft chapter's second labor-model case."
     },
     {
       "periodStartedAt": "2020-01-18",
@@ -58,9 +62,11 @@
       "periodStartedAt": "2020-02-01",
       "periodEndedAt": "2020-02-07",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-became-pro-cycling-exit-interview-2020"
+      ],
+      "reason": "Old Man Winter's mixed field of road champions, gravel winners, former WorldTour riders, and 1,200 participants shows the alternative market operating in public."
     },
     {
       "periodStartedAt": "2020-02-08",

--- a/data/gravel-weekly/history/2020-gravel-became-pro-cycling-exit-interview.json
+++ b/data/gravel-weekly/history/2020-gravel-became-pro-cycling-exit-interview.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-became-pro-cycling-exit-interview-2020",
+  "activeFrom": "2020-01-04",
+  "activeThrough": "2020-02-05",
+  "status": "draft",
+  "headline": "Gravel Became Pro Cycling's Exit Interview",
+  "point": "Peter Stetina and Ian Boswell did not move from the WorldTour into ordinary retirement. They used gravel to unbundle professional cycling: racing, sponsorship, media, brand work, and a life outside the road calendar could become separate jobs instead of one team-controlled package. When both appeared beside reigning U.S. road champions at Old Man Winter weeks later, gravel looked less like an alumni ride than a competing labor market.",
+  "priorJudgment": "Leaving the WorldTour meant an elite rider's serious racing career was over, and gravel was a softer landing where retired road professionals could trade on old fitness and name recognition.",
+  "changedJudgment": "Gravel offered experienced riders a different professional structure rather than a simple comedown. Stetina could leave in his prime and build a sponsor-backed privateer program; Boswell could decline another road contract while combining racing with podcast and brand work. The freedom was real, although access depended heavily on elite credentials, relationships, and sponsors that most privateers did not possess.",
+  "stakes": "This shift changed who entered major gravel races, how riders made a living, what brands bought, how road and off-road calendars competed for talent, and whether nominally open events could remain competitively open once former WorldTour riders arrived with professional engines and existing commercial networks.",
+  "credibleOpposition": "Two prominent male American riders did not establish a broad or equitable labor market. Stetina arrived with WorldTour recognition and sponsor relationships; Boswell paired racing with a Wahoo job after a serious concussion and did not initially describe gravel as a full replacement salary. Their choices could be read as unusual personal transitions, and their advantages could make life harder for career privateers rather than prove that gravel offered the same path to everyone.",
+  "whatHappened": "On January 4, Cyclingnews published a podcast with Peter Stetina after he left the WorldTour for a season of gravel races. Stetina described himself as stepping away in his prime after ten years at the top level. Eleven days later, Ian Boswell announced that he would retire from professional road cycling, turn to a North American gravel program, podcasting, and a role with Wahoo. Boswell's choice followed the sixth concussion of his career, but it was not forced by an absence of options: he said Rally Cycling had offered him a 2020 contract and that he no longer wanted the sacrifices required by the road lifestyle. On February 5, the two supposed escapees appeared in the Old Man Winter field with reigning U.S. road champions Alex Howes and Ruth Winder, Dirty Kanza winners Colin Strickland and Amity Rockwell, and 1,200 registered participants. The start list collapsed the distinction between active road star, former WorldTour rider, gravel specialist, multisport athlete, and amateur. In June 2021, Boswell won Unbound Gravel 200 in his first appearance, while Stetina was part of the late lead group. The exit route had become a route to the top of another sport.",
+  "take": "Model draft, not Matti's approved view: Road cycling called it retirement because road cycling has always assumed it owns the definition of employment. Stetina left in his prime. Boswell turned down a contract. Both immediately acquired schedules, sponsors, obligations, and people asking what tires they were running. Very restful. Gravel's actual innovation was not rescuing washed pros. It was letting riders separate the parts of the job they still wanted from the institution they no longer did. Race hard, make a podcast, represent a brand, host an event, sleep in your own time zone occasionally. By Old Man Winter, the reigning U.S. road champions were lining up with the new retirees and 1,196 of their closest friends. A year later Boswell won Unbound. The important warning is embedded in the success: a WorldTour résumé makes privateering much less private. These riders brought engines, names, and sponsor phone numbers that local racers could not manufacture. Gravel created an exit from the team bus, then discovered that the people getting off already had first-class luggage.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The evidence establishes Stetina's and Boswell's stated transitions, Boswell's road-contract option, the Old Man Winter field, and Boswell's later Unbound win. It does not establish the riders' complete compensation, sponsor terms, comparative income, or whether other athletes had equivalent access. Calling gravel a competing labor market is an interpretation of the combined racing, sponsor, media, event, and brand roles visible in their transitions, not a claim that gravel already supported a mature or equitable employment system in 2020.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_stetina_leaves_worldtour_in_prime_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/peter-stetina-from-the-worldtour-to-gravel-racing-podcast/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-01-04T13:53:17Z",
+      "quoteExcerpt": "I'm stepping away in my prime",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_boswell_gravel_media_brand_transition_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/ian-boswell-retires-from-worldtour-racing-to-begin-gravel-adventure/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-01-15T13:02:32Z",
+      "quoteExcerpt": "turn his attention to gravel racing, podcasting and a position at Wahoo",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_boswell_declined_road_contract_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/ian-boswell-retires-from-worldtour-racing-to-begin-gravel-adventure/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-01-15T13:02:32Z",
+      "quoteExcerpt": "Once I had an offer on the table from Rally ... I just wasn't willing to go back",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_old_man_winter_mixed_elite_field_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/us-pro-road-champs-line-up-for-gravel-test-at-old-man-winter/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-02-05T14:27:25Z",
+      "quoteExcerpt": "US pro road race champions ... will join ... Dirty Kanza winners",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_old_man_winter_1200_participants_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/us-pro-road-champs-line-up-for-gravel-test-at-old-man-winter/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-02-05T14:27:25Z",
+      "quoteExcerpt": "1,200 registered participants",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_boswell_wins_unbound_2021",
+      "canonicalUrl": "https://www.cyclingnews.com/races/unbound-gravel-2021/unbound-gravel-200-men/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2021-06-05T00:00:00Z",
+      "quoteExcerpt": "win the Unbound Gravel 200",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_stetina_leaves_worldtour_in_prime_2020",
+        "claim_boswell_gravel_media_brand_transition_2020",
+        "claim_boswell_declined_road_contract_2020",
+        "claim_old_man_winter_mixed_elite_field_2020",
+        "claim_boswell_wins_unbound_2021"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T19:30:00Z",
+  "contentHash": "2784f0d91868090c5fe59f57c616c96c8a899c9a7269615706af9094e4099dbe"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -685,10 +685,10 @@ def test_2020_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 88
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 16
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 3
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 6
     assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
     assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 20
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 14
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 11
     assert validated["complete"] is False
 
 


### PR DESCRIPTION
## Summary
- add a draft 2020 Gravel Weekly chapter on gravel becoming an alternative professional labor structure
- connect Stetina, Boswell, and Old Man Winter source windows to one evidence-backed narrative
- keep Unbound implications editorial-review-only and preserve human publication approval

## Verification
- history and 2020 backfill validators
- `python3 -m pytest tests/test_gravel_weekly.py -q` (37 passed)
- both slop detectors: zero findings
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill metadata only; no runtime or security paths, with explicit human approval and no auto-publish.
> 
> **Overview**
> Adds a **draft** Gravel Weekly history chapter (`history-gravel-became-pro-cycling-exit-interview-2020`) arguing that Stetina and Boswell used gravel to unbundle racing, sponsors, and media—not simple retirement—and ties that narrative to Cyclingnews receipts (WorldTour exits, declined road contract, Old Man Winter field) plus later Boswell/Unbound evidence.
> 
> The **2020 backfill ledger** moves three early-2020 weeks from `pending_review` to `covered_by_draft`, each linked to that entry with Stetina-, Boswell-, and Old Man Winter–specific reasons. Publication stays gated: `status: draft`, `humanApprovalRequired`, `autoPublishAllowed: false`, and Unbound impact is `editorial_review` on `race.biased_opinion` without auto-fix.
> 
> **Tests** update expected 2020 ledger disposition counts (`covered_by_draft` 3→6, `pending_review` 14→11).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 494cc2c1cf292a3da0ba2efff8d10df6c213e525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->