### PR TITLE
Complete the 2007 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2007.json
+++ b/data/gravel-weekly/backfill/2007.json
@@ -1,0 +1,441 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2007,
+  "asOf": "2007-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/70",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33174744555",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2006-12-30",
+      "periodEndedAt": "2007-01-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-01-06",
+      "periodEndedAt": "2007-01-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-01-13",
+      "periodEndedAt": "2007-01-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-01-20",
+      "periodEndedAt": "2007-01-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-01-27",
+      "periodEndedAt": "2007-02-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-02-03",
+      "periodEndedAt": "2007-02-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-02-10",
+      "periodEndedAt": "2007-02-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-02-17",
+      "periodEndedAt": "2007-02-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-02-24",
+      "periodEndedAt": "2007-03-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-03-03",
+      "periodEndedAt": "2007-03-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-03-10",
+      "periodEndedAt": "2007-03-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-03-17",
+      "periodEndedAt": "2007-03-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-03-24",
+      "periodEndedAt": "2007-03-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-03-31",
+      "periodEndedAt": "2007-04-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-04-07",
+      "periodEndedAt": "2007-04-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-04-14",
+      "periodEndedAt": "2007-04-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-04-21",
+      "periodEndedAt": "2007-04-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-04-28",
+      "periodEndedAt": "2007-05-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-05-05",
+      "periodEndedAt": "2007-05-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-05-12",
+      "periodEndedAt": "2007-05-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-05-19",
+      "periodEndedAt": "2007-05-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-05-26",
+      "periodEndedAt": "2007-06-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-06-02",
+      "periodEndedAt": "2007-06-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-06-09",
+      "periodEndedAt": "2007-06-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-06-16",
+      "periodEndedAt": "2007-06-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-06-23",
+      "periodEndedAt": "2007-06-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-06-30",
+      "periodEndedAt": "2007-07-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-07-07",
+      "periodEndedAt": "2007-07-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-07-14",
+      "periodEndedAt": "2007-07-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-07-21",
+      "periodEndedAt": "2007-07-27",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-colorado-trail-race-zero-paperwork-2007"
+      ],
+      "reason": "Three contemporary Colorado reports anchor the inaugural Colorado Trail Race format and finish in this window."
+    },
+    {
+      "periodStartedAt": "2007-07-28",
+      "periodEndedAt": "2007-08-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-08-04",
+      "periodEndedAt": "2007-08-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-08-11",
+      "periodEndedAt": "2007-08-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-08-18",
+      "periodEndedAt": "2007-08-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-08-25",
+      "periodEndedAt": "2007-08-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-09-01",
+      "periodEndedAt": "2007-09-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-09-08",
+      "periodEndedAt": "2007-09-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-09-15",
+      "periodEndedAt": "2007-09-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-09-22",
+      "periodEndedAt": "2007-09-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-09-29",
+      "periodEndedAt": "2007-10-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-10-06",
+      "periodEndedAt": "2007-10-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-10-13",
+      "periodEndedAt": "2007-10-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-10-20",
+      "periodEndedAt": "2007-10-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-10-27",
+      "periodEndedAt": "2007-11-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-11-03",
+      "periodEndedAt": "2007-11-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-11-10",
+      "periodEndedAt": "2007-11-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-11-17",
+      "periodEndedAt": "2007-11-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-11-24",
+      "periodEndedAt": "2007-11-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-12-01",
+      "periodEndedAt": "2007-12-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-12-08",
+      "periodEndedAt": "2007-12-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-12-15",
+      "periodEndedAt": "2007-12-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-12-22",
+      "periodEndedAt": "2007-12-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2007-12-29",
+      "periodEndedAt": "2008-01-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    }
+  ],
+  "updatedAt": "2026-08-28T18:00:00Z"
+}

--- a/data/gravel-weekly/history/2007-colorado-trail-race-zero-paperwork.json
+++ b/data/gravel-weekly/history/2007-colorado-trail-race-zero-paperwork.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-colorado-trail-race-zero-paperwork-2007",
+  "activeFrom": "2007-07-24",
+  "activeThrough": "2007-07-26",
+  "status": "draft",
+  "headline": "Colorado Trail Race Started With Ten Riders, One Fixie, and No Prize",
+  "point": "In 2007, the first Colorado Trail Race reduced an event to route, rules, results, and trust: ten riders, roughly 535 miles and 60,000 feet of climbing, word-of-mouth promotion, no entry fee, no prize, self-support, an honor system, and one fixed-gear bike. Contemporary Colorado coverage identified unsanctioned endurance racing as a response to insurance and regulatory barriers. Six riders finished. Sporting meaning survived the removal of almost every conventional production layer.",
+  "priorJudgment": "A real race needs registration, fees, prizes, formal sanction, officials, and a promoter visibly producing the competition.",
+  "changedJudgment": "The inaugural Colorado Trail Race showed that a difficult route, legible rules, trusted results, and voluntary participation could create a meaningful contest even when the normal event apparatus was deliberately absent.",
+  "stakes": "Current events can confuse production value with sporting value, then pass the overhead back to riders through higher fees and more sponsor theater. The useful historical standard is not that insurance, permits, or safety obligations are optional; it is that each layer should justify itself by making the contest safer, fairer, or more accessible rather than merely more official-looking.",
+  "credibleOpposition": "A contemporary local writer described insurance and regulation as forces behind a broader unsanctioned-racing trend, but no organizer quote here establishes legal avoidance as the Colorado Trail Race's sole or primary motive. Public-land rules and rider safety obligations did not disappear. A ten-person honor system also does not prove that the same minimal structure scales cleanly to a large field.",
+  "whatHappened": "During late July 2007, ten mountain bikers attempted the first Colorado Trail Race from the Denver side of the Colorado Trail toward Durango. Contemporary coverage described about 535 miles and 60,000 feet of climbing, word-of-mouth promotion, no entry fee or prize, self-supported riding, honor-system rules, and one fixed-gear entrant. A Colorado Springs outdoors blog called the event unofficial, unsponsored, and part of a growing workaround to insurance and regulatory barriers. Riders called in from specified towns. Jefe Branham reached Durango first in about five days and five hours and was already talking about returning. Later race records list six finishers and four non-finishers.",
+  "take": "Model draft, not Matti's approved view: In 2007, somebody looked at race insurance and invented 'we are all just leaving Denver at the same time.' The first Colorado Trail Race had ten riders, roughly 535 miles, 60,000 feet of climbing, no entry fee, no prize, no support, an honor system, and one fixed gear because apparently the format had not made its point forcefully enough. Contemporary local coverage called this an increasingly big trend: insurance and regulatory barriers went up, and racers found a way around them. Six finished. Jefe Branham got to Durango first in five days and change and immediately started talking about next year. This was not an absence of organization. It was organization stripped to route, rules, and results. You can remove almost every ceremonial object from a race and still have a race. Remove shared trust, and the result becomes a group ride with creative accounting. The Colorado Trail was the venue, the difficulty was the prize purse, and the honor system was the governing body.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The live July 24-26 reporting establishes the event window, format, leader, call-in system, and finish chronology. Singletracks' preserved article lists June 13 as the start despite being published during the active late-July race and conflicting with the five-day finish chronology; this entry treats that exact date as an archival error and does not use it. The six-finisher count and exact 5d05h30m result come from later race records and 2020 reporting.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_ctr_unsanctioned_trend_2007",
+      "canonicalUrl": "https://gazetteoutthere.blogspot.com/2007/07/",
+      "publisher": "Out There",
+      "publishedAt": "2007-07-24T09:03:00-07:00",
+      "quoteExcerpt": "Insurance and regulations have put barriers in front of racing",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_ctr_ten_fixie_2007",
+      "canonicalUrl": "https://www.singletracks.com/community/first-ever-colorado-trail-race/",
+      "publisher": "Singletracks",
+      "publishedAt": "2007-07-25T12:32:33-07:00",
+      "quoteExcerpt": "There's even a guy in the race on a fixed gear bike",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_ctr_first_finish_2007",
+      "canonicalUrl": "https://gazetteoutthere.blogspot.com/2007/07/",
+      "publisher": "Out There",
+      "publishedAt": "2007-07-26T07:38:00-07:00",
+      "quoteExcerpt": "The first bikers in the unofficial, un-sanctioned, Colorado Trail Race finished",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_ctr_first_field_result_2020",
+      "canonicalUrl": "https://velo.outsideonline.com/mountain/the-colorado-trail-race-is-on-for-2021/",
+      "publisher": "Velo / Outside",
+      "publishedAt": "2020-12-15T12:36:00-07:00",
+      "quoteExcerpt": "debuted in 2007 with 10 riders, six of whom finished",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:colorado-trail-race",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_ctr_unsanctioned_trend_2007",
+        "claim_ctr_ten_fixie_2007",
+        "claim_ctr_first_finish_2007",
+        "claim_ctr_first_field_result_2020"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T18:00:00Z",
+  "contentHash": "239a3a4f2a1266de829a299db7dcff6647b3c1ee2ae839edc371891ccdbfa361"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -872,6 +872,21 @@ def test_2008_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2007_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2007.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 52
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary\n- complete the 2007 Saturday–Friday Gravel Weekly ledger from a zero-card annual census\n- preserve 52 explicit quiet windows and link one week to three contemporary reports\n- add a draft-only Colorado Trail Race chapter about trust-based sporting value and the unsanctioned response to insurance/regulatory barriers\n- disclose and quarantine an unreliable archival start-date field instead of repeating it\n- queue the Colorado Trail Race profile implication for human editorial review only\n\n## Evidence\n- contemporary July 2007 Singletracks and Colorado local reports\n- later Velo/Outside field and result confirmation\n- annual source census: https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33174744555\n- assigning ledger: https://github.com/wattgod/race-intelligence-control-plane/issues/70\n\n## Safety\n- draft/model-draft only\n- human approval required\n- auto-publish disabled\n- race impact is editorial-review only; auto-fix disabled\n\n## Verification\n- pytest -q tests/test_gravel_weekly.py — 50 passed\n- history and backfill validators pass\n- both slop detectors report zero\n- git diff --check passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and contract tests only; content stays draft with no auto-publish or auto-fix on race data.
> 
> **Overview**
> Adds the **2007 Gravel Weekly backfill ledger** (`2007.json`) from a **zero Cyclingnews source-card census**: all 53 Saturday–Friday windows are accounted for, with **52 `explicit_gap`** weeks and **one `covered_by_draft`** week (late July) tied to a new history entry. The ledger is marked **complete** but keeps **human approval required** and **auto-publish disabled**.
> 
> Introduces a **draft-only** history chapter for the **inaugural 2007 Colorado Trail Race**—contemporary Colorado/Singletracks receipts plus later Velo/Outside corroboration, documented uncertainty around a conflicting Singletracks start date, and a **model-draft** take. It queues an **`editorial_review`** race impact on `gravel:colorado-trail-race` (`race.biased_opinion`) with **auto-fix off**.
> 
> Adds **`test_2007_backfill_ledger_starts_from_the_complete_source_census`** to lock the 52/1 disposition split and validator pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6568b6bfc069f63df3a5ccd4572690367d836f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->