### PR TITLE
Complete the 2011 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2011.json
+++ b/data/gravel-weekly/backfill/2011.json
@@ -1,0 +1,446 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2011,
+  "asOf": "2011-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/66",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33172355590",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 1,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2011-01-01",
+      "periodEndedAt": "2011-01-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-01-08",
+      "periodEndedAt": "2011-01-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-01-15",
+      "periodEndedAt": "2011-01-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-01-22",
+      "periodEndedAt": "2011-01-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-01-29",
+      "periodEndedAt": "2011-02-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-02-05",
+      "periodEndedAt": "2011-02-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-02-12",
+      "periodEndedAt": "2011-02-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-02-19",
+      "periodEndedAt": "2011-02-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-02-26",
+      "periodEndedAt": "2011-03-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-03-05",
+      "periodEndedAt": "2011-03-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-03-12",
+      "periodEndedAt": "2011-03-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-03-19",
+      "periodEndedAt": "2011-03-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-03-26",
+      "periodEndedAt": "2011-04-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-04-02",
+      "periodEndedAt": "2011-04-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-04-09",
+      "periodEndedAt": "2011-04-15",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-crusher-made-wrong-bike-the-point-2011"
+      ],
+      "reason": "A contemporary preview records Swindlehurst’s deliberate no-correct-bike design and the one-bike constraint."
+    },
+    {
+      "periodStartedAt": "2011-04-16",
+      "periodEndedAt": "2011-04-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-04-23",
+      "periodEndedAt": "2011-04-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-04-30",
+      "periodEndedAt": "2011-05-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-05-07",
+      "periodEndedAt": "2011-05-13",
+      "sourceCardCount": 1,
+      "disposition": "rejected",
+      "entryIds": [],
+      "reason": "The sole Cyclingnews card concerns Giro d’Italia road-stage gravel safety, not the North American gravel-racing narrative; reject it rather than manufacture relevance."
+    },
+    {
+      "periodStartedAt": "2011-05-14",
+      "periodEndedAt": "2011-05-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-05-21",
+      "periodEndedAt": "2011-05-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-05-28",
+      "periodEndedAt": "2011-06-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-06-04",
+      "periodEndedAt": "2011-06-10",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-crusher-made-wrong-bike-the-point-2011"
+      ],
+      "reason": "A contemporary local preview establishes the planned asphalt-and-dirt course and promoter origin."
+    },
+    {
+      "periodStartedAt": "2011-06-11",
+      "periodEndedAt": "2011-06-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-06-18",
+      "periodEndedAt": "2011-06-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-06-25",
+      "periodEndedAt": "2011-07-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-07-02",
+      "periodEndedAt": "2011-07-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-07-09",
+      "periodEndedAt": "2011-07-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-07-16",
+      "periodEndedAt": "2011-07-22",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-crusher-made-wrong-bike-the-point-2011"
+      ],
+      "reason": "A contemporary race report establishes the final course, winners, opposing bike choices, starter count, and the organizer’s satisfaction that riders wanted different equipment."
+    },
+    {
+      "periodStartedAt": "2011-07-23",
+      "periodEndedAt": "2011-07-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-07-30",
+      "periodEndedAt": "2011-08-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-08-06",
+      "periodEndedAt": "2011-08-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-08-13",
+      "periodEndedAt": "2011-08-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-08-20",
+      "periodEndedAt": "2011-08-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-08-27",
+      "periodEndedAt": "2011-09-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-09-03",
+      "periodEndedAt": "2011-09-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-09-10",
+      "periodEndedAt": "2011-09-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-09-17",
+      "periodEndedAt": "2011-09-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-09-24",
+      "periodEndedAt": "2011-09-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-10-01",
+      "periodEndedAt": "2011-10-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-10-08",
+      "periodEndedAt": "2011-10-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-10-15",
+      "periodEndedAt": "2011-10-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-10-22",
+      "periodEndedAt": "2011-10-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-10-29",
+      "periodEndedAt": "2011-11-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-11-05",
+      "periodEndedAt": "2011-11-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-11-12",
+      "periodEndedAt": "2011-11-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-11-19",
+      "periodEndedAt": "2011-11-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-11-26",
+      "periodEndedAt": "2011-12-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-12-03",
+      "periodEndedAt": "2011-12-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-12-10",
+      "periodEndedAt": "2011-12-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-12-17",
+      "periodEndedAt": "2011-12-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-12-24",
+      "periodEndedAt": "2011-12-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2011-12-31",
+      "periodEndedAt": "2012-01-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    }
+  ],
+  "updatedAt": "2026-08-28T15:30:00Z"
+}
+

--- a/data/gravel-weekly/history/2011-crusher-made-wrong-bike-the-point.json
+++ b/data/gravel-weekly/history/2011-crusher-made-wrong-bike-the-point.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-crusher-made-wrong-bike-the-point-2011",
+  "activeFrom": "2011-04-15",
+  "activeThrough": "2011-07-21",
+  "status": "draft",
+  "headline": "Crusher Made the Wrong Bike the Whole Point",
+  "point": "The inaugural Crusher in the Tushar did not merely tolerate equipment uncertainty; Burke Swindlehurst designed it. Riders had to choose one machine for pavement, technical dirt, more than 10,000 feet of climbing, and an 11,000-foot finish. The men's winner used a cyclocross bike, the women's winner used a 29er hardtail, and the organizer delighted that everyone finished wanting a different setup. Gravel's enduring equipment argument was already the product.",
+  "priorJudgment": "A responsible race course should make the correct equipment obvious enough that the contest measures riders rather than punishing an unlucky interpretation of the route.",
+  "changedJudgment": "Crusher made the pre-race interpretation part of the competition. Its one-bike rule forced road, cyclocross, and mountain-bike athletes to wager on where speed, traction, gearing, weight, and control would matter most, then live with the parts of the course that made the wager look foolish.",
+  "stakes": "A race's identity cannot be reduced to its gravel percentage or elevation total. The sequence and severity of its surfaces determine whether any equipment compromise can dominate. Gravel God race intelligence should explain that decision structure rather than issue a falsely universal 'best bike' answer, because Crusher's core value is precisely that every answer carries a penalty somewhere.",
+  "credibleOpposition": "Mixed-surface races and equipment tradeoffs existed long before Crusher, so the event did not invent the problem. Its first field was modest, the women's turnout was low enough for Clara Hughes to call for more participation, and elite winners on different bikes do not prove every option was equally competitive. The announced course also changed from 79 miles and 12,000 feet of climbing to a reported 69 miles and more than 10,000 feet, complicating comparisons between preview claims and the race riders actually completed.",
+  "whatHappened": "On April 15, 2011, Velo reported that retired road pro Burke Swindlehurst was promoting a Utah race deliberately designed not to suit one bike type; cyclocross bikes, mountain bikes, and improvised road hybrids were welcome, but riders could not change bikes. A June preview described a planned 79-mile point-to-point route mixing asphalt and dirt with more than 12,000 feet of climbing. The July race report described the final course as 69 miles with more than 10,000 feet of climbing and a finish around 11,000 feet. Road pro Tyler Wren won the men's race on a cyclocross frameset. Olympic gold medalist Clara Hughes won the women's race by 22 minutes on a 29er hardtail. Velo reported 179 starters, and Swindlehurst said riders' conviction that they had chosen the wrong bike was exactly the response he wanted.",
+  "take": "Model draft, not Matti's approved view: Burke Swindlehurst built a race where buying the correct bike was impossible because the correct bike did not exist. This was either excellent course design or an unusually scenic way to make 179 adults resent their own garages. Crusher offered pavement, technical dirt, more than 10,000 feet of climbing, an 11,000-foot finish, and one useful rule: whatever mistake you brought, you had to keep riding it. Tyler Wren won on a cyclocross bike. Clara Hughes won on a 29er hardtail. Everyone finished convinced another setup would have been better, and Swindlehurst said that was exactly what he wanted. There is the point. Most races hide their compromises inside a recommended tire width and pretend the spreadsheet has achieved certainty. Crusher made uncertainty the contest. The gravel industry would spend the next decade selling increasingly confident answers to a question this race had deliberately designed not to have one.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources establish Swindlehurst's stated design intent, the one-bike constraint, the reported final course, winners, equipment, and starter count. The June preview's 325-person field and 79-mile, 12,000-foot route were forward-looking; the July account reported 179 starters on 69 miles with more than 10,000 feet, while a December recap described 200 racers. This entry treats 179 as actual starters and 200 as approximate participation, and does not claim every rider literally preferred another bike beyond the organizer's reported finish-line impression.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_crusher_designed_for_no_single_bike_2011",
+      "canonicalUrl": "https://velo.outsideonline.com/road/swindlehurst-promotes-tough-roadoff-road-race-in-utah/",
+      "publisher": "Velo",
+      "publishedAt": "2011-04-15T12:37:00-04:00",
+      "quoteExcerpt": "not to suit any particular type of bike",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_crusher_preview_mixed_surface_2011",
+      "canonicalUrl": "https://www.cyclingwest.com/racing/road-racing/crusher-in-the-tushar-joins-suite-of-endurance-races/",
+      "publisher": "Cycling West",
+      "publishedAt": "2011-06-08T12:00:00-06:00",
+      "quoteExcerpt": "a mixture of asphalt and dirt road",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_crusher_wren_cx_hughes_29er_2011",
+      "canonicalUrl": "https://velo.outsideonline.com/news/wren-and-hughes-win-first-ever-crusher-in-the-tushar-on-off-road-race-in-utah/",
+      "publisher": "Velo",
+      "publishedAt": "2011-07-21T09:46:00-04:00",
+      "quoteExcerpt": "Hughes chose a 29er mountain bike",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_crusher_wrong_bike_intent_2011",
+      "canonicalUrl": "https://velo.outsideonline.com/news/wren-and-hughes-win-first-ever-crusher-in-the-tushar-on-off-road-race-in-utah/",
+      "publisher": "Velo",
+      "publishedAt": "2011-07-21T09:46:00-04:00",
+      "quoteExcerpt": "they were on the wrong bike",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_crusher_inaugural_reach_2011",
+      "canonicalUrl": "https://www.cyclingnews.com/news/crusher-in-the-tushar-back-for-another-helping/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2011-12-05T12:00:00Z",
+      "quoteExcerpt": "200 racers from 17 states and Canada",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:crusher-in-the-tushar",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_crusher_designed_for_no_single_bike_2011",
+        "claim_crusher_preview_mixed_surface_2011",
+        "claim_crusher_wren_cx_hughes_29er_2011",
+        "claim_crusher_wrong_bike_intent_2011",
+        "claim_crusher_inaugural_reach_2011"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T15:30:00Z",
+  "contentHash": "8fd1d2d6803de9277007aeddf8951ff839804d4c82506cc4a1971c483aede65c"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -812,6 +812,21 @@ def test_2012_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2011_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2011.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 49
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 3
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weeks in the 2011 historical census
- reject the sole irrelevant road-stage source card rather than manufacture relevance
- preserve 49 explicit quiet windows and cover three receipt-backed weeks
- draft the inaugural Crusher chapter around its deliberately unsolvable bike-choice problem
- keep publication and race impacts human-review-only

## Verification
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2011-crusher-made-wrong-bike-the-point.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2011.json`
- `pytest -q tests/test_gravel_weekly.py` (46 passed)
- both slop detectors: zero violations
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static editorial JSON and a contract test only; publication and race-field updates remain gated on human approval.
> 
> **Overview**
> Adds the **2011 Gravel Weekly backfill ledger** so all **53 weeks** are accounted for: **49** `explicit_gap` quiet windows, **one** Cyclingnews card **rejected** (Giro gravel-safety, off-narrative), and **three** weeks **`covered_by_draft`** tied to a single history entry. The ledger is marked **`complete`** with **`humanApprovalRequired`** and no auto-publish.
> 
> Introduces a **draft** history entry **`history-crusher-made-wrong-bike-the-point-2011`** (“Crusher Made the Wrong Bike the Whole Point”) with contemporary receipts, uncertainty notes, and a **human-review-only** `raceImpacts` proposal for `gravel:crusher-in-the-tushar` / `race.biased_opinion`.
> 
> Locks the census in **`test_2011_backfill_ledger_starts_from_the_complete_source_census`** via `validate_backfill_ledger`, matching the pattern used for other years.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfcb04c19c3cd8be2f2fce43d08fb0793676e894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->