### PR TITLE
Open 1995 Gravel Weekly archival backfill

### DIFF
--- a/data/gravel-weekly/backfill/1995.json
+++ b/data/gravel-weekly/backfill/1995.json
@@ -1,0 +1,445 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 1995,
+  "asOf": "1995-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/83",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33182484781",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceArchiveCoverage": "unavailable",
+  "sourceArchiveErrors": [
+    "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
+  ],
+  "sourceCardCount": 0,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "1994-12-31",
+      "periodEndedAt": "1995-01-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-01-07",
+      "periodEndedAt": "1995-01-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-01-14",
+      "periodEndedAt": "1995-01-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-01-21",
+      "periodEndedAt": "1995-01-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-01-28",
+      "periodEndedAt": "1995-02-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-02-04",
+      "periodEndedAt": "1995-02-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-02-11",
+      "periodEndedAt": "1995-02-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-02-18",
+      "periodEndedAt": "1995-02-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-02-25",
+      "periodEndedAt": "1995-03-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-03-04",
+      "periodEndedAt": "1995-03-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-03-11",
+      "periodEndedAt": "1995-03-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-03-18",
+      "periodEndedAt": "1995-03-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-03-25",
+      "periodEndedAt": "1995-03-31",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-04-01",
+      "periodEndedAt": "1995-04-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-04-08",
+      "periodEndedAt": "1995-04-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-04-15",
+      "periodEndedAt": "1995-04-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-04-22",
+      "periodEndedAt": "1995-04-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-04-29",
+      "periodEndedAt": "1995-05-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-05-06",
+      "periodEndedAt": "1995-05-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-05-13",
+      "periodEndedAt": "1995-05-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-05-20",
+      "periodEndedAt": "1995-05-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-05-27",
+      "periodEndedAt": "1995-06-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-06-03",
+      "periodEndedAt": "1995-06-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-06-10",
+      "periodEndedAt": "1995-06-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-06-17",
+      "periodEndedAt": "1995-06-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-06-24",
+      "periodEndedAt": "1995-06-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-07-01",
+      "periodEndedAt": "1995-07-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-07-08",
+      "periodEndedAt": "1995-07-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-07-15",
+      "periodEndedAt": "1995-07-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-07-22",
+      "periodEndedAt": "1995-07-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-07-29",
+      "periodEndedAt": "1995-08-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-08-05",
+      "periodEndedAt": "1995-08-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-08-12",
+      "periodEndedAt": "1995-08-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-08-19",
+      "periodEndedAt": "1995-08-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-08-26",
+      "periodEndedAt": "1995-09-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-09-02",
+      "periodEndedAt": "1995-09-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-09-09",
+      "periodEndedAt": "1995-09-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-09-16",
+      "periodEndedAt": "1995-09-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-09-23",
+      "periodEndedAt": "1995-09-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-09-30",
+      "periodEndedAt": "1995-10-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-10-07",
+      "periodEndedAt": "1995-10-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-10-14",
+      "periodEndedAt": "1995-10-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-10-21",
+      "periodEndedAt": "1995-10-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-10-28",
+      "periodEndedAt": "1995-11-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-11-04",
+      "periodEndedAt": "1995-11-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-11-11",
+      "periodEndedAt": "1995-11-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-11-18",
+      "periodEndedAt": "1995-11-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-11-25",
+      "periodEndedAt": "1995-12-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-12-02",
+      "periodEndedAt": "1995-12-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-12-09",
+      "periodEndedAt": "1995-12-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-12-16",
+      "periodEndedAt": "1995-12-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-12-23",
+      "periodEndedAt": "1995-12-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1995-12-30",
+      "periodEndedAt": "1996-01-05",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-flint-hills-death-ride-spite-1995"
+      ],
+      "reason": "Manual archival recovery found The Land Institute's Fall 1995 report documenting the 100K Flint Hills Death Ride and roughly 400 participants; the resulting draft remains unpublished pending human approval."
+    }
+  ],
+  "updatedAt": "2026-08-28T14:55:33Z"
+}

--- a/data/gravel-weekly/history/1995-flint-hills-death-ride-spite.json
+++ b/data/gravel-weekly/history/1995-flint-hills-death-ride-spite.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-flint-hills-death-ride-spite-1995",
+  "activeFrom": "1995-08-01",
+  "activeThrough": "1995-12-31",
+  "status": "draft",
+  "headline": "Kansas Built a 400-Rider Gravel Event Out of Spite",
+  "point": "By 1995, the annual Matfield Green Death Ride was sending roughly 400 cyclists around a 100K loop of Flint Hills backroads and using the school grounds in a town of about fifty as its start and finish. Organizer John Hobbs later explained that the route grew from Kansans getting tired of cycling media reserving adventure for California and Colorado while treating Kansas as flat and boring. The Midwest did not accidentally become gravel's center because it had spare roads. Riders deliberately turned regional dismissal into a sporting identity.",
+  "priorJudgment": "The Flint Hills became gravel's heartland mainly because its road network happened to suit a new kind of cycling that organizers discovered in the 2000s.",
+  "changedJudgment": "A mass mixed-surface culture was already operating in Matfield Green in the mid-1990s. Its organizers were not merely using available terrain; they were answering a cultural insult, proving that Kansas could produce an adventure harsher and more distinctive than the mountain-bike destinations receiving national attention.",
+  "stakes": "Gravel's origin story changes when the Flint Hills are treated as an active cultural invention rather than an empty backdrop awaiting Unbound. It also explains why place, local pride, weather, self-sufficiency, and suspicion of coastal status have remained central to the American gravel register.",
+  "credibleOpposition": "The 1995 Land Report calls the Death Ride a tour, not a race or gravel event, and does not identify participants' bicycle types. The organizer's later trail guide is proudly myth-making, uses deliberately insulting period humor, and has no recovered original publication date. Sports Illustrated and the Gravel Cycling Hall of Fame apply the gravel lineage retrospectively. The evidence supports a large Flint Hills backroad event and its regional motive, not an exclusive claim that Kansas invented gravel cycling.",
+  "whatHappened": "The Land Institute's Fall 1995 report described Matfield Green as a Kansas village of about fifty people. In the same issue, Cathy Bylinowski reported that John and Carol Sue Hobbs sponsored the annual Matfield Green Death Ride, a 100K August tour of Flint Hills backroads. About 400 cyclists used the former grade-school grounds as the start and finish; members of the Oz Bicycle Club returned in June for a volunteer work weekend as thanks. A later Death Ride trail guide said the organizers had begun exploring remote Flint Hills roads on mountain bikes in the early 1980s. They resented cycling coverage that celebrated California and Colorado while using Kansas as shorthand for flat and boring, so they combined their hardest loops into the Matfield Green 100K. The guide estimated a 20% to 30% bonk rate and said the distance was limited partly because retrieving failed riders from fifty miles out was worse than retrieving them from thirty. John Hobbs later told Sports Illustrated that the group wanted a course difficult in good conditions and nearly impossible in bad ones. The Gravel Cycling Hall of Fame dates Hobbs's event from 1989 and says it sometimes drew more than 600 riders at its peak.",
+  "take": "Model draft, not Matti's approved view: The Flint Hills did not become gravel's holy land because a branding committee discovered authenticity. A group of Kansans got tired of mountain-bike magazines treating California and Colorado as the only places where anything epic could happen and using Kansas as a synonym for flat and boring. So they built a 100K August death march through Flint Hills backroads. By 1995, roughly 400 cyclists were using the school in a town of about fifty as start and finish. The event's own history more or less admits the operating theory was regional spite, heat, wind, bad water decisions, and a 20% to 30% bonk rate. This is a better origin story than the usual garage-company bullshit. Gravel's most important geography was not discovered. It got mad.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The Fall 1995 Land Report does not print an exact publication day, so its receipt is conservatively indexed at the year-end knowledge cutoff rather than presented as a known release date. The scanned Death Ride trail guide was uploaded by the Gravel Cycling Hall of Fame in 2024, but its original compilation date is not established; it is used only as later evidence. Later sources disagree about whether Hobbs's original event ended in 2000 or continued through 2001. The 400-participant figure and 100K backroad format are contemporary; the gravel classification and argument about regional identity are retrospective analysis requiring human review.",
+  "editorialScore": 100,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_matfield_green_death_ride_100k_1995",
+      "canonicalUrl": "https://landinstitute.org/wp-content/uploads/2018/06/LR-54.pdf",
+      "publisher": "The Land Institute",
+      "publishedAt": "1995-12-31T12:00:00-06:00",
+      "quoteExcerpt": "a grueling 100K tour of Flint Hills backroads",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_matfield_green_400_cyclists_1995",
+      "canonicalUrl": "https://landinstitute.org/wp-content/uploads/2018/06/LR-54.pdf",
+      "publisher": "The Land Institute",
+      "publishedAt": "1995-12-31T12:00:00-06:00",
+      "quoteExcerpt": "some 400 cyclists to use the school grounds",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_death_ride_regional_motive_2016",
+      "canonicalUrl": "https://www.si.com/edge/2016/06/07/gravel-grinders-cycling-races-events-advice",
+      "publisher": "Sports Illustrated",
+      "publishedAt": "2016-06-07T12:00:00-04:00",
+      "quoteExcerpt": "We got tired of reading how truly epic rides were only in places like California and Colorado",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_death_ride_bonk_rate_guide_2024",
+      "canonicalUrl": "https://www.gravelcyclinghof.com/s/Death-Ride-Trail-Guide.pdf",
+      "publisher": "Gravel Cycling Hall of Fame / Death Ride Trail Guide",
+      "publishedAt": "2024-05-21T12:00:00-05:00",
+      "quoteExcerpt": "the bonk rate is between 20% and 30%",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_death_ride_peak_participation_2025",
+      "canonicalUrl": "https://www.gravelcyclinghof.com/hall-of-famers-2025/john-hobbs",
+      "publisher": "Gravel Cycling Hall of Fame",
+      "publishedAt": "2025-01-17T12:00:00-06:00",
+      "quoteExcerpt": "often attracted more than 600 riders at its peak",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:flint-hills-death-ride",
+      "fieldPath": "race.history",
+      "claimIds": [
+        "claim_matfield_green_death_ride_100k_1995",
+        "claim_matfield_green_400_cyclists_1995",
+        "claim_death_ride_regional_motive_2016",
+        "claim_death_ride_bonk_rate_guide_2024",
+        "claim_death_ride_peak_participation_2025"
+      ],
+      "confidence": 0.94,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T14:55:33Z",
+  "contentHash": "6cd45e0f9731746134a12d6b9f58acb264a6292ba2ffaa2ce997c9a73275b655"
+}

--- a/scripts/validate_gravel_weekly_backfill.py
+++ b/scripts/validate_gravel_weekly_backfill.py
@@ -39,7 +39,7 @@ def validate_backfill_ledger(value: Any, history_entries: list[dict[str, Any]]) 
     if ledger.get("schemaVersion") != "gravel-weekly-backfill-ledger/v1":
         raise IssueValidationError("unsupported Gravel Weekly backfill ledger schema")
     year = ledger.get("year")
-    if not isinstance(year, int) or isinstance(year, bool) or not 2000 <= year <= 2100:
+    if not isinstance(year, int) or isinstance(year, bool) or not 1980 <= year <= 2100:
         raise IssueValidationError("backfill year is invalid")
     _iso(ledger.get("asOf"), "asOf")
     _url(ledger.get("sourceLedgerIssue"), "sourceLedgerIssue")

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -991,6 +991,21 @@ def test_2000_backfill_ledger_accounts_for_the_unavailable_legacy_archive():
     assert validated["complete"] is True
 
 
+def test_1995_backfill_ledger_opens_pre_web_research_debt_without_hiding_the_recovered_story():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "1995.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert validated["sourceArchiveCoverage"] == "unavailable"
+    assert len(validated["sourceArchiveErrors"]) == 1
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 52
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
+    assert validated["complete"] is False
+
+
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():
     discovery = {
         "schemaVersion": "gravel-weekly-historical-ledger/v1",


### PR DESCRIPTION
## Summary
- extend primary backfill ledgers to the pre-web boundary established by the control plane
- add a 1995 Death Ride draft documenting a 400-rider Flint Hills backroad event in a town of about fifty
- preserve the organizer’s later regional motive as later evidence: Kansas built its own ordeal after cycling media treated California and Colorado as the only epic places
- leave 52 weeks explicitly unresearched instead of manufacturing quiet, and keep the story/race impact human-review-only

## Verification
- Gravel Weekly focused suite: 58 passed
- 1995 history and ledger validators pass
- both anti-slop detectors: zero findings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data and validation/test changes only; editorial content is unpublished and publication safety flags block auto-publish.
> 
> **Overview**
> Extends Gravel Weekly archival backfill to **1995** by adding a year ledger and widening backfill validation to accept years from **1980** (was 2000).
> 
> The new **`1995.json`** ledger marks automated Cyclingnews archive coverage as unavailable, leaves **52** weekly windows **`unresearched`** (explicit research debt, not quiet gaps), and flags the year **`complete: false`**. One week is **`covered_by_draft`** and links **`history-flint-hills-death-ride-spite-1995`**.
> 
> That draft history entry documents the mid-1990s Matfield Green **100K Flint Hills Death Ride** (~400 riders) from a Fall 1995 Land Institute report, with later sources for regional motive and scale. It stays **`draft`** with **`humanApprovalRequired`**, model-draft take provenance, and a human-review-only race history impact on **`gravel:flint-hills-death-ride`**.
> 
> Tests add **`test_1995_backfill_ledger_opens_pre_web_research_debt_without_hiding_the_recovered_story`** to lock the unresearched vs draft accounting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3baf246c1a72c4d7c25f5347846d806776d2a8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->