### PR TITLE
Complete the 2016 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2016.json
+++ b/data/gravel-weekly/backfill/2016.json
@@ -1,0 +1,445 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2016,
+  "asOf": "2016-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/61",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33170449175",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2015-12-26",
+      "periodEndedAt": "2016-01-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-01-02",
+      "periodEndedAt": "2016-01-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-01-09",
+      "periodEndedAt": "2016-01-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-01-16",
+      "periodEndedAt": "2016-01-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-01-23",
+      "periodEndedAt": "2016-01-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-01-30",
+      "periodEndedAt": "2016-02-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-02-06",
+      "periodEndedAt": "2016-02-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-02-13",
+      "periodEndedAt": "2016-02-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-02-20",
+      "periodEndedAt": "2016-02-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-02-27",
+      "periodEndedAt": "2016-03-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-03-05",
+      "periodEndedAt": "2016-03-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-03-12",
+      "periodEndedAt": "2016-03-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-03-19",
+      "periodEndedAt": "2016-03-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-03-26",
+      "periodEndedAt": "2016-04-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-04-02",
+      "periodEndedAt": "2016-04-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-04-09",
+      "periodEndedAt": "2016-04-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-04-16",
+      "periodEndedAt": "2016-04-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-04-23",
+      "periodEndedAt": "2016-04-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-04-30",
+      "periodEndedAt": "2016-05-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-05-07",
+      "periodEndedAt": "2016-05-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-05-14",
+      "periodEndedAt": "2016-05-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-05-21",
+      "periodEndedAt": "2016-05-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-05-28",
+      "periodEndedAt": "2016-06-03",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-ted-king-prototyped-gravel-pro-2016"
+      ],
+      "reason": "King’s pre-race account establishes his first Dirty Kanza, the mass-participation appeal, and the unfamiliar self-support requirements behind the draft."
+    },
+    {
+      "periodStartedAt": "2016-06-04",
+      "periodEndedAt": "2016-06-10",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-ted-king-prototyped-gravel-pro-2016"
+      ],
+      "reason": "BikeRadar documents the recently retired WorldTour rider winning Dirty Kanza, repairing three flats himself, and turning a sponsor-equipped bike into a visible new calling."
+    },
+    {
+      "periodStartedAt": "2016-06-11",
+      "periodEndedAt": "2016-06-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-06-18",
+      "periodEndedAt": "2016-06-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-06-25",
+      "periodEndedAt": "2016-07-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-07-02",
+      "periodEndedAt": "2016-07-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-07-09",
+      "periodEndedAt": "2016-07-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-07-16",
+      "periodEndedAt": "2016-07-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-07-23",
+      "periodEndedAt": "2016-07-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-07-30",
+      "periodEndedAt": "2016-08-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-08-06",
+      "periodEndedAt": "2016-08-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-08-13",
+      "periodEndedAt": "2016-08-19",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-ted-king-prototyped-gravel-pro-2016"
+      ],
+      "reason": "King’s Outside essay shows the sponsor-supported, self-managed adventure calendar that became the early privateer prototype."
+    },
+    {
+      "periodStartedAt": "2016-08-20",
+      "periodEndedAt": "2016-08-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-08-27",
+      "periodEndedAt": "2016-09-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-09-03",
+      "periodEndedAt": "2016-09-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-09-10",
+      "periodEndedAt": "2016-09-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-09-17",
+      "periodEndedAt": "2016-09-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-09-24",
+      "periodEndedAt": "2016-09-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-10-01",
+      "periodEndedAt": "2016-10-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-10-08",
+      "periodEndedAt": "2016-10-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-10-15",
+      "periodEndedAt": "2016-10-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-10-22",
+      "periodEndedAt": "2016-10-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-10-29",
+      "periodEndedAt": "2016-11-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-11-05",
+      "periodEndedAt": "2016-11-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-11-12",
+      "periodEndedAt": "2016-11-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-11-19",
+      "periodEndedAt": "2016-11-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-11-26",
+      "periodEndedAt": "2016-12-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-12-03",
+      "periodEndedAt": "2016-12-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-12-10",
+      "periodEndedAt": "2016-12-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-12-17",
+      "periodEndedAt": "2016-12-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2016-12-24",
+      "periodEndedAt": "2016-12-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    }
+  ],
+  "updatedAt": "2026-08-28T12:50:00Z"
+}

--- a/data/gravel-weekly/history/2016-ted-king-prototyped-gravel-pro.json
+++ b/data/gravel-weekly/history/2016-ted-king-prototyped-gravel-pro.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-ted-king-prototyped-gravel-pro-2016",
+  "activeFrom": "2016-06-02",
+  "activeThrough": "2016-08-17",
+  "status": "draft",
+  "headline": "Ted King Retired and Accidentally Prototyped the Gravel Pro",
+  "point": "Ted King left the WorldTour, entered Dirty Kanza for the first time, won after fixing his own flats, and spent the rest of the summer describing a sponsor-supported calendar built around races he actually wanted to attend. Gravel had created the independent athlete-ambassador job before the sport had agreed that gravel professional was a job title.",
+  "priorJudgment": "A WorldTour rider retired from professional racing into ordinary life, occasional riding, or a conventional industry role; mass-participation off-road events were recreation rather than a credible second athletic career.",
+  "changedJudgment": "King showed that a rider could leave the road-team system without leaving performance, sponsors, audience, or relevance. The new career was less a salaried race program than a portable mixture of competition, personality, equipment testing, owned media, and sponsor relationships—the basic privateer formula before gravel named it.",
+  "stakes": "The modern gravel economy depends on athletes being racers, media outlets, product demonstrators, and small businesses at once. That independence can give riders freedom and a longer career, but it also transfers logistics, storytelling, sponsor service, and financial risk from a team onto the athlete. The origin story matters because the freedom and the unpaid overhead arrived together.",
+  "credibleOpposition": "King was not an ordinary retiree discovering an open market. He brought a decade of WorldTour credibility, existing sponsors, a bike-company relationship, technical support, industry contacts, and elite fitness to his first Dirty Kanza. His win did not prove that a sustainable gravel profession was broadly available, and contemporary reporting described fun, sponsor support, belt buckles, and bragging rights rather than a disclosed independent-athlete income statement.",
+  "whatHappened": "Before his first Dirty Kanza, King described the event as a mass-participation challenge, said he was less fit than during his WorldTour career, and emphasized unfamiliar self-support variables such as tires, gearing, food, and the absence of a follow car. On June 4 he won the 206-mile race after riding roughly 100 miles alone and repairing three flats himself. BikeRadar framed the recently retired WorldTour rider as having found a new calling and documented the highly specific Cannondale Slate, sponsor equipment, hydration, and nutrition setup around the win. By August, King wrote that retirement had replaced team-controlled austerity with a sponsor-supported calendar of Dirty Kanza, Leadville, and Grinduro; he valued managing his own logistics and racing for adventure, belt buckles, and bragging rights rather than because a team job depended on the result.",
+  "take": "Model draft, not Matti's approved view: Ted King retired from professional cycling and immediately found a better cycling job, except nobody had invented its title or payroll department. He arrived at Dirty Kanza on a Cannondale Slate—a road bike that appeared to have swallowed a tiny suspension fork—fixed three flats without a mechanic, rode alone for roughly 100 miles, and beat more than a thousand people to a belt buckle. Then he filled his calendar with events he actually wanted to race while his sponsors, products, blog, and personality traveled with him. This was the gravel-privateer prototype hiding inside a retirement tour. The freedom was real: no team director, no assigned race, no recovery-drink monastery. So was the new labor. King became rider, mechanic, logistics desk, media channel, product demo, and sponsor inventory in one maple-syrup-powered person. Gravel did not abolish the job. It compressed the whole company into the athlete and called the result fun.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The contemporary sources establish King’s first Dirty Kanza, win, WorldTour retirement, self-supported repairs, sponsor-backed equipment, and stated preference for an adventure-led calendar. They do not disclose his compensation, contract structure, operating costs, sponsor obligations, or whether he considered the arrangement a new profession in 2016. Calling it a prototype privateer career is an editorial inference informed by the later gravel model, not a period job classification.",
+  "editorialScore": 97,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_king_first_dirty_kanza_self_support_2016",
+      "canonicalUrl": "https://www.iamtedking.com/blog/2016/06/toto-were-in-kansas-again",
+      "publisher": "Ted King",
+      "publishedAt": "2016-06-02T12:00:00Z",
+      "quoteExcerpt": "There is no follow car! You're entirely self-supported!",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_king_won_dirty_kanza_new_calling_2016",
+      "canonicalUrl": "https://www.bikeradar.com/features/pro-bike/ted-kings-cannondale-slate-gravel-racer",
+      "publisher": "BikeRadar",
+      "publishedAt": "2016-06-07T19:00:00Z",
+      "quoteExcerpt": "may have found his next calling as a gravel racer",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_king_sponsor_supported_adventure_calendar_2016",
+      "canonicalUrl": "https://www.outsideonline.com/outdoor-gear/bikes-and-biking/why-life-got-more-fun-after-i-retired-pro-cycling/",
+      "publisher": "Outside",
+      "publishedAt": "2016-08-17T06:00:00Z",
+      "quoteExcerpt": "I get to race for racing's sake",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_king_2016_win_expanded_gravel_reach_2017",
+      "canonicalUrl": "https://www.iamtedking.com/blog/2017/06/gravel-is-dead-long-live-gravel",
+      "publisher": "Ted King",
+      "publishedAt": "2017-06-01T12:00:00Z",
+      "quoteExcerpt": "bringing my European racing history to Kansas in 2016",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_king_first_dirty_kanza_self_support_2016",
+        "claim_king_won_dirty_kanza_new_calling_2016",
+        "claim_king_sponsor_supported_adventure_calendar_2016",
+        "claim_king_2016_win_expanded_gravel_reach_2017"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T12:45:00Z",
+  "contentHash": "3df436ff5b5991598938aa48a4247a82e0e9b055fc510b48a036e63a0b4a9463"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -737,6 +737,21 @@ def test_2017_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2016_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2016.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 50
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 3
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weekly windows in the 2016 Cyclingnews census, which returned zero cards
- preserve 50 explicit gaps while using a broader contemporary-source pass to recover three evidence-bearing weeks
- add a citation-backed model draft on Ted King’s first Dirty Kanza win and the sponsor/media/racer bundle that prototyped the gravel privateer
- route the Unbound consequence only to controlled race editorial review; retain all human-approval and no-auto-publish safety gates
- leave zero pending windows

## Verification
- history validator
- backfill validator
- `pytest -q tests/test_gravel_weekly.py` (41 passed)
- both slop detectors: zero findings
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only editorial artifacts and a regression test; no runtime, auth, or publish-path changes, with draft status and approval gates preserved.
> 
> **Overview**
> Adds the **2016 Gravel Weekly backfill ledger** so all 53 weekly windows are accounted for after a zero-card Cyclingnews census: **50 explicit gaps**, **three weeks** marked `covered_by_draft` via non-Cyclingnews contemporary sources, **`complete: true`**, and the usual **human-approval / no-auto-publish** flags.
> 
> Introduces a **draft history entry** (`history-ted-king-prototyped-gravel-pro-2016`) on Ted King’s 2016 Dirty Kanza arc—citation-backed receipts, `model_draft` take, editorial gates—and wires those three ledger weeks to it. A single **Unbound** `raceImpacts` row targets controlled **editorial review** on `race.biased_opinion` with `autoFixAllowed: false`.
> 
> Locks the ledger shape in **`test_2016_backfill_ledger_starts_from_the_complete_source_census`**, consistent with other year backfill contract tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee8fdf390ccf04cb82188b24fe73b547dba85056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->