### PR TITLE
Complete the 2018 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2018.json
+++ b/data/gravel-weekly/backfill/2018.json
@@ -1,0 +1,441 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2018,
+  "asOf": "2018-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/59",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33169644134",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 7,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2017-12-30",
+      "periodEndedAt": "2018-01-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-01-06",
+      "periodEndedAt": "2018-01-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-01-13",
+      "periodEndedAt": "2018-01-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-01-20",
+      "periodEndedAt": "2018-01-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-01-27",
+      "periodEndedAt": "2018-02-02",
+      "sourceCardCount": 1,
+      "disposition": "rejected",
+      "entryIds": [],
+      "reason": "One disputed Herald Sun Tour neutralization is a road-race course incident without enough independent consequence for a season chapter."
+    },
+    {
+      "periodStartedAt": "2018-02-03",
+      "periodEndedAt": "2018-02-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-02-10",
+      "periodEndedAt": "2018-02-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-02-17",
+      "periodEndedAt": "2018-02-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-02-24",
+      "periodEndedAt": "2018-03-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-03-03",
+      "periodEndedAt": "2018-03-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-03-10",
+      "periodEndedAt": "2018-03-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-03-17",
+      "periodEndedAt": "2018-03-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-03-24",
+      "periodEndedAt": "2018-03-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-03-31",
+      "periodEndedAt": "2018-04-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-04-07",
+      "periodEndedAt": "2018-04-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-04-14",
+      "periodEndedAt": "2018-04-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-04-21",
+      "periodEndedAt": "2018-04-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-04-28",
+      "periodEndedAt": "2018-05-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-05-05",
+      "periodEndedAt": "2018-05-11",
+      "sourceCardCount": 1,
+      "disposition": "rejected",
+      "entryIds": [],
+      "reason": "Sagan's gravel gran fondo gallery is promotional personality coverage without a changed judgment or durable competitive consequence."
+    },
+    {
+      "periodStartedAt": "2018-05-12",
+      "periodEndedAt": "2018-05-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-05-19",
+      "periodEndedAt": "2018-05-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-05-26",
+      "periodEndedAt": "2018-06-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-06-02",
+      "periodEndedAt": "2018-06-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-06-09",
+      "periodEndedAt": "2018-06-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-06-16",
+      "periodEndedAt": "2018-06-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-06-23",
+      "periodEndedAt": "2018-06-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-06-30",
+      "periodEndedAt": "2018-07-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-07-07",
+      "periodEndedAt": "2018-07-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-07-14",
+      "periodEndedAt": "2018-07-20",
+      "sourceCardCount": 1,
+      "disposition": "rejected",
+      "entryIds": [],
+      "reason": "A Tour de France gravel-gallery feature supplies striking imagery but no independent argument beyond the road stage's surface."
+    },
+    {
+      "periodStartedAt": "2018-07-21",
+      "periodEndedAt": "2018-07-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-07-28",
+      "periodEndedAt": "2018-08-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-08-04",
+      "periodEndedAt": "2018-08-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-08-11",
+      "periodEndedAt": "2018-08-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-08-18",
+      "periodEndedAt": "2018-08-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-08-25",
+      "periodEndedAt": "2018-08-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-09-01",
+      "periodEndedAt": "2018-09-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-09-08",
+      "periodEndedAt": "2018-09-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-09-15",
+      "periodEndedAt": "2018-09-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-09-22",
+      "periodEndedAt": "2018-09-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-09-29",
+      "periodEndedAt": "2018-10-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-10-06",
+      "periodEndedAt": "2018-10-12",
+      "sourceCardCount": 2,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-paris-tours-gravel-argument-2018"
+      ],
+      "reason": "Opposing reactions from Lefevere and Prudhomme turn the new Paris-Tours vineyard tracks into a draft chapter about spectacle, puncture risk, and course legitimacy."
+    },
+    {
+      "periodStartedAt": "2018-10-13",
+      "periodEndedAt": "2018-10-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-10-20",
+      "periodEndedAt": "2018-10-26",
+      "sourceCardCount": 1,
+      "disposition": "rejected",
+      "entryIds": [],
+      "reason": "A Pinarello gravel and cyclocross bike launch records category interest but remains product inventory rather than a story."
+    },
+    {
+      "periodStartedAt": "2018-10-27",
+      "periodEndedAt": "2018-11-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-11-03",
+      "periodEndedAt": "2018-11-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-11-10",
+      "periodEndedAt": "2018-11-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-11-17",
+      "periodEndedAt": "2018-11-23",
+      "sourceCardCount": 1,
+      "disposition": "rejected",
+      "entryIds": [],
+      "reason": "A short Nibali gravel-skills and disc-brake video is personality and equipment content without a season-level consequence."
+    },
+    {
+      "periodStartedAt": "2018-11-24",
+      "periodEndedAt": "2018-11-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-12-01",
+      "periodEndedAt": "2018-12-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-12-08",
+      "periodEndedAt": "2018-12-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-12-15",
+      "periodEndedAt": "2018-12-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-12-22",
+      "periodEndedAt": "2018-12-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2018-12-29",
+      "periodEndedAt": "2019-01-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    }
+  ],
+  "updatedAt": "2026-08-28T12:30:00Z"
+}

--- a/data/gravel-weekly/history/2018-paris-tours-gravel-argument.json
+++ b/data/gravel-weekly/history/2018-paris-tours-gravel-argument.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-paris-tours-gravel-argument-2018",
+  "activeFrom": "2018-10-08",
+  "activeThrough": "2018-10-08",
+  "status": "draft",
+  "headline": "Paris-Tours Made Gravel the Argument, Not Just the Surface",
+  "point": "When Paris-Tours inserted nine vineyard tracks into its final 60 kilometres, gravel stopped being background scenery and became a referendum on what road racing owed riders and viewers. ASO wanted route-design madness to fight monotony; teams saw punctures, unsuitable equipment, and a lottery. The race was exciting precisely because the surface redistributed control, which meant spectacle and competitive legitimacy could no longer be discussed separately.",
+  "priorJudgment": "An old road classic should preserve the competitive identity riders and teams prepared for; adding unpaved sectors was either harmless variety or an off-road gimmick outside the event's contract.",
+  "changedJudgment": "The new tracks did not merely decorate Paris-Tours. They deliberately changed who entered, how equipment mattered, where chance operated, and what the audience watched. That could revitalize a race, but organizers had to own the competitive costs instead of pretending excitement and fairness were unrelated questions.",
+  "stakes": "Promoters can use surface to manufacture selection and television drama, while teams absorb punctures, equipment compromises, roster decisions, and uncertainty. The 2018 dispute anticipated gravel's broader influence on road-course design and the recurring fight over whether unpredictability is legitimate difficulty or an organizer-created lottery.",
+  "credibleOpposition": "Road racing has always used imperfect surfaces, weather, cobbles, and route changes, and the final result did not look random: Søren Kragh Andersen and Niki Terpstra had placed second and third on the conventional route in 2017, then finished first and second in 2018. Several riders loved the new finale, and sterilizing every puncture risk would eliminate much of classic racing. The criticism was strongest where tracks produced repeated equipment losses or changed the race beyond what teams believed Paris-Tours promised.",
+  "whatHappened": "For the 2018 Paris-Tours, ASO replaced the traditional sprint-oriented finale with nine gravel vineyard sectors inside the last 60 kilometres. The race produced many punctures, while Søren Kragh Andersen won solo ahead of Niki Terpstra and Benoît Cosnefroy. Quick-Step manager Patrick Lefevere said the tracks had nothing to do with road cycling and threatened not to return. Oliver Naesen called the punctures a lottery; multiple Dimension Data riders punctured; Philippe Gilbert, Arnaud Démare, and others objected to the format. Andersen and Sep Vanmarcke praised it. Race director Christian Prudhomme defended the decision as necessary madness in a sport criticized for sanitized, monotonous courses and pointed out that the top two had already been near the front on the old route the year before.",
+  "take": "Model draft, not Matti's approved view: Paris-Tours poured nine strips of vineyard gravel into a sprinters' classic and discovered that everybody loves innovation until the innovation eats their tire. ASO got exactly what it ordered: spectacular pictures, a broken-up race, furious team managers, delighted viewers, and enough punctures to make the result feel partly sponsored by bad luck. Prudhomme said cycling dies without some madness. Lefevere said it was not road cycling. Annoyingly, both had a point. A course is supposed to decide a race. The argument starts when the course decides it through failure modes teams could not reasonably prepare for. Yet the first two riders were the same men who had finished second and third on the boring version a year earlier, which is an awkward way for pure-lottery theory to end. Gravel's gift to Paris-Tours was not authenticity. It was conflict. The organizer just had to admit that the conflict was the product.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The contemporary reports establish the route change, nine sectors, punctures, result, and competing reactions. They do not provide a complete puncture census, equipment choices for the full field, measured audience response, organizer safety analysis, or a counterfactual result on the former route. Prudhomme's messages from viewers were anecdotal, and the repeated 2017 and 2018 placings do not prove the surface had no random effect. The entry evaluates course design, not whether Paris-Tours should be classified as a gravel race.",
+  "editorialScore": 95,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_paris_tours_gravel_opposition_2018",
+      "canonicalUrl": "https://www.cyclingnews.com/news/off-road-division-quick-step-boss-lefevere-not-keen-on-paris-tours-gravel-tracks/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2018-10-08T02:14:00Z",
+      "quoteExcerpt": "nothing to do with road cycling",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_prudhomme_defended_paris_tours_gravel_2018",
+      "canonicalUrl": "https://www.cyclingnews.com/news/prudhomme-defends-inclusion-of-gravel-tracks-in-paris-tours/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2018-10-08T09:43:00Z",
+      "quoteExcerpt": "We chose to do something out of the ordinary",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T12:30:00Z",
+  "contentHash": "758aa689f09e0f41af5959b92ea92f801307f06672a8fe89c3642a011a0b59a5"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -707,6 +707,21 @@ def test_2019_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2018_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2018.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 7
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 47
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 5
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weekly windows in the 2018 source census
- preserve 47 explicit gaps and reject five weak source cards
- cover the one viable arc with a citation-backed Paris-Tours model draft
- leave zero pending cards and retain all human-approval and no-auto-publish safety gates

## Verification
- history validator
- backfill validator
- `pytest -q tests/test_gravel_weekly.py` (39 passed)
- both slop detectors: zero findings
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and a regression test only; no application logic or publish-path changes beyond validator-backed data contracts.
> 
> **Overview**
> Adds the **2018 Gravel Weekly backfill ledger** (`data/gravel-weekly/backfill/2018.json`), closing all 53 weekly windows against the seven-card source census: 47 explicit gaps, five rejected weak cards, zero pending review, and `complete: true` with human-approval and no-auto-publish flags unchanged.
> 
> The only week marked **`covered_by_draft`** links to a new **draft history entry** on 2018 Paris-Tours vineyard gravel (Lefevere vs Prudhomme), with Cyclingnews receipts, editorial gates, and `model_draft` take provenance.
> 
> A new pytest contract test **`test_2018_backfill_ledger_starts_from_the_complete_source_census`** locks those disposition counts through `validate_backfill_ledger`, matching the pattern used for 2019–2025 ledgers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d5536a659f148323059784af7096cbbe76adba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->