### PR TITLE
Complete the 2012 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2012.json
+++ b/data/gravel-weekly/backfill/2012.json
@@ -1,0 +1,442 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2012,
+  "asOf": "2012-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/65",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33171915239",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2011-12-31",
+      "periodEndedAt": "2012-01-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-01-07",
+      "periodEndedAt": "2012-01-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-01-14",
+      "periodEndedAt": "2012-01-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-01-21",
+      "periodEndedAt": "2012-01-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-01-28",
+      "periodEndedAt": "2012-02-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-02-04",
+      "periodEndedAt": "2012-02-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-02-11",
+      "periodEndedAt": "2012-02-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-02-18",
+      "periodEndedAt": "2012-02-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-02-25",
+      "periodEndedAt": "2012-03-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-03-03",
+      "periodEndedAt": "2012-03-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-03-10",
+      "periodEndedAt": "2012-03-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-03-17",
+      "periodEndedAt": "2012-03-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-03-24",
+      "periodEndedAt": "2012-03-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-03-31",
+      "periodEndedAt": "2012-04-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-04-07",
+      "periodEndedAt": "2012-04-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-04-14",
+      "periodEndedAt": "2012-04-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-04-21",
+      "periodEndedAt": "2012-04-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-04-28",
+      "periodEndedAt": "2012-05-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-05-05",
+      "periodEndedAt": "2012-05-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-05-12",
+      "periodEndedAt": "2012-05-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-05-19",
+      "periodEndedAt": "2012-05-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-05-26",
+      "periodEndedAt": "2012-06-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-06-02",
+      "periodEndedAt": "2012-06-08",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-rusch-nearly-won-whole-thing-2012"
+      ],
+      "reason": "Three contemporary accounts establish Dirty Kanza’s breakout field, Rusch’s reluctant discovery of gravel, the navigational chaos, and her third-place overall finish six minutes behind the joint winners."
+    },
+    {
+      "periodStartedAt": "2012-06-09",
+      "periodEndedAt": "2012-06-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-06-16",
+      "periodEndedAt": "2012-06-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-06-23",
+      "periodEndedAt": "2012-06-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-06-30",
+      "periodEndedAt": "2012-07-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-07-07",
+      "periodEndedAt": "2012-07-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-07-14",
+      "periodEndedAt": "2012-07-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-07-21",
+      "periodEndedAt": "2012-07-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-07-28",
+      "periodEndedAt": "2012-08-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-08-04",
+      "periodEndedAt": "2012-08-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-08-11",
+      "periodEndedAt": "2012-08-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-08-18",
+      "periodEndedAt": "2012-08-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-08-25",
+      "periodEndedAt": "2012-08-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-09-01",
+      "periodEndedAt": "2012-09-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-09-08",
+      "periodEndedAt": "2012-09-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-09-15",
+      "periodEndedAt": "2012-09-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-09-22",
+      "periodEndedAt": "2012-09-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-09-29",
+      "periodEndedAt": "2012-10-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-10-06",
+      "periodEndedAt": "2012-10-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-10-13",
+      "periodEndedAt": "2012-10-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-10-20",
+      "periodEndedAt": "2012-10-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-10-27",
+      "periodEndedAt": "2012-11-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-11-03",
+      "periodEndedAt": "2012-11-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-11-10",
+      "periodEndedAt": "2012-11-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-11-17",
+      "periodEndedAt": "2012-11-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-11-24",
+      "periodEndedAt": "2012-11-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-12-01",
+      "periodEndedAt": "2012-12-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-12-08",
+      "periodEndedAt": "2012-12-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-12-15",
+      "periodEndedAt": "2012-12-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-12-22",
+      "periodEndedAt": "2012-12-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2012-12-29",
+      "periodEndedAt": "2013-01-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    }
+  ],
+  "updatedAt": "2026-08-28T15:00:00Z"
+}
+

--- a/data/gravel-weekly/history/2012-rusch-nearly-won-whole-thing.json
+++ b/data/gravel-weekly/history/2012-rusch-nearly-won-whole-thing.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-rusch-nearly-won-whole-thing-2012",
+  "activeFrom": "2012-06-02",
+  "activeThrough": "2012-06-08",
+  "status": "draft",
+  "headline": "Rebecca Rusch Came to Kansas as a Favor and Nearly Won the Whole Thing",
+  "point": "Dirty Kanza's 2012 breakout was not merely that more than 420 people entered. Dan Hughes nagged an established endurance world champion who barely knew gravel racing existed into trying it; Rebecca Rusch then finished third overall, six minutes behind the joint winners, and left calling it one of the best races she had done. Gravel's persuasive power was becoming the experience itself: it could recruit credibility from another discipline and convert the celebrity rather than merely rent her endorsement.",
+  "priorJudgment": "Gravel was a regional curiosity for committed amateurs, while nationally credible endurance athletes did serious work in established mountain-bike, road, and cyclocross events.",
+  "changedJudgment": "A three-time world champion arrived skeptical, adapted a cyclocross bike, survived the same navigation and support bargain as everyone else, nearly won the combined race, and became an advocate. The scene had grown enough to attract elite outsiders while remaining strange enough to surprise them.",
+  "stakes": "The strongest growth signal is not attendance alone but conversion: who enters reluctantly, what the event makes them feel, and whether they carry that conviction elsewhere. Rusch's result gave Dirty Kanza athletic legitimacy, but her public change of mind gave gravel something more durable—a credible person explaining that the odd little race was worth caring about because it had changed her own judgment.",
+  "credibleOpposition": "One exceptional athlete's result does not prove that gravel offered equal opportunity or that its 2012 format should be romanticized. Rusch received friendly pushes early, used wheels when available, and rejoined Hughes and Rusty Folger late before the climbs separated them. Mild conditions and packed gravel helped produce record times, and the men's co-winners chose to finish together rather than sprint. Her six-minute gap is dramatic, but it is not evidence that she would have won a separately started race or that mixed-field dynamics were uncomplicated.",
+  "whatHappened": "On June 2, 2012, more than 420 riders started Dirty Kanza in Emporia, with participants reported from 38 states, Canada, and Great Britain. Contemporary coverage called it the race's breakout year. Rusch wrote that Hughes had entered her while she was skiing after repeatedly urging her to come, and that she had not understood the gravel-riding phenomenon before the trip. The lead group missed an early turn, forcing riders back through much of the field. Rusch later followed markings for a running course near the finish. Hughes and Folger tied in a course-record 11:56:01; Rusch finished in 12:02:00, third overall, and lowered the women's record by more than an hour. A participant tally recorded 267 finishers from 420 entrants.",
+  "take": "Model draft, not Matti's approved view: Dan Hughes would not shut up about a bike race in Kansas. That was the media strategy. He nagged a three-time world champion until she came, submitted her entry while she was skiing, and accidentally gave gravel one of the cleanest conversion stories it has ever had. Rebecca Rusch arrived barely aware that gravel was a phenomenon. She took a wrong turn with the leaders around mile 15, fought back through nearly the entire field, followed the wrong paint again half a mile from the finish, and still placed third overall—six minutes behind two men who crossed arm in arm. Twelve hours earlier, Kansas was not high on her list of places to visit. At the finish, she called Dirty Kanza one of the best races she had ever done. That is the point. Gravel did not borrow a famous athlete and ask her to repeat a campaign brief. It put her through its deeply underfunded obstacle course and changed her mind in public. More than 420 starters made 2012 a breakout on paper. Rusch nearly winning the whole thing made the breakout a story people could repeat at a party.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The contemporary sources agree on the leading times, Rusch's third-place overall finish, the wrong turns, and a field exceeding 420 starters. They differ slightly on finishers: one forum summary reported 260 while a participant's numerical recap reported 267, so this entry uses the latter and does not claim a definitive official count. The conversion and legitimacy argument is editorial inference from Rusch's own before-and-after account and the independent race report, not a quantified measure of gravel's national popularity.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_dirty_kanza_breakout_field_2012",
+      "canonicalUrl": "https://dirtscrolls.com/14921968-200-miles-bad-road-dirty-kanza-200-race-report",
+      "publisher": "Dirt Rag",
+      "publishedAt": "2012-06-05T10:52:00-05:00",
+      "quoteExcerpt": "2012 will go down as the breakout year",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_rusch_third_overall_record_2012",
+      "canonicalUrl": "https://dirtscrolls.com/14921968-200-miles-bad-road-dirty-kanza-200-race-report",
+      "publisher": "Dirt Rag",
+      "publishedAt": "2012-06-05T10:52:00-05:00",
+      "quoteExcerpt": "finishing third overall",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_rusch_discovered_gravel_2012",
+      "canonicalUrl": "https://rebeccaruschblog.wordpress.com/2012/06/05/the-dirty-kanza-200-recap/",
+      "publisher": "Rebecca Rusch",
+      "publishedAt": "2012-06-05T12:00:00-05:00",
+      "quoteExcerpt": "I didn't really know about the whole gravel road riding phenomenon",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_rusch_wrong_turns_and_six_minute_gap_2012",
+      "canonicalUrl": "https://rebeccaruschblog.wordpress.com/2012/06/05/the-dirty-kanza-200-recap/",
+      "publisher": "Rebecca Rusch",
+      "publishedAt": "2012-06-05T12:00:00-05:00",
+      "quoteExcerpt": "I was 6 minutes back",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_dirty_kanza_420_entered_267_finished_2012",
+      "canonicalUrl": "https://chainringtatt.wordpress.com/2012/06/08/dirty-kanza-200-by-the-numbers/",
+      "publisher": "Chainring Tattoo",
+      "publishedAt": "2012-06-08T12:00:00-05:00",
+      "quoteExcerpt": "Racers Entered: 420",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_dirty_kanza_breakout_field_2012",
+        "claim_rusch_third_overall_record_2012",
+        "claim_rusch_discovered_gravel_2012",
+        "claim_rusch_wrong_turns_and_six_minute_gap_2012",
+        "claim_dirty_kanza_420_entered_267_finished_2012"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T15:00:00Z",
+  "contentHash": "dc80a7942cc405ecdb4fd12da345cbfc3e8414460f14618d2f7f4d342551b4d5"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -797,6 +797,21 @@ def test_2013_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2012_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2012.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 52
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weeks in the 2012 historical census
- preserve 52 explicit quiet windows and cover one receipt-backed week
- draft the story of Rebecca Rusch discovering gravel and finishing third overall at Dirty Kanza
- keep publication and race impacts human-review-only

## Verification
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2012-rusch-nearly-won-whole-thing.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2012.json`
- `pytest -q tests/test_gravel_weekly.py` (45 passed)
- both slop detectors: zero violations
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and contract tests only; draft content is not auto-published and race impacts require human approval.
> 
> **Overview**
> Adds the **2012 Gravel Weekly backfill ledger** so all 53 weekly windows are accounted for: **52** stay **`explicit_gap`** (no Cyclingnews source cards) and **one** week (**2012-06-02–2012-06-08**) is **`covered_by_draft**` via a new history entry. The ledger is marked **`complete`** with **`humanApprovalRequired`** and no auto-publish.
> 
> Introduces a **draft** history entry **`history-rusch-nearly-won-whole-thing-2012`** about Rebecca Rusch’s reluctant 2012 Dirty Kanza run—420+ starters, wrong turns, third overall six minutes behind the joint winners—with contemporary receipts (Dirt Rag, Rusch’s blog, Chainring Tattoo) and a proposed **`editorial_review`** race impact on **`gravel:unbound-gravel`** (`race.biased_opinion`), still human-review-only.
> 
> Adds **`test_2012_backfill_ledger_starts_from_the_complete_source_census`** mirroring other low-source years (0 source cards, 52 gaps, 1 draft-covered week).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b597519732f2f9f7d35f6218eecf2f7e0ae9113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->