### PR TITLE
Complete the 2013 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2013.json
+++ b/data/gravel-weekly/backfill/2013.json
@@ -1,0 +1,444 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2013,
+  "asOf": "2013-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/64",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33171409396",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2012-12-29",
+      "periodEndedAt": "2013-01-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-01-05",
+      "periodEndedAt": "2013-01-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-01-12",
+      "periodEndedAt": "2013-01-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-01-19",
+      "periodEndedAt": "2013-01-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-01-26",
+      "periodEndedAt": "2013-02-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-02-02",
+      "periodEndedAt": "2013-02-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-02-09",
+      "periodEndedAt": "2013-02-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-02-16",
+      "periodEndedAt": "2013-02-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-02-23",
+      "periodEndedAt": "2013-03-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-03-02",
+      "periodEndedAt": "2013-03-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-03-09",
+      "periodEndedAt": "2013-03-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-03-16",
+      "periodEndedAt": "2013-03-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-03-23",
+      "periodEndedAt": "2013-03-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-03-30",
+      "periodEndedAt": "2013-04-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-04-06",
+      "periodEndedAt": "2013-04-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-04-13",
+      "periodEndedAt": "2013-04-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-04-20",
+      "periodEndedAt": "2013-04-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-04-27",
+      "periodEndedAt": "2013-05-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-05-04",
+      "periodEndedAt": "2013-05-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-05-11",
+      "periodEndedAt": "2013-05-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-05-18",
+      "periodEndedAt": "2013-05-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-05-25",
+      "periodEndedAt": "2013-05-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-06-01",
+      "periodEndedAt": "2013-06-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-06-08",
+      "periodEndedAt": "2013-06-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-06-15",
+      "periodEndedAt": "2013-06-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-06-22",
+      "periodEndedAt": "2013-06-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-06-29",
+      "periodEndedAt": "2013-07-05",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-race-bike-before-rulebook-2013"
+      ],
+      "reason": "A contemporary production-owner review connects Dirty Kanza demand to the Warbird’s purpose-built geometry and records the first-year rim mismatch."
+    },
+    {
+      "periodStartedAt": "2013-07-06",
+      "periodEndedAt": "2013-07-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-07-13",
+      "periodEndedAt": "2013-07-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-07-20",
+      "periodEndedAt": "2013-07-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-07-27",
+      "periodEndedAt": "2013-08-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-08-03",
+      "periodEndedAt": "2013-08-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-08-10",
+      "periodEndedAt": "2013-08-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-08-17",
+      "periodEndedAt": "2013-08-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-08-24",
+      "periodEndedAt": "2013-08-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-08-31",
+      "periodEndedAt": "2013-09-06",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-race-bike-before-rulebook-2013"
+      ],
+      "reason": "A contemporary independent test at Almanzo identifies the Warbird as a distinct gravel-racing machine and separates its design brief from cyclocross and touring."
+    },
+    {
+      "periodStartedAt": "2013-09-07",
+      "periodEndedAt": "2013-09-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-09-14",
+      "periodEndedAt": "2013-09-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-09-21",
+      "periodEndedAt": "2013-09-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-09-28",
+      "periodEndedAt": "2013-10-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-10-05",
+      "periodEndedAt": "2013-10-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-10-12",
+      "periodEndedAt": "2013-10-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-10-19",
+      "periodEndedAt": "2013-10-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-10-26",
+      "periodEndedAt": "2013-11-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-11-02",
+      "periodEndedAt": "2013-11-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-11-09",
+      "periodEndedAt": "2013-11-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-11-16",
+      "periodEndedAt": "2013-11-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-11-23",
+      "periodEndedAt": "2013-11-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-11-30",
+      "periodEndedAt": "2013-12-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-12-07",
+      "periodEndedAt": "2013-12-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-12-14",
+      "periodEndedAt": "2013-12-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-12-21",
+      "periodEndedAt": "2013-12-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2013-12-28",
+      "periodEndedAt": "2014-01-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    }
+  ],
+  "updatedAt": "2026-08-28T14:15:00Z"
+}
+

--- a/data/gravel-weekly/history/2013-gravel-race-bike-before-rulebook.json
+++ b/data/gravel-weekly/history/2013-gravel-race-bike-before-rulebook.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-race-bike-before-rulebook-2013",
+  "activeFrom": "2013-07-02",
+  "activeThrough": "2013-09-06",
+  "status": "draft",
+  "headline": "Gravel Got a Race Bike Before It Got a Rulebook",
+  "point": "By 2013, gravel racing was coherent enough for Salsa to sell the Warbird as equipment for a distinct competitive problem, even though the sport still lacked a common series, governing authority, or settled category language. The bike's stable geometry, compliance, tire clearance, bottle capacity, and disc brakes were an argument: a hundred or two hundred miles of loose roads was not merely cyclocross with worse scheduling.",
+  "priorJudgment": "Gravel racing was too informal and mechanically ordinary to justify its own race bike. Riders could borrow a cyclocross, touring, mountain, or road bike and choose whichever compromise annoyed them least.",
+  "changedJudgment": "The Warbird recognized that the discipline's defining demands formed a product brief of their own. A purpose-built race bike made gravel legible as a category before organizers, media, and governing bodies had agreed what the category was.",
+  "stakes": "Equipment does not merely respond to a sport; it tells riders and retailers which distinctions deserve to exist. The Warbird helped move gravel from an eccentric use case into a market with its own geometry and expectations. That made the racing better served and easier to enter, while beginning the familiar cycle in which an accessible scene acquires specialist equipment, price tiers, and eventually an arms race.",
+  "credibleOpposition": "Salsa did not invent riding or racing drop-bar bikes on dirt, and even a favorable contemporary review said it was not the first gravel bike. The Warbird borrowed recognizable cyclocross and touring ideas, its first-year aluminum build shipped with rims one owner considered badly too narrow, and two enthusiastic reviews do not establish broad sales or causal responsibility for gravel's later growth. Calling it the moment gravel became a category would confuse an unusually clear product signal with the whole history.",
+  "whatHappened": "A production Warbird 2 owner wrote on July 2, 2013 that finishing the Dirty Kanza 200 in 18:55 made him want another gravel race and a bike designed for the Midwest scene. He praised its stable long-wheelbase handling and compliant frame after Odin's Revenge, but replaced the factory 13.3-millimeter internal-width rims before racing because he considered them inappropriate for the job. On September 5, GearJunkie reported testing the 2013 Warbird Ti for hundreds of miles, including the Almanzo 100 with nearly a thousand riders. The reviewer entered skeptical that cycling needed another road-bike subspecies and finished arguing that Salsa may have been first to market a gravel racing bike distinct from cyclocross and touring rigs.",
+  "take": "Model draft, not Matti's approved view: Gravel got its own race bike before it got a rulebook, a television package, or anyone important enough to ruin a comment section by announcing the spirit was dead. Salsa looked at riders spending all day being shaken across Minnesota and Kansas and reached the radical conclusion that this was not cyclocross with an administrative error. The Warbird was longer, calmer, more compliant, carried three bottles, cleared real tires, and used disc brakes. It was an argument disguised as an orange bicycle: these races imposed a specific enough kind of misery to deserve specific equipment. The funniest detail is that the first-year aluminum build reportedly arrived with 13.3-millimeter rims, as if the frame department had discovered gravel while purchasing was still shopping for 2009. That does not weaken the story. It proves the category knew what problem it was solving before the supply chain knew what shelf to put it on. The Warbird did not invent gravel, but it helped make gravel commercially undeniable—and once a sport receives a purpose-built machine, the price of claiming it is merely a weird little scene begins going up very quickly.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The contemporary evidence is two detailed first-person reviews, one from a named GearJunkie contributor and one from an individual owner. It establishes how the 2013 Warbird was described, equipped, and experienced at Dirty Kanza, Odin's Revenge, and Almanzo; it does not establish production volume, sales, Salsa's internal decision process, or that the model caused later category growth. The phrase 'before it got a rulebook' is editorial shorthand for the absence of a unified gravel authority or standard, not a claim that individual races had no rules.",
+  "editorialScore": 97,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_warbird_owner_dirty_kanza_and_odin_2013",
+      "canonicalUrl": "https://xcmtbjason.blogspot.com/2013/07/salsa-warbird-2-review.html",
+      "publisher": "XCmtbJason",
+      "publishedAt": "2013-07-02T20:40:00-05:00",
+      "quoteExcerpt": "inspired by and designed for the Midwest gravel scene",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_warbird_first_year_narrow_rims_2013",
+      "canonicalUrl": "https://xcmtbjason.blogspot.com/2013/07/salsa-warbird-2-review.html",
+      "publisher": "XCmtbJason",
+      "publishedAt": "2013-07-02T20:40:00-05:00",
+      "quoteExcerpt": "not a good thing for the first year of production",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_warbird_new_gravel_race_genre_2013",
+      "canonicalUrl": "https://gearjunkie.com/biking/salsa-warbird-gravel-bike",
+      "publisher": "GearJunkie",
+      "publishedAt": "2013-09-05T23:07:00-04:00",
+      "quoteExcerpt": "a new genre for the industry",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_warbird_distinct_geometry_and_compliance_2013",
+      "canonicalUrl": "https://gearjunkie.com/biking/salsa-warbird-gravel-bike",
+      "publisher": "GearJunkie",
+      "publishedAt": "2013-09-05T23:07:00-04:00",
+      "quoteExcerpt": "relaxed and stable geometry for long days",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_salsa_warbird_purpose_built_retrospective_2020",
+      "canonicalUrl": "https://www.salsacycles.com/blogs/articles/warbird-gravel-since-the-beginning-1",
+      "publisher": "Salsa Cycles",
+      "publishedAt": "2020-01-14T12:00:00Z",
+      "quoteExcerpt": "first purpose-built gravel bike",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_warbird_owner_dirty_kanza_and_odin_2013",
+        "claim_warbird_first_year_narrow_rims_2013"
+      ],
+      "confidence": 0.92,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:spring-valley-100",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_warbird_new_gravel_race_genre_2013",
+        "claim_warbird_distinct_geometry_and_compliance_2013"
+      ],
+      "confidence": 0.94,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T14:15:00Z",
+  "contentHash": "de500e9f5d96d71344801f35a81a1ec289b58b57b98ede97a10fbbabcd77f2f9"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -782,6 +782,21 @@ def test_2014_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2013_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2013.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 51
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weeks in the 2013 historical census
- preserve 51 explicit quiet windows and cover two receipt-backed weeks
- draft the Warbird chapter as the point when gravel got a race bike before a rulebook
- keep publication and race impacts human-review-only

## Verification
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2013-gravel-race-bike-before-rulebook.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2013.json`
- `pytest -q tests/test_gravel_weekly.py` (44 passed)
- both slop detectors: zero violations
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static editorial JSON and a contract test; no runtime or auth changes, and publication remains blocked until human approval.
> 
> **Overview**
> Adds the **2013 Gravel Weekly backfill ledger**, marking all 53 weeks complete with zero Cyclingnews source cards: **51 explicit quiet windows** and **two weeks** tied to a single draft history entry (`history-gravel-race-bike-before-rulebook-2013`).
> 
> Introduces that **draft history chapter** (“Gravel Got a Race Bike Before It Got a Rulebook”) about the 2013 Salsa Warbird, with contemporary receipts (owner review, GearJunkie), later evidence, and proposed **human-review-only** race impacts on Unbound and Spring Valley 100. Ledger and entry both keep **`humanApprovalRequired`** and **`autoPublishAllowed: false`**.
> 
> Adds **`test_2013_backfill_ledger_starts_from_the_complete_source_census`** so the 2013 ledger must pass `validate_backfill_ledger` with the same disposition counts as the committed data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44163d65a6cb88cf023513f86852261d5091cc05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->