### PR TITLE
Complete the 2019 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2019.json
+++ b/data/gravel-weekly/backfill/2019.json
@@ -6,7 +6,7 @@
   "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33168713397",
   "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
   "sourceCardCount": 16,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -38,17 +38,17 @@
       "periodStartedAt": "2019-01-19",
       "periodEndedAt": "2019-01-25",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Two bare Gravel and Tar result pages record winners but provide no independent conflict, changed judgment, or cultural consequence."
     },
     {
       "periodStartedAt": "2019-01-26",
       "periodEndedAt": "2019-02-01",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A single Herald Sun Tour gravel-stage report shows a selective road surface but does not establish a durable 2019 gravel narrative."
     },
     {
       "periodStartedAt": "2019-02-02",
@@ -158,9 +158,11 @@
       "periodStartedAt": "2019-05-04",
       "periodEndedAt": "2019-05-10",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-got-own-department-2019"
+      ],
+      "reason": "Shimano's GRX launch begins the draft chapter about a rider-built equipment category receiving a complete mainstream product platform."
     },
     {
       "periodStartedAt": "2019-05-11",
@@ -190,9 +192,11 @@
       "periodStartedAt": "2019-06-01",
       "periodEndedAt": "2019-06-07",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-got-own-department-2019"
+      ],
+      "reason": "Dirty Kanza's mixed equipment gallery shows newly released GRX entering a field that still rewarded creative, non-uniform solutions."
     },
     {
       "periodStartedAt": "2019-06-08",
@@ -270,9 +274,11 @@
       "periodStartedAt": "2019-08-10",
       "periodEndedAt": "2019-08-16",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-became-economy-before-league-2019"
+      ],
+      "reason": "Tuft's planned adventure-guiding business supplies the first role in the draft chapter about gravel work emerging outside a conventional league."
     },
     {
       "periodStartedAt": "2019-08-17",
@@ -294,9 +300,9 @@
       "periodStartedAt": "2019-08-31",
       "periodEndedAt": "2019-09-06",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Lopez's Vuelta crash on one gravel sector is a road-race incident without enough evidence for a distinct gravel-season change point."
     },
     {
       "periodStartedAt": "2019-09-07",
@@ -366,17 +372,19 @@
       "periodStartedAt": "2019-11-02",
       "periodEndedAt": "2019-11-08",
       "sourceCardCount": 3,
-      "disposition": "pending_review",
-      "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-became-economy-before-league-2019"
+      ],
+      "reason": "Stetina's WorldTour exit and Life Time's Big Sugar launch complete the draft chapter's athlete and event-business cases; the bike-category explainer is supporting context only."
     },
     {
       "periodStartedAt": "2019-11-09",
       "periodEndedAt": "2019-11-15",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A single Colnago gravel-bike launch confirms manufacturer interest but supplies no independent story beyond the product."
     },
     {
       "periodStartedAt": "2019-11-16",
@@ -398,25 +406,25 @@
       "periodStartedAt": "2019-11-30",
       "periodEndedAt": "2019-12-06",
       "sourceCardCount": 1,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A carbon-frame buying argument is commercial service content without a historical conflict or demonstrated consequence."
     },
     {
       "periodStartedAt": "2019-12-07",
       "periodEndedAt": "2019-12-13",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "A bike review and tyre-insert launch are product evaluation and inventory, not a Current Thing."
     },
     {
       "periodStartedAt": "2019-12-14",
       "periodEndedAt": "2019-12-20",
       "sourceCardCount": 2,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Source census complete; assigning-desk research and disposition remain pending."
+      "reason": "Steel-bike and e-gravel-bike announcements show category breadth but neither establishes a separate season-level argument."
     },
     {
       "periodStartedAt": "2019-12-21",
@@ -435,5 +443,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T11:52:00Z"
+  "updatedAt": "2026-08-28T12:15:00Z"
 }

--- a/data/gravel-weekly/history/2019-gravel-became-economy-before-league.json
+++ b/data/gravel-weekly/history/2019-gravel-became-economy-before-league.json
@@ -1,0 +1,86 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-became-economy-before-league-2019",
+  "activeFrom": "2019-08-15",
+  "activeThrough": "2019-11-07",
+  "status": "draft",
+  "headline": "Gravel Became an Economy Before It Became a League",
+  "point": "By late 2019, gravel could support three different professional bets without a coherent league: Svein Tuft planned a guiding business after road retirement, Peter Stetina left the WorldTour to remain a sponsor-backed racer, and Life Time used Dirty Kanza's model to launch Big Sugar in Bentonville. The sport's economic structure arrived as tours, privateering, and event expansion before rules, teams, rankings, or a governing calendar caught up.",
+  "priorJudgment": "Gravel was a participatory side scene and post-career hobby: riders might visit it for adventure, but serious professional work still meant a road contract or an established cycling institution.",
+  "changedJudgment": "Gravel did not need to become a conventional league before people could build work around it. Its commercial unit could be an experience, an individual athlete, or an event property. That flexibility created opportunity, while concentrating early access among famous riders, established promoters, sponsors, and cycling destinations.",
+  "stakes": "The emerging economy determined who could call gravel a job, which towns and promoters captured event growth, what sponsors purchased from athletes, and whether the discipline would professionalize through teams or through a patchwork of personal brands and experiences. It also created the incentives that later forced gravel to confront labor standards, competitive equity, consolidation, and governance.",
+  "credibleOpposition": "Tuft's guiding company was still a plan, Stetina entered with a decade of WorldTour reputation and sponsor access, and Big Sugar had not yet staged its first edition. Three prominent announcements do not prove that gravel offered durable employment or broad opportunity. The lack of salaries, benefits, contracts, and shared rules could be described as precarity rather than freedom, and the 2020 pandemic would immediately disrupt both tourism and events.",
+  "whatHappened": "On August 15, 42-year-old Svein Tuft said he would end a professional career begun in 2002 and hoped to run adventure gravel tours in the Pyrenees, Canada, and eventually elsewhere. He described gravel as a way to move away from traffic and combine riding with exploration. On November 6, Peter Stetina announced that he would leave Trek-Segafredo and the WorldTour for gravel and ultra-endurance mountain-bike racing after mixing those events with a full road season. He explicitly rejected retirement, described the move as freshness, joy, progression, and longevity, and said he would represent brands that valued the scene. One day later, Life Time announced Big Sugar in Bentonville: 171.2- and 78.8-kilometre routes, an 800-rider cap, and a plan to reproduce the event-making capacity it had applied to Dirty Kanza and Leadville. Gravel now had a guide, a privateer, and an expanding event company, but no single institution employing or governing all three.",
+  "take": "Model draft, not Matti's approved view: Gravel professionalized like a strip mall thrown up before the city finished zoning. Svein Tuft opened the adventure-tour storefront. Peter Stetina quit the WorldTour and opened a one-man race team next door. Life Time arrived with an anchor tenant and announced Big Sugar in Bentonville. Nobody had built the league, the labor agreement, the rankings, or even a shared definition of professional gravel, but the economy was already taking deposits. This was the category's great freedom and its original loophole. Work could mean guiding regular people through the Pyrenees, selling a sponsor your own race calendar, or turning one famous event into a second event property. It also meant every worker brought his own safety net, reputation, insurance, audience, and bargaining power. Gravel escaped the team bus and discovered the gig economy waiting beside a Subaru. By the time governance arrived, the businesses were already open.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The contemporary sources establish the announced plans, Stetina's stated transition, and Big Sugar's proposed format. They do not disclose compensation, sponsor contracts, business revenue, insurance, employment status, profitability, or how many livelihoods gravel supported in 2019. Tuft's and Big Sugar's plans were later disrupted by the pandemic, and none of the three cases represents ordinary access. Describing an emerging economy is an interpretation of distinct commercial roles, not a claim that gravel already had a stable labor market.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_tuft_planned_gravel_guiding_2019",
+      "canonicalUrl": "https://www.cyclingnews.com/news/tuft-to-retire-at-end-of-2019-and-take-up-gravel-bike-guiding/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2019-08-15T18:32:00Z",
+      "quoteExcerpt": "run some crazy adventure gravel tours",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_stetina_left_worldtour_for_gravel_2019",
+      "canonicalUrl": "https://www.cyclingnews.com/news/stetina-abandons-worldtour-for-gravel-racing/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2019-11-06T17:14:36Z",
+      "quoteExcerpt": "This IS NOT a retirement",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_life_time_launched_big_sugar_2019",
+      "canonicalUrl": "https://www.cyclingnews.com/news/dirty-kanza-organisers-launch-all-new-gravel-race-in-2020/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2019-11-07T17:23:51Z",
+      "quoteExcerpt": "launched a new event call the Big Sugar-NWA Gravel",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_stetina_left_worldtour_for_gravel_2019",
+        "claim_life_time_launched_big_sugar_2019"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:big-sugar-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_life_time_launched_big_sugar_2019"
+      ],
+      "confidence": 0.99,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T12:15:00Z",
+  "contentHash": "a2f9a3f5b42cd415858c779f4e7f39387d2284164523c90fac845bf431af760d"
+}

--- a/data/gravel-weekly/history/2019-gravel-got-own-department.json
+++ b/data/gravel-weekly/history/2019-gravel-got-own-department.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-got-own-department-2019",
+  "activeFrom": "2019-05-07",
+  "activeThrough": "2019-06-03",
+  "status": "draft",
+  "headline": "Shimano Gave Gravel Its Own Department",
+  "point": "GRX mattered less because Shimano invented every component than because the world's dominant drivetrain company stopped treating gravel as an improvised overlap between road, cyclocross, and mountain bikes. A named family across three tiers, mechanical and electronic shifting, one- and two-chainring options, gravel ergonomics, wheels, and dropper control made the category legible to manufacturers and ordinary buyers. Dirty Kanza showed the transition in public a month later: the new group sat among custom race bikes, road electronics, suspension stems, extreme chainrings, and home-brewed solutions rather than instantly replacing them.",
+  "priorJudgment": "A gravel bike was whatever riders assembled from road, cyclocross, and mountain-bike parts; dedicated component families were unnecessary marketing for problems that existing equipment already solved.",
+  "changedJudgment": "The parts-bin approach still worked, but gravel had accumulated enough distinct demand for Shimano to build and name a complete platform around rough-surface braking, chain retention, gearing, clearance, wheel size, and cockpit control. That institutional recognition did not create gravel, but it made the category easier to standardize, sell, and scale.",
+  "stakes": "Component categories shape which bikes manufacturers can spec, what shops can explain, which price levels buyers can enter, and which equipment choices become normal at races. The same standardization that improves availability can also narrow a creative culture into a purchasable checklist and let marketing claim ownership of solutions riders developed themselves.",
+  "credibleOpposition": "GRX recombined technologies that already existed in Shimano's road and mountain-bike systems, relied on existing cassettes and chains, and arrived after riders and small brands had established the category. Dirty Kanza's equipment remained radically mixed, proving there was no single required gravel setup. The launch was strong evidence of commercial recognition, not proof that a new groupset caused participation growth or made older bikes obsolete.",
+  "whatHappened": "On May 7, Shimano announced GRX as what it called the world's first dedicated gravel and adventure component series. The family included RX400, RX600, and RX800 levels; 10- and 11-speed mechanical options; Di2 electronic shifting; one- and two-chainring configurations; hydraulic brakes; 700c and 650b tubeless wheels; rough-surface lever shapes; clutch derailleurs; wider chainlines and gearing; and an option to control a dropper post from the left shift lever. Shimano still specified road or mountain-bike cassettes and chains, making GRX a curated bridge rather than a clean-sheet invention. On June 3, Cyclingnews's Dirty Kanza gallery showed that bridge operating inside a deliberately unruly field: Jake Wells used newly released GRX for the XL, while elite bikes also carried SRAM road electronics, custom frames, aero chainrings, suspension stems, 35mm tyres, and enough equipment to push one bike beyond 30 pounds.",
+  "take": "Model draft, not Matti's approved view: Before GRX, a gravel drivetrain was a custody dispute between the road and mountain-bike departments. You took the shifters from one parent, the cassette from the other, added a clutch derailleur, and hoped everybody behaved during the washboard. Shimano did not invent that family. It gave the family matching shirts and a product code. That sounds like marketing because it was marketing, but category names are infrastructure. Three price levels, one-by, two-by, Di2, wide gearing, textured levers, little wheels, big wheels, and even a dropper switch told bike companies and shop employees that gravel was no longer a weird customer request assembled behind the counter. Dirty Kanza immediately kept the story honest. The new GRX group shared a gallery with road electronics, a suspension stem, a leather saddle, a 56-tooth chainring, skinny tyres, custom frames, and a 30-pound expedition bike. Gravel got its own department. It did not accept a uniform.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources establish Shimano's launch claims, configurations, shared compatibility, and the equipment photographed at Dirty Kanza. They do not provide GRX sales, market share, pricing at launch in every territory, adoption rates, causal effects on bike sales, or a representative census of race equipment. 'World's first' is Shimano's positioning and should not erase earlier gravel-specific components from smaller brands. The category interpretation is editorial and does not claim that GRX created gravel riding.",
+  "editorialScore": 94,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_shimano_launched_dedicated_grx_2019",
+      "canonicalUrl": "https://www.cyclingnews.com/news/shimano-grx-gravel-specific-groupset-launched/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2019-05-07T15:00:00Z",
+      "quoteExcerpt": "world's first dedicated gravel/adventure component series",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_dirty_kanza_mixed_equipment_lab_2019",
+      "canonicalUrl": "https://www.cyclingnews.com/features/dirty-kanza-2019-gravel-race-tech-gallery/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2019-06-03T23:15:00Z",
+      "quoteExcerpt": "equipped with the recently-released Shimano GRX group",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_shimano_launched_dedicated_grx_2019",
+        "claim_dirty_kanza_mixed_equipment_lab_2019"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T12:15:00Z",
+  "contentHash": "0b0621fbb2b073dd05c3e81abb9a1a345f17dd94d4abc033c4b86d3a98e096e7"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -700,11 +700,11 @@ def test_2019_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 16
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 42
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 4
     assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 11
-    assert validated["complete"] is False
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 7
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
 
 
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():


### PR DESCRIPTION
## Summary
- close every remaining 2019 review window
- add sourced drafts about GRX formalizing the equipment category and gravel becoming an economy before a league
- reject seven generic-result, road-incident, and product-only windows
- preserve 42 explicit quiet windows

## Safety
- both entries remain model drafts requiring human approval
- publishing is disabled
- race impacts are editorial-review only and cannot auto-fix data

## Verification
- history and backfill validators pass
- 38 focused Gravel Weekly tests pass
- both slop detectors report zero findings
- git diff --check passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and test expectations only; drafts stay unpublished and cannot auto-fix race data.
> 
> **Overview**
> Finishes the **2019 Gravel Weekly backfill ledger** by clearing the last eleven `pending_review` weeks: four weeks now **`covered_by_draft`** (linked to new history entries), seven are **`rejected`** with editorial reasons, and **`complete`** is set to **true** while the 42 explicit quiet windows stay unchanged.
> 
> Adds two **`draft`** history entries—**Shimano GRX** formalizing gravel as a product category (`history-gravel-got-own-department-2019`) and **gravel as an economy before a league** (`history-gravel-became-economy-before-league-2019`)—each with Cyclingnews receipts, model-draft takes, **`humanApprovalRequired`**, no auto-publish, and **`editorial_review`-only** race impacts (`autoFixAllowed: false`).
> 
> Updates **`test_2019_backfill_ledger_starts_from_the_complete_source_census`** so disposition counts and `complete` match the closed ledger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054176c284267d4a87e59624ed9d340462995533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->