### PR TITLE
Complete the 2004 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2004.json
+++ b/data/gravel-weekly/backfill/2004.json
@@ -1,0 +1,441 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2004,
+  "asOf": "2004-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/73",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33176923290",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2003-12-27",
+      "periodEndedAt": "2004-01-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-01-03",
+      "periodEndedAt": "2004-01-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-01-10",
+      "periodEndedAt": "2004-01-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-01-17",
+      "periodEndedAt": "2004-01-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-01-24",
+      "periodEndedAt": "2004-01-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-01-31",
+      "periodEndedAt": "2004-02-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-02-07",
+      "periodEndedAt": "2004-02-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-02-14",
+      "periodEndedAt": "2004-02-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-02-21",
+      "periodEndedAt": "2004-02-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-02-28",
+      "periodEndedAt": "2004-03-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-03-06",
+      "periodEndedAt": "2004-03-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-03-13",
+      "periodEndedAt": "2004-03-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-03-20",
+      "periodEndedAt": "2004-03-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-03-27",
+      "periodEndedAt": "2004-04-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-04-03",
+      "periodEndedAt": "2004-04-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-04-10",
+      "periodEndedAt": "2004-04-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-04-17",
+      "periodEndedAt": "2004-04-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-04-24",
+      "periodEndedAt": "2004-04-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-05-01",
+      "periodEndedAt": "2004-05-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-05-08",
+      "periodEndedAt": "2004-05-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-05-15",
+      "periodEndedAt": "2004-05-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-05-22",
+      "periodEndedAt": "2004-05-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-05-29",
+      "periodEndedAt": "2004-06-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-06-05",
+      "periodEndedAt": "2004-06-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-06-12",
+      "periodEndedAt": "2004-06-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-06-19",
+      "periodEndedAt": "2004-06-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-06-26",
+      "periodEndedAt": "2004-07-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-07-03",
+      "periodEndedAt": "2004-07-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-07-10",
+      "periodEndedAt": "2004-07-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-07-17",
+      "periodEndedAt": "2004-07-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-07-24",
+      "periodEndedAt": "2004-07-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-07-31",
+      "periodEndedAt": "2004-08-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-08-07",
+      "periodEndedAt": "2004-08-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-08-14",
+      "periodEndedAt": "2004-08-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-08-21",
+      "periodEndedAt": "2004-08-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-08-28",
+      "periodEndedAt": "2004-09-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-09-04",
+      "periodEndedAt": "2004-09-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-09-11",
+      "periodEndedAt": "2004-09-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-09-18",
+      "periodEndedAt": "2004-09-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-09-25",
+      "periodEndedAt": "2004-10-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-10-02",
+      "periodEndedAt": "2004-10-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-10-09",
+      "periodEndedAt": "2004-10-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-10-16",
+      "periodEndedAt": "2004-10-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-10-23",
+      "periodEndedAt": "2004-10-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-10-30",
+      "periodEndedAt": "2004-11-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-11-06",
+      "periodEndedAt": "2004-11-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-11-13",
+      "periodEndedAt": "2004-11-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-11-20",
+      "periodEndedAt": "2004-11-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-11-27",
+      "periodEndedAt": "2004-12-03",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-trans-iowa-tire-revolt-2004"
+      ],
+      "reason": "The official Trans Iowa rules surface was published in this window; later evidence reconstructs the pre-race tire-rule dispute."
+    },
+    {
+      "periodStartedAt": "2004-12-04",
+      "periodEndedAt": "2004-12-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-12-11",
+      "periodEndedAt": "2004-12-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-12-18",
+      "periodEndedAt": "2004-12-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2004-12-25",
+      "periodEndedAt": "2004-12-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "Cyclingnews exposed no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    }
+  ],
+  "updatedAt": "2026-08-28T19:15:00Z"
+}

--- a/data/gravel-weekly/history/2004-trans-iowa-tire-revolt.json
+++ b/data/gravel-weekly/history/2004-trans-iowa-tire-revolt.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-trans-iowa-tire-revolt-2004",
+  "activeFrom": "2004-11-29",
+  "activeThrough": "2004-11-29",
+  "status": "draft",
+  "headline": "Gravel’s First Bike Rule Did Not Survive Gravel Riders",
+  "point": "Trans Iowa began as a mountain-bike race and, according to its organizer’s later reconstruction, initially required tires at least two inches wide. Cyclocross riders challenged the restriction before the first event. The surviving official rules page allows mountain bikes, cyclocross bikes, 29ers, and even road bikes while merely warning that Iowa gravel might make skinny tires hurt. Gravel’s equipment category began with a failed attempt to close it.",
+  "priorJudgment": "A new cycling discipline needs organizers to define the correct bicycle before riders can compete fairly or safely.",
+  "changedJudgment": "Trans Iowa’s first equipment fight showed that the route could arbitrate bike choice better than a promoter’s category rule. Rider dissent widened the experiment before the event had produced a single finisher.",
+  "stakes": "Gravel still mistakes equipment boundaries for sporting principles. This origin suggests a better test: prohibit actual competitive distortions, publish the terrain honestly, and let riders choose how much speed, comfort, and regret to carry.",
+  "credibleOpposition": "The two-inch minimum and the online revolt are documented in a 2019 organizer retrospective, not a recovered 2004 forum thread. The official rules post retains its November 2004 publication date but is visibly a living document with later additions, so its current wording cannot prove the exact date when the rule changed. A minimum tire width can also be a defensible safety measure when route hazards are poorly understood.",
+  "whatHappened": "On November 29, 2004, Trans Iowa’s official site published rules for a non-stop, self-supported competition on rural Iowa gravel. The surviving page calls it the Trans-Iowa Mountain Bike Race but permits mountain bikes, cyclocross bikes, 29ers, and road bikes, adding that a rider on the latter might be stupid and suggesting at least a 1.95-inch tire according to how much the rider wants to hurt. Mark Stevenson later wrote that co-founder Jeff Kerkove had originally required tires two inches or wider because mountain bikes seemed safer and more comfortable. Cyclocross riders objected in the MTBR endurance forum, and Stevenson was assigned to deal with the argument. Most riders in the inaugural 2005 field still used mountain bikes, but the exclusion did not survive to govern the experiment.",
+  "take": "Model draft, not Matti's approved view: Gravel had tire discourse before it had a finish line. In 2004, Trans Iowa was still called a mountain-bike race and initially wanted two-inch tires. Cyclocross riders entered the forum like public defenders for 33-millimeter rubber, and the restriction cracked before anybody had crossed Iowa. The surviving rules page allows mountain bikes, cyclocross bikes, 29ers, and road bikes 'if you really want to be stupid,' then recommends 1.95 inches according to how much you want to hurt. This may be the cleanest founding document gravel could have produced: no consensus, four bike categories, and a tire argument resolved by letting the roads humiliate everyone equally. The category did not begin with a gravel bike. It began when the category police lost.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The official rules URL is a mutable Blogger post: it retains a 2004 publication timestamp but includes obvious later edits, including the event’s closure and an electric-assist rule. This entry uses it as evidence that a rules surface originated in 2004, not as proof that every surviving sentence appeared that day. The original two-inch requirement, forum dissent, and rule reversal rely on Stevenson’s 2019 first-person retrospective. No preserved 2004 MTBR thread or contemporaneous independent account has yet been recovered, so the entry remains a human-review draft.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_trans_iowa_rules_surface_2004",
+      "canonicalUrl": "https://transiowa.blogspot.com/2004/11/race-rules.html",
+      "publisher": "The Trans Iowa Race",
+      "publishedAt": "2004-11-29T14:20:00-06:00",
+      "quoteExcerpt": "Bike choice is up to you! We are allowing mnt bikes, cyclocross bikes, 29\"ers, and road bikes",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_trans_iowa_self_support_rule_2014",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2014/09/trans-iowa-v11-look-at-rules-part-3.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2014-09-28T01:30:00-05:00",
+      "quoteExcerpt": "Competitors must carry with them ALL necessary equipment.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_trans_iowa_mountain_bike_intent_2014",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2014/11/trans-iowa-v11-look-at-rules-part-8.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2014-11-05T01:30:00-05:00",
+      "quoteExcerpt": "That's why initially it was called the \"Trans Iowa Mountain Bike Race\".",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_trans_iowa_two_inch_dissent_2019",
+      "canonicalUrl": "https://g-tedproductions.blogspot.com/2019/07/trans-iowa-stories-dissenters.html",
+      "publisher": "Guitar Ted Productions",
+      "publishedAt": "2019-07-14T01:30:00-05:00",
+      "quoteExcerpt": "all riders had to be on 2 inch or wider tires",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:trans-iowa",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_trans_iowa_rules_surface_2004",
+        "claim_trans_iowa_self_support_rule_2014",
+        "claim_trans_iowa_mountain_bike_intent_2014",
+        "claim_trans_iowa_two_inch_dissent_2019"
+      ],
+      "confidence": 0.86,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T19:15:00Z",
+  "contentHash": "70ff6cbb48c376416d2cc1804d8761a5a2756b85eb94d14dcfeddeacaee5a640"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -917,6 +917,21 @@ def test_2005_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2004_backfill_ledger_starts_from_the_complete_source_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2004.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 52
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- account for all 53 weekly windows in the 2004 historical backfill
- recover Trans Iowa’s pre-race tire-rule revolt as the year’s qualifying Current Thing
- disclose that the official 2004 rules URL is mutable and quarantine the later reconstruction accordingly
- keep publication and race-profile effects behind human editorial review

## Verification
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_history.py data/gravel-weekly/history/2004-trans-iowa-tire-revolt.json`
- `PYTHONPATH=scripts python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2004.json`
- `pytest -q tests/test_gravel_weekly.py` (53 passed)
- both Gravel Weekly anti-slop detectors: zero findings
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds editorial backfill data and tests only; publication and race-profile updates remain behind human approval flags.
> 
> **Overview**
> **Completes the 2004 Gravel Weekly historical backfill** by adding a full-year ledger that marks all **53 weekly windows** as accounted for: **52 explicit gaps** (no Cyclingnews or recovered contemporary story passed editorial gates) and **one week** tied to a new draft history entry.
> 
> That draft covers **Trans Iowa’s 2004 rules surface and the pre-race tire-width dispute** (two-inch minimum vs. cyclocross dissent), with receipts split between the **November 2004 rules post** and **later organizer retrospectives**. The entry labels the take as **model draft**, documents **mutable Blogger URL uncertainty**, and routes a **Trans Iowa race editorial review** impact with **no auto-publish**.
> 
> A contract test asserts the **2004 ledger validates** against loaded history entries with the expected disposition counts and `complete: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d27948a6076386524f6ef77cf549b6b09fbb09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->