### PR TITLE
Complete the 2017 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2017.json
+++ b/data/gravel-weekly/backfill/2017.json
@@ -1,0 +1,447 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2017,
+  "asOf": "2017-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/60",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33170054490",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 2,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2016-12-31",
+      "periodEndedAt": "2017-01-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-01-07",
+      "periodEndedAt": "2017-01-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-01-14",
+      "periodEndedAt": "2017-01-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-01-21",
+      "periodEndedAt": "2017-01-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-01-28",
+      "periodEndedAt": "2017-02-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-02-04",
+      "periodEndedAt": "2017-02-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-02-11",
+      "periodEndedAt": "2017-02-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-02-18",
+      "periodEndedAt": "2017-02-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-02-25",
+      "periodEndedAt": "2017-03-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-03-04",
+      "periodEndedAt": "2017-03-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-03-11",
+      "periodEndedAt": "2017-03-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-03-18",
+      "periodEndedAt": "2017-03-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-03-25",
+      "periodEndedAt": "2017-03-31",
+      "sourceCardCount": 1,
+      "disposition": "rejected",
+      "entryIds": [],
+      "reason": "The new gravel Plugstreets preview for Gent-Wevelgem is an interesting road-course experiment, but one speculative impact article does not establish a distinct season consequence beyond the better-supported 2018 Paris-Tours argument."
+    },
+    {
+      "periodStartedAt": "2017-04-01",
+      "periodEndedAt": "2017-04-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-04-08",
+      "periodEndedAt": "2017-04-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-04-15",
+      "periodEndedAt": "2017-04-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-04-22",
+      "periodEndedAt": "2017-04-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-04-29",
+      "periodEndedAt": "2017-05-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-05-06",
+      "periodEndedAt": "2017-05-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-05-13",
+      "periodEndedAt": "2017-05-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-05-20",
+      "periodEndedAt": "2017-05-26",
+      "sourceCardCount": 1,
+      "disposition": "rejected",
+      "entryIds": [],
+      "reason": "The Tour of Utah route announcement treats ten kilometres of gravel as one course feature and provides no independent changed judgment worth a Gravel Weekly chapter."
+    },
+    {
+      "periodStartedAt": "2017-05-27",
+      "periodEndedAt": "2017-06-02",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-got-huge-before-important-2017"
+      ],
+      "reason": "Contemporary Kansas reporting establishes Dirty Kanza as a major local economy before the race, opening the draft chapter on gravel scaling without a formal league."
+    },
+    {
+      "periodStartedAt": "2017-06-03",
+      "periodEndedAt": "2017-06-09",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-got-huge-before-important-2017"
+      ],
+      "reason": "Bicycling records Alison Tetrick breaking the women’s course record during the mass-participation growth of Dirty Kanza."
+    },
+    {
+      "periodStartedAt": "2017-06-10",
+      "periodEndedAt": "2017-06-16",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-got-huge-before-important-2017"
+      ],
+      "reason": "A contemporary Tetrick interview supplies the five-second finish, road-pro crossover, and first-gravel-race evidence for the draft."
+    },
+    {
+      "periodStartedAt": "2017-06-17",
+      "periodEndedAt": "2017-06-23",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-got-huge-before-important-2017"
+      ],
+      "reason": "A participant report supplies the 2,200-rider scale, registration demand, and evidence that the event still felt personal at that size."
+    },
+    {
+      "periodStartedAt": "2017-06-24",
+      "periodEndedAt": "2017-06-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-07-01",
+      "periodEndedAt": "2017-07-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-07-08",
+      "periodEndedAt": "2017-07-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-07-15",
+      "periodEndedAt": "2017-07-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-07-22",
+      "periodEndedAt": "2017-07-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-07-29",
+      "periodEndedAt": "2017-08-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-08-05",
+      "periodEndedAt": "2017-08-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-08-12",
+      "periodEndedAt": "2017-08-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-08-19",
+      "periodEndedAt": "2017-08-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-08-26",
+      "periodEndedAt": "2017-09-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-09-02",
+      "periodEndedAt": "2017-09-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-09-09",
+      "periodEndedAt": "2017-09-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-09-16",
+      "periodEndedAt": "2017-09-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-09-23",
+      "periodEndedAt": "2017-09-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-09-30",
+      "periodEndedAt": "2017-10-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-10-07",
+      "periodEndedAt": "2017-10-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-10-14",
+      "periodEndedAt": "2017-10-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-10-21",
+      "periodEndedAt": "2017-10-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-10-28",
+      "periodEndedAt": "2017-11-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-11-04",
+      "periodEndedAt": "2017-11-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-11-11",
+      "periodEndedAt": "2017-11-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-11-18",
+      "periodEndedAt": "2017-11-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-11-25",
+      "periodEndedAt": "2017-12-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-12-02",
+      "periodEndedAt": "2017-12-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-12-09",
+      "periodEndedAt": "2017-12-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-12-16",
+      "periodEndedAt": "2017-12-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-12-23",
+      "periodEndedAt": "2017-12-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2017-12-30",
+      "periodEndedAt": "2018-01-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    }
+  ],
+  "updatedAt": "2026-08-28T12:30:00Z"
+}

--- a/data/gravel-weekly/history/2017-gravel-got-huge-before-important.json
+++ b/data/gravel-weekly/history/2017-gravel-got-huge-before-important.json
@@ -1,0 +1,86 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-got-huge-before-important-2017",
+  "activeFrom": "2017-06-02",
+  "activeThrough": "2017-06-23",
+  "status": "draft",
+  "headline": "Gravel Got Huge Before It Learned to Act Important",
+  "point": "The 2017 Dirty Kanza had already become a 2,200-rider destination with thousands more chasing entries and millions of dollars moving through Emporia, yet its strongest competitive story was a gravel newcomer and a two-time champion sprinting after 206 miles. Gravel did not need a governing body, a television package, or a polished professional league to prove that mass participation and serious racing could inhabit the same event.",
+  "priorJudgment": "A race built around self-supported amateurs, local volunteers, and an all-day rural course could grow into a beloved festival, but serious competition and broad public consequence belonged to professional road racing.",
+  "changedJudgment": "Dirty Kanza had become economically consequential and competitively credible without surrendering the participant-first culture that created it. Its scale came from making ordinary riders part of the product; elite drama intensified that product instead of replacing it.",
+  "stakes": "Modern gravel repeatedly argues about whether growth, professional riders, and commercial attention corrupt its character. The 2017 evidence shows that size itself was not the original betrayal: more than two thousand riders, a consequential local economy, a course-record women's race, and a personal event atmosphere coexisted. The harder question is whether later owners and leagues kept participants inside the story or converted them into scenery for a professional show.",
+  "credibleOpposition": "Dirty Kanza was not an improvised club ride by 2017. Entry scarcity, sponsor-supported professionals, purpose-built equipment, organized checkpoints, and a large economic footprint already made it a commercial institution. Contemporary accounts celebrating its personal atmosphere were participant impressions, not independent measurements of access, community benefit, or who the growth excluded. One dramatic women's finish also cannot prove the entire event had achieved sporting maturity.",
+  "whatHappened": "Dirty Kanza's 2017 editions drew roughly 2,200 riders across its distances, while more than 4,000 people reportedly logged on seeking places. A Kansas report projected about 2,500 participants and a $2.2 million annual economic effect for Emporia. In the 206-mile race, road professional and first-time gravel racer Alison Tetrick broke the women's course record in 11 hours 41 minutes and beat two-time champion Amanda Nauman by five seconds. Tetrick said she regarded Dirty Kanza as gravel's pinnacle and had asked her professional road team for permission to enter. A participant account later contrasted the huge field with the event's continuing personal relationship to its organizers and town.",
+  "take": "Model draft, not Matti's approved view: Dirty Kanza got huge before gravel learned to hold a panel discussion about what huge was doing to gravel. In 2017, thousands of riders stampeded the registration page, Emporia expected a couple million dollars to fall out of their jersey pockets, and the women's 206-mile race ended in a five-second sprint. This was not a tiny counterculture protecting itself from the outside world. The outside world was already refreshing BikeReg. The useful part is what had not disappeared yet. Ordinary riders were not the audience planted behind barriers while professionals performed importance for them. They were the event, and Alison Tetrick's course record made the same day sharper without making everyone else irrelevant. Gravel's original scaling trick was almost offensively simple: let the crowd participate in the myth. Everything that came later should be judged by whether it preserved that trick or merely found a cleaner way to invoice it.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "Contemporary reports vary between roughly 2,200 and 2,500 participants because some describe registrations, expected starts, or different distance totals. The $2.2 million figure was attributed by KSAL to Wichita Eagle reporting and was an estimate, not an audited impact study. The sources establish Tetrick's win, five-second margin, course record, road-team support, and first gravel-race status, but they do not measure broadcast reach, organizer finances, participant demographics, or whether every rider experienced the event as personal and accessible.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_dirty_kanza_economic_scale_2017",
+      "canonicalUrl": "https://www.ksal.com/200-mile-kansas-bike-race-has-grown-into-major-event/",
+      "publisher": "KSAL",
+      "publishedAt": "2017-06-02T12:00:00Z",
+      "quoteExcerpt": "an estimated $2.2 million every spring",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_tetrick_record_and_womens_inclusion_2017",
+      "canonicalUrl": "https://www.bicycling.com/racing/a20042725/tetrick-kanza-record/",
+      "publisher": "Bicycling",
+      "publishedAt": "2017-06-06T18:20:00Z",
+      "quoteExcerpt": "smashing the former women's course record",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_tetrick_gravel_newcomer_five_second_win_2017",
+      "canonicalUrl": "https://www.cxmagazine.com/interview-alison-tetrick-queen-dirty-kanza-200-2017",
+      "publisher": "Cyclocross Magazine",
+      "publishedAt": "2017-06-14T12:00:00Z",
+      "quoteExcerpt": "first true gravel race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_dirty_kanza_scale_and_personal_character_2017",
+      "canonicalUrl": "https://singletrackworld.com/gritcx/2017/06/23/dirty-kanza-2017/",
+      "publisher": "Singletrack World",
+      "publishedAt": "2017-06-23T12:00:00Z",
+      "quoteExcerpt": "over 4000 riders were logged on seeking a spot",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_dirty_kanza_economic_scale_2017",
+        "claim_tetrick_record_and_womens_inclusion_2017",
+        "claim_tetrick_gravel_newcomer_five_second_win_2017",
+        "claim_dirty_kanza_scale_and_personal_character_2017"
+      ],
+      "confidence": 0.95,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T12:25:00Z",
+  "contentHash": "8c7b0fd51eb589396b85a803c6fbd2641d80fdfb7424a81f05bb462d728ed4b2"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -722,6 +722,21 @@ def test_2018_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2017_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2017.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 47
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 4
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weekly windows in the 2017 Cyclingnews source census
- preserve 47 explicit gaps and reject the two weak census cards
- add a broader contemporary-source pass that recovers the real 2017 chapter: Dirty Kanza scaled to thousands of participants and major local economic consequence while retaining participant-led identity and producing a five-second women’s finish
- cover four evidence-bearing weeks with one citation-backed model draft and leave zero pending windows
- route the Unbound consequence only to controlled race editorial review; retain all human-approval and no-auto-publish safety gates

## Verification
- history validator
- backfill validator
- `pytest -q tests/test_gravel_weekly.py` (40 passed)
- both slop detectors: zero findings
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial data and contract tests only; draft content stays gated from auto-publish and public history loaders.
> 
> **Overview**
> Adds the **2017 Gravel Weekly backfill ledger** so all **53 weekly windows** are accounted for: **47 explicit gaps**, **two rejected** Cyclingnews census cards (Gent-Wevelgem preview, Tour of Utah gravel segment), and **four late-May/June weeks** marked **`covered_by_draft`** with **no pending review** and **`complete: true`**.
> 
> Introduces a **draft history entry** (`history-gravel-got-huge-before-important-2017`) on 2017 Dirty Kanza scale, Tetrick’s win, and participant-first culture, backed by **four contemporary receipts**, **`model_draft` take**, and a **race editorial review** impact on `gravel:unbound-gravel` with **human approval** and **no auto-publish**.
> 
> Adds **`test_2017_backfill_ledger_starts_from_the_complete_source_census`** to lock disposition counts against `validate_backfill_ledger`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad763d6fdf4807c73c9ca855e5cd7f8b622b2409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->