### PR TITLE
Complete the 2005 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2005.json
+++ b/data/gravel-weekly/backfill/2005.json
@@ -1,0 +1,443 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2005,
+  "asOf": "2005-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/72",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33175966529",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2005-01-01",
+      "periodEndedAt": "2005-01-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-01-08",
+      "periodEndedAt": "2005-01-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-01-15",
+      "periodEndedAt": "2005-01-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-01-22",
+      "periodEndedAt": "2005-01-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-01-29",
+      "periodEndedAt": "2005-02-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-02-05",
+      "periodEndedAt": "2005-02-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-02-12",
+      "periodEndedAt": "2005-02-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-02-19",
+      "periodEndedAt": "2005-02-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-02-26",
+      "periodEndedAt": "2005-03-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-03-05",
+      "periodEndedAt": "2005-03-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-03-12",
+      "periodEndedAt": "2005-03-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-03-19",
+      "periodEndedAt": "2005-03-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-03-26",
+      "periodEndedAt": "2005-04-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-04-02",
+      "periodEndedAt": "2005-04-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-04-09",
+      "periodEndedAt": "2005-04-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-04-16",
+      "periodEndedAt": "2005-04-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-04-23",
+      "periodEndedAt": "2005-04-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-04-30",
+      "periodEndedAt": "2005-05-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-05-07",
+      "periodEndedAt": "2005-05-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-05-14",
+      "periodEndedAt": "2005-05-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-05-21",
+      "periodEndedAt": "2005-05-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-05-28",
+      "periodEndedAt": "2005-06-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-06-04",
+      "periodEndedAt": "2005-06-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-06-11",
+      "periodEndedAt": "2005-06-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-06-18",
+      "periodEndedAt": "2005-06-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-06-25",
+      "periodEndedAt": "2005-07-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-07-02",
+      "periodEndedAt": "2005-07-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-07-09",
+      "periodEndedAt": "2005-07-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-07-16",
+      "periodEndedAt": "2005-07-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-07-23",
+      "periodEndedAt": "2005-07-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-07-30",
+      "periodEndedAt": "2005-08-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-08-06",
+      "periodEndedAt": "2005-08-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-08-13",
+      "periodEndedAt": "2005-08-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-08-20",
+      "periodEndedAt": "2005-08-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-08-27",
+      "periodEndedAt": "2005-09-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-09-03",
+      "periodEndedAt": "2005-09-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-09-10",
+      "periodEndedAt": "2005-09-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-09-17",
+      "periodEndedAt": "2005-09-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-09-24",
+      "periodEndedAt": "2005-09-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-10-01",
+      "periodEndedAt": "2005-10-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-10-08",
+      "periodEndedAt": "2005-10-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-10-15",
+      "periodEndedAt": "2005-10-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-10-22",
+      "periodEndedAt": "2005-10-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-10-29",
+      "periodEndedAt": "2005-11-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-11-05",
+      "periodEndedAt": "2005-11-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-11-12",
+      "periodEndedAt": "2005-11-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-11-19",
+      "periodEndedAt": "2005-11-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-11-26",
+      "periodEndedAt": "2005-12-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-12-03",
+      "periodEndedAt": "2005-12-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-12-10",
+      "periodEndedAt": "2005-12-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2005-12-17",
+      "periodEndedAt": "2005-12-23",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-copyable-format-2005"
+      ],
+      "reason": "Two contemporary organizer posts define the Trans Iowa challenge and announce its Kansas adaptation in this window."
+    },
+    {
+      "periodStartedAt": "2005-12-24",
+      "periodEndedAt": "2005-12-30",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-copyable-format-2005"
+      ],
+      "reason": "Two contemporary organizer posts document wider inquiries and the Kansas event’s continuous-loop adaptation in this window."
+    },
+    {
+      "periodStartedAt": "2005-12-31",
+      "periodEndedAt": "2006-01-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    }
+  ],
+  "updatedAt": "2026-08-28T19:00:00Z"
+}

--- a/data/gravel-weekly/history/2005-gravel-copyable-format.json
+++ b/data/gravel-weekly/history/2005-gravel-copyable-format.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-gravel-copyable-format-2005",
+  "activeFrom": "2005-12-22",
+  "activeThrough": "2005-12-30",
+  "status": "draft",
+  "headline": "Gravel Became a Format When Kansas Copied Iowa",
+  "point": "The inaugural Trans Iowa could have remained one ambitious Midwest stunt. By December 2005, its organizers were announcing a Kansas event 'spawned' by it, fielding questions from prospective organizers in Florida and Pennsylvania, and asking whether low-key, self-supported races beyond 200 miles were becoming a trend. The important change was not that one gravel race existed. The format had become portable enough for another place to adapt.",
+  "priorJudgment": "A sport begins when someone stages the first sufficiently famous event and earns ownership of the origin story.",
+  "changedJudgment": "A format becomes a movement when other communities can copy its governing logic, alter it for local terrain, and produce something distinct. Trans Iowa mattered because the idea traveled to Kansas within the same year.",
+  "stakes": "Gravel histories that hunt only for a single inventor miss how the sport actually grew. Following adaptation reveals which rules traveled, which details stayed local, and why a deliberately obscure challenge could propagate faster than a conventional sanctioned series.",
+  "credibleOpposition": "Guitar Ted explicitly credited the Grand Loop, Kokopelli, Great Divide Race, and Idita-Bike as forebears, so Trans Iowa did not invent self-supported endurance racing. Calling the Kansas event a copy is playful shorthand, not an allegation of plagiarism: its organizers changed the distance, landscape, and point-to-point design. The contemporary causal language comes from Trans Iowa’s organizer rather than an independent statement from the Kansas founders.",
+  "whatHappened": "Jeff Kerkove and Mark Stevenson staged the first Trans Iowa in April 2005. In late December, Stevenson described its governing idea as a challenge against time, distance, and nature whose success did not depend on a large finisher count. On December 23, he interrupted a Christmas post about bike parts with a 'RED ALERT' announcing a 200-mile Flint Hills loop in Kansas, then using the working name Flint Hills 200 and calling it 'spawned' by Trans Iowa. The next day, he reported receiving inquiries about Trans Iowa-style events from Florida, Pennsylvania, and Kansas and asked whether low-key, high-challenge, self-supported events over 200 miles had become a trend. By December 30, he was contrasting Trans Iowa’s point-to-point route with the Kansas race’s continuous loop. The Kansas event became Dirty Kanza and later Unbound Gravel.",
+  "take": "Model draft, not Matti's approved view: A sport gets real when a second person copies the weird thing. On December 23, 2005, Guitar Ted interrupted a Christmas post about purple hubs and a pink headset with 'RED ALERT!!!' A Kansas event, then called Flint Hills 200, had been 'spawned' by Trans Iowa. The next day he reported emails from Florida and Pennsylvania and asked whether this was a trend. Yes, Mark. It was going okay. Trans Iowa had translated western ultra-endurance into something dangerously portable: find overlooked local roads, publish rules, withhold comfort, and let riders discover what 2 a.m. does to navigation. Kansas changed a cross-Iowa challenge into a 200-mile Flint Hills loop. That adaptation became Dirty Kanza and then Unbound. The founding act was not owning an idea. It was making the idea clear enough for another town to mutate.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The four contemporary receipts all come from Guitar Ted’s blog, so they establish how a Trans Iowa co-founder understood the propagation but do not independently prove the Kansas founders’ motives. Later organizer retrospectives confirm the Flint Hills 200 working name and connection. The entry describes a documented adaptation pathway, not a claim that Trans Iowa was the first gravel race or sole cause of Dirty Kanza.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_trans_iowa_challenge_logic_2005",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2005/12/its-challenge-right.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2005-12-22T19:26:00-05:00",
+      "quoteExcerpt": "this event wasn't so much a race as it was a challenge",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_flint_hills_spawned_2005",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2005/12/merry-christmas_23.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2005-12-23T17:22:00-05:00",
+      "quoteExcerpt": "This is the event \"spawned\" by Trans Iowa.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_trans_iowa_format_spreading_2005",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2005/12/a-new-trend.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2005-12-24T18:33:00-05:00",
+      "quoteExcerpt": "I've gotten several e-mails from all over the U.S.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_trans_iowa_april_flint_loop_2005",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2005/12/a-look-over-shoulder.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2005-12-30T06:39:00-05:00",
+      "quoteExcerpt": "The un-officially named \"Flint Hills 200\" has set their course as one continuous loop",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_dirty_kanza_trans_iowa_link_2013",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2013/09/trans-iowa-ten-years-of-tales-2.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2013-09-14T01:30:00-05:00",
+      "quoteExcerpt": "Dirty Kanza 200 (Which was called the Flint Hills 200 early on)",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_flint_hills_working_name_2020",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2020/04/friday-news-and-views_24.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2020-04-24T01:30:00-05:00",
+      "quoteExcerpt": "One of the working names for the event was the Flint Hills 200.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:trans-iowa",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_trans_iowa_challenge_logic_2005",
+        "claim_flint_hills_spawned_2005",
+        "claim_trans_iowa_format_spreading_2005",
+        "claim_trans_iowa_april_flint_loop_2005",
+        "claim_dirty_kanza_trans_iowa_link_2013"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_flint_hills_spawned_2005",
+        "claim_trans_iowa_format_spreading_2005",
+        "claim_trans_iowa_april_flint_loop_2005",
+        "claim_dirty_kanza_trans_iowa_link_2013",
+        "claim_flint_hills_working_name_2020"
+      ],
+      "confidence": 0.95,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T19:00:00Z",
+  "contentHash": "dc9161b6d351147c5fbe85deb7f0eddb8bc13b49ba72b39040caa2d252b49901"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -902,6 +902,21 @@ def test_2006_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2005_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2005.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 51
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weekly windows in the 2005 historical backfill
- recover the moment Trans Iowa became a portable format and the Flint Hills race that became Unbound was announced
- credit earlier western ultra-endurance forebears and quarantine the organizer-side causal claim
- keep publication and both race-profile effects behind human editorial review

## Verification
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2005-gravel-copyable-format.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2005.json`
- `pytest -q tests/test_gravel_weekly.py` (52 passed)
- both Gravel Weekly anti-slop detectors: zero findings
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only editorial artifacts kept in draft with human-approval gates; no application logic changes, though approved content could later influence race editorial fields.
> 
> **Overview**
> Adds a **complete 2005 Gravel Weekly backfill ledger** (`2005.json`) that assigns all 53 weekly windows: 51 as `explicit_gap` (no Cyclingnews cards and no recovered story past editorial gates) and **two late-December weeks** as `covered_by_draft`, both pointing at a new history entry.
> 
> Introduces **`history-gravel-copyable-format-2005`**, a **draft** history piece framed around December 2005 Guitar Ted posts—Trans Iowa as a portable challenge, the Kansas “Flint Hills 200” announcement, and wider organizer interest—with receipts, uncertainty/credible-opposition copy, and **non-auto** `editorial_review` race impacts for Trans Iowa and Unbound. Publication and ledger auto-publish stay off (`humanApprovalRequired`, `autoPublishAllowed: false`).
> 
> Adds **`test_2005_backfill_ledger_starts_from_the_complete_source_census`** so CI enforces the 53-week disposition mix and `complete: true` against `validate_backfill_ledger`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340ae98e2da7fc2ad8ca722dbb8b15ffa53da125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->