### PR TITLE
Complete the 2020 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2020.json
+++ b/data/gravel-weekly/backfill/2020.json
@@ -6,7 +6,7 @@
   "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33165794431",
   "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
   "sourceCardCount": 88,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -82,9 +82,9 @@
       "periodStartedAt": "2020-02-15",
       "periodEndedAt": "2020-02-21",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A single deep-gravel-corner crash during a road stage was unexpected but did not establish a durable gravel-season argument beyond the incident itself."
     },
     {
       "periodStartedAt": "2020-02-22",
@@ -182,33 +182,41 @@
       "periodStartedAt": "2020-05-09",
       "periodEndedAt": "2020-05-15",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-race-cancelled-gravel-everywhere-2020"
+      ],
+      "reason": "SBT GRVL's cancellation and free distributed substitute begin the draft chapter about gravel becoming a portable ritual when its physical gatherings disappeared."
     },
     {
       "periodStartedAt": "2020-05-16",
       "periodEndedAt": "2020-05-22",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-race-cancelled-gravel-everywhere-2020"
+      ],
+      "reason": "Dirty Kanzelled reduced the cancelled event to distance, date, local route, and public proof, supplying the draft chapter's minimum viable gravel ritual."
     },
     {
       "periodStartedAt": "2020-05-23",
       "periodEndedAt": "2020-05-29",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-race-cancelled-gravel-everywhere-2020"
+      ],
+      "reason": "Van Aert's announced participation shows elite visibility moving into the distributed substitute before the rides occurred."
     },
     {
       "periodStartedAt": "2020-05-30",
       "periodEndedAt": "2020-06-05",
       "sourceCardCount": 4,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-race-cancelled-gravel-everywhere-2020"
+      ],
+      "reason": "Van Aert's 320-kilometre completion and King's 310-mile ride turned a decentralized substitute into visible gravel spectacle."
     },
     {
       "periodStartedAt": "2020-06-06",
@@ -222,9 +230,11 @@
       "periodStartedAt": "2020-06-13",
       "periodEndedAt": "2020-06-19",
       "sourceCardCount": 16,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-race-cancelled-gravel-everywhere-2020"
+      ],
+      "reason": "Cyclingnews's concentrated Gravel Week package shows the cancelled-event season becoming a coherent media, instruction, personality, and product category."
     },
     {
       "periodStartedAt": "2020-06-20",
@@ -270,9 +280,11 @@
       "periodStartedAt": "2020-07-25",
       "periodEndedAt": "2020-07-31",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-road-racing-borrowed-gravel-drama-2020"
+      ],
+      "reason": "Kwiatkowski's August Strade Bianche warning begins the draft chapter about road promoters inheriting gravel-specific risk and equipment responsibilities."
     },
     {
       "periodStartedAt": "2020-08-01",
@@ -326,9 +338,11 @@
       "periodStartedAt": "2020-09-12",
       "periodEndedAt": "2020-09-18",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-road-racing-borrowed-gravel-drama-2020"
+      ],
+      "reason": "The Giro Rosa gravel stage changed the race lead, forced Van Vleuten to run after a mechanical, and produced her explicit objection to gravel inside stage races."
     },
     {
       "periodStartedAt": "2020-09-19",
@@ -374,9 +388,11 @@
       "periodStartedAt": "2020-10-24",
       "periodEndedAt": "2020-10-30",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-heritage-not-consent-2020"
+      ],
+      "reason": "The October 29 Unbound announcement completes the draft chapter about the Kaw Nation's request, the organizer's reversal, and consent to a borrowed identity."
     },
     {
       "periodStartedAt": "2020-10-31",
@@ -451,5 +467,5 @@
       "reason": "A standalone bike review closes the archive as product evaluation, not a season-level story."
     }
   ],
-  "updatedAt": "2026-08-28T15:30:00Z"
+  "updatedAt": "2026-08-28T20:15:00Z"
 }

--- a/data/gravel-weekly/history/2020-heritage-not-consent.json
+++ b/data/gravel-weekly/history/2020-heritage-not-consent.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-heritage-not-consent-2020",
+  "activeFrom": "2020-08-18",
+  "activeThrough": "2020-10-29",
+  "status": "draft",
+  "headline": "Gravel's Biggest Name Learned That Heritage Is Not Consent",
+  "point": "Dirty Kanza's 2020 renaming was not a cosmetic response to generic internet pressure. After the Kaw Nation asked organizers to dissolve the race name's connection to its people, the event reversed its own April defense and became Unbound Gravel. Long use, regional pride, and good intent did not create permanent permission to turn another community's identity into a commercial race brand.",
+  "priorJudgment": "The name honored the Flint Hills and the Kaw people, fifteen years of use had made it inseparable from gravel history, and earlier cooperation with tribal representatives was enough to establish legitimacy despite objections.",
+  "changedJudgment": "A relationship could change when the people being invoked changed or clarified their position. The relevant evidence was not what organizers had intended or previously heard; it was the Kaw Nation's current request that the connection end. Preserving gravel history therefore required changing the brand, not freezing it.",
+  "stakes": "The episode set a governance test for gravel events built from local land, history, and borrowed identity: who gets to define respect, whether consultation is ongoing, and whether an organizer can distinguish attachment to its brand from entitlement to somebody else's name. Unbound's scale made the answer visible across the sport.",
+  "credibleOpposition": "The original name was presented as regional homage rather than deliberate insult, an April statement had defended the relationship, and fifteen years of recognition created real local, participant, and commercial attachment. Renaming a major event carries confusion and cost, and not every critic agreed on the term's history or meaning. None of that, however, overrides the Kaw Nation's explicit request to end the association with its people.",
+  "whatHappened": "In April 2020, organizers had co-signed a statement defending the Dirty Kanza name and its relationship to the Kaw Nation. As criticism grew, an event delegation met the Tribal Council on July 22. On August 18, the organizer acknowledged that more Kaw members wanted the name changed, that the council had asked the race to move forward without a connection to the tribe, and that this represented a change from the April rhetoric. Kaw Nation Chairwoman Lynn Williams stated that elders and members had discussed the issue and respectfully asked for the name change to dissolve the connection to the Kanza. On October 29, Life Time announced Unbound Gravel, a new logo, and a task-force process involving Emporia leaders, athletes, cycling representatives, partners, and the Kaw Nation Tribal Council. The race did not erase its history; it stopped treating that history as perpetual authorization.",
+  "take": "Model draft, not Matti's approved view: Gravel spent fifteen years treating a race name like a belt buckle: earn it once, display it forever. Then the people inside the name asked to be taken out. This should have made the decision simple. Instead, organizers first defended the brand, met with the Kaw Nation, admitted the conversation had changed, and finally arrived at Unbound. That sequence matters because heritage is not a lifetime software license. You do not get permanent naming rights to somebody else's identity because your intentions were wholesome in 2006, your logo sells hats, or everybody in Emporia knows what race weekend means. The Kaw Nation did not ask cyclists to litigate the race on its behalf. It asked that the connection end. Unbound was therefore more than reputation management. It was a useful institutional lesson: if your celebration depends on a community's name, that community retains the right to stop celebrating with you.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The primary statements and contemporary reporting establish the Kaw Nation's request, the organizer's acknowledged reversal from April, the consultation process, and the October 29 rebrand. They do not establish the views of every Kaw citizen, every local resident, or every participant, nor do they quantify financial cost, registration effects, or later inclusion outcomes. This entry distinguishes intent from permission but does not purport to settle every historical or linguistic claim made during the controversy.",
+  "editorialScore": 97,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_kaw_nation_requested_name_connection_end_2020",
+      "canonicalUrl": "https://www.unboundgravel.com/statement-from-kaw-nation-chairwoman-lynn-williams/",
+      "publisher": "Kaw Nation statement via Unbound Gravel",
+      "publishedAt": "2020-08-18T16:43:10Z",
+      "quoteExcerpt": "asked that the name be changed to dissolve the connection to our people",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_organizer_acknowledged_april_reversal_2020",
+      "canonicalUrl": "https://www.unboundgravel.com/an-update-from-hq-in-emporia/",
+      "publisher": "Unbound Gravel",
+      "publishedAt": "2020-08-18T13:43:12Z",
+      "quoteExcerpt": "We acknowledge this is a change in rhetoric from our April co-signed statement",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_dirty_kanza_became_unbound_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/dirty-kanza-renamed-unbound-gravel-after-complaints-term-insulted-native-americans/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-10-29T19:46:33Z",
+      "quoteExcerpt": "renaming it 'UNBOUND Gravel'",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_kaw_nation_requested_name_connection_end_2020",
+        "claim_organizer_acknowledged_april_reversal_2020",
+        "claim_dirty_kanza_became_unbound_2020"
+      ],
+      "confidence": 0.99,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T20:15:00Z",
+  "contentHash": "7fd9e6bad741171db1921e3100db902645a497fafffe1e3cb947e819822f1cb7"
+}

--- a/data/gravel-weekly/history/2020-race-cancelled-gravel-everywhere.json
+++ b/data/gravel-weekly/history/2020-race-cancelled-gravel-everywhere.json
@@ -1,0 +1,115 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-race-cancelled-gravel-everywhere-2020",
+  "activeFrom": "2020-05-13",
+  "activeThrough": "2020-06-19",
+  "status": "draft",
+  "headline": "The Race Was Cancelled; Gravel Happened Everywhere",
+  "point": "When the pandemic erased gravel's gathering places, organizers and riders discovered that the event could be reduced to a date, a distance, a route file, and public proof that somebody had done the absurd thing. SBT VRTL and Dirty Kanzelled were not replacements for racing, but they showed that gravel's identity was portable enough to survive without a start line—and valuable enough for a major cycling publication to package as an entire week of culture, instruction, personalities, and products.",
+  "priorJudgment": "A gravel event was inseparable from its physical place, mass start, timing, aid stations, finish line, and shared community; cancel the gathering and the event simply did not exist.",
+  "changedJudgment": "The physical race remained irreplaceable, but its minimum viable ritual could travel. Organizers supplied distance and date, riders supplied local roads and self-documentation, professionals supplied spectacle, and media supplied a shared audience. That portability kept gravel culturally active during shutdown while also exposing how quickly participation could become content and commerce.",
+  "stakes": "The 2020 improvisation anticipated remote challenges, route platforms, social proof, event-owned media, and a gravel market that could keep sponsors and audiences engaged without operating the race itself. It also clarified what those substitutes could not reproduce: fair comparison, emergency support, equal access, local economic activity, or the social density of an actual event.",
+  "credibleOpposition": "A solo route was not a race. Dirty Kanzelled had no common course, timing standard, neutral support, or comparable conditions, and SBT VRTL did not reproduce Steamboat's roads or gathering. The most visible examples came from famous professionals with sponsors, enormous fitness, and media reach. Calling the format portable risks turning an emergency substitute into evidence that organizers can charge for less or that online attention equals community.",
+  "whatHappened": "On May 13, SBT GRVL cancelled its sold-out Steamboat event after concluding that pandemic precautions would compromise safety and the event itself. It offered deferrals or refunds and announced free SBT VRTL participation for August 16: four distances, regional routes, and Ride with GPS navigation open to everyone. On May 21, Dirty Kanzelled asked riders to complete 100 or 200 miles on their own routes in accordance with local restrictions instead of traveling to the cancelled Dirty Kanza. Wout van Aert joined Laurens ten Dam's version and completed 320 kilometres; Ted King extended the premise into a 310-mile, roughly 20-hour ride. Two weeks later Cyclingnews devoted June 15 through 19 to Gravel Week, publishing 16 archive cards across rider essays, interviews, race lists, skills, preparation, equipment, Instagram, and an argument about the discipline's future. In five weeks, gravel moved from cancelled destinations to a distributed ritual and then into a coherent media category.",
+  "take": "Model draft, not Matti's approved view: COVID cancelled the race and gravel responded by becoming a chain letter with a GPX file. Ride 100 or 200 miles wherever you live, post evidence, tag your friends, and somebody with WorldTour legs will inevitably misunderstand the assignment so violently that 200 miles becomes 320 kilometres or 310 miles. It was ridiculous, but it proved something useful. Gravel did not need a barricaded stadium to remain legible. It needed a stupid distance, a date, local dirt, and enough witnesses to know you had made poor choices on purpose. Then Cyclingnews ran Gravel Week and completed the conversion: the missing race became profiles, tips, bike parts, Instagram, and a debate about the soul of the sport. That was not community in full. Nobody could compare weather, receive equal support, or hand you a beer at the same finish line. But the year revealed gravel's minimum viable product, and it fit inside a route link. The race disappeared; the ritual escaped.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed reporting establishes the cancellations, published formats, selected professional rides, and Cyclingnews package. It does not establish participation totals for Dirty Kanzelled or SBT VRTL, demographic reach, sponsor value, completion verification, accident rates, or whether ordinary riders experienced a comparable sense of community. Cyclingnews's 16 matching archive cards include commercial and service material as well as editorial stories; their concentration demonstrates category treatment, not that every card was influential. The claim is about a visible 2020 adaptation, not that remote challenges originated that year or adequately replaced events.",
+  "editorialScore": 94,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_sbt_cancelled_and_launched_vrtl_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/sbt-grvl-prioritise-public-safety-in-cancellation-of-2020-gravel-race/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-05-13T16:22:04Z",
+      "quoteExcerpt": "launched SBT VRTL for participants to ride one of four distances",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_dirty_kanzelled_distributed_substitute_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/dirty-kanzelled-is-your-gravel-race-substitute-event/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-05-21T12:06:21Z",
+      "quoteExcerpt": "your gravel race substitute event",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_van_aert_joins_dirty_kanzelled_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/wout-van-aert-to-take-part-in-laurens-ten-dams-dirty-kanzelled-gravel-ride/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-05-29T11:29:18Z",
+      "quoteExcerpt": "Wout van Aert to take part",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_van_aert_completes_320km_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/wout-van-aert-completes-320km-dirty-kanzelled-gravel-ride/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-06-01T01:23:20Z",
+      "quoteExcerpt": "completes 320km 'Dirty Kanzelled' gravel ride",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_ted_king_310_mile_ride_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/ted-king-puts-down-phenomenal-20-hour-310-mile-gravel-ride/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-06-02T14:23:20Z",
+      "quoteExcerpt": "20-hour 310-mile gravel ride",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_week_portable_media_category_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/features/future-gravel-where-does-cyclings-hottest-trend-go-from-here/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-06-17T08:50:11Z",
+      "quoteExcerpt": "More from Gravel Week",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:sbt-grvl",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_sbt_cancelled_and_launched_vrtl_2020"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_dirty_kanzelled_distributed_substitute_2020",
+        "claim_van_aert_joins_dirty_kanzelled_2020",
+        "claim_van_aert_completes_320km_2020",
+        "claim_ted_king_310_mile_ride_2020"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T20:15:00Z",
+  "contentHash": "42553fc4ab0b7d9b76c907f1d898167745e188414dc54686c1c0c60b49ef7088"
+}

--- a/data/gravel-weekly/history/2020-road-racing-borrowed-gravel-drama.json
+++ b/data/gravel-weekly/history/2020-road-racing-borrowed-gravel-drama.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-road-racing-borrowed-gravel-drama-2020",
+  "activeFrom": "2020-07-31",
+  "activeThrough": "2020-09-13",
+  "status": "draft",
+  "headline": "Road Racing Wanted Gravel's Drama Without Gravel's Homework",
+  "point": "The 2020 road calendar used gravel as a spectacle amplifier, then discovered that a surface is not decorative. Moving Strade Bianche into August changed grip, heat, equipment compromise, and peloton risk; putting two gravel sectors inside the Giro Rosa changed the general classification and forced the eventual stage winner to run. Gravel delivered television-grade chaos, but it also demanded surface-specific course judgment that road racing could not outsource to the riders.",
+  "priorJudgment": "Gravel sectors were a reliable way to make road racing harder and more cinematic while leaving the essential race intact; skilled riders could recon the course, choose equipment, and treat the surface as another legitimate selective feature.",
+  "changedJudgment": "The same road could become a materially different competitive object when season, weather, field dynamics, equipment, and stage-race stakes changed. Reconnaissance and bike choice could reduce risk but not erase it, so promoters had to evaluate gravel as an operating condition rather than a visual ingredient.",
+  "stakes": "Surface choices can decide general classification, equipment failures, crashes, and whether risk falls predictably across a field. The argument reaches beyond two Italian races: any promoter borrowing gravel's drama also inherits responsibility for timing, preparation, course communication, support, and the consequences of inserting technical randomness into a stage race.",
+  "credibleOpposition": "Strade Bianche is a purpose-built and celebrated one-day classic whose loose white roads are the race, not an ambush. The Giro Rosa riders reconnoitred the stage, Van Vleuten attacked knowingly, survived the mechanical, and won by more than a minute. Technical unpredictability is legitimate racing, and removing every sector that can cause a puncture or separation would sterilize the sport. The narrower claim is that gravel requires context-specific design, not that gravel belongs outside road racing.",
+  "whatHappened": "On July 31, two-time Strade Bianche winner Michał Kwiatkowski warned that moving the race from March to August had left its gravel looser and dustier, reduced grip, raised forecast temperatures to 37°C, and complicated equipment selection because long asphalt and the steep Siena finish remained decisive. He called the race dangerous and risky after reconnoitring its final 75 kilometres. Six weeks later, stage 2 of the Giro Rosa included two gravel sectors, 3,100 metres of climbing, and a decisive Seggiano sector 16 kilometres from the finish. Race leader Elisa Longo Borghini lost the maglia rosa. Annemiek van Vleuten slid out, required a wheel change, ran part of the climb while holding her bike, and still won by 1:16 to take the lead. The next day she argued that such sections were unnecessary, crazy, and dangerous inside stage races and should be left to a one-day event like Strade Bianche.",
+  "take": "Model draft, not Matti's approved view: Road racing looked at gravel and saw instant seasoning. Sprinkle white rocks on a stage, cue the helicopter, and suddenly everybody gets to say epic without inventing a new plot. Unfortunately, gravel is not paprika. Move Strade Bianche from March to August and the same postcard becomes loose dust at 37 degrees with a peloton trying to brake on it. Put a Seggiano goat path inside the Giro Rosa and the world champion can slide out, change a wheel, shoulder the bike, and win anyway while the race leader loses pink. Great television. Also a fairly loud memo from the surface. The road world wanted gravel's chaos but kept assigning the homework to riders: recon harder, choose one bike for incompatible demands, and please make the mechanical look heroic. Van Vleuten's complaint was not that races should be easy. She had just won the hard one. Her point was that a one-day classic can make the terrain the contract; a stage race can make it an ambush with consequences that persist for a week. Borrow the drama if you want. You also borrow the duty of care.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed reporting establishes the changed Strade Bianche conditions, Kwiatkowski's assessment, the Giro Rosa route features, Van Vleuten's mechanical and victory, Longo Borghini's loss of the lead, and Van Vleuten's criticism. It does not establish injury rates, organizer deliberations, whether the sectors exceeded governing standards, or the counterfactual general classification on an all-paved route. The phrase 'duty of care' is an editorial judgment about course responsibility, not a legal conclusion or an allegation that either promoter was negligent.",
+  "editorialScore": 93,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_strade_august_gravel_risk_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/kwiatkowski-strade-bianche-gravel-will-be-dangerous-and-risky/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-07-31T00:16:07Z",
+      "quoteExcerpt": "sections of gravel are just looser",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_longo_borghini_lost_lead_on_gravel_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/giro-rosa-longo-borghini-loses-leaders-jersey-on-gravel-stage/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-09-12T19:30:09Z",
+      "quoteExcerpt": "loses leader's jersey on gravel stage",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_van_vleuten_ran_and_won_gravel_stage_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/giro-rosa-annemiek-van-vleuten-takes-maglia-rosa-after-being-forced-to-run-up-seggiano-gravel-climb/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-09-12T20:54:31Z",
+      "quoteExcerpt": "run up the decisive final gravel climb",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_van_vleuten_criticised_stage_gravel_2020",
+      "canonicalUrl": "https://www.cyclingnews.com/news/annemiek-van-vleuten-critical-of-strade-bianche-style-gravel-stage-at-giro-rosa/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2020-09-13T13:25:51Z",
+      "quoteExcerpt": "gravel sections in stage races are unnecessary, crazy and dangerous",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T20:15:00Z",
+  "contentHash": "085d09a4d24bd2af4825c460114b9e22bf0d94de87999e1796e2ae561feb85ce"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -685,11 +685,11 @@ def test_2020_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 88
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 16
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 8
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 16
     assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 20
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 9
-    assert validated["complete"] is False
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 21
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
 
 
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():


### PR DESCRIPTION
## Summary
- close all nine remaining 2020 review windows
- add sourced drafts about distributed pandemic-era gravel, road racing borrowing gravel risk, and the Unbound rename
- reject the isolated Volta ao Algarve crash and mark the 53-week ledger complete

## Safety
- all entries remain model drafts requiring human approval
- publishing is disabled
- race impacts are editorial-review only and cannot auto-fix data

## Verification
- history and backfill validators pass
- 37 focused Gravel Weekly tests pass
- both slop detectors report zero findings
- git diff --check passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and test expectations only; new content stays draft with publishing disabled, though the Unbound/Kaw Nation narrative is socially sensitive if approved later.
> 
> **Overview**
> **Finishes the 2020 Gravel Weekly backfill ledger** by clearing the last nine `pending_review` weeks: eight now link to new draft history entries via `covered_by_draft`, one mid-February window is **rejected** (isolated road-stage crash), and the year ledger is marked **`complete: true`** with zero pending windows.
> 
> **Adds three sourced `gravel-weekly-history-entry` drafts** (still `status: draft`, human approval required, no auto-publish): pandemic distributed substitutes (`history-race-cancelled-gravel-everywhere-2020`), road stage races borrowing gravel risk (`history-road-racing-borrowed-gravel-drama-2020`), and Dirty Kanza → Unbound / Kaw Nation consent (`history-heritage-not-consent-2020`). Two entries flag **editorial-review-only** `raceImpacts` on SBT GRVL and Unbound; the road-racing chapter has no race impacts.
> 
> **Updates** `test_2020_backfill_ledger_starts_from_the_complete_source_census` to expect 16 `covered_by_draft`, 21 `rejected`, 0 `pending_review`, and `complete` true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a262c45163ebc44542be97a09af73d8b5da1b224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->