### PR TITLE
Complete the 2014 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2014.json
+++ b/data/gravel-weekly/backfill/2014.json
@@ -1,0 +1,443 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2014,
+  "asOf": "2014-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/63",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33171075626",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2013-12-28",
+      "periodEndedAt": "2014-01-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-01-04",
+      "periodEndedAt": "2014-01-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-01-11",
+      "periodEndedAt": "2014-01-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-01-18",
+      "periodEndedAt": "2014-01-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-01-25",
+      "periodEndedAt": "2014-01-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-02-01",
+      "periodEndedAt": "2014-02-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-02-08",
+      "periodEndedAt": "2014-02-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-02-15",
+      "periodEndedAt": "2014-02-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-02-22",
+      "periodEndedAt": "2014-02-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-03-01",
+      "periodEndedAt": "2014-03-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-03-08",
+      "periodEndedAt": "2014-03-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-03-15",
+      "periodEndedAt": "2014-03-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-03-22",
+      "periodEndedAt": "2014-03-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-03-29",
+      "periodEndedAt": "2014-04-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-04-05",
+      "periodEndedAt": "2014-04-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-04-12",
+      "periodEndedAt": "2014-04-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-04-19",
+      "periodEndedAt": "2014-04-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-04-26",
+      "periodEndedAt": "2014-05-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-05-03",
+      "periodEndedAt": "2014-05-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-05-10",
+      "periodEndedAt": "2014-05-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-05-17",
+      "periodEndedAt": "2014-05-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-05-24",
+      "periodEndedAt": "2014-05-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-05-31",
+      "periodEndedAt": "2014-06-06",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-rusch-built-gravel-home-game-2014"
+      ],
+      "reason": "Two contemporary reports establish Dirty Kanza’s growth, Rusch’s women’s win and 19th-place overall finish, and her competitive authority before the athlete-promoter chapter."
+    },
+    {
+      "periodStartedAt": "2014-06-07",
+      "periodEndedAt": "2014-06-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-06-14",
+      "periodEndedAt": "2014-06-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-06-21",
+      "periodEndedAt": "2014-06-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-06-28",
+      "periodEndedAt": "2014-07-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-07-05",
+      "periodEndedAt": "2014-07-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-07-12",
+      "periodEndedAt": "2014-07-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-07-19",
+      "periodEndedAt": "2014-07-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-07-26",
+      "periodEndedAt": "2014-08-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-08-02",
+      "periodEndedAt": "2014-08-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-08-09",
+      "periodEndedAt": "2014-08-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-08-16",
+      "periodEndedAt": "2014-08-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-08-23",
+      "periodEndedAt": "2014-08-29",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-rusch-built-gravel-home-game-2014"
+      ],
+      "reason": "The second Rebecca’s Private Idaho announcement establishes Rusch as host and organizer of a place-specific race-and-ride with multiple distances and charitable beneficiaries."
+    },
+    {
+      "periodStartedAt": "2014-08-30",
+      "periodEndedAt": "2014-09-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-09-06",
+      "periodEndedAt": "2014-09-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-09-13",
+      "periodEndedAt": "2014-09-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-09-20",
+      "periodEndedAt": "2014-09-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-09-27",
+      "periodEndedAt": "2014-10-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-10-04",
+      "periodEndedAt": "2014-10-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-10-11",
+      "periodEndedAt": "2014-10-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-10-18",
+      "periodEndedAt": "2014-10-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-10-25",
+      "periodEndedAt": "2014-10-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-11-01",
+      "periodEndedAt": "2014-11-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-11-08",
+      "periodEndedAt": "2014-11-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-11-15",
+      "periodEndedAt": "2014-11-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-11-22",
+      "periodEndedAt": "2014-11-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-11-29",
+      "periodEndedAt": "2014-12-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-12-06",
+      "periodEndedAt": "2014-12-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-12-13",
+      "periodEndedAt": "2014-12-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-12-20",
+      "periodEndedAt": "2014-12-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2014-12-27",
+      "periodEndedAt": "2015-01-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    }
+  ],
+  "updatedAt": "2026-08-28T13:30:00Z"
+}

--- a/data/gravel-weekly/history/2014-rusch-built-gravel-home-game.json
+++ b/data/gravel-weekly/history/2014-rusch-built-gravel-home-game.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-rusch-built-gravel-home-game-2014",
+  "activeFrom": "2014-06-01",
+  "activeThrough": "2014-08-25",
+  "status": "draft",
+  "headline": "Rebecca Rusch Built Gravel a Home Game Before It Had a League",
+  "point": "In 2014, Rebecca Rusch won Dirty Kanza for a third consecutive time and then returned to Idaho to host the second edition of her own participant-first gravel event. Before gravel supplied athletes with a formal series, stable profession, or promoter-controlled calendar, one of its defining racers used competitive authority to become the promoter, choose the place, widen the invitation, and connect the event to local identity and charity.",
+  "priorJudgment": "An elite endurance athlete proved value by winning the established events sponsors sent her to; creating and hosting a mass-participation ride was a separate promoter’s job or a ceremonial retirement project.",
+  "changedJudgment": "Rusch treated sporting credibility as the seed for event ownership while she was still winning the discipline’s premier test. Rebecca’s Private Idaho made the athlete’s home terrain, personality, and values the product, giving gravel an early model in which a racer could shape the calendar instead of merely supplying results to it.",
+  "stakes": "Athlete-owned events can preserve place, community, and a recognizable point of view better than interchangeable series stops. They can also concentrate brand, labor, and authority around one personality. Gravel’s later creator-athlete economy owes something to this model, so race intelligence should distinguish athlete authorship and local purpose from a name attached only for marketing.",
+  "credibleOpposition": "Rebecca’s Private Idaho was not created alone or outside commerce. The 2014 event relied on tourism promotion, production partners, sponsors, volunteers, public roads, and a press release making explicit marketing claims. A namesake event can amplify personality as readily as community, and one successful second edition did not prove a durable business. Rusch also followed an existing gran fondo and namesake-event tradition rather than inventing athlete promotion from nothing.",
+  "whatHappened": "On May 31, 2014, Rusch won the Dirty Kanza women’s race in 12:11:15 and placed 19th overall. Contemporary reports described Dirty Kanza as one of the earliest and most popular gravel races and noted nearly 1,500 registered riders. It was Rusch’s third consecutive women’s victory there. On August 25, Visit Sun Valley announced the second Rebecca’s Private Idaho, hosted and organized by Rusch for August 31 around Ketchum and the Pioneer Mountains. The event mixed ride and race, offered 95-mile Big Potato, 50-mile Small Fry, and new 25-mile Tater Tot routes, and raised money for World Bicycle Relief, PeopleForBikes, and the Wood River Bike Coalition alongside the town’s Labor Day festivities.",
+  "take": "Model draft, not Matti's approved view: Rebecca Rusch did not wait for gravel to build a respectable calendar around her. She won Dirty Kanza for the third straight year, went home to Idaho, and built the home game herself. The long route was the Big Potato. The middle route was the Small Fry. The new short route was the Tater Tot. This is already more editorial discipline than several modern race series have managed with a branding agency. The serious point is that Rusch understood the athlete could be more than the fast person rented for a sponsor photo. She could choose the roads, set the tone, invite people who were not racing for first, attach the weekend to a town, and decide where some of the money and attention went. Gravel’s creator economy did not begin when riders learned to film vertical video. It began when athletes realized the calendar was another thing they could stop waiting for somebody else to make.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources establish the 2014 Dirty Kanza result, approximate registration scale, and the announced structure, partners, sponsors, and charitable aims of the second Rebecca’s Private Idaho. The RPI evidence is a tourism press release, not independent attendance, financial, or beneficiary reporting. The entry does not quantify Rusch’s ownership, compensation, production labor, or decision authority, and its connection to the later creator-athlete economy is an editorial inference.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_dirty_kanza_scale_rusch_overall_2014",
+      "canonicalUrl": "https://stevetilford.com/2014/06/01/dk-200-race-results/",
+      "publisher": "Steve Tilford",
+      "publishedAt": "2014-06-01T12:00:00Z",
+      "quoteExcerpt": "finished 19th overall",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_rusch_dirty_kanza_win_2014",
+      "canonicalUrl": "https://www.cxmagazine.com/jensen-rusch-dirty-kanza-200-mile-results-2014",
+      "publisher": "Cyclocross Magazine",
+      "publishedAt": "2014-06-01T13:00:00Z",
+      "quoteExcerpt": "Rebecca Rusch took the win",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_rusch_hosted_second_rpi_2014",
+      "canonicalUrl": "https://www.prweb.com/releases/visit_sun_valley_welcomes_rebecca_s_private_idaho_gravel_road_race_and_charity_ride_to_labor_day_celebrations/prweb12119801.htm",
+      "publisher": "Visit Sun Valley",
+      "publishedAt": "2014-08-25T22:45:00Z",
+      "quoteExcerpt": "one part fun group ride and one part race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_rpi_persona_and_place_2020",
+      "canonicalUrl": "https://velo.outsideonline.com/road/road-racing/monuments-of-gravel-rebeccas-private-idaho/",
+      "publisher": "Velo",
+      "publishedAt": "2020-03-06T15:57:00Z",
+      "quoteExcerpt": "larger-than-life persona helped boost",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_dirty_kanza_scale_rusch_overall_2014",
+        "claim_rusch_dirty_kanza_win_2014"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:rebeccas-private-idaho",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_rusch_hosted_second_rpi_2014",
+        "claim_rpi_persona_and_place_2020"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T13:25:00Z",
+  "contentHash": "415a91523fb298753dff2ec3dd641d7df8e3b77752e5ec7386deb5ca3a7ac65b"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -767,6 +767,21 @@ def test_2015_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2014_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2014.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 51
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weekly windows in the 2014 Cyclingnews census, which returned zero cards
- preserve 51 explicit gaps while using a broader contemporary-source pass to recover two evidence-bearing weeks
- add a citation-backed model draft on Rebecca Rusch winning Dirty Kanza and building an athlete-authored home event before gravel had a formal league
- route Unbound and Rebecca’s Private Idaho consequences only to controlled race editorial review
- retain all human-approval and no-auto-publish safety gates and leave zero pending windows

## Verification
- history validator
- backfill validator
- `pytest -q tests/test_gravel_weekly.py` (43 passed)
- both slop detectors: zero findings
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only Gravel Weekly backfill and draft history content with existing validation gates; no runtime or auth changes.
> 
> **Overview**
> Adds the **2014 Gravel Weekly backfill ledger** so all 53 weekly windows are accounted for after a Cyclingnews census that returned zero source cards. **51 weeks** stay **explicit gaps**; **two weeks** are **`covered_by_draft`** and point at a single new history entry.
> 
> That entry is a **citation-backed model draft** on Rebecca Rusch’s 2014 Dirty Kanza win (third straight women’s title, 19th overall) and hosting the second Rebecca’s Private Idaho—framed as athlete-authored gravel before a formal league. It keeps **`humanApprovalRequired`**, **`autoPublishAllowed: false`**, and routes race consequences only to **`editorial_review`** on `gravel:unbound-gravel` and `gravel:rebeccas-private-idaho` (no auto-fix).
> 
> A new pytest case locks the 2014 ledger disposition counts and **`complete: true`** through `validate_backfill_ledger`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6204f350c620af550a50c806392f1b70f47f8dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->