### PR TITLE
Recover 2003 Gravel Weekly origin story

### DIFF
--- a/data/gravel-weekly/backfill/2003.json
+++ b/data/gravel-weekly/backfill/2003.json
@@ -1,0 +1,445 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2003,
+  "asOf": "2003-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/75",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33177897752",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceArchiveCoverage": "unavailable",
+  "sourceArchiveErrors": [
+    "Cyclingnews exposed no monthly sitemaps for 2003"
+  ],
+  "sourceCardCount": 0,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2002-12-28",
+      "periodEndedAt": "2003-01-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-01-04",
+      "periodEndedAt": "2003-01-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-01-11",
+      "periodEndedAt": "2003-01-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-01-18",
+      "periodEndedAt": "2003-01-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-01-25",
+      "periodEndedAt": "2003-01-31",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-02-01",
+      "periodEndedAt": "2003-02-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-02-08",
+      "periodEndedAt": "2003-02-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-02-15",
+      "periodEndedAt": "2003-02-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-02-22",
+      "periodEndedAt": "2003-02-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-03-01",
+      "periodEndedAt": "2003-03-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-03-08",
+      "periodEndedAt": "2003-03-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-03-15",
+      "periodEndedAt": "2003-03-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-03-22",
+      "periodEndedAt": "2003-03-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-03-29",
+      "periodEndedAt": "2003-04-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-04-05",
+      "periodEndedAt": "2003-04-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-04-12",
+      "periodEndedAt": "2003-04-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-04-19",
+      "periodEndedAt": "2003-04-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-04-26",
+      "periodEndedAt": "2003-05-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-05-03",
+      "periodEndedAt": "2003-05-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-05-10",
+      "periodEndedAt": "2003-05-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-05-17",
+      "periodEndedAt": "2003-05-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-05-24",
+      "periodEndedAt": "2003-05-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-05-31",
+      "periodEndedAt": "2003-06-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-06-07",
+      "periodEndedAt": "2003-06-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-06-14",
+      "periodEndedAt": "2003-06-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-06-21",
+      "periodEndedAt": "2003-06-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-06-28",
+      "periodEndedAt": "2003-07-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-07-05",
+      "periodEndedAt": "2003-07-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-07-12",
+      "periodEndedAt": "2003-07-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-07-19",
+      "periodEndedAt": "2003-07-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-07-26",
+      "periodEndedAt": "2003-08-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-08-02",
+      "periodEndedAt": "2003-08-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-08-09",
+      "periodEndedAt": "2003-08-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-08-16",
+      "periodEndedAt": "2003-08-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-08-23",
+      "periodEndedAt": "2003-08-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-08-30",
+      "periodEndedAt": "2003-09-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-09-06",
+      "periodEndedAt": "2003-09-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-09-13",
+      "periodEndedAt": "2003-09-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-09-20",
+      "periodEndedAt": "2003-09-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-09-27",
+      "periodEndedAt": "2003-10-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-10-04",
+      "periodEndedAt": "2003-10-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-10-11",
+      "periodEndedAt": "2003-10-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-10-18",
+      "periodEndedAt": "2003-10-24",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-iron-cross-gravel-before-name-2003"
+      ],
+      "reason": "Broader contemporary-source recovery found a high-value origin-story change-point despite the unavailable monthly sitemap archive; the draft remains human-review only."
+    },
+    {
+      "periodStartedAt": "2003-10-25",
+      "periodEndedAt": "2003-10-31",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-11-01",
+      "periodEndedAt": "2003-11-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-11-08",
+      "periodEndedAt": "2003-11-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-11-15",
+      "periodEndedAt": "2003-11-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-11-22",
+      "periodEndedAt": "2003-11-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-11-29",
+      "periodEndedAt": "2003-12-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-12-06",
+      "periodEndedAt": "2003-12-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-12-13",
+      "periodEndedAt": "2003-12-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-12-20",
+      "periodEndedAt": "2003-12-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    },
+    {
+      "periodStartedAt": "2003-12-27",
+      "periodEndedAt": "2004-01-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+    }
+  ],
+  "updatedAt": "2026-08-28T20:15:00Z"
+}

--- a/data/gravel-weekly/history/2003-iron-cross-gravel-before-name.json
+++ b/data/gravel-weekly/history/2003-iron-cross-gravel-before-name.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-iron-cross-gravel-before-name-2003",
+  "activeFrom": "2003-10-19",
+  "activeThrough": "2003-10-21",
+  "status": "draft",
+  "headline": "Gravel Arrived Disguised as a 58-Mile Cyclocross Race",
+  "point": "The inaugural Iron Cross had cyclocross laps at the start and finish, but the event between them was a 53-mile main loop through rocky Pennsylvania terrain with nearly 6,000 feet of climbing. Contemporary coverage allowed both mountain and cyclocross bikes; its founder later described the event as 100 kilometers and mostly gravel. The format existed before American cycling had settled on the category name.",
+  "priorJudgment": "American gravel history starts when promoters explicitly called their events gravel races and riders arrived on gravel bikes.",
+  "changedJudgment": "Iron Cross shows that the format preceded the vocabulary. In 2003, a long mixed-surface race could behave like gravel while borrowing cyclocross's name, bikes, and institutional filing cabinet.",
+  "stakes": "If the database follows labels instead of event design, it erases the experiments that made modern gravel possible. Iron Cross belongs in the origin story precisely because nobody yet knew which category owned it.",
+  "credibleOpposition": "Every contemporary source filed Iron Cross as cyclocross, the course included traditional cross laps, run-ups, trails, and barriers, and the strongest explicit description of it as mostly gravel comes from a 2019 retrospective interview. Treating it as a modern gravel race is therefore an interpretive classification, not a contemporaneous fact.",
+  "whatHappened": "On October 19, 2003, 73 riders started the inaugural Iron Cross in Michaux State Forest, Pennsylvania. BikeReg's preserved result record describes a traditional cyclocross layout at both ends of a 53-mile main loop with nearly 6,000 feet of climbing. Cyclingnews published a full report in its cyclocross results archive, and Mountain Bike Action described a 58-mile event mixing fire road, pavement, difficult climbs, run-ups, and descents while permitting mountain and cyclocross bikes. Chris Eatough won in 3:30:03; Andy Applegate finished second and was recorded as the first rider on a cyclocross bike. In a 2019 interview, founder Mike Kuhn described Iron Cross as 100 kilometers, mostly gravel, with pavement and singletrack mixed in to make bike choice deliberately ambiguous.",
+  "take": "Model draft, not Matti's approved view: Gravel did not wait for a gravel bike, a gravel category, or a tasteful earth-tone logo. It showed up in Pennsylvania wearing cyclocross's name, bolted a 53-mile main loop between two ceremonial laps, and made everyone argue with 6,000 feet of climbing. Mountain bikes were legal. Cross bikes were legal. The winner needed three and a half hours, which is a very long way of saying this was not cyclocross in any normal human sense. Iron Cross matters because categories are usually written after the weirdos have already built the thing. Gravel's prehistory was hiding in the cyclocross results.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The event date is consistently preserved as October 19, 2003, and Cyclingnews's October index lists the full report on October 21. The direct Cyclingnews report header says October 8, an impossible date before the event and likely an archival labeling error, so this entry uses the dated index for chronology and discloses the conflict. BikeReg's narrative begins 'October 18' despite its event header saying October 19. The description of Iron Cross as mostly gravel is from an automatically transcribed 2019 founder interview, not contemporary language. The classification remains an editorial interpretation requiring human review.",
+  "editorialScore": 97,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_iron_cross_inaugural_2003",
+      "canonicalUrl": "https://www.bikereg.com/results/s/15745/iron-cross-americas-longest-cyclocross-race",
+      "publisher": "BikeReg",
+      "publishedAt": "2003-10-19T12:00:00-04:00",
+      "quoteExcerpt": "the inaugural edition of America's longest cyclocross race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_iron_cross_cyclingnews_report_2003",
+      "canonicalUrl": "https://autobus.cyclingnews.com/cross.php?id=cross/2003/oct03/oct08USAironcross",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2003-10-21T12:00:00Z",
+      "quoteExcerpt": "a 53 mile main loop with nearly 6,000 feet of climbing",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_iron_cross_mixed_bikes_2003",
+      "canonicalUrl": "https://mbaction.com/worlds-toughest-cyclocross-oct-21/",
+      "publisher": "Mountain Bike Action",
+      "publishedAt": "2003-10-21T12:00:00-04:00",
+      "quoteExcerpt": "Both mountain and cyclocross bikes were allowed.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_iron_cross_mostly_gravel_2019",
+      "canonicalUrl": "https://www.gravelcyclist.com/training-rides/podcast-a-conversation-with-mike-kuhn-of-unpaved-founder-of-iron-cross-gunner-bregy-promoter-of-iron-cross-pennsylvania-gravel/",
+      "publisher": "Gravel Cyclist",
+      "publishedAt": "2019-08-07T12:00:00-04:00",
+      "quoteExcerpt": "iron cross is a hundred kilometers. It's mostly gravel.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:iron-cross",
+      "fieldPath": "race.history",
+      "claimIds": [
+        "claim_iron_cross_inaugural_2003",
+        "claim_iron_cross_cyclingnews_report_2003",
+        "claim_iron_cross_mixed_bikes_2003",
+        "claim_iron_cross_mostly_gravel_2019"
+      ],
+      "confidence": 0.92,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T20:15:00Z",
+  "contentHash": "26a9b455fa7904cb8ef7b1b627fb451ad39bd889adf695a7ea15a7e88fd798cc"
+}

--- a/scripts/prepare_gravel_weekly_backfill_ledger.py
+++ b/scripts/prepare_gravel_weekly_backfill_ledger.py
@@ -54,13 +54,22 @@ def build_initial_backfill_ledger(
     if not isinstance(year, int) or isinstance(year, bool):
         raise IssueValidationError("historical discovery year is invalid")
 
+    coverage = discovery.get("archiveCoverage")
+    if coverage not in {"complete", "partial", "unavailable"}:
+        raise IssueValidationError("historical archiveCoverage is invalid")
     requested = discovery.get("archiveMonthsRequested")
     succeeded = discovery.get("archiveMonthsSucceeded")
     errors = _list(discovery.get("archiveMonthErrors"), "archiveMonthErrors")
-    if not isinstance(requested, int) or requested <= 0:
+    if not isinstance(requested, int) or requested < 0:
         raise IssueValidationError("archiveMonthsRequested is invalid")
-    if succeeded != requested or errors:
-        raise IssueValidationError("historical discovery ledger is incomplete")
+    if not isinstance(succeeded, int) or succeeded < 0 or succeeded > requested:
+        raise IssueValidationError("archiveMonthsSucceeded is invalid")
+    if coverage == "complete" and (requested == 0 or succeeded != requested or errors):
+        raise IssueValidationError("complete historical discovery coverage is inconsistent")
+    if coverage == "partial" and (succeeded == 0 or succeeded == requested or not errors):
+        raise IssueValidationError("partial historical discovery coverage is inconsistent")
+    if coverage == "unavailable" and (succeeded != 0 or not errors):
+        raise IssueValidationError("unavailable historical discovery coverage is inconsistent")
 
     cards = [_record(card, f"sourceCards[{index}]") for index, card in enumerate(_list(discovery.get("sourceCards"), "sourceCards"))]
     card_ids: list[str] = []
@@ -85,16 +94,26 @@ def build_initial_backfill_ledger(
                 raise IssueValidationError(f"weeks[{index}].sourceCardIds[{source_index}] is invalid")
             assigned_ids.append(source_id)
         count = len(source_ids)
+        status = week.get("status")
+        if status not in {"source_census_ready", "explicit_gap", "unresearched"}:
+            raise IssueValidationError(f"weeks[{index}].status is invalid")
+        if count and status != "source_census_ready":
+            raise IssueValidationError(f"weeks[{index}] has source cards without source_census_ready status")
+        if not count and status == "source_census_ready":
+            raise IssueValidationError(f"weeks[{index}] is source_census_ready without source cards")
+        disposition = "pending_review" if count else status
         weeks.append({
             "periodStartedAt": _timestamp_day(week.get("periodStartedAt"), f"weeks[{index}].periodStartedAt"),
             "periodEndedAt": _timestamp_day(week.get("periodEndedAt"), f"weeks[{index}].periodEndedAt"),
             "sourceCardCount": count,
-            "disposition": "explicit_gap" if count == 0 else "pending_review",
+            "disposition": disposition,
             "entryIds": [],
             "reason": (
-                "Cyclingnews exposed no matching source card; preserve the quiet window."
-                if count == 0
-                else "Source census complete; assigning-desk research and disposition remain pending."
+                "Source census found candidate metadata; assigning-desk research and disposition remain pending."
+                if count
+                else "Cyclingnews archive coverage is complete for this window and exposed no matching source card; preserve the quiet window."
+                if status == "explicit_gap"
+                else "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
             ),
         })
 
@@ -112,8 +131,9 @@ def build_initial_backfill_ledger(
         "sourceLedgerIssue": source_ledger_issue,
         "sourceLedgerRun": source_ledger_run,
         "programIssue": program_issue,
+        "sourceArchiveCoverage": coverage,
         "sourceCardCount": source_count,
-        "complete": not any(week["disposition"] == "pending_review" for week in weeks),
+        "complete": not any(week["disposition"] in {"pending_review", "unresearched"} for week in weeks),
         "humanApprovalRequired": True,
         "autoPublishAllowed": False,
         "weeks": weeks,

--- a/scripts/validate_gravel_weekly_backfill.py
+++ b/scripts/validate_gravel_weekly_backfill.py
@@ -16,6 +16,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 BACKFILL_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "backfill"
 DISPOSITIONS = {
     "explicit_gap",
+    "unresearched",
     "pending_review",
     "covered_by_draft",
     "held_for_evidence",
@@ -49,6 +50,9 @@ def validate_backfill_ledger(value: Any, history_entries: list[dict[str, Any]]) 
         raise IssueValidationError("sourceCardCount is invalid")
     if ledger.get("humanApprovalRequired") is not True or ledger.get("autoPublishAllowed") is not False:
         raise IssueValidationError("backfill publication safety flags are invalid")
+    source_archive_coverage = ledger.get("sourceArchiveCoverage")
+    if source_archive_coverage is not None and source_archive_coverage not in {"complete", "partial", "unavailable"}:
+        raise IssueValidationError("sourceArchiveCoverage is invalid")
 
     histories = {entry["entryId"]: entry for entry in history_entries}
     weeks = _list(ledger.get("weeks"), "weeks", 54)
@@ -56,7 +60,7 @@ def validate_backfill_ledger(value: Any, history_entries: list[dict[str, Any]]) 
         raise IssueValidationError("backfill ledger requires weekly accounting")
     previous_end: datetime | None = None
     counted_sources = 0
-    pending = 0
+    unresolved = 0
     for index, week_value in enumerate(weeks):
         name = f"weeks[{index}]"
         week = _record(week_value, name)
@@ -89,6 +93,8 @@ def validate_backfill_ledger(value: Any, history_entries: list[dict[str, Any]]) 
         reason = _text(week.get("reason"), f"{name}.reason", 1_000)
         if disposition == "explicit_gap" and (count != 0 or entry_ids):
             raise IssueValidationError("explicit gaps require zero source cards and no entries")
+        if disposition == "unresearched" and (count != 0 or entry_ids):
+            raise IssueValidationError("unresearched windows require zero source cards and no entries")
         if disposition == "pending_review" and (count == 0 or entry_ids):
             raise IssueValidationError("pending windows require source cards and no linked entries")
         if disposition in {"covered_by_draft", "approved"} and not entry_ids:
@@ -97,15 +103,15 @@ def validate_backfill_ledger(value: Any, history_entries: list[dict[str, Any]]) 
             raise IssueValidationError("covered_by_draft windows must link only draft entries")
         if disposition == "approved" and any(histories[entry_id]["status"] not in {"approved", "published"} for entry_id in entry_ids):
             raise IssueValidationError("approved windows require approved or published entries")
-        if disposition == "pending_review":
-            pending += 1
+        if disposition in {"pending_review", "unresearched"}:
+            unresolved += 1
         if not reason:
             raise IssueValidationError(f"{name}.reason is required")
     if counted_sources != source_total:
         raise IssueValidationError(f"weekly source-card sum {counted_sources} does not match {source_total}")
     complete = ledger.get("complete")
-    if not isinstance(complete, bool) or complete != (pending == 0):
-        raise IssueValidationError("complete must be true exactly when no weekly window remains pending")
+    if not isinstance(complete, bool) or complete != (unresolved == 0):
+        raise IssueValidationError("complete must be true exactly when no weekly window remains pending or unresearched")
     _iso(ledger.get("updatedAt"), "updatedAt")
     return ledger
 

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -932,11 +932,31 @@ def test_2004_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
+def test_2003_backfill_ledger_preserves_unavailable_archive_research_debt():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2003.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert validated["sourceArchiveCoverage"] == "unavailable"
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 52
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
+    assert validated["complete"] is False
+
+    dishonest_completion = copy.deepcopy(ledger)
+    dishonest_completion["complete"] = True
+    with pytest.raises(IssueValidationError, match="pending or unresearched"):
+        validate_backfill_ledger(dishonest_completion, histories)
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",
         "year": 2024,
         "asOf": "2024-12-31T23:59:59Z",
+        "archiveCoverage": "complete",
         "archiveMonthsRequested": 12,
         "archiveMonthsSucceeded": 12,
         "archiveMonthErrors": [],
@@ -947,11 +967,13 @@ def test_initial_backfill_ledger_accounts_for_every_discovery_card():
                 "periodStartedAt": "2023-12-30T00:00:00Z",
                 "periodEndedAt": "2024-01-05T23:59:59Z",
                 "sourceCardIds": ["source-1"],
+                "status": "source_census_ready",
             },
             {
                 "periodStartedAt": "2024-01-06T00:00:00Z",
                 "periodEndedAt": "2024-01-12T23:59:59Z",
                 "sourceCardIds": [],
+                "status": "explicit_gap",
             },
         ],
     }
@@ -968,34 +990,47 @@ def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     assert sum(week["sourceCardCount"] for week in ledger["weeks"]) == 1
 
 
-def test_initial_backfill_ledger_rejects_partial_archive_and_bad_card_accounting():
+def test_initial_backfill_ledger_preserves_partial_archive_research_debt_and_rejects_bad_card_accounting():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",
         "year": 2024,
         "asOf": "2024-12-31T23:59:59Z",
-        "archiveMonthsRequested": 12,
-        "archiveMonthsSucceeded": 11,
-        "archiveMonthErrors": ["December failed"],
-        "sourceCardCount": 1,
-        "sourceCards": [{"id": "source-1"}],
-        "weeks": [{
-            "periodStartedAt": "2023-12-30T00:00:00Z",
-            "periodEndedAt": "2024-01-05T23:59:59Z",
-            "sourceCardIds": ["source-1"],
-        }],
+        "archiveCoverage": "partial",
+        "archiveMonthsRequested": 2,
+        "archiveMonthsSucceeded": 1,
+        "archiveMonthErrors": ["February failed"],
+        "sourceCardCount": 0,
+        "sourceCards": [],
+        "weeks": [
+            {
+                "periodStartedAt": "2023-12-30T00:00:00Z",
+                "periodEndedAt": "2024-01-05T23:59:59Z",
+                "sourceCardIds": [],
+                "status": "explicit_gap",
+            },
+            {
+                "periodStartedAt": "2024-01-06T00:00:00Z",
+                "periodEndedAt": "2024-01-12T23:59:59Z",
+                "sourceCardIds": [],
+                "status": "unresearched",
+            },
+        ],
     }
-    with pytest.raises(IssueValidationError, match="incomplete"):
-        build_initial_backfill_ledger(
-            discovery,
-            source_ledger_issue="https://github.com/example/project/issues/1",
-            source_ledger_run="https://github.com/example/project/actions/runs/2",
-            program_issue="https://github.com/example/project/issues/3",
-            updated_at="2026-08-28T06:30:00Z",
-        )
+    ledger = build_initial_backfill_ledger(
+        discovery,
+        source_ledger_issue="https://github.com/example/project/issues/1",
+        source_ledger_run="https://github.com/example/project/actions/runs/2",
+        program_issue="https://github.com/example/project/issues/3",
+        updated_at="2026-08-28T06:30:00Z",
+    )
+    assert ledger["sourceArchiveCoverage"] == "partial"
+    assert ledger["complete"] is False
+    assert [week["disposition"] for week in ledger["weeks"]] == ["explicit_gap", "unresearched"]
 
-    discovery["archiveMonthsSucceeded"] = 12
-    discovery["archiveMonthErrors"] = []
+    discovery["sourceCardCount"] = 1
+    discovery["sourceCards"] = [{"id": "source-1"}]
     discovery["weeks"][0]["sourceCardIds"] = ["unknown-source"]
+    discovery["weeks"][0]["status"] = "source_census_ready"
     with pytest.raises(IssueValidationError, match="accounting mismatch"):
         build_initial_backfill_ledger(
             discovery,


### PR DESCRIPTION
## Summary
- add a human-review-only 2003 Iron Cross narrative change-point
- preserve 52 unavailable-archive weeks as unresearched instead of false gaps
- teach the canonical backfill ledger to retain complete, partial, and unavailable source coverage
- keep race impact limited to editorial review of Iron Cross history

## Evidence boundary
The contemporary record calls Iron Cross cyclocross. Its classification as a gravel predecessor is disclosed as an editorial interpretation, and the conflicting archival dates are preserved in uncertainty.

## Verification
- 7,315 passed, 331 skipped: python3 -m pytest tests/
- all Gravel Weekly history entries validated
- all Gravel Weekly backfill ledgers validated
- both anti-slop detectors: zero findings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes editorial/historical narrative and backfill completeness semantics; mitigated by draft-only status, human-approval flags, and stricter validation that blocks false “complete” years.
> 
> **Overview**
> Adds **2003 Gravel Weekly backfill** data and tightens how years with broken Cyclingnews archive coverage are represented.
> 
> The new **`2003.json` backfill ledger** records `sourceArchiveCoverage: unavailable`, leaves **52 weeks as `unresearched`** (not `explicit_gap`), marks the year **`complete: false`**, and links one week to a draft history entry. A new **draft history entry** for inaugural **Iron Cross (2003)** argues the long mixed-surface format predated the “gravel” label, with contemporary receipts, later founder evidence, disclosed date conflicts, and **`editorial_review`-only** race impact on `gravel:iron-cross` (no auto-publish).
> 
> **Backfill tooling** now carries **`sourceArchiveCoverage`** (`complete` / `partial` / `unavailable`) from discovery ledgers, maps week **`status`** into dispositions including **`unresearched`**, and treats **`pending_review` and `unresearched`** as blocking completion. Partial/unavailable archives are accepted instead of failing ledger preparation. **Validators and tests** enforce the new disposition rules and add coverage for the 2003 ledger and dishonest `complete: true` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5379b7911ca4a591ccdc651dc4b1df35565fcf4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->