### PR TITLE
Complete the 2015 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2015.json
+++ b/data/gravel-weekly/backfill/2015.json
@@ -1,0 +1,445 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2015,
+  "asOf": "2015-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/62",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33170760940",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2014-12-27",
+      "periodEndedAt": "2015-01-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-01-03",
+      "periodEndedAt": "2015-01-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-01-10",
+      "periodEndedAt": "2015-01-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-01-17",
+      "periodEndedAt": "2015-01-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-01-24",
+      "periodEndedAt": "2015-01-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-01-31",
+      "periodEndedAt": "2015-02-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-02-07",
+      "periodEndedAt": "2015-02-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-02-14",
+      "periodEndedAt": "2015-02-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-02-21",
+      "periodEndedAt": "2015-02-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-02-28",
+      "periodEndedAt": "2015-03-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-03-07",
+      "periodEndedAt": "2015-03-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-03-14",
+      "periodEndedAt": "2015-03-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-03-21",
+      "periodEndedAt": "2015-03-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-03-28",
+      "periodEndedAt": "2015-04-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-04-04",
+      "periodEndedAt": "2015-04-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-04-11",
+      "periodEndedAt": "2015-04-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-04-18",
+      "periodEndedAt": "2015-04-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-04-25",
+      "periodEndedAt": "2015-05-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-05-02",
+      "periodEndedAt": "2015-05-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-05-09",
+      "periodEndedAt": "2015-05-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-05-16",
+      "periodEndedAt": "2015-05-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-05-23",
+      "periodEndedAt": "2015-05-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-05-30",
+      "periodEndedAt": "2015-06-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-06-06",
+      "periodEndedAt": "2015-06-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-06-13",
+      "periodEndedAt": "2015-06-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-06-20",
+      "periodEndedAt": "2015-06-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-06-27",
+      "periodEndedAt": "2015-07-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-07-04",
+      "periodEndedAt": "2015-07-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-07-11",
+      "periodEndedAt": "2015-07-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-07-18",
+      "periodEndedAt": "2015-07-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-07-25",
+      "periodEndedAt": "2015-07-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-08-01",
+      "periodEndedAt": "2015-08-07",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-bike-industry-built-gravel-before-name-2015"
+      ],
+      "reason": "The near-production Cannondale Slate supplies the competing category names, unusual 650b suspension design, and explicit absence of settled gravel rules."
+    },
+    {
+      "periodStartedAt": "2015-08-08",
+      "periodEndedAt": "2015-08-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-08-15",
+      "periodEndedAt": "2015-08-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-08-22",
+      "periodEndedAt": "2015-08-28",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-bike-industry-built-gravel-before-name-2015"
+      ],
+      "reason": "The Open U.P. Eurobike ride supplies the GravelPlus label, multi-format tire design, and contemporary description of the bike as deliberately genre-fuzzying."
+    },
+    {
+      "periodStartedAt": "2015-08-29",
+      "periodEndedAt": "2015-09-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-09-05",
+      "periodEndedAt": "2015-09-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-09-12",
+      "periodEndedAt": "2015-09-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-09-19",
+      "periodEndedAt": "2015-09-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-09-26",
+      "periodEndedAt": "2015-10-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-10-03",
+      "periodEndedAt": "2015-10-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-10-10",
+      "periodEndedAt": "2015-10-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-10-17",
+      "periodEndedAt": "2015-10-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-10-24",
+      "periodEndedAt": "2015-10-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-10-31",
+      "periodEndedAt": "2015-11-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-11-07",
+      "periodEndedAt": "2015-11-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-11-14",
+      "periodEndedAt": "2015-11-20",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-bike-industry-built-gravel-before-name-2015"
+      ],
+      "reason": "Gear Patrol documents category-wide manufacturer participation and frames the U.P. as a ground-up response to a growing sport."
+    },
+    {
+      "periodStartedAt": "2015-11-21",
+      "periodEndedAt": "2015-11-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-11-28",
+      "periodEndedAt": "2015-12-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-12-05",
+      "periodEndedAt": "2015-12-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-12-12",
+      "periodEndedAt": "2015-12-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-12-19",
+      "periodEndedAt": "2015-12-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2015-12-26",
+      "periodEndedAt": "2016-01-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    }
+  ],
+  "updatedAt": "2026-08-28T13:10:00Z"
+}

--- a/data/gravel-weekly/history/2015-bike-industry-built-gravel-before-name.json
+++ b/data/gravel-weekly/history/2015-bike-industry-built-gravel-before-name.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-bike-industry-built-gravel-before-name-2015",
+  "activeFrom": "2015-08-04",
+  "activeThrough": "2015-11-16",
+  "status": "draft",
+  "headline": "The Bike Industry Built Gravel Before It Could Name It",
+  "point": "By late 2015, Cannondale and Open had built radically different purpose-designed answers to the same appetite for fast riding beyond pavement, while the industry was still juggling adventure, all-road, road-plus, gnarmac, GravelPlus, cyclocross, and drop-bar mountain bike. Gravel became a product category through shared capability before it became a discipline with shared language or rules.",
+  "priorJudgment": "Mixed-surface riders could improvise with cyclocross, touring, mountain, or endurance-road bikes; a dedicated gravel category was either unnecessary marketing or too incoherent to design around.",
+  "changedJudgment": "The category did not require one canonical bike. It required designers to protect road-like speed while creating room for larger tires, lower pressure, rough-surface control, and multiple wheel formats. The disagreement over names and implementations was evidence that gravel was a design problem worth competing to solve, not evidence that the category was fake.",
+  "stakes": "Modern arguments about the correct gravel bike often pretend the category began with a stable rulebook. Its commercial origin was the opposite: Cannondale added a one-sided suspension fork and fixed 650b format, while Open emphasized wheel and tire interchangeability. Remembering that productive disagreement helps separate useful experimentation from equipment orthodoxy and keeps race recommendations tied to terrain rather than fashion.",
+  "credibleOpposition": "Bike companies are skilled at creating categories to sell another bicycle, and the 2015 machines were expensive, proprietary, and imperfect. The Slate used a distinctive fork and a narrow intended tire choice; the Open frameset cost $2,900 before components. Existing cyclocross, mountain, touring, and road bikes already crossed unpaved ground. A new label did not make the riding new, and early product excitement did not establish what most riders needed or could afford.",
+  "whatHappened": "In August 2015, road.cc examined Cannondale’s near-production Slate: an aluminum road-oriented bike with 650b x 42mm tires and a 30mm single-sided Lefty Oliver suspension fork. The report said American gravel racing may have sparked a new category whose competing names included adventure, all-road, road-plus, and Cannondale’s preferred gnarmac; it called the Slate the boldest interpretation of a genre without defined rules. Later that month, Open unveiled the U.P. at Eurobike as a GravelPlus bike for cyclocross, gravel racing, and adventure. Its dropped chainstay allowed configurations from 700c road tires to 650b x 2.25-inch mountain-bike tires. A November Gear Patrol assessment called gravel cycling the most-hyped segment, said most major manufacturers already offered gravel-labeled bikes, and presented the U.P. as a ground-up design for the growing sport rather than a road frame with wider tires.",
+  "take": "Model draft, not Matti's approved view: If a product needs seven category names, it is normally trapped in a conference room with a whiteboard and no adult supervision. In 2015, it meant bike designers had finally noticed that riders wanted to go fast after the pavement ended. Cannondale answered with the Slate, a road bike wearing 42-millimeter tires and a one-legged suspension fork, then suggested “gnarmac” with a straight face. Open answered with the U.P., called it GravelPlus, and built enough tire clearance to make three existing bike categories nervous. Reviewers reached for adventure, all-road, road-plus, cyclocross, and drop-bar mountain bike because no single noun could contain the useful mess. That mess is the point. Gravel was not born as one correct machine. It was born as permission to steal whatever worked. Every modern equipment purity test should have to explain why the founding documents look like two engineers independently breaking different rules.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources document two influential 2015 launches and contemporary category language, not the first gravel bicycle or a complete global product census. Riders and small builders had combined similar capabilities long before major-brand labeling. Gear Patrol’s claim that almost every major manufacturer offered a gravel-labeled bike is a period assessment rather than audited market data. The entry treats the Slate and U.P. as visible category signals, not sole inventions of gravel riding or technology.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_slate_category_names_and_design_2015",
+      "canonicalUrl": "https://road.cc/content/news/159616-cannondale-s-slate-nears-production",
+      "publisher": "road.cc",
+      "publishedAt": "2015-08-04T10:23:00Z",
+      "quoteExcerpt": "a genre that has no clearly defined rules",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_open_up_gravelplus_multiformat_2015",
+      "canonicalUrl": "https://road.cc/content/news/162396-open-eurobike-first-ride-review",
+      "publisher": "road.cc",
+      "publishedAt": "2015-08-27T14:30:00Z",
+      "quoteExcerpt": "proper genre fuzzying bike",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_dedicated_category_hype_2015",
+      "canonicalUrl": "https://www.gearpatrol.com/archive/a175118/open-cycle-up-gp100/",
+      "publisher": "Gear Patrol",
+      "publishedAt": "2015-11-16T12:00:00Z",
+      "quoteExcerpt": "the most hyped segment in cycling",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_open_up_shook_category_2018",
+      "canonicalUrl": "https://www.bikeradar.com/news/fit-and-trim-the-open-up-gets-a-refresh-for-2018",
+      "publisher": "BikeRadar",
+      "publishedAt": "2018-06-28T12:00:00Z",
+      "quoteExcerpt": "shook up the gravel bike category",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T13:05:00Z",
+  "contentHash": "1a8b608e367112e63210ec650d1687b93384786bde7604b453e91a5127823bc3"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -752,6 +752,21 @@ def test_2016_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2015_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2015.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 50
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 3
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weekly windows in the 2015 Cyclingnews census, which returned zero cards
- preserve 50 explicit gaps while using a broader contemporary-source pass to recover three evidence-bearing weeks
- add a citation-backed model draft on Cannondale Slate, Open U.P., and the moment the bike industry built gravel before it could agree what to call it
- retain all human-approval and no-auto-publish safety gates and leave zero pending windows

## Verification
- history validator
- backfill validator
- `pytest -q tests/test_gravel_weekly.py` (42 passed)
- both slop detectors: zero findings
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds validated editorial JSON and a regression test only; draft content stays behind human-approval and non-auto-publish gates with no runtime or auth changes.
> 
> **Overview**
> Finishes the **2015 Gravel Weekly backfill** by adding `data/gravel-weekly/backfill/2015.json`: all 53 weekly windows are accounted for with **zero** Cyclingnews source cards, **50** `explicit_gap` weeks, and **three** `covered_by_draft` weeks tied to contemporary coverage (Cannondale Slate, Open U.P., Gear Patrol). The ledger is marked **complete** with no pending review and keeps **human approval required** / **no auto-publish**.
> 
> Adds a **model-draft** history entry (`history-bike-industry-built-gravel-before-name-2015`) on late-2015 industry naming and product divergence, with road.cc and Gear Patrol receipts and editorial gates passing but not published.
> 
> Locks the census in with **`test_2015_backfill_ledger_starts_from_the_complete_source_census`**, matching the existing 2016 backfill contract test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a12b4f587d7b5c436d692c25f6134248f8879a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->