### PR TITLE
Reconcile complete 2003 Gravel Weekly census

### DIFF
--- a/data/gravel-weekly/backfill/2003.json
+++ b/data/gravel-weekly/backfill/2003.json
@@ -3,14 +3,12 @@
   "year": 2003,
   "asOf": "2003-12-31T23:59:59.000Z",
   "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/75",
-  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33177897752",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33179286556",
   "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
-  "sourceArchiveCoverage": "unavailable",
-  "sourceArchiveErrors": [
-    "Cyclingnews exposed no monthly sitemaps for 2003"
-  ],
-  "sourceCardCount": 0,
-  "complete": false,
+  "sourceArchiveCoverage": "complete",
+  "sourceArchiveErrors": [],
+  "sourceCardCount": 1,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -18,428 +16,428 @@
       "periodStartedAt": "2002-12-28",
       "periodEndedAt": "2003-01-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-01-04",
       "periodEndedAt": "2003-01-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-01-11",
       "periodEndedAt": "2003-01-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-01-18",
       "periodEndedAt": "2003-01-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-01-25",
       "periodEndedAt": "2003-01-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-02-01",
       "periodEndedAt": "2003-02-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-02-08",
       "periodEndedAt": "2003-02-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-02-15",
       "periodEndedAt": "2003-02-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-02-22",
       "periodEndedAt": "2003-02-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-03-01",
       "periodEndedAt": "2003-03-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-03-08",
       "periodEndedAt": "2003-03-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-03-15",
       "periodEndedAt": "2003-03-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-03-22",
       "periodEndedAt": "2003-03-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-03-29",
       "periodEndedAt": "2003-04-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-04-05",
       "periodEndedAt": "2003-04-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-04-12",
       "periodEndedAt": "2003-04-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-04-19",
       "periodEndedAt": "2003-04-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-04-26",
       "periodEndedAt": "2003-05-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-05-03",
       "periodEndedAt": "2003-05-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-05-10",
       "periodEndedAt": "2003-05-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-05-17",
       "periodEndedAt": "2003-05-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-05-24",
       "periodEndedAt": "2003-05-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-05-31",
       "periodEndedAt": "2003-06-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-06-07",
       "periodEndedAt": "2003-06-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-06-14",
       "periodEndedAt": "2003-06-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-06-21",
       "periodEndedAt": "2003-06-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-06-28",
       "periodEndedAt": "2003-07-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-07-05",
       "periodEndedAt": "2003-07-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-07-12",
       "periodEndedAt": "2003-07-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-07-19",
       "periodEndedAt": "2003-07-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-07-26",
       "periodEndedAt": "2003-08-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-08-02",
       "periodEndedAt": "2003-08-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-08-09",
       "periodEndedAt": "2003-08-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-08-16",
       "periodEndedAt": "2003-08-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-08-23",
       "periodEndedAt": "2003-08-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-08-30",
       "periodEndedAt": "2003-09-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-09-06",
       "periodEndedAt": "2003-09-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-09-13",
       "periodEndedAt": "2003-09-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-09-20",
       "periodEndedAt": "2003-09-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-09-27",
       "periodEndedAt": "2003-10-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-10-04",
       "periodEndedAt": "2003-10-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-10-11",
       "periodEndedAt": "2003-10-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-10-18",
       "periodEndedAt": "2003-10-24",
-      "sourceCardCount": 0,
+      "sourceCardCount": 1,
       "disposition": "covered_by_draft",
       "entryIds": [
         "history-iron-cross-gravel-before-name-2003"
       ],
-      "reason": "Broader contemporary-source recovery found a high-value origin-story change-point despite the unavailable monthly sitemap archive; the draft remains human-review only."
+      "reason": "The legacy Cyclingnews census found the October 21 Iron Cross report; broader contemporary recovery verified the origin-story change-point, and the draft remains human-review only."
     },
     {
       "periodStartedAt": "2003-10-25",
       "periodEndedAt": "2003-10-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-11-01",
       "periodEndedAt": "2003-11-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-11-08",
       "periodEndedAt": "2003-11-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-11-15",
       "periodEndedAt": "2003-11-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-11-22",
       "periodEndedAt": "2003-11-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-11-29",
       "periodEndedAt": "2003-12-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-12-06",
       "periodEndedAt": "2003-12-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-12-13",
       "periodEndedAt": "2003-12-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-12-20",
       "periodEndedAt": "2003-12-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2003-12-27",
       "periodEndedAt": "2004-01-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "Cyclingnews exposes no monthly sitemap archive for 2003. Broader source recovery remains required before this window can be called quiet."
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     }
   ],
-  "updatedAt": "2026-08-28T20:15:00Z"
+  "updatedAt": "2026-08-28T20:30:00Z"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -932,23 +932,18 @@ def test_2004_backfill_ledger_starts_from_the_complete_source_census():
     assert validated["complete"] is True
 
 
-def test_2003_backfill_ledger_preserves_unavailable_archive_research_debt():
+def test_2003_backfill_ledger_reconciles_the_complete_legacy_archive_census():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2003.json").read_text())
     validated = validate_backfill_ledger(ledger, histories)
 
     assert len(validated["weeks"]) == 53
-    assert validated["sourceArchiveCoverage"] == "unavailable"
-    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 52
+    assert validated["sourceArchiveCoverage"] == "complete"
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 0
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
-    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
-    assert validated["complete"] is False
-
-    dishonest_completion = copy.deepcopy(ledger)
-    dishonest_completion["complete"] = True
-    with pytest.raises(IssueValidationError, match="pending or unresearched"):
-        validate_backfill_ledger(dishonest_completion, histories)
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 52
+    assert validated["complete"] is True
 
 
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():


### PR DESCRIPTION
## Summary
- replace the temporary unavailable-archive state with the successful 12/12 legacy Cyclingnews census
- account for the single Iron Cross source card in its Friday-ended window
- convert the other 52 covered windows to explicit source gaps
- preserve the Iron Cross story as a human-review-only draft

## Verification
- 54 focused Gravel Weekly tests passed
- 2003 history entry validated
- 2003 backfill ledger validated
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial backfill JSON and contract tests only; no runtime, auth, or publish-path changes. Main risk is mis-stating historical coverage if the census data were wrong.
> 
> **Overview**
> Updates the **2003 Gravel Weekly backfill ledger** to reflect a finished legacy Cyclingnews archive census instead of the prior “unavailable sitemap” research-debt state.
> 
> **Ledger metadata:** `sourceArchiveCoverage` is **complete**, archive errors are cleared, **`sourceCardCount` is 1**, **`complete` is true**, and `sourceLedgerRun` / `updatedAt` point at the new census run.
> 
> **Weekly windows:** **52** weeks move from **`unresearched`** to **`explicit_gap`** with reasons that cite the full census plus contemporary-source recovery with no editorially gated story. The **Oct 18–24, 2003** window keeps **`covered_by_draft`** for `history-iron-cross-gravel-before-name-2003`, now with **`sourceCardCount` 1** and an updated reason tying the week to the October 21 Iron Cross report.
> 
> **Tests:** `test_2003_backfill_ledger_reconciles_the_complete_legacy_archive_census` replaces the old unavailable-archive test and asserts the new coverage, disposition counts, and **`complete: true`**; the negative test that blocked marking incomplete ledgers complete is removed as no longer applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169733da39b01325dc2933e3b7bbd7e1c947ba0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->