### PR TITLE
Complete the 2006 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2006.json
+++ b/data/gravel-weekly/backfill/2006.json
@@ -1,0 +1,443 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2006,
+  "asOf": "2006-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/71",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33175224958",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2005-12-31",
+      "periodEndedAt": "2006-01-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-01-07",
+      "periodEndedAt": "2006-01-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-01-14",
+      "periodEndedAt": "2006-01-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-01-21",
+      "periodEndedAt": "2006-01-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-01-28",
+      "periodEndedAt": "2006-02-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-02-04",
+      "periodEndedAt": "2006-02-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-02-11",
+      "periodEndedAt": "2006-02-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-02-18",
+      "periodEndedAt": "2006-02-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-02-25",
+      "periodEndedAt": "2006-03-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-03-04",
+      "periodEndedAt": "2006-03-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-03-11",
+      "periodEndedAt": "2006-03-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-03-18",
+      "periodEndedAt": "2006-03-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-03-25",
+      "periodEndedAt": "2006-03-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-04-01",
+      "periodEndedAt": "2006-04-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-04-08",
+      "periodEndedAt": "2006-04-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-04-15",
+      "periodEndedAt": "2006-04-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-04-22",
+      "periodEndedAt": "2006-04-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-04-29",
+      "periodEndedAt": "2006-05-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-05-06",
+      "periodEndedAt": "2006-05-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-05-13",
+      "periodEndedAt": "2006-05-19",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-dirty-kanza-final-boss-car-2006"
+      ],
+      "reason": "A contemporary pre-race report anchors the remote course hazards in this window."
+    },
+    {
+      "periodStartedAt": "2006-05-20",
+      "periodEndedAt": "2006-05-26",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-dirty-kanza-final-boss-car-2006"
+      ],
+      "reason": "Two contemporary participant reports anchor the inaugural Dirty Kanza finish and collision in this window."
+    },
+    {
+      "periodStartedAt": "2006-05-27",
+      "periodEndedAt": "2006-06-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-06-03",
+      "periodEndedAt": "2006-06-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-06-10",
+      "periodEndedAt": "2006-06-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-06-17",
+      "periodEndedAt": "2006-06-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-06-24",
+      "periodEndedAt": "2006-06-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-07-01",
+      "periodEndedAt": "2006-07-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-07-08",
+      "periodEndedAt": "2006-07-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-07-15",
+      "periodEndedAt": "2006-07-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-07-22",
+      "periodEndedAt": "2006-07-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-07-29",
+      "periodEndedAt": "2006-08-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-08-05",
+      "periodEndedAt": "2006-08-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-08-12",
+      "periodEndedAt": "2006-08-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-08-19",
+      "periodEndedAt": "2006-08-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-08-26",
+      "periodEndedAt": "2006-09-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-09-02",
+      "periodEndedAt": "2006-09-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-09-09",
+      "periodEndedAt": "2006-09-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-09-16",
+      "periodEndedAt": "2006-09-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-09-23",
+      "periodEndedAt": "2006-09-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-09-30",
+      "periodEndedAt": "2006-10-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-10-07",
+      "periodEndedAt": "2006-10-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-10-14",
+      "periodEndedAt": "2006-10-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-10-21",
+      "periodEndedAt": "2006-10-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-10-28",
+      "periodEndedAt": "2006-11-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-11-04",
+      "periodEndedAt": "2006-11-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-11-11",
+      "periodEndedAt": "2006-11-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-11-18",
+      "periodEndedAt": "2006-11-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-11-25",
+      "periodEndedAt": "2006-12-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-12-02",
+      "periodEndedAt": "2006-12-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-12-09",
+      "periodEndedAt": "2006-12-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-12-16",
+      "periodEndedAt": "2006-12-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-12-23",
+      "periodEndedAt": "2006-12-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2006-12-30",
+      "periodEndedAt": "2007-01-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    }
+  ],
+  "updatedAt": "2026-08-28T18:30:00Z"
+}

--- a/data/gravel-weekly/history/2006-dirty-kanza-final-boss-car.json
+++ b/data/gravel-weekly/history/2006-dirty-kanza-final-boss-car.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-dirty-kanza-final-boss-car-2006",
+  "activeFrom": "2006-05-18",
+  "activeThrough": "2006-05-24",
+  "status": "draft",
+  "headline": "The First Dirty Kanza’s Final Boss Was a Car Three Blocks From the Finish",
+  "point": "The first Dirty Kanza advertised the Flint Hills as the danger: about 200 miles of gravel, low-water crossings, heat, cattle, isolation, and finally a thunderstorm. David Pals survived that chosen difficulty, then a turning driver hit him three blocks from the finish. He remounted and finished. The incident draws a line gravel still blurs: terrain risk is the contest; routine traffic danger does not become part of the romance merely because it happened during a race.",
+  "priorJudgment": "Any danger endured on the way to a gravel finish belongs to the event’s epic mythology, and surviving it makes the story better.",
+  "changedJudgment": "The inaugural Dirty Kanza separated chosen sporting difficulty from ordinary road violence. Pals finishing after the collision was brave; the driver striking him was not an extra feature of the course.",
+  "stakes": "Gravel’s appetite for hardship can flatten every hazard into the same marketable legend. That makes it easier to celebrate preventable traffic exposure instead of distinguishing what riders intentionally entered from what organizers, towns, and drivers should work to reduce.",
+  "credibleOpposition": "The collision is documented by a contemporary participant who was traveling with Pals, not by a police report or medical record. He wrote that Pals and the bike suffered little damage and did not allege organizer negligence. An open-road race cannot eliminate every third-party driving error, and the record here does not establish that this collision was preventable by the organizers.",
+  "whatHappened": "In May 2006, the inaugural Dirty Kanza sent riders onto an unmarked route of about 200 miles through the Flint Hills. Pre-race reporting warned of 11 low-water crossings, sharp gravel, open-range cattle, and long remote stretches. A participant described heat, scarce water, and a relaxed finish in Emporia. Late that night, a severe thunderstorm arrived while David Pals was the only rider still expected. Contemporary organizer Guitar Ted wrote that, three blocks from the finish, a young driver turned into Pals and knocked him onto the wet pavement. Pals and the bike sustained little damage; he remounted and finished to applause around 12:30 a.m. Later accounts disagree on the exact number of starters and finishers, so this entry does not use either count as a settled fact.",
+  "take": "Model draft, not Matti's approved view: The first Dirty Kanza spent all day advertising Kansas as the threat: 11 low-water crossings, sharp gravel, heat, open-range cattle, and then a thunderstorm. David Pals survived all of it. Three blocks from the finish, a driver turned into him and knocked him onto the wet pavement. Pals got up, remounted, and finished around 12:30 in the morning because early gravel had not yet invented the concept of ending a story normally. It is a perfect origin myth for the wrong reason. Gravel likes to call every danger epic because suffering sells. But course risk and traffic risk are not morally interchangeable. Choosing 200 miles of Flint Hills is the sport. Being hit by a driver inside town is traffic danger wearing a race anecdote. The brave part is that Pals finished. The useful part is refusing to call the car part of the adventure.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "Guitar Ted’s May 24 account is contemporary and first-hand as a race participant and Pals’s travel companion, but the collision lacks an independent police, medical, or local-news receipt in the recovered evidence. The exact finish time varies between about 12:30 a.m. and 1:00 a.m. Later sources also conflict on starter and finisher counts. The entry preserves the approximate time, omits the disputed field totals, and makes no claim of organizer fault.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_dirty_kanza_remote_hazards_2006",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2006/05/off-to-dirty-kanza.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2006-05-18T06:15:00-05:00",
+      "quoteExcerpt": "There will be 11 of these low water crossings on course!",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_dirty_kanza_heat_finish_2006",
+      "canonicalUrl": "https://partridgeracing.blogspot.com/2006/05/super-long-dirty-kanza-post.html",
+      "publisher": "Partridge Racing",
+      "publishedAt": "2006-05-22T17:51:00-07:00",
+      "quoteExcerpt": "We rolled into Emporia a few minutes after 10 PM.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_dirty_kanza_pals_collision_finish_2006",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2006/05/rocks-dust-and-fun-part-iv.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2006-05-24T04:55:00-05:00",
+      "quoteExcerpt": "David had been struck by a car only three blocks from the finish!",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_dirty_kanza_pals_retrospective_2016",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2016/05/minus-ten-review-20.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2016-05-21T01:30:00-05:00",
+      "quoteExcerpt": "David was hit by a car just three blocks from the finish",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_dirty_kanza_first_race_context_2020",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/monuments-of-gravel-dirty-kanza-200/",
+      "publisher": "Velo / Outside",
+      "publishedAt": "2020-03-02T08:08:46Z",
+      "quoteExcerpt": "an unmarked 200-mile course through the Flint Hills",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_dirty_kanza_remote_hazards_2006",
+        "claim_dirty_kanza_heat_finish_2006",
+        "claim_dirty_kanza_pals_collision_finish_2006",
+        "claim_dirty_kanza_pals_retrospective_2016",
+        "claim_dirty_kanza_first_race_context_2020"
+      ],
+      "confidence": 0.94,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T18:30:00Z",
+  "contentHash": "d562e624350e9b2840eaad1570f09d87d1652da0b72b2d2f20f1767298621653"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -887,6 +887,21 @@ def test_2007_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2006_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2006.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 51
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weekly windows in the 2006 historical backfill
- recover an evidence-grounded inaugural Dirty Kanza story that separates chosen terrain risk from traffic danger
- preserve conflicting field totals and finish times as explicit uncertainty
- keep publication and race-profile effects behind human editorial review

## Verification
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2006-dirty-kanza-final-boss-car.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2006.json`
- `pytest -q tests/test_gravel_weekly.py` (51 passed)
- both Gravel Weekly anti-slop detectors: zero findings
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only editorial/backfill JSON plus test expectations; no runtime or auth changes, and publication and race-profile impacts stay behind human review.
> 
> **Overview**
> Adds the **2006 Gravel Weekly backfill ledger** so all **53 weekly windows** are accounted for: **51 explicit gaps** (no Cyclingnews card and no recovered story that cleared editorial gates) and **two May 2006 windows** marked **`covered_by_draft`** for a single history entry.
> 
> Introduces a **draft history entry** on the inaugural Dirty Kanza—David Pals hit by a car near the finish after ~200 miles of course risk—grounded in contemporary blog receipts and later sources, with **explicit uncertainty** on finish time and starter/finisher counts. The narrative separates **chosen terrain risk** from **traffic danger**; the take remains **`model_draft`** with **`humanApprovalRequired`** and no auto-publish.
> 
> A **contract test** asserts the 2006 ledger validates against loaded history entries with the expected disposition counts and **`complete: true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a89419a9f3f614c7c7ff8c3f62cd672ffc0c13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->