### PR TITLE
Complete the 2010 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2010.json
+++ b/data/gravel-weekly/backfill/2010.json
@@ -1,0 +1,442 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2010,
+  "asOf": "2010-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/67",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33172902179",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2009-12-26",
+      "periodEndedAt": "2010-01-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-01-02",
+      "periodEndedAt": "2010-01-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-01-09",
+      "periodEndedAt": "2010-01-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-01-16",
+      "periodEndedAt": "2010-01-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-01-23",
+      "periodEndedAt": "2010-01-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-01-30",
+      "periodEndedAt": "2010-02-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-02-06",
+      "periodEndedAt": "2010-02-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-02-13",
+      "periodEndedAt": "2010-02-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-02-20",
+      "periodEndedAt": "2010-02-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-02-27",
+      "periodEndedAt": "2010-03-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-03-06",
+      "periodEndedAt": "2010-03-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-03-13",
+      "periodEndedAt": "2010-03-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-03-20",
+      "periodEndedAt": "2010-03-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-03-27",
+      "periodEndedAt": "2010-04-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-04-03",
+      "periodEndedAt": "2010-04-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-04-10",
+      "periodEndedAt": "2010-04-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-04-17",
+      "periodEndedAt": "2010-04-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-04-24",
+      "periodEndedAt": "2010-04-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-05-01",
+      "periodEndedAt": "2010-05-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-05-08",
+      "periodEndedAt": "2010-05-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-05-15",
+      "periodEndedAt": "2010-05-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-05-22",
+      "periodEndedAt": "2010-05-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-05-29",
+      "periodEndedAt": "2010-06-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-06-05",
+      "periodEndedAt": "2010-06-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-06-12",
+      "periodEndedAt": "2010-06-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-06-19",
+      "periodEndedAt": "2010-06-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-06-26",
+      "periodEndedAt": "2010-07-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-07-03",
+      "periodEndedAt": "2010-07-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-07-10",
+      "periodEndedAt": "2010-07-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-07-17",
+      "periodEndedAt": "2010-07-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-07-24",
+      "periodEndedAt": "2010-07-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-07-31",
+      "periodEndedAt": "2010-08-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-08-07",
+      "periodEndedAt": "2010-08-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-08-14",
+      "periodEndedAt": "2010-08-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-08-21",
+      "periodEndedAt": "2010-08-27",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-worlds-powerball-governance-2010"
+      ],
+      "reason": "A contemporary participant report establishes the free inaugural Gravel Worlds, Pirate Cycling League involvement, mandatory checkpoint tickets, approximate distance, heat, winner, and championship jersey."
+    },
+    {
+      "periodStartedAt": "2010-08-28",
+      "periodEndedAt": "2010-09-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-09-04",
+      "periodEndedAt": "2010-09-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-09-11",
+      "periodEndedAt": "2010-09-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-09-18",
+      "periodEndedAt": "2010-09-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-09-25",
+      "periodEndedAt": "2010-10-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-10-02",
+      "periodEndedAt": "2010-10-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-10-09",
+      "periodEndedAt": "2010-10-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-10-16",
+      "periodEndedAt": "2010-10-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-10-23",
+      "periodEndedAt": "2010-10-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-10-30",
+      "periodEndedAt": "2010-11-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-11-06",
+      "periodEndedAt": "2010-11-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-11-13",
+      "periodEndedAt": "2010-11-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-11-20",
+      "periodEndedAt": "2010-11-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-11-27",
+      "periodEndedAt": "2010-12-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-12-04",
+      "periodEndedAt": "2010-12-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-12-11",
+      "periodEndedAt": "2010-12-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-12-18",
+      "periodEndedAt": "2010-12-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    },
+    {
+      "periodStartedAt": "2010-12-25",
+      "periodEndedAt": "2010-12-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
+    }
+  ],
+  "updatedAt": "2026-08-28T16:00:00Z"
+}
+

--- a/data/gravel-weekly/history/2010-gravel-worlds-powerball-governance.json
+++ b/data/gravel-weekly/history/2010-gravel-worlds-powerball-governance.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-worlds-powerball-governance-2010",
+  "activeFrom": "2010-08-21",
+  "activeThrough": "2010-08-23",
+  "status": "draft",
+  "headline": "Gravel Declared a World Championship With Powerball Tickets",
+  "point": "In 2010, a Nebraska ride became Gravel Worlds without waiting for a federation to recognize gravel, much less award it a championship. Riders followed cue sheets, used small-town lottery tickets as checkpoint proof, and crowned champions inside a free event run with the Pirate Cycling League. The joke became an institution because the ritual, labor, and community were real before the title was official.",
+  "priorJudgment": "A world championship is granted from the top down: a governing body defines the discipline, sanctions the contest, supplies officials, and authorizes the jersey.",
+  "changedJudgment": "Gravel Worlds demonstrated the opposite path. A local community could invent a credible title from the bottom up by building a hard course, recognizable rituals, peer accountability, and enough continuity that people chose to treat the title as meaningful.",
+  "stakes": "Gravel's culture was shaped by institutions that began as shared jokes but survived through volunteer labor and repetition. That history matters when later owners, sponsors, and governing bodies claim authority over names, formats, and championships. The useful question is not only who has legal sanction, but who created the ritual people kept showing up to perform.",
+  "credibleOpposition": "The 2010 'world' title was knowingly unofficial, geographically narrow, and not drawn from a representative global field. The strongest contemporary source is one participant's account; the Powerball-ticket and cue-sheet system is described more completely in a later first-hand history by another early gravel organizer. The event's eventual trademark and prominence do not retroactively make its first champions equivalent to federation-recognized world champions.",
+  "whatHappened": "On August 21, 2010, the event previously called the Good Life Gravel Adventure became the inaugural Gravel Worlds around Lincoln, Nebraska. A contemporary participant described a free race of about 149 miles in 97-degree heat, organized by Corey Godfrey with the Pirate Cycling League and local sponsors. Riders passed mandatory checkpoints, collected tickets, navigated the course themselves, and raced for a Gravel Worlds jersey. Mike Marchand won the open men's race in 8:51. A 2024 history by Guitar Ted describes the title as deliberately tongue-in-cheek and says riders followed printed cue sheets, bought Nebraska Powerball tickets at four required business stops to prove passage, and earned category rainbow jerseys that were not sold to non-winners.",
+  "take": "Model draft, not Matti's approved view: Before the UCI discovered gravel, people in Nebraska declared a world championship, handed everybody cue sheets, and used Powerball tickets as anti-cheating technology. This remains a more coherent governance system than several things cycling has tried since. There were no officials hiding behind a hedge with a tablet. There was the Pirate Cycling League, roughly 150 miles of roads, 97-degree heat, a gas-station timestamp, and the basic threat that your friends would know if you cheated at their free bike race. Mike Marchand got the Gravel Worlds jersey because he finished first, not because anyone in Switzerland had opened the correct attachment. Of course the title was a joke. The part people miss is that jokes become institutions when somebody does the work every year and everyone keeps agreeing to the bit. Gravel did not wait for recognition before creating history. It created rituals ridiculous and durable enough that authority eventually had to catch up.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The contemporary account establishes the event name, free entry, organizer and sponsor network, approximate distance, heat, checkpoint tickets, men's winner, and jersey. A later first-hand history supplies the four-stop Powerball-verification and cue-sheet details retrospectively. The field size, women's result, complete route, and exact relationship among registrations, starters, and finishers are not established here, and the entry treats 'world championship' as the event's intentionally unofficial claim rather than an internationally representative sporting title.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_gravel_worlds_free_pirate_event_2010",
+      "canonicalUrl": "https://savedbythebike.blogspot.com/?m=0",
+      "publisher": "Saved By The Bike",
+      "publishedAt": "2010-08-22T21:23:00-05:00",
+      "quoteExcerpt": "all his sponsors who helped make it FREE",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_worlds_checkpoint_ticket_jersey_2010",
+      "canonicalUrl": "https://savedbythebike.blogspot.com/?m=0",
+      "publisher": "Saved By The Bike",
+      "publishedAt": "2010-08-22T21:23:00-05:00",
+      "quoteExcerpt": "now has the Gravel Worlds Jersey",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_gravel_worlds_2010_powerball_history",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2024/04/gravel-grinder-news-changes-at-gravel.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2024-04-16T08:00:00-05:00",
+      "quoteExcerpt": "four required stops at businesses",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_worlds_unofficial_official_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/features/gravel-worlds-vs-gravel-world-championships-whats-in-a-name/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-06-16T12:00:00Z",
+      "quoteExcerpt": "first unofficial, official Gravel Worlds",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:gravel-worlds",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_gravel_worlds_free_pirate_event_2010",
+        "claim_gravel_worlds_checkpoint_ticket_jersey_2010",
+        "claim_gravel_worlds_2010_powerball_history",
+        "claim_gravel_worlds_unofficial_official_2022"
+      ],
+      "confidence": 0.95,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T16:00:00Z",
+  "contentHash": "297c2b0ca6743fca8e11ad9d195cd6f0b6a24b8f90ad7ed19de6254b055ae157"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -827,6 +827,21 @@ def test_2011_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2010_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2010.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 52
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weeks in the 2010 historical census
- preserve 52 explicit quiet windows and cover one receipt-backed week
- draft the inaugural Gravel Worlds chapter around its deliberately unofficial title and Powerball-ticket governance
- keep publication and race impacts human-review-only

## Verification
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2010-gravel-worlds-powerball-governance.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2010.json`
- `pytest -q tests/test_gravel_weekly.py` (47 passed)
- both slop detectors: zero violations
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only editorial/backfill artifacts plus a regression test; no runtime or auth changes, and publication remains human-gated.
> 
> **Overview**
> Adds the **2010 Gravel Weekly backfill ledger**, marking all 53 weeks complete with zero Cyclingnews source cards: **52 `explicit_gap`** quiet windows and **one `covered_by_draft`** week (2010-08-21–27) tied to a new history entry. Ledger flags **`humanApprovalRequired`** and **`autoPublishAllowed: false`**.
> 
> Introduces a **draft** history chapter **`history-gravel-worlds-powerball-governance-2010`** on the inaugural Gravel Worlds (Nebraska, Pirate Cycling League, checkpoint tickets/Powerball governance), with contemporary and later receipts, **`model_draft`** take, and a **`race.biased_opinion`** editorial-review impact on `gravel:gravel-worlds` (no auto-fix).
> 
> Adds **`test_2010_backfill_ledger_starts_from_the_complete_source_census`** to lock the 2010 disposition counts through `validate_backfill_ledger`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44af798b411ff04e0fa349f15123ef8345e28284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->