### PR TITLE
Complete 2000 Gravel Weekly narrative ledger

### DIFF
--- a/data/gravel-weekly/backfill/2000.json
+++ b/data/gravel-weekly/backfill/2000.json
@@ -1,24 +1,24 @@
 {
   "schemaVersion": "gravel-weekly-backfill-ledger/v1",
-  "year": 2001,
-  "asOf": "2001-12-31T23:59:59.000Z",
-  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/78",
-  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33181924695",
+  "year": 2000,
+  "asOf": "2000-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/79",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33181744607",
   "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
   "sourceArchiveCoverage": "unavailable",
   "sourceArchiveErrors": [
-    "https://autobus.cyclingnews.com/results/?id=2001/jan01: legacy Cyclingnews archive is unavailable",
-    "https://autobus.cyclingnews.com/results/?id=2001/feb01: legacy Cyclingnews archive is unavailable",
-    "https://autobus.cyclingnews.com/results/?id=2001/mar01: legacy Cyclingnews archive is unavailable",
-    "https://autobus.cyclingnews.com/results/?id=2001/apr01: legacy Cyclingnews archive is unavailable",
-    "https://autobus.cyclingnews.com/results/?id=2001/may01: legacy Cyclingnews archive is unavailable",
-    "https://autobus.cyclingnews.com/results/?id=2001/jun01: legacy Cyclingnews archive is unavailable",
-    "https://autobus.cyclingnews.com/results/?id=2001/jul01: legacy Cyclingnews archive is unavailable",
-    "https://autobus.cyclingnews.com/results/?id=2001/aug01: legacy Cyclingnews archive is unavailable",
-    "https://autobus.cyclingnews.com/results/?id=2001/sep01: legacy Cyclingnews archive is unavailable",
-    "https://autobus.cyclingnews.com/results/?id=2001/oct01: legacy Cyclingnews archive is unavailable",
-    "https://autobus.cyclingnews.com/results/?id=2001/nov01: legacy Cyclingnews archive is unavailable",
-    "https://autobus.cyclingnews.com/results/?id=2001/dec01: legacy Cyclingnews archive is unavailable"
+    "https://autobus.cyclingnews.com/results/?id=2000/jan00: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2000/feb00: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2000/mar00: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2000/apr00: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2000/may00: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2000/jun00: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2000/jul00: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2000/aug00: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2000/sep00: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2000/oct00: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2000/nov00: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2000/dec00: legacy Cyclingnews archive is unavailable"
   ],
   "sourceCardCount": 0,
   "complete": true,
@@ -26,429 +26,433 @@
   "autoPublishAllowed": false,
   "weeks": [
     {
+      "periodStartedAt": "2000-01-01",
+      "periodEndedAt": "2000-01-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-01-08",
+      "periodEndedAt": "2000-01-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-01-15",
+      "periodEndedAt": "2000-01-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-01-22",
+      "periodEndedAt": "2000-01-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-01-29",
+      "periodEndedAt": "2000-02-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-02-05",
+      "periodEndedAt": "2000-02-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-02-12",
+      "periodEndedAt": "2000-02-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-02-19",
+      "periodEndedAt": "2000-02-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-02-26",
+      "periodEndedAt": "2000-03-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-03-04",
+      "periodEndedAt": "2000-03-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-03-11",
+      "periodEndedAt": "2000-03-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-03-18",
+      "periodEndedAt": "2000-03-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-03-25",
+      "periodEndedAt": "2000-03-31",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-04-01",
+      "periodEndedAt": "2000-04-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-04-08",
+      "periodEndedAt": "2000-04-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-04-15",
+      "periodEndedAt": "2000-04-21",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-04-22",
+      "periodEndedAt": "2000-04-28",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-04-29",
+      "periodEndedAt": "2000-05-05",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-05-06",
+      "periodEndedAt": "2000-05-12",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-05-13",
+      "periodEndedAt": "2000-05-19",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-05-20",
+      "periodEndedAt": "2000-05-26",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-05-27",
+      "periodEndedAt": "2000-06-02",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-06-03",
+      "periodEndedAt": "2000-06-09",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-06-10",
+      "periodEndedAt": "2000-06-16",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-06-17",
+      "periodEndedAt": "2000-06-23",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-06-24",
+      "periodEndedAt": "2000-06-30",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-07-01",
+      "periodEndedAt": "2000-07-07",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-07-08",
+      "periodEndedAt": "2000-07-14",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-07-15",
+      "periodEndedAt": "2000-07-21",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-zinger-women-halftime-show-2000"
+      ],
+      "reason": "Broader contemporary-source recovery found the inaugural Zinger's exclusion of women from its 138-mile mixed-surface race and Vicky Sama's on-course protest; the draft clears the editorial gates but remains unpublished pending human approval."
+    },
+    {
+      "periodStartedAt": "2000-07-22",
+      "periodEndedAt": "2000-07-28",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-zinger-women-halftime-show-2000"
+      ],
+      "reason": "Cyclingnews published the post-race protest account and organizer response in this window; the resulting historical draft remains unpublished pending human approval."
+    },
+    {
+      "periodStartedAt": "2000-07-29",
+      "periodEndedAt": "2000-08-04",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-08-05",
+      "periodEndedAt": "2000-08-11",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-08-12",
+      "periodEndedAt": "2000-08-18",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-08-19",
+      "periodEndedAt": "2000-08-25",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-08-26",
+      "periodEndedAt": "2000-09-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-09-02",
+      "periodEndedAt": "2000-09-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-09-09",
+      "periodEndedAt": "2000-09-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-09-16",
+      "periodEndedAt": "2000-09-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-09-23",
+      "periodEndedAt": "2000-09-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-09-30",
+      "periodEndedAt": "2000-10-06",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-10-07",
+      "periodEndedAt": "2000-10-13",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-10-14",
+      "periodEndedAt": "2000-10-20",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-10-21",
+      "periodEndedAt": "2000-10-27",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-10-28",
+      "periodEndedAt": "2000-11-03",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-11-04",
+      "periodEndedAt": "2000-11-10",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-11-11",
+      "periodEndedAt": "2000-11-17",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-11-18",
+      "periodEndedAt": "2000-11-24",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-11-25",
+      "periodEndedAt": "2000-12-01",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-12-02",
+      "periodEndedAt": "2000-12-08",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-12-09",
+      "periodEndedAt": "2000-12-15",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-12-16",
+      "periodEndedAt": "2000-12-22",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
+      "periodStartedAt": "2000-12-23",
+      "periodEndedAt": "2000-12-29",
+      "sourceCardCount": 0,
+      "disposition": "explicit_gap",
+      "entryIds": [],
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+    },
+    {
       "periodStartedAt": "2000-12-30",
       "periodEndedAt": "2001-01-05",
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
       "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-01-06",
-      "periodEndedAt": "2001-01-12",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-01-13",
-      "periodEndedAt": "2001-01-19",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-01-20",
-      "periodEndedAt": "2001-01-26",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-01-27",
-      "periodEndedAt": "2001-02-02",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-02-03",
-      "periodEndedAt": "2001-02-09",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-02-10",
-      "periodEndedAt": "2001-02-16",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-02-17",
-      "periodEndedAt": "2001-02-23",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-02-24",
-      "periodEndedAt": "2001-03-02",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-03-03",
-      "periodEndedAt": "2001-03-09",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-03-10",
-      "periodEndedAt": "2001-03-16",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-03-17",
-      "periodEndedAt": "2001-03-23",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-03-24",
-      "periodEndedAt": "2001-03-30",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-03-31",
-      "periodEndedAt": "2001-04-06",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-04-07",
-      "periodEndedAt": "2001-04-13",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-04-14",
-      "periodEndedAt": "2001-04-20",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-04-21",
-      "periodEndedAt": "2001-04-27",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-04-28",
-      "periodEndedAt": "2001-05-04",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-05-05",
-      "periodEndedAt": "2001-05-11",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-05-12",
-      "periodEndedAt": "2001-05-18",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-05-19",
-      "periodEndedAt": "2001-05-25",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-05-26",
-      "periodEndedAt": "2001-06-01",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-06-02",
-      "periodEndedAt": "2001-06-08",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-06-09",
-      "periodEndedAt": "2001-06-15",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-06-16",
-      "periodEndedAt": "2001-06-22",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-06-23",
-      "periodEndedAt": "2001-06-29",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-06-30",
-      "periodEndedAt": "2001-07-06",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-07-07",
-      "periodEndedAt": "2001-07-13",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-07-14",
-      "periodEndedAt": "2001-07-20",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-07-21",
-      "periodEndedAt": "2001-07-27",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-07-28",
-      "periodEndedAt": "2001-08-03",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-08-04",
-      "periodEndedAt": "2001-08-10",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-08-11",
-      "periodEndedAt": "2001-08-17",
-      "sourceCardCount": 0,
-      "disposition": "rejected",
-      "entryIds": [],
-      "reason": "Broader recovery found the 2001 Saturn Cycling Classic, but its bike-change and caravan-access argument is represented more completely by the selected 2002 entry; repeating it would add chronology without a new judgment."
-    },
-    {
-      "periodStartedAt": "2001-08-18",
-      "periodEndedAt": "2001-08-24",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-08-25",
-      "periodEndedAt": "2001-08-31",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-09-01",
-      "periodEndedAt": "2001-09-07",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-09-08",
-      "periodEndedAt": "2001-09-14",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-09-15",
-      "periodEndedAt": "2001-09-21",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-09-22",
-      "periodEndedAt": "2001-09-28",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-09-29",
-      "periodEndedAt": "2001-10-05",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-10-06",
-      "periodEndedAt": "2001-10-12",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-10-13",
-      "periodEndedAt": "2001-10-19",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-10-20",
-      "periodEndedAt": "2001-10-26",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-10-27",
-      "periodEndedAt": "2001-11-02",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-11-03",
-      "periodEndedAt": "2001-11-09",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-11-10",
-      "periodEndedAt": "2001-11-16",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-11-17",
-      "periodEndedAt": "2001-11-23",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-11-24",
-      "periodEndedAt": "2001-11-30",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-12-01",
-      "periodEndedAt": "2001-12-07",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-12-08",
-      "periodEndedAt": "2001-12-14",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-12-15",
-      "periodEndedAt": "2001-12-21",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-12-22",
-      "periodEndedAt": "2001-12-28",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
-    },
-    {
-      "periodStartedAt": "2001-12-29",
-      "periodEndedAt": "2002-01-04",
-      "sourceCardCount": 0,
-      "disposition": "explicit_gap",
-      "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
     }
   ],
-  "updatedAt": "2026-08-28T21:00:00Z"
+  "updatedAt": "2026-08-28T14:39:13Z"
 }

--- a/data/gravel-weekly/backfill/2002.json
+++ b/data/gravel-weekly/backfill/2002.json
@@ -3,10 +3,15 @@
   "year": 2002,
   "asOf": "2002-12-31T23:59:59.000Z",
   "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/77",
-  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33179818962",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33181999249",
   "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
-  "sourceArchiveCoverage": "complete",
-  "sourceArchiveErrors": [],
+  "sourceArchiveCoverage": "partial",
+  "sourceArchiveErrors": [
+    "https://autobus.cyclingnews.com/results/?id=2002/jan02: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2002/feb02: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2002/mar02: legacy Cyclingnews archive is unavailable",
+    "https://autobus.cyclingnews.com/results/?id=2002/apr02: legacy Cyclingnews archive is unavailable"
+  ],
   "sourceCardCount": 0,
   "complete": true,
   "humanApprovalRequired": true,
@@ -18,7 +23,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-01-05",
@@ -26,7 +31,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-01-12",
@@ -34,7 +39,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-01-19",
@@ -42,7 +47,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-01-26",
@@ -50,7 +55,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-02-02",
@@ -58,7 +63,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-02-09",
@@ -66,7 +71,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-02-16",
@@ -74,7 +79,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-02-23",
@@ -82,7 +87,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-03-02",
@@ -90,7 +95,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-03-09",
@@ -98,7 +103,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-03-16",
@@ -106,7 +111,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-03-23",
@@ -114,7 +119,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-03-30",
@@ -122,7 +127,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-04-06",
@@ -130,7 +135,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-04-13",
@@ -138,7 +143,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-04-20",
@@ -146,7 +151,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-04-27",
@@ -154,7 +159,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-05-04",
@@ -172,7 +177,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-05-18",
@@ -180,7 +185,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-05-25",
@@ -188,7 +193,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-06-01",
@@ -196,7 +201,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-06-08",
@@ -204,7 +209,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-06-15",
@@ -212,7 +217,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-06-22",
@@ -220,7 +225,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-06-29",
@@ -228,7 +233,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-07-06",
@@ -236,7 +241,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-07-13",
@@ -244,7 +249,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-07-20",
@@ -252,7 +257,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-07-27",
@@ -260,7 +265,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-08-03",
@@ -268,7 +273,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-08-10",
@@ -286,7 +291,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-08-24",
@@ -294,7 +299,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-08-31",
@@ -302,7 +307,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-09-07",
@@ -310,7 +315,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-09-14",
@@ -318,7 +323,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-09-21",
@@ -326,7 +331,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-09-28",
@@ -334,7 +339,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-10-05",
@@ -342,7 +347,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-10-12",
@@ -350,7 +355,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-10-19",
@@ -358,7 +363,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-10-26",
@@ -366,7 +371,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-11-02",
@@ -374,7 +379,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-11-09",
@@ -382,7 +387,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-11-16",
@@ -390,7 +395,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-11-23",
@@ -398,7 +403,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-11-30",
@@ -406,7 +411,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-12-07",
@@ -414,7 +419,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-12-14",
@@ -422,7 +427,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-12-21",
@@ -430,7 +435,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     },
     {
       "periodStartedAt": "2002-12-28",
@@ -438,7 +443,7 @@
       "sourceCardCount": 0,
       "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The complete legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     }
   ],
   "updatedAt": "2026-08-28T20:45:00Z"

--- a/data/gravel-weekly/history/2000-zinger-women-halftime-show.json
+++ b/data/gravel-weekly/history/2000-zinger-women-halftime-show.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-zinger-women-halftime-show-2000",
+  "activeFrom": "2000-07-15",
+  "activeThrough": "2000-07-23",
+  "status": "draft",
+  "headline": "Colorado Built a Gravel Epic, Then Made Women the Halftime Show",
+  "point": "The inaugural Zinger Cycling Challenge supplied nearly every ingredient of a modern Colorado gravel spectacle: 138 to 140 miles, 14,000 feet of climbing, dirt mountain passes, road racers mixing with mountain bikers, and only 20 finishers. It reserved that epic for men. Women received a 45-minute elimination criterium in Breckenridge; one team boycotted, and Vicky Sama rode onto the men's course wearing a 'Women Can Climb Too!' sign until police threatened arrest. Gravel's later equal-distance ideal did not grow automatically from adventurous terrain. Riders had to contest who was allowed to be adventurous.",
+  "priorJudgment": "Gravel's inclusive reputation was a natural consequence of escaping traditional road-racing institutions and putting everyone on the same dirt roads.",
+  "changedJudgment": "The Zinger shows that terrain does not create equality. A race can look uncannily like modern gravel while reproducing the old hierarchy in its start list, distance, presentation, and support. Inclusion arrived through argument, boycott, protest, and changed expectations—not through dirt alone.",
+  "stakes": "Modern gravel routinely sells participation, equal distance, and equal recognition as part of its identity. Remembering the Zinger's launch prevents that progress from being mistaken for an original setting. It also gives current disputes about field access, coverage, safety, and prize money a specific historical baseline instead of a vague morality tale.",
+  "credibleOpposition": "Race director Len Pettyjohn said the event lacked enough state patrol, moto marshals, experienced drivers, and other personnel to operate two safe race caravans. Women did have a separate criterium, and the Zinger was sanctioned and described as road racing rather than gravel. The connection to modern gravel is therefore an editorial comparison of terrain, format, and values—not a claim that the Zinger belonged to a category that did not yet exist.",
+  "whatHappened": "On July 15, 2000, the first Zinger Cycling Challenge ran from Boulder to Breckenridge across roughly 140 miles, multiple high-altitude climbs, and dirt sections including Oh My God Road and Guanella Pass. Cyclingnews reported that three of the first five finishers were mountain bikers and that only 20 men finished. The women's event was a 45-minute miss-and-out criterium on the Breckenridge finishing circuit. Charles Schwab's women's team declined to attend, citing disparities in distance, prize money, and promotion. Local racer Vicky Sama said the organizer had told her women could not compete in such a race. She rode ahead of the men's field with a 'Women Can Climb Too!' sign, completed a pass with the race, rejoined after an initial police stop, and was then held under threat of arrest until the caravan passed. Pettyjohn answered that the staffing and public-safety resources required for a concurrent women's road race did not exist. In 2023, USA Cycling introduced its gravel national championship with equal elite distance and prize money and publicly described those terms as representative of a true American gravel race.",
+  "take": "Model draft, not Matti's approved view: The inaugural Zinger invented half of modern gravel in one afternoon: enormous distance, dirt mountain passes, roadies getting mugged by mountain bikers, and a finish list that looked like a casualty report. Then it put the women in a 45-minute elimination crit and called that the program. Vicky Sama supplied the only sensible editorial note. She rode onto the men's route wearing 'Women Can Climb Too!' and stayed with the race until police threatened arrest. That is not a quirky footnote. Gravel did not inherit equality from dirt; people had to drag it there while organizers explained that logistics, staffing, and apparently female physiology made the obvious impossible. Twenty-three years later, USA Cycling called equal distance and equal money the definition of a true American gravel race. The dirt was never the radical part. Letting everyone race it was.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The contemporary record conflicts slightly on route length and climbing count: the race report and rider diary use 140 miles and six climbs, while the post-race account uses 138 miles and seven mountain passes. Vicky Sama's protest narrative, the Charles Schwab boycott letter, and the organizer's response are preserved as first-person statements within one Cyclingnews page; an independent contemporary publication has not yet been recovered. No source calls the event gravel in 2000, and the comparison to later gravel equality is editorial analysis requiring human review.",
+  "editorialScore": 100,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_zinger_mixed_surface_results_2000",
+      "canonicalUrl": "https://autobus.cyclingnews.com/results/2000/jul00/zinger00.shtml",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2000-07-15T12:00:00-06:00",
+      "quoteExcerpt": "three of those five would be mountain bikers",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_zinger_rider_diary_2000",
+      "canonicalUrl": "https://autobus.cyclingnews.com/results/2000/diary00/lieswyn007.shtml",
+      "publisher": "John Lieswyn diary / Cyclingnews",
+      "publishedAt": "2000-07-15T18:00:00-06:00",
+      "quoteExcerpt": "140 miles, 6 climbs, several above 11,000 feet altitude",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_zinger_women_protest_2000",
+      "canonicalUrl": "https://autobus.cyclingnews.com/results/2000/jul00/jul23news.shtml",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2000-07-23T12:00:00-06:00",
+      "quoteExcerpt": "I had a sign on my back that read 'Women Can Climb Too!'",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_gravel_nationals_equal_distance_pay_2023",
+      "canonicalUrl": "https://usacycling.org/article/inaugural-usa-cycling-gravel-national-championship-heads-to-nebraska",
+      "publisher": "USA Cycling",
+      "publishedAt": "2023-03-16T09:55:00-06:00",
+      "quoteExcerpt": "The course has equal distance and prize money",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:zinger-cycling-challenge",
+      "fieldPath": "race.history",
+      "claimIds": [
+        "claim_zinger_mixed_surface_results_2000",
+        "claim_zinger_rider_diary_2000",
+        "claim_zinger_women_protest_2000",
+        "claim_gravel_nationals_equal_distance_pay_2023"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T14:39:13Z",
+  "contentHash": "8c349be7b5ddf2feeb69d65bba415eda3602423449843fd880810ffae7ec7683"
+}

--- a/scripts/validate_gravel_weekly_backfill.py
+++ b/scripts/validate_gravel_weekly_backfill.py
@@ -53,6 +53,16 @@ def validate_backfill_ledger(value: Any, history_entries: list[dict[str, Any]]) 
     source_archive_coverage = ledger.get("sourceArchiveCoverage")
     if source_archive_coverage is not None and source_archive_coverage not in {"complete", "partial", "unavailable"}:
         raise IssueValidationError("sourceArchiveCoverage is invalid")
+    source_archive_errors_value = ledger.get("sourceArchiveErrors")
+    if source_archive_errors_value is not None:
+        source_archive_errors = [
+            _text(error, f"sourceArchiveErrors[{index}]", 2_000)
+            for index, error in enumerate(_list(source_archive_errors_value, "sourceArchiveErrors", 12))
+        ]
+        if source_archive_coverage == "complete" and source_archive_errors:
+            raise IssueValidationError("complete sourceArchiveCoverage cannot contain sourceArchiveErrors")
+        if source_archive_coverage in {"partial", "unavailable"} and not source_archive_errors:
+            raise IssueValidationError(f"{source_archive_coverage} sourceArchiveCoverage requires sourceArchiveErrors")
 
     histories = {entry["entryId"]: entry for entry in history_entries}
     weeks = _list(ledger.get("weeks"), "weeks", 54)

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -946,13 +946,14 @@ def test_2003_backfill_ledger_reconciles_the_complete_legacy_archive_census():
     assert validated["complete"] is True
 
 
-def test_2002_backfill_ledger_accounts_for_the_complete_legacy_archive_census():
+def test_2002_backfill_ledger_accounts_for_the_partial_legacy_archive_census():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2002.json").read_text())
     validated = validate_backfill_ledger(ledger, histories)
 
     assert len(validated["weeks"]) == 53
-    assert validated["sourceArchiveCoverage"] == "complete"
+    assert validated["sourceArchiveCoverage"] == "partial"
+    assert len(validated["sourceArchiveErrors"]) == 4
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 51
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
@@ -966,11 +967,27 @@ def test_2001_backfill_ledger_rejects_a_redundant_saturn_story():
     validated = validate_backfill_ledger(ledger, histories)
 
     assert len(validated["weeks"]) == 53
-    assert validated["sourceArchiveCoverage"] == "complete"
+    assert validated["sourceArchiveCoverage"] == "unavailable"
+    assert len(validated["sourceArchiveErrors"]) == 12
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 52
     assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 1
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
+
+
+def test_2000_backfill_ledger_accounts_for_the_unavailable_legacy_archive():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2000.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert validated["sourceArchiveCoverage"] == "unavailable"
+    assert len(validated["sourceArchiveErrors"]) == 12
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 51
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 0
     assert validated["complete"] is True
 
 


### PR DESCRIPTION
## Summary
- add a 2000 Zinger historical draft on women being excluded from the mixed-surface epic and Vicky Sama’s on-course protest
- account for all 53 weeks with 51 explicit gaps and two draft-covered windows
- correct 2000–2001 automated archive coverage to unavailable and 2002 to partial after dead-end-shell detection
- validate archive errors consistently and keep every publication/race impact human-review-only

## Verification
- full suite: 7,858 passed, 331 skipped
- Gravel Weekly focused suite: 57 passed
- all 68 historical entries and 27 year ledgers validate
- both anti-slop detectors: zero findings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly editorial JSON and stricter ledger validation; publication remains human-review-only with no auto-publish changes.
> 
> **Overview**
> Adds the **2000** Gravel Weekly backfill ledger and a **draft** history entry on the inaugural Zinger Cycling Challenge—women excluded from the long mixed-surface race and Vicky Sama’s on-course protest—with two mid-July weeks marked `covered_by_draft` and the rest as explicit gaps under **unavailable** legacy Cyclingnews archive coverage.
> 
> **Reclassifies** automated archive metadata for **2001** (`unavailable`, 12 monthly errors) and **2002** (`partial`, four errors), and rewrites weekly gap reasons so they cite archive unavailability or partial census instead of a “complete” census. Backfill validation now **requires** `sourceArchiveErrors` when coverage is `partial` or `unavailable`, and forbids errors when coverage is `complete`; tests add **2000** and update **2001**/**2002** expectations accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d657619ff12432aadead84920ce4519b8d70ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->