### PR TITLE
Complete 2002 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2002.json
+++ b/data/gravel-weekly/backfill/2002.json
@@ -1,0 +1,445 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 2002,
+  "asOf": "2002-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/77",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33179818962",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceArchiveCoverage": "complete",
+  "sourceArchiveErrors": [],
+  "sourceCardCount": 0,
+  "complete": true,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "2001-12-29",
+      "periodEndedAt": "2002-01-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-01-05",
+      "periodEndedAt": "2002-01-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-01-12",
+      "periodEndedAt": "2002-01-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-01-19",
+      "periodEndedAt": "2002-01-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-01-26",
+      "periodEndedAt": "2002-02-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-02-02",
+      "periodEndedAt": "2002-02-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-02-09",
+      "periodEndedAt": "2002-02-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-02-16",
+      "periodEndedAt": "2002-02-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-02-23",
+      "periodEndedAt": "2002-03-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-03-02",
+      "periodEndedAt": "2002-03-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-03-09",
+      "periodEndedAt": "2002-03-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-03-16",
+      "periodEndedAt": "2002-03-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-03-23",
+      "periodEndedAt": "2002-03-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-03-30",
+      "periodEndedAt": "2002-04-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-04-06",
+      "periodEndedAt": "2002-04-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-04-13",
+      "periodEndedAt": "2002-04-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-04-20",
+      "periodEndedAt": "2002-04-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-04-27",
+      "periodEndedAt": "2002-05-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-05-04",
+      "periodEndedAt": "2002-05-10",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-saturn-classic-team-car-gravel-2002"
+      ],
+      "reason": "Broader contemporary-source recovery verified the Saturn Cycling Classic change-point outside the literal Cyclingnews term census; the draft remains human-review only."
+    },
+    {
+      "periodStartedAt": "2002-05-11",
+      "periodEndedAt": "2002-05-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-05-18",
+      "periodEndedAt": "2002-05-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-05-25",
+      "periodEndedAt": "2002-05-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-06-01",
+      "periodEndedAt": "2002-06-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-06-08",
+      "periodEndedAt": "2002-06-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-06-15",
+      "periodEndedAt": "2002-06-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-06-22",
+      "periodEndedAt": "2002-06-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-06-29",
+      "periodEndedAt": "2002-07-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-07-06",
+      "periodEndedAt": "2002-07-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-07-13",
+      "periodEndedAt": "2002-07-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-07-20",
+      "periodEndedAt": "2002-07-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-07-27",
+      "periodEndedAt": "2002-08-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-08-03",
+      "periodEndedAt": "2002-08-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-08-10",
+      "periodEndedAt": "2002-08-16",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-saturn-classic-team-car-gravel-2002"
+      ],
+      "reason": "Broader contemporary-source recovery verified the Saturn Cycling Classic change-point outside the literal Cyclingnews term census; the draft remains human-review only."
+    },
+    {
+      "periodStartedAt": "2002-08-17",
+      "periodEndedAt": "2002-08-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-08-24",
+      "periodEndedAt": "2002-08-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-08-31",
+      "periodEndedAt": "2002-09-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-09-07",
+      "periodEndedAt": "2002-09-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-09-14",
+      "periodEndedAt": "2002-09-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-09-21",
+      "periodEndedAt": "2002-09-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-09-28",
+      "periodEndedAt": "2002-10-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-10-05",
+      "periodEndedAt": "2002-10-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-10-12",
+      "periodEndedAt": "2002-10-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-10-19",
+      "periodEndedAt": "2002-10-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-10-26",
+      "periodEndedAt": "2002-11-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-11-02",
+      "periodEndedAt": "2002-11-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-11-09",
+      "periodEndedAt": "2002-11-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-11-16",
+      "periodEndedAt": "2002-11-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-11-23",
+      "periodEndedAt": "2002-11-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-11-30",
+      "periodEndedAt": "2002-12-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-12-07",
+      "periodEndedAt": "2002-12-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-12-14",
+      "periodEndedAt": "2002-12-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-12-21",
+      "periodEndedAt": "2002-12-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2002-12-28",
+      "periodEndedAt": "2003-01-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+    }
+  ],
+  "updatedAt": "2026-08-28T20:45:00Z"
+}

--- a/data/gravel-weekly/history/2002-saturn-classic-team-car-gravel.json
+++ b/data/gravel-weekly/history/2002-saturn-classic-team-car-gravel.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-saturn-classic-team-car-gravel-2002",
+  "activeFrom": "2002-05-07",
+  "activeThrough": "2002-08-10",
+  "status": "draft",
+  "headline": "Before Gravel Bikes, Colorado Solved Gravel With a Team Car",
+  "point": "The 2002 Saturn Cycling Classic sent elite road and mountain-bike racers across 140 Colorado miles, more than 14,000 feet of climbing, and dirt passes rough enough that leaders switched from road bikes to mountain bikes and back. The rules restricted replacement bikes to team vehicles, and Cyclingnews noted that only front riders could reliably receive the advantage. Modern gravel's one-bike and self-support norms were not merely aesthetic rebellion; they made mixed-surface racing possible without a moving equipment warehouse.",
+  "priorJudgment": "Gravel bikes and self-support rules were lifestyle packaging applied to terrain that road racing could already handle.",
+  "changedJudgment": "The Saturn Classic shows the opposite. Pro road racing could traverse extreme mixed surfaces, but its solution depended on multiple bikes, team cars, caravan position, and unequal access. The later gravel format simplified a logistics problem as much as it created a new discipline.",
+  "stakes": "The origin story should distinguish riding gravel from building a repeatable gravel sport. That distinction explains why equipment convergence and equal support rules mattered: they let the route select the rider without first selecting who had a team vehicle.",
+  "credibleOpposition": "The Saturn Classic was explicitly a professional road race, not a gravel event, and bike changes were a race-specific response to an unusually rough descent rather than proof that a new discipline existed. Its sponsor's 2003 withdrawal was attributed to marketing priorities and a difficult economy, not the equipment model. The connection to modern gravel is an editorial interpretation of format and access.",
+  "whatHappened": "Saturn announced its August 10, 2002 Cycling Classic as a 140-mile Boulder-to-Breckenridge race with more than 14,000 feet of climbing on paved and dirt roads. Cyclingnews reported that Oh My God Road mixed rough pavement, dirt, and gravel before the race reached 11,671-foot Guanella Pass. The climb deteriorated into rough dirt, followed by a 3,000-foot dirt descent. Many leaders changed to mountain bikes, but rules required replacement bikes to come from a team vehicle in the race caravan; only riders near the front could count on the car getting ahead in time to provide another road bike at the pavement. Velo's live report recorded the leaders switching to mountain bikes at the summit and Jonathan Vaughters waiting at the bottom because his team car had not arrived. Chris Wherry won in 7:09:28. In March 2003, Saturn withdrew title sponsorship and the organizer said the event's future was uncertain.",
+  "take": "Model draft, not Matti's approved view: Before gravel bikes, Colorado solved gravel with a convoy. The leaders climbed Guanella Pass on road bikes, changed into mountain bikes at 11,671 feet, dropped 3,000 feet down a dirt road, then asked the team car to please return their road bikes before the race resumed. Everyone behind them received the traditional privateer package: worse equipment and no menu. This is the missing link between mixed-surface road racing and gravel. The terrain was already magnificent. The delivery system was absurd. Gravel's breakthrough was not discovering dirt; it was deciding one bike and the same support rules should be enough for everybody.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The route, elevation, terrain, bike changes, caravan restriction, and finishing result are documented by contemporary sources. The AutoChannel page republishes a Saturn press release rather than independent reporting. Contemporary sources classify the event as road racing, and no source claims that its equipment logistics caused its disappearance. The argument that one-bike and self-support norms made later gravel more scalable is editorial analysis requiring human review.",
+  "editorialScore": 99,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_saturn_classic_route_2002",
+      "canonicalUrl": "https://www.theautochannel.com/news/2002/05/07/139989.html",
+      "publisher": "The Auto Channel / Saturn press release",
+      "publishedAt": "2002-05-07T12:00:00-04:00",
+      "quoteExcerpt": "140-mile adventure across the Continental Divide from Boulder to Breckenridge",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_saturn_classic_caravan_access_2002",
+      "canonicalUrl": "https://autobus.cyclingnews.com/road/2002/aug02/saturnclassic02/?id=results",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2002-08-10T12:00:00-06:00",
+      "quoteExcerpt": "only the very front riders from each team can have this advantage",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_saturn_classic_bike_switch_2002",
+      "canonicalUrl": "https://velo.outsideonline.com/road/road-racing/wherry-takes-emotional-win-at-saturn-classic/?scope=anon",
+      "publisher": "VeloNews",
+      "publishedAt": "2002-08-10T01:00:00-06:00",
+      "quoteExcerpt": "All switched to mountain bikes for the descent.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_saturn_classic_sponsor_withdrawal_2003",
+      "canonicalUrl": "https://velo.outsideonline.com/news/saturn-withdraws-support-from-classic/?scope=anon",
+      "publisher": "VeloNews",
+      "publishedAt": "2003-03-18T01:00:00-07:00",
+      "quoteExcerpt": "we have decided to focus on long-standing components of the Saturn Cycling program",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:saturn-cycling-classic",
+      "fieldPath": "race.history",
+      "claimIds": [
+        "claim_saturn_classic_route_2002",
+        "claim_saturn_classic_caravan_access_2002",
+        "claim_saturn_classic_bike_switch_2002",
+        "claim_saturn_classic_sponsor_withdrawal_2003"
+      ],
+      "confidence": 0.95,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T20:45:00Z",
+  "contentHash": "eb22ffeea50a11740a62fadc5748eb1fc2e053c0481f247de74209cc7a19be16"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -946,6 +946,20 @@ def test_2003_backfill_ledger_reconciles_the_complete_legacy_archive_census():
     assert validated["complete"] is True
 
 
+def test_2002_backfill_ledger_accounts_for_the_complete_legacy_archive_census():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2002.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert validated["sourceArchiveCoverage"] == "complete"
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 51
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- add the human-review-only Saturn Cycling Classic origin-story change-point
- account for all 53 Friday-ended windows from the complete 12/12 legacy archive census
- connect the event to a review-only proposed race-history record without auto-fixing any race data
- preserve the road-race classification and causal uncertainty

## Verification
- 55 focused Gravel Weekly tests passed
- 2002 history entry validated
- 2002 backfill ledger validated
- both anti-slop detectors: zero findings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and contract tests only; content stays draft with no auto-publish or automatic race-data fixes.
> 
> **Overview**
> Adds the **2002 Gravel Weekly backfill ledger**, closing all 53 weekly windows under a complete legacy Cyclingnews archive census with **zero source cards**. Fifty-one weeks are **`explicit_gap`**; two (early May announcement and mid-August race) are **`covered_by_draft`** and point at a new history entry.
> 
> Introduces a **draft** history entry for the 2002 Saturn Cycling Classic—team-car bike swaps, caravan access, and an editorial link to modern gravel logistics—backed by contemporary receipts, explicit uncertainty, and a **`raceImpacts`** row for **`gravel:saturn-cycling-classic`** with **`autoFixAllowed: false`**. Ledger and entry both require human approval and disallow auto-publish.
> 
> Adds **`test_2002_backfill_ledger_accounts_for_the_complete_legacy_archive_census`** to lock disposition counts and validation via **`validate_backfill_ledger`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 280c15d77d013c08b88bf50f9bd04460a7b48e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->