### PR TITLE
Complete the 2008 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2008.json
+++ b/data/gravel-weekly/backfill/2008.json
@@ -1,0 +1,445 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2008,
+  "asOf": "2008-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/69",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33174246099",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2007-12-29",
+      "periodEndedAt": "2008-01-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-01-05",
+      "periodEndedAt": "2008-01-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-01-12",
+      "periodEndedAt": "2008-01-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-01-19",
+      "periodEndedAt": "2008-01-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-01-26",
+      "periodEndedAt": "2008-02-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-02-02",
+      "periodEndedAt": "2008-02-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-02-09",
+      "periodEndedAt": "2008-02-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-02-16",
+      "periodEndedAt": "2008-02-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-02-23",
+      "periodEndedAt": "2008-02-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-03-01",
+      "periodEndedAt": "2008-03-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-03-08",
+      "periodEndedAt": "2008-03-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-03-15",
+      "periodEndedAt": "2008-03-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-03-22",
+      "periodEndedAt": "2008-03-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-03-29",
+      "periodEndedAt": "2008-04-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-04-05",
+      "periodEndedAt": "2008-04-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-04-12",
+      "periodEndedAt": "2008-04-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-04-19",
+      "periodEndedAt": "2008-04-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-04-26",
+      "periodEndedAt": "2008-05-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-05-03",
+      "periodEndedAt": "2008-05-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-05-10",
+      "periodEndedAt": "2008-05-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-05-17",
+      "periodEndedAt": "2008-05-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-05-24",
+      "periodEndedAt": "2008-05-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-05-31",
+      "periodEndedAt": "2008-06-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-06-07",
+      "periodEndedAt": "2008-06-13",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-tour-divide-fargo-category-2008"
+      ],
+      "reason": "Contemporary preview and participant receipts anchor the inaugural Tour Divide start in this window."
+    },
+    {
+      "periodStartedAt": "2008-06-14",
+      "periodEndedAt": "2008-06-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-06-21",
+      "periodEndedAt": "2008-06-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-06-28",
+      "periodEndedAt": "2008-07-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-07-05",
+      "periodEndedAt": "2008-07-11",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-tour-divide-fargo-category-2008"
+      ],
+      "reason": "A contemporary Cyclingnews result anchors Matthew Lee’s inaugural Tour Divide win in this window."
+    },
+    {
+      "periodStartedAt": "2008-07-12",
+      "periodEndedAt": "2008-07-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-07-19",
+      "periodEndedAt": "2008-07-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-07-26",
+      "periodEndedAt": "2008-08-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-08-02",
+      "periodEndedAt": "2008-08-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-08-09",
+      "periodEndedAt": "2008-08-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-08-16",
+      "periodEndedAt": "2008-08-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-08-23",
+      "periodEndedAt": "2008-08-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-08-30",
+      "periodEndedAt": "2008-09-05",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-tour-divide-fargo-category-2008"
+      ],
+      "reason": "A contemporary road.cc report anchors the Salsa Fargo reveal and its WTF reaction in this window."
+    },
+    {
+      "periodStartedAt": "2008-09-06",
+      "periodEndedAt": "2008-09-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-09-13",
+      "periodEndedAt": "2008-09-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-09-20",
+      "periodEndedAt": "2008-09-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-09-27",
+      "periodEndedAt": "2008-10-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-10-04",
+      "periodEndedAt": "2008-10-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-10-11",
+      "periodEndedAt": "2008-10-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-10-18",
+      "periodEndedAt": "2008-10-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-10-25",
+      "periodEndedAt": "2008-10-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-11-01",
+      "periodEndedAt": "2008-11-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-11-08",
+      "periodEndedAt": "2008-11-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-11-15",
+      "periodEndedAt": "2008-11-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-11-22",
+      "periodEndedAt": "2008-11-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-11-29",
+      "periodEndedAt": "2008-12-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-12-06",
+      "periodEndedAt": "2008-12-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-12-13",
+      "periodEndedAt": "2008-12-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-12-20",
+      "periodEndedAt": "2008-12-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2008-12-27",
+      "periodEndedAt": "2009-01-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    }
+  ],
+  "updatedAt": "2026-08-28T17:30:00Z"
+}

--- a/data/gravel-weekly/history/2008-tour-divide-fargo-category.json
+++ b/data/gravel-weekly/history/2008-tour-divide-fargo-category.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-tour-divide-fargo-category-2008",
+  "activeFrom": "2008-06-12",
+  "activeThrough": "2008-09-04",
+  "status": "draft",
+  "headline": "Tour Divide Started Before Cycling Had a Name for Its Bike",
+  "point": "In 2008, the inaugural Tour Divide and the Salsa Fargo arrived within twelve weeks of each other. The race asked riders to cross roughly 2,700 miles self-supported; the bike answered with drop bars, 29er wheels, disc brakes, 2.1-inch tires, and five bottle cages. Road.cc gave it a WTF award. The terrain had already written the modern all-road and bikepacking design brief before the bicycle market had settled on a category for it.",
+  "priorJudgment": "The bicycle industry defines a category, sells an optimized machine, and events emerge to give owners somewhere to use it.",
+  "changedJudgment": "Tour Divide and the Great Divide route reversed that order. A specific, unreasonable use case exposed the failure of road, mountain, and touring boundaries; the useful hybrid appeared because the job was clearer than the category language.",
+  "stakes": "Gravel still wastes energy arguing whether a drop-bar bike with mountain-bike tires is truly gravel, secretly a mountain bike, or evidence that the category has lost the plot. The 2008 record suggests the opposite: terrain should govern equipment, and product labels should be treated as lagging paperwork.",
+  "credibleOpposition": "The Fargo was designed for the Great Divide Mountain Bike Route and bikepacking, not proved to be a direct response to the inaugural Tour Divide field, and no evidence here says a 2008 Tour Divide starter rode a production Fargo. Drop-bar off-road bikes also predated it. The story is about the route, race, and production design converging in the same year, not a claim that one bicycle invented gravel or modern bikepacking.",
+  "whatHappened": "On June 13, 2008, the inaugural Tour Divide left Banff for the Mexican border. A preview counted 16 registered riders; participant Felix Wong counted 17 at the Banff YWCA start. The race covered about 2,700 miles, prohibited outside support, offered no prize money, and used a SPOT-powered online leaderboard. Organizer Matthew Lee finished first in 19 days and 12 hours. On September 4, road.cc introduced the Salsa Fargo as a rigid steel 29er mountain bike with drop bars, disc brakes, five bottle cages, and 2.1-inch tires, awarding it the show's 'WTF!' distinction while conceding that the strange combination might work. Salsa product manager Joe Meiser later said the company found no adequate equipment for racing the Great Divide route and launched the drop-bar Fargo for that route and bikepacking in 2008. In 2026, Victor Bosoni set a Tour Divide record of 11 days, 8 hours, and 27 minutes on an aerodynamic carbon bike with drop bars and 2.2-inch gravel tires.",
+  "take": "Model draft, not Matti's approved view: In June 2008, 17 riders left a Banff YWCA to race to Mexico without crews or prize money. In September, road.cc met the Salsa Fargo: a rigid steel 29er with drop bars, disc brakes, five bottle cages, and 2.1-inch tires. It gave the bike the day's WTF award. Correct reaction, wrong verdict. The Fargo looked confused because the route was not. The Divide had asked a perfectly clear question: what survives 2,700 miles of dirt, pavement, snow, mud, washboard, and small-town resupply without turning the rider's hands into pulled pork? Road, mountain, and touring were filing cabinets; the route was the job. Eighteen years later, Victor Bosoni set the Tour Divide record on carbon, drop bars, and 2.2-inch gravel tires. The equipment changed from expedition mule to aero missile, but the punchline held: build for the problem and let the category department find you later.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "Contemporary previews and participant accounts disagree only on 16 registered riders versus 17 people at the start, which this entry preserves rather than resolving. The 2008 sources establish the race, rules, result, Fargo reveal, and component mix. The explicit statement that Salsa designed the Fargo for the Great Divide route and bikepacking is a 2026 first-person retrospective from product manager Joe Meiser. The 2026 record bike demonstrates later convergence, not direct design lineage from the Fargo.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_tour_divide_inaugural_preview_2008",
+      "canonicalUrl": "https://www.feedthehabit.com/adventure-cycling-association-great-divide-mountain-bike-route/",
+      "publisher": "FeedTheHabit.com",
+      "publishedAt": "2008-06-12T12:00:00-06:00",
+      "quoteExcerpt": "the inaugural Tour Divide will set out",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_tour_divide_seventeen_start_2008",
+      "canonicalUrl": "https://felixwong.com/2008/06/tour-divide-day-1/",
+      "publisher": "Felix Wong",
+      "publishedAt": "2008-06-13T12:00:00-06:00",
+      "quoteExcerpt": "Seventeen racers, including myself",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_tour_divide_lee_result_2008",
+      "canonicalUrl": "https://www.cyclingnews.com/news/divide-racing-wrapping-up/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2008-07-11T12:00:00Z",
+      "quoteExcerpt": "finished first in 19 day and 12 hours",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_fargo_wtf_reveal_2008",
+      "canonicalUrl": "https://road.cc/content/news/101-salsa-fargo",
+      "publisher": "road.cc",
+      "publishedAt": "2008-09-04T19:33:00+01:00",
+      "quoteExcerpt": "gets Day one's WTF! Award",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_fargo_divide_design_2026",
+      "canonicalUrl": "https://www.adventurecycling.org/blog/salsa-cutthroat-bike-giveaway/",
+      "publisher": "Adventure Cycling Association",
+      "publishedAt": "2026-02-23T12:00:00-07:00",
+      "quoteExcerpt": "there was no adequate equipment for the route",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_tour_divide_record_bike_2026",
+      "canonicalUrl": "https://bikepacking.com/plog/victor-bosoni-wins-the-2026-tour-divide/",
+      "publisher": "BIKEPACKING.com",
+      "publishedAt": "2026-06-23T12:00:00-06:00",
+      "quoteExcerpt": "drop bars and 2.2-inch gravel tires",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:tour-divide",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_tour_divide_inaugural_preview_2008",
+        "claim_tour_divide_seventeen_start_2008",
+        "claim_tour_divide_lee_result_2008",
+        "claim_fargo_wtf_reveal_2008",
+        "claim_fargo_divide_design_2026",
+        "claim_tour_divide_record_bike_2026"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T17:30:00Z",
+  "contentHash": "0b375cc21eaed1e13fe73fe294d0ca37bd327d7da8dc9e454b7b9944985bbaed"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -857,6 +857,21 @@ def test_2009_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2008_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2008.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 50
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 3
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary\n- complete the 2008 Saturday–Friday Gravel Weekly ledger from a zero-card annual census\n- preserve 50 explicit quiet windows and link three weeks to a source-backed draft\n- add a draft-only historical chapter connecting the inaugural Tour Divide, the Salsa Fargo reveal, and the unresolved equipment-category argument\n- queue the Tour Divide race-profile implication for human editorial review only\n\n## Evidence\n- contemporary Tour Divide preview, participant start report, Cyclingnews result, and road.cc Fargo reveal\n- later first-person Salsa product history and the 2026 Tour Divide record-bike report\n- annual source census: https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33174246099\n- assigning ledger: https://github.com/wattgod/race-intelligence-control-plane/issues/69\n\n## Safety\n- draft/model-draft only\n- human approval required\n- auto-publish disabled\n- race impact is editorial-review only; auto-fix disabled\n\n## Verification\n- pytest -q tests/test_gravel_weekly.py — 49 passed\n- history and backfill validators pass\n- both slop detectors report zero\n- git diff --check passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and contract tests only; no runtime or publish path changes, with explicit human-approval and no auto-publish on new content.
> 
> **Overview**
> Adds the **2008 Gravel Weekly backfill ledger** for a zero–source-card census: all 53 Saturday–Friday windows are assigned, with **50 explicit gaps** and **three weeks** marked `covered_by_draft` and linked to a single history entry.
> 
> Introduces a **draft** historical chapter (`history-tour-divide-fargo-category-2008`) tying the inaugural Tour Divide, Matthew Lee’s result, and the Salsa Fargo / road.cc reveal to contemporary and later receipts. It stays **model-draft**, requires human approval, disables auto-publish, and queues a **Tour Divide** `race.biased_opinion` editorial-review impact with auto-fix off.
> 
> Adds **`test_2008_backfill_ledger_starts_from_the_complete_source_census`** so `validate_backfill_ledger` locks the expected disposition counts and `complete: true` for 2008.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49350c5e7c3a7f7bc77a7671cb6abe2c92ef6981. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->