### PR TITLE
Complete the 2009 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2009.json
+++ b/data/gravel-weekly/backfill/2009.json
@@ -1,0 +1,443 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2009,
+  "asOf": "2009-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/68",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33173577258",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 3,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2008-12-27",
+      "periodEndedAt": "2009-01-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-01-03",
+      "periodEndedAt": "2009-01-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-01-10",
+      "periodEndedAt": "2009-01-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-01-17",
+      "periodEndedAt": "2009-01-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-01-24",
+      "periodEndedAt": "2009-01-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-01-31",
+      "periodEndedAt": "2009-02-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-02-07",
+      "periodEndedAt": "2009-02-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-02-14",
+      "periodEndedAt": "2009-02-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-02-21",
+      "periodEndedAt": "2009-02-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-02-28",
+      "periodEndedAt": "2009-03-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-03-07",
+      "periodEndedAt": "2009-03-13",
+      "sourceCardCount": 1,
+      "disposition": "rejected",
+      "entryIds": [],
+      "reason": "The Cyclingnews card concerns Eroica road-race tactics on gravel sectors, not the North American gravel scene."
+    },
+    {
+      "periodStartedAt": "2009-03-14",
+      "periodEndedAt": "2009-03-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-03-21",
+      "periodEndedAt": "2009-03-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-03-28",
+      "periodEndedAt": "2009-04-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-04-04",
+      "periodEndedAt": "2009-04-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-04-11",
+      "periodEndedAt": "2009-04-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-04-18",
+      "periodEndedAt": "2009-04-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-04-25",
+      "periodEndedAt": "2009-05-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-05-02",
+      "periodEndedAt": "2009-05-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-05-09",
+      "periodEndedAt": "2009-05-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-05-16",
+      "periodEndedAt": "2009-05-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-05-23",
+      "periodEndedAt": "2009-05-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-05-30",
+      "periodEndedAt": "2009-06-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-06-06",
+      "periodEndedAt": "2009-06-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-06-13",
+      "periodEndedAt": "2009-06-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-06-20",
+      "periodEndedAt": "2009-06-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-06-27",
+      "periodEndedAt": "2009-07-03",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-almanzo-open-sourced-gravel-2009"
+      ],
+      "reason": "A contemporary 2009 Almanzo film receipt anchors the draft in this window."
+    },
+    {
+      "periodStartedAt": "2009-07-04",
+      "periodEndedAt": "2009-07-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-07-11",
+      "periodEndedAt": "2009-07-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-07-18",
+      "periodEndedAt": "2009-07-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-07-25",
+      "periodEndedAt": "2009-07-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-08-01",
+      "periodEndedAt": "2009-08-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-08-08",
+      "periodEndedAt": "2009-08-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-08-15",
+      "periodEndedAt": "2009-08-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-08-22",
+      "periodEndedAt": "2009-08-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-08-29",
+      "periodEndedAt": "2009-09-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-09-05",
+      "periodEndedAt": "2009-09-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-09-12",
+      "periodEndedAt": "2009-09-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-09-19",
+      "periodEndedAt": "2009-09-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-09-26",
+      "periodEndedAt": "2009-10-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-10-03",
+      "periodEndedAt": "2009-10-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-10-10",
+      "periodEndedAt": "2009-10-16",
+      "sourceCardCount": 1,
+      "disposition": "rejected",
+      "entryIds": [],
+      "reason": "The Cyclingnews card concerns a planned Giro d’Italia road stage on Siena gravel, not gravel racing as a discipline."
+    },
+    {
+      "periodStartedAt": "2009-10-17",
+      "periodEndedAt": "2009-10-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-10-24",
+      "periodEndedAt": "2009-10-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-10-31",
+      "periodEndedAt": "2009-11-06",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-almanzo-open-sourced-gravel-2009"
+      ],
+      "reason": "A contemporary announcement of the Almanzo Gravel Road Series anchors the draft in this window."
+    },
+    {
+      "periodStartedAt": "2009-11-07",
+      "periodEndedAt": "2009-11-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-11-14",
+      "periodEndedAt": "2009-11-20",
+      "sourceCardCount": 1,
+      "disposition": "rejected",
+      "entryIds": [],
+      "reason": "The Cyclingnews card concerns Michele Bartoli previewing Giro d’Italia road-stage gravel, not the North American gravel scene."
+    },
+    {
+      "periodStartedAt": "2009-11-21",
+      "periodEndedAt": "2009-11-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-11-28",
+      "periodEndedAt": "2009-12-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-12-05",
+      "periodEndedAt": "2009-12-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-12-12",
+      "periodEndedAt": "2009-12-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-12-19",
+      "periodEndedAt": "2009-12-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2009-12-26",
+      "periodEndedAt": "2010-01-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    }
+  ],
+  "updatedAt": "2026-08-28T17:00:00Z"
+}

--- a/data/gravel-weekly/history/2009-almanzo-open-sourced-gravel.json
+++ b/data/gravel-weekly/history/2009-almanzo-open-sourced-gravel.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-almanzo-open-sourced-gravel-2009",
+  "activeFrom": "2009-05-16",
+  "activeThrough": "2009-10-31",
+  "status": "draft",
+  "headline": "Almanzo’s Most Important 2009 Result Was Another Race",
+  "point": "In 2009, the Almanzo 100 did more than stage a free, self-supported gravel race. Jeremy Kershaw rode it, drove home wanting to create something similar near Duluth, and built the inaugural Heck of the North. By October, Heck and Almanzo were listed together in a five-event series. Early gravel scaled because a good event gave riders a format they could copy, not a brand they had to license.",
+  "priorJudgment": "A sport grows when an established promoter expands, a governing body sanctions more events, or a commercial series places new races on a calendar.",
+  "changedJudgment": "The early gravel scene expanded through permissionless imitation. Riders experienced a compelling event, carried its operating ideas home, adapted them to different roads and communities, and then linked the resulting races together without waiting for a central owner.",
+  "stakes": "Gravel now talks constantly about protecting community while entry fees, media rights, ownership, and series consolidation pull events toward uniformity. The 2009 record supplies a harder standard: community was not decoration around the product. It was how the product reproduced.",
+  "credibleOpposition": "The causal link rests mainly on Kershaw's 2022 recollection and Chris Skogen's 2011 account, not a contemporaneous announcement that Almanzo directly caused Heck of the North. Kershaw also credits an earlier Red Wing race, and the Almanzo series had sponsors, points, and prizes, so this is not evidence that early gravel was purely noncommercial or allergic to structure.",
+  "whatHappened": "The 2009 Almanzo 100 ran in southern Minnesota on May 16. Organizer Chris Skogen later described the event as free, self-supported, and navigated by rider-held directions. An unedited 16mm sample uploaded by Skogen in July identifies footage from that year's race. Jeremy Kershaw later said he raced gravel events in Red Wing and Rochester that spring, was struck by their creativity, hospitality, and challenge, and began thinking on the drive home from Almanzo about creating something similar around Duluth. He spent months building a route and launched Heck of the North in 2009. On October 31, Guitar Ted reported that Almanzo, Ragnarok 105, the Gentleman's Ride, Heck of the North, and CIRREM had banded together as the Almanzo Gravel Road Series.",
+  "take": "Model draft, not Matti's approved view: In 2009, the most consequential thing to leave Almanzo was not a winner. It was Jeremy Kershaw driving north with the extremely inconvenient conviction that Duluth needed its own version. He had raced Almanzo, been flattened by its creativity, hospitality, and challenge, and started imagining Heck of the North on the ride home. By October, Heck was listed beside Almanzo and several other events in an actual series. This was gravel's primitive replication protocol: ride somebody else's free race, copy the emotional architecture, spend months squinting at paper maps, and invite everyone over. No franchise agreement. No territorial exclusivity. No licensing deck explaining how to preserve brand consistency. The early scene grew because its best product was not a race entry. It was the dangerous idea that you and your friends could make one too. Modern gravel loves to tell itself that community is the differentiator. In 2009, community was the distribution model.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The event date comes from a contemporary participant's 2009 calendar, while Vimeo establishes that the footage was captured during the 2009 Almanzo. The October series announcement is contemporary. Kershaw's account of conceiving Heck on the drive home and Skogen's account that Kershaw returned north and started it are retrospective but first-person. The evidence does not isolate Almanzo from the Red Wing event as Kershaw's sole inspiration, establish that every series event used identical rules, or show that copying was formally encouraged.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_almanzo_date_2009",
+      "canonicalUrl": "https://cpfarrow.blogspot.com/",
+      "publisher": "Charlie Farrow's Amateur Bike Racing Website",
+      "publishedAt": "2009-03-08T12:00:00-06:00",
+      "quoteExcerpt": "May 16th Almanzo 100-- near Rochester",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_almanzo_2009_film",
+      "canonicalUrl": "https://vimeo.com/5420419",
+      "publisher": "Chris Skogen on Vimeo",
+      "publishedAt": "2009-07-02T03:31:19Z",
+      "quoteExcerpt": "captured during the 2009 Almanzo 100",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_almanzo_gravel_series_2009",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2009/10/",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2009-10-31T01:00:00-05:00",
+      "quoteExcerpt": "under the radar classics are banding together",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_almanzo_inspired_heck_2022",
+      "canonicalUrl": "https://www.boreal.org/2022/05/12/399906/getting-to-know-jeremy-kershaw-gravel-cycling-and-hosting-cycling-events-around-cook-county",
+      "publisher": "Boreal Community Media",
+      "publishedAt": "2022-05-12T08:29:00-05:00",
+      "quoteExcerpt": "On the drive home from the Rochester race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_almanzo_free_replication_2011",
+      "canonicalUrl": "https://urbanvelo.org/issue26/urbanvelo26.pdf",
+      "publisher": "Urban Velo",
+      "publishedAt": "2011-07-01T12:00:00Z",
+      "quoteExcerpt": "They're happening in the same way",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:spring-valley-100",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_almanzo_date_2009",
+        "claim_almanzo_2009_film",
+        "claim_almanzo_gravel_series_2009",
+        "claim_almanzo_inspired_heck_2022",
+        "claim_almanzo_free_replication_2011"
+      ],
+      "confidence": 0.94,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:heck-of-the-north",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_almanzo_gravel_series_2009",
+        "claim_almanzo_inspired_heck_2022",
+        "claim_almanzo_free_replication_2011"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T17:00:00Z",
+  "contentHash": "f19fe9b44fef21031ef96cbf4679bc6f931e076a3c2079679d7757f3ca85aa84"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -842,6 +842,21 @@ def test_2010_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2009_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2009.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 3
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 48
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 3
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary\n- complete the 2009 Saturday–Friday Gravel Weekly backfill ledger from the successful annual census\n- reject three Cyclingnews road-racing false positives and preserve 48 explicit quiet windows\n- add a draft-only historical chapter on Almanzo's permissionless replication into Heck of the North and the Almanzo Gravel Road Series\n- queue Spring Valley/Almanzo and Heck implications for human editorial review only\n\n## Evidence\n- contemporary 2009 Almanzo date listing, Chris Skogen film sample, and Guitar Ted series announcement\n- later first-person accounts from Jeremy Kershaw and Chris Skogen\n- annual source census: https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33173577258\n- assigning ledger: https://github.com/wattgod/race-intelligence-control-plane/issues/68\n\n## Safety\n- draft/model-draft only\n- human approval required\n- auto-publish disabled\n- race impacts are editorial-review only; auto-fix disabled\n\n## Verification\n- pytest -q tests/test_gravel_weekly.py — 48 passed\n- history and backfill validators pass\n- both slop detectors report zero\n- git diff --check passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static editorial data and contract tests only; draft content cannot auto-publish and does not change runtime application code.
> 
> **Overview**
> Adds the **2009 Gravel Weekly backfill ledger** as a completed year census: 53 weeks, three Cyclingnews source cards (all rejected as off-topic European road/gravel), forty-eight explicit gaps, and two weeks tied to a single draft history entry via `covered_by_draft`. The ledger is marked `complete` with **human approval required** and links to the control-plane source run.
> 
> Introduces **`history-almanzo-open-sourced-gravel-2009`**, a **draft** history piece on how the 2009 Almanzo 100 and the Almanzo Gravel Road Series relate to Heck of the North and permissionless event copying, with contemporary receipts, later evidence, editorial gates, and flagged race impacts for Spring Valley 100 and Heck of the North (no auto-publish).
> 
> Adds **`test_2009_backfill_ledger_starts_from_the_complete_source_census`** so CI locks the expected disposition and source-card totals for `2009.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97c878fe67a459275cf4f66a2731161fe2802223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->