### PR TITLE
Open 1998 Gravel Weekly archival backfill

### DIFF
--- a/data/gravel-weekly/backfill/1998.json
+++ b/data/gravel-weekly/backfill/1998.json
@@ -1,0 +1,445 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 1998,
+  "asOf": "1998-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/84",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33183442001",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceArchiveCoverage": "unavailable",
+  "sourceArchiveErrors": [
+    "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
+  ],
+  "sourceCardCount": 0,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "1997-12-27",
+      "periodEndedAt": "1998-01-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-01-03",
+      "periodEndedAt": "1998-01-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-01-10",
+      "periodEndedAt": "1998-01-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-01-17",
+      "periodEndedAt": "1998-01-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-01-24",
+      "periodEndedAt": "1998-01-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-01-31",
+      "periodEndedAt": "1998-02-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-02-07",
+      "periodEndedAt": "1998-02-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-02-14",
+      "periodEndedAt": "1998-02-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-02-21",
+      "periodEndedAt": "1998-02-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-02-28",
+      "periodEndedAt": "1998-03-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-03-07",
+      "periodEndedAt": "1998-03-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-03-14",
+      "periodEndedAt": "1998-03-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-03-21",
+      "periodEndedAt": "1998-03-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-03-28",
+      "periodEndedAt": "1998-04-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-04-04",
+      "periodEndedAt": "1998-04-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-04-11",
+      "periodEndedAt": "1998-04-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-04-18",
+      "periodEndedAt": "1998-04-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-04-25",
+      "periodEndedAt": "1998-05-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-05-02",
+      "periodEndedAt": "1998-05-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-05-09",
+      "periodEndedAt": "1998-05-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-05-16",
+      "periodEndedAt": "1998-05-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-05-23",
+      "periodEndedAt": "1998-05-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-05-30",
+      "periodEndedAt": "1998-06-05",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-great-divide-maps-made-race-1998"
+      ],
+      "reason": "Manual archival recovery found contemporary reporting that the full six-map Great Divide route set arrived in Missoula, with 400 advance buyers and only one prior through-rider; the resulting draft remains unpublished pending human approval."
+    },
+    {
+      "periodStartedAt": "1998-06-06",
+      "periodEndedAt": "1998-06-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-06-13",
+      "periodEndedAt": "1998-06-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-06-20",
+      "periodEndedAt": "1998-06-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-06-27",
+      "periodEndedAt": "1998-07-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-07-04",
+      "periodEndedAt": "1998-07-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-07-11",
+      "periodEndedAt": "1998-07-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-07-18",
+      "periodEndedAt": "1998-07-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-07-25",
+      "periodEndedAt": "1998-07-31",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-08-01",
+      "periodEndedAt": "1998-08-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-08-08",
+      "periodEndedAt": "1998-08-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-08-15",
+      "periodEndedAt": "1998-08-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-08-22",
+      "periodEndedAt": "1998-08-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-08-29",
+      "periodEndedAt": "1998-09-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-09-05",
+      "periodEndedAt": "1998-09-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-09-12",
+      "periodEndedAt": "1998-09-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-09-19",
+      "periodEndedAt": "1998-09-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-09-26",
+      "periodEndedAt": "1998-10-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-10-03",
+      "periodEndedAt": "1998-10-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-10-10",
+      "periodEndedAt": "1998-10-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-10-17",
+      "periodEndedAt": "1998-10-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-10-24",
+      "periodEndedAt": "1998-10-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-10-31",
+      "periodEndedAt": "1998-11-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-11-07",
+      "periodEndedAt": "1998-11-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-11-14",
+      "periodEndedAt": "1998-11-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-11-21",
+      "periodEndedAt": "1998-11-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-11-28",
+      "periodEndedAt": "1998-12-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-12-05",
+      "periodEndedAt": "1998-12-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-12-12",
+      "periodEndedAt": "1998-12-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-12-19",
+      "periodEndedAt": "1998-12-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1998-12-26",
+      "periodEndedAt": "1999-01-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    }
+  ],
+  "updatedAt": "2026-08-28T15:08:00Z"
+}

--- a/data/gravel-weekly/history/1998-great-divide-maps-made-race.json
+++ b/data/gravel-weekly/history/1998-great-divide-maps-made-race.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-great-divide-maps-made-race-1998",
+  "activeFrom": "1998-05-25",
+  "activeThrough": "1998-06-30",
+  "status": "draft",
+  "headline": "Tour Divide Started as Six Maps in a Mailroom",
+  "point": "In May 1998, maps for the entire 2,500-mile Great Divide Mountain Bike Route arrived at Adventure Cycling's Missoula office. Only one person had ridden the full line, but 400 buyers had already paid for the six-map set and all fourteen places on the first guided through-ride were filled. Within a year, John Stamstad used that same route to establish the first end-to-end speed benchmark. Tour Divide did not begin when a promoter announced a race. It began when cartographers turned thousands of disconnected dirt roads into one legible, repeatable argument about where a bicycle could go.",
+  "priorJudgment": "Tour Divide history begins with ultra-racers inventing an unsupported competition across the Continental Divide.",
+  "changedJudgment": "The decisive infrastructure came first from a nonprofit route-publishing project. Once a researched line, maps, resupply information, and a common start and finish made the Divide repeatable, riders could convert a private expedition into a comparable sporting record without needing a conventional organizer.",
+  "stakes": "This changes what counts as race infrastructure. In self-supported cycling, the course publisher can matter more than the promoter: a trustworthy shared route creates participation, records, equipment demands, safety assumptions, and the historical continuity that lets later riders argue over what the race is.",
+  "credibleOpposition": "The Great Divide route was designed for touring, not racing, and individual riders had traveled Continental Divide terrain before 1998. The 1998 newspaper report describes anticipation and route publication, not the birth of a sport. John Stamstad's 1999 ride and the 2008 Tour Divide were separate competitive acts, so this entry should not imply that Adventure Cycling organized either race or intended their consequences.",
+  "whatHappened": "On May 31, 1998, The Spokesman-Review reported that maps covering the entire 2,500-mile Great Divide Mountain Bike Route had arrived the previous week at Adventure Cycling Association in Missoula. Staff began shipping the six-map set to 400 advance buyers, and all fourteen slots for the first guided 70-day through-ride had filled. Adventure Cycling spokesman Kevin Condit said research began in 1994, when Mac McCoy was commissioned to connect existing roads and trails between Canada and Mexico. The paper reported that only Drew Walker had yet ridden the entire route. Adventure Cycling later described the project as an attempt to join loaded road touring with day-trip mountain biking, said membership contributions and an REI grant funded the mapping, and recalled finishing field research in 1997. In 1999, John Stamstad established the route's first end-to-end time. The organized Tour Divide followed in 2008 on substantially the same published line.",
+  "take": "Model draft, not Matti's approved view: Tour Divide's original race director was a stack of paper. In May 1998, six maps covering 2,500 miles arrived at Adventure Cycling's office in Missoula. Four hundred people had already paid for them. Only one person had actually ridden the whole thing. This is the part modern gravel tends to reverse-engineer out of its own creation myth: before the dot-watching, before the record arguments, before someone invented a bike with seventeen places to bolt luggage, a nonprofit spent years driving dead ends and asking land managers whether a bicycle could get through. Then it published the answer. John Stamstad supplied the stopwatch a year later. The route became a race because somebody first made the impossible trip legible.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The contemporary report says the full U.S. map set covered 2,500 miles and six sections; the modern route includes Canada and is longer, so current mileage must not be projected backward. Later Adventure Cycling accounts vary between two and a half, three, and four years when summarizing planning and mapping. Sources consistently separate Adventure Cycling's touring route from the competitive efforts that followed. The exact 1999 Stamstad start and finish details rely on later institutional history because no contemporaneous 1999 ride report has yet been recovered.",
+  "editorialScore": 100,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_great_divide_full_maps_arrived_1998",
+      "canonicalUrl": "https://www.spokesman.com/stories/1998/may/31/rocky-mountain-high-road-route-takes-cyclists/",
+      "publisher": "The Spokesman-Review",
+      "publishedAt": "1998-05-31T12:00:00-07:00",
+      "quoteExcerpt": "Maps for the entire 2,500 miles of the Great Divide Mountain Bike Route arrived last week",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_great_divide_advance_buyers_guided_ride_1998",
+      "canonicalUrl": "https://www.spokesman.com/stories/1998/may/31/rocky-mountain-high-road-route-takes-cyclists/",
+      "publisher": "The Spokesman-Review",
+      "publishedAt": "1998-05-31T12:00:00-07:00",
+      "quoteExcerpt": "shipping the six-map set to the 400 people who had put down their money in advance",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_great_divide_one_through_rider_1998",
+      "canonicalUrl": "https://www.spokesman.com/stories/1998/may/31/rocky-mountain-high-road-route-takes-cyclists/",
+      "publisher": "The Spokesman-Review",
+      "publishedAt": "1998-05-31T12:00:00-07:00",
+      "quoteExcerpt": "only one person has ridden the entire Great Divide Mountain Bike Route",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_great_divide_route_creation_motive_2018",
+      "canonicalUrl": "https://www.adventurecycling.org/blog/the-genesis-of-the-great-divide/",
+      "publisher": "Adventure Cycling Association",
+      "publishedAt": "2018-06-09T12:00:00-06:00",
+      "quoteExcerpt": "Very few have toured off-pavement carrying a full complement of gear. We want to change that.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_stamstad_first_divide_time_2019",
+      "canonicalUrl": "https://www.adventurecycling.org/blog/a-long-meditation/",
+      "publisher": "Adventure Cycling Association",
+      "publishedAt": "2019-06-25T12:00:00-06:00",
+      "quoteExcerpt": "In 1999, Mountain Bike Hall of Famer John Stamstad was the first to establish a time for the route",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_tour_divide_route_published_1998_later",
+      "canonicalUrl": "https://tourdivide.org/about_the_route",
+      "publisher": "Tour Divide",
+      "publishedAt": "2014-06-01T12:00:00-06:00",
+      "quoteExcerpt": "mapped over a 4 year span, and published in 1998 by Adventure Cycling Association",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:tour-divide",
+      "fieldPath": "race.history",
+      "claimIds": [
+        "claim_great_divide_full_maps_arrived_1998",
+        "claim_great_divide_advance_buyers_guided_ride_1998",
+        "claim_great_divide_one_through_rider_1998",
+        "claim_great_divide_route_creation_motive_2018",
+        "claim_stamstad_first_divide_time_2019",
+        "claim_tour_divide_route_published_1998_later"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T15:08:00Z",
+  "contentHash": "5de676d1c8dabdaeb9a6399690d61eb1186f291d398fc430b02594134087d23b"
+}


### PR DESCRIPTION
## What changed
- add an explicit 1998 pre-web backfill ledger tied to control-plane run 33183442001 and issue #84
- stage one hidden historical draft about the Great Divide map set turning a private expedition into repeatable race infrastructure
- bind the draft to contemporary 1998 reporting, later institutional evidence, and review-only Tour Divide race history impact
- leave the other 52 windows explicitly unresearched; no fake quiet-year claim

## Safety
- `status: draft`
- `takeProvenance: model_draft`
- `humanApprovalRequired: true`
- `autoPublishAllowed: false`
- race impact is `editorial_review`; `autoFixAllowed: false`

## Verification
- 58 Gravel Weekly focused tests pass
- all 70 historical entries validate
- all 29 backfill ledgers validate
- both anti-slop detectors report zero findings
- local Gravel Weekly render succeeds and excludes draft history

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are draft editorial JSON only; publication and automatic race-data updates remain disabled pending human review.
> 
> **Overview**
> Adds **1998 pre-web archival backfill** as a new year ledger (`1998.json`) tied to the control-plane run and issue links, with **archive connector coverage marked unavailable** (automated Cyclingnews coverage starts in 2000).
> 
> For **53 weekly windows**, all but one are explicitly **`unresearched`** with a shared reason not to treat missing sources as a quiet year. The **1998-05-30–1998-06-05** window is **`covered_by_draft`**, pointing at a new history entry about the **1998 Great Divide six-map route publication** in Missoula.
> 
> The staged history file **`1998-great-divide-maps-made-race.json`** is a **`draft`** with **`takeProvenance: model_draft`**, contemporary *Spokesman-Review* receipts plus later institutional sources, and a **review-only** Tour Divide **`race.history`** impact (`autoFixAllowed: false`). Ledger and entry both require **human approval** and disallow **auto-publish**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d6aadeae560a4d777e9bafc1c3aa0e4672938c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->