### PR TITLE
Preserve legacy archive research debt

### DIFF
--- a/data/gravel-weekly/backfill/2000.json
+++ b/data/gravel-weekly/backfill/2000.json
@@ -21,7 +21,7 @@
     "https://autobus.cyclingnews.com/results/?id=2000/dec00: legacy Cyclingnews archive is unavailable"
   ],
   "sourceCardCount": 0,
-  "complete": true,
+  "complete": false,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -29,225 +29,225 @@
       "periodStartedAt": "2000-01-01",
       "periodEndedAt": "2000-01-07",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-01-08",
       "periodEndedAt": "2000-01-14",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-01-15",
       "periodEndedAt": "2000-01-21",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-01-22",
       "periodEndedAt": "2000-01-28",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-01-29",
       "periodEndedAt": "2000-02-04",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-02-05",
       "periodEndedAt": "2000-02-11",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-02-12",
       "periodEndedAt": "2000-02-18",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-02-19",
       "periodEndedAt": "2000-02-25",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-02-26",
       "periodEndedAt": "2000-03-03",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-03-04",
       "periodEndedAt": "2000-03-10",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-03-11",
       "periodEndedAt": "2000-03-17",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-03-18",
       "periodEndedAt": "2000-03-24",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-03-25",
       "periodEndedAt": "2000-03-31",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-04-01",
       "periodEndedAt": "2000-04-07",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-04-08",
       "periodEndedAt": "2000-04-14",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-04-15",
       "periodEndedAt": "2000-04-21",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-04-22",
       "periodEndedAt": "2000-04-28",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-04-29",
       "periodEndedAt": "2000-05-05",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-05-06",
       "periodEndedAt": "2000-05-12",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-05-13",
       "periodEndedAt": "2000-05-19",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-05-20",
       "periodEndedAt": "2000-05-26",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-05-27",
       "periodEndedAt": "2000-06-02",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-06-03",
       "periodEndedAt": "2000-06-09",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-06-10",
       "periodEndedAt": "2000-06-16",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-06-17",
       "periodEndedAt": "2000-06-23",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-06-24",
       "periodEndedAt": "2000-06-30",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-07-01",
       "periodEndedAt": "2000-07-07",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-07-08",
       "periodEndedAt": "2000-07-14",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-07-15",
@@ -273,186 +273,186 @@
       "periodStartedAt": "2000-07-29",
       "periodEndedAt": "2000-08-04",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-08-05",
       "periodEndedAt": "2000-08-11",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-08-12",
       "periodEndedAt": "2000-08-18",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-08-19",
       "periodEndedAt": "2000-08-25",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-08-26",
       "periodEndedAt": "2000-09-01",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-09-02",
       "periodEndedAt": "2000-09-08",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-09-09",
       "periodEndedAt": "2000-09-15",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-09-16",
       "periodEndedAt": "2000-09-22",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-09-23",
       "periodEndedAt": "2000-09-29",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-09-30",
       "periodEndedAt": "2000-10-06",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-10-07",
       "periodEndedAt": "2000-10-13",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-10-14",
       "periodEndedAt": "2000-10-20",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-10-21",
       "periodEndedAt": "2000-10-27",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-10-28",
       "periodEndedAt": "2000-11-03",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-11-04",
       "periodEndedAt": "2000-11-10",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-11-11",
       "periodEndedAt": "2000-11-17",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-11-18",
       "periodEndedAt": "2000-11-24",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-11-25",
       "periodEndedAt": "2000-12-01",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-12-02",
       "periodEndedAt": "2000-12-08",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-12-09",
       "periodEndedAt": "2000-12-15",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-12-16",
       "periodEndedAt": "2000-12-22",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-12-23",
       "periodEndedAt": "2000-12-29",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2000-12-30",
       "periodEndedAt": "2001-01-05",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     }
   ],
-  "updatedAt": "2026-08-28T14:39:13Z"
+  "updatedAt": "2026-08-28T15:20:00Z"
 }

--- a/data/gravel-weekly/backfill/2001.json
+++ b/data/gravel-weekly/backfill/2001.json
@@ -21,7 +21,7 @@
     "https://autobus.cyclingnews.com/results/?id=2001/dec01: legacy Cyclingnews archive is unavailable"
   ],
   "sourceCardCount": 0,
-  "complete": true,
+  "complete": false,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -29,257 +29,257 @@
       "periodStartedAt": "2000-12-30",
       "periodEndedAt": "2001-01-05",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-01-06",
       "periodEndedAt": "2001-01-12",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-01-13",
       "periodEndedAt": "2001-01-19",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-01-20",
       "periodEndedAt": "2001-01-26",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-01-27",
       "periodEndedAt": "2001-02-02",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-02-03",
       "periodEndedAt": "2001-02-09",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-02-10",
       "periodEndedAt": "2001-02-16",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-02-17",
       "periodEndedAt": "2001-02-23",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-02-24",
       "periodEndedAt": "2001-03-02",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-03-03",
       "periodEndedAt": "2001-03-09",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-03-10",
       "periodEndedAt": "2001-03-16",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-03-17",
       "periodEndedAt": "2001-03-23",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-03-24",
       "periodEndedAt": "2001-03-30",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-03-31",
       "periodEndedAt": "2001-04-06",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-04-07",
       "periodEndedAt": "2001-04-13",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-04-14",
       "periodEndedAt": "2001-04-20",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-04-21",
       "periodEndedAt": "2001-04-27",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-04-28",
       "periodEndedAt": "2001-05-04",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-05-05",
       "periodEndedAt": "2001-05-11",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-05-12",
       "periodEndedAt": "2001-05-18",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-05-19",
       "periodEndedAt": "2001-05-25",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-05-26",
       "periodEndedAt": "2001-06-01",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-06-02",
       "periodEndedAt": "2001-06-08",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-06-09",
       "periodEndedAt": "2001-06-15",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-06-16",
       "periodEndedAt": "2001-06-22",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-06-23",
       "periodEndedAt": "2001-06-29",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-06-30",
       "periodEndedAt": "2001-07-06",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-07-07",
       "periodEndedAt": "2001-07-13",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-07-14",
       "periodEndedAt": "2001-07-20",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-07-21",
       "periodEndedAt": "2001-07-27",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-07-28",
       "periodEndedAt": "2001-08-03",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-08-04",
       "periodEndedAt": "2001-08-10",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-08-11",
@@ -293,162 +293,162 @@
       "periodStartedAt": "2001-08-18",
       "periodEndedAt": "2001-08-24",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-08-25",
       "periodEndedAt": "2001-08-31",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-09-01",
       "periodEndedAt": "2001-09-07",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-09-08",
       "periodEndedAt": "2001-09-14",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-09-15",
       "periodEndedAt": "2001-09-21",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-09-22",
       "periodEndedAt": "2001-09-28",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-09-29",
       "periodEndedAt": "2001-10-05",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-10-06",
       "periodEndedAt": "2001-10-12",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-10-13",
       "periodEndedAt": "2001-10-19",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-10-20",
       "periodEndedAt": "2001-10-26",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-10-27",
       "periodEndedAt": "2001-11-02",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-11-03",
       "periodEndedAt": "2001-11-09",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-11-10",
       "periodEndedAt": "2001-11-16",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-11-17",
       "periodEndedAt": "2001-11-23",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-11-24",
       "periodEndedAt": "2001-11-30",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-12-01",
       "periodEndedAt": "2001-12-07",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-12-08",
       "periodEndedAt": "2001-12-14",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-12-15",
       "periodEndedAt": "2001-12-21",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-12-22",
       "periodEndedAt": "2001-12-28",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2001-12-29",
       "periodEndedAt": "2002-01-04",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
     }
   ],
-  "updatedAt": "2026-08-28T21:00:00Z"
+  "updatedAt": "2026-08-28T15:20:00Z"
 }

--- a/data/gravel-weekly/backfill/2002.json
+++ b/data/gravel-weekly/backfill/2002.json
@@ -13,7 +13,7 @@
     "https://autobus.cyclingnews.com/results/?id=2002/apr02: legacy Cyclingnews archive is unavailable"
   ],
   "sourceCardCount": 0,
-  "complete": true,
+  "complete": false,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -21,145 +21,145 @@
       "periodStartedAt": "2001-12-29",
       "periodEndedAt": "2002-01-04",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-01-05",
       "periodEndedAt": "2002-01-11",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-01-12",
       "periodEndedAt": "2002-01-18",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-01-19",
       "periodEndedAt": "2002-01-25",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-01-26",
       "periodEndedAt": "2002-02-01",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-02-02",
       "periodEndedAt": "2002-02-08",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-02-09",
       "periodEndedAt": "2002-02-15",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-02-16",
       "periodEndedAt": "2002-02-22",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-02-23",
       "periodEndedAt": "2002-03-01",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-03-02",
       "periodEndedAt": "2002-03-08",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-03-09",
       "periodEndedAt": "2002-03-15",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-03-16",
       "periodEndedAt": "2002-03-22",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-03-23",
       "periodEndedAt": "2002-03-29",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-03-30",
       "periodEndedAt": "2002-04-05",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-04-06",
       "periodEndedAt": "2002-04-12",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-04-13",
       "periodEndedAt": "2002-04-19",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-04-20",
       "periodEndedAt": "2002-04-26",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-04-27",
       "periodEndedAt": "2002-05-03",
       "sourceCardCount": 0,
-      "disposition": "explicit_gap",
+      "disposition": "unresearched",
       "entryIds": [],
-      "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
+      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
     },
     {
       "periodStartedAt": "2002-05-04",
@@ -446,5 +446,5 @@
       "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     }
   ],
-  "updatedAt": "2026-08-28T20:45:00Z"
+  "updatedAt": "2026-08-28T15:20:00Z"
 }

--- a/scripts/validate_gravel_weekly_backfill.py
+++ b/scripts/validate_gravel_weekly_backfill.py
@@ -88,6 +88,10 @@ def validate_backfill_ledger(value: Any, history_entries: list[dict[str, Any]]) 
         disposition = week.get("disposition")
         if disposition not in DISPOSITIONS:
             raise IssueValidationError(f"{name}.disposition is invalid")
+        if source_archive_coverage == "unavailable" and disposition == "explicit_gap":
+            raise IssueValidationError(
+                f"{name} cannot claim an explicit gap when source archive coverage is unavailable"
+            )
         entry_ids = [
             _text(entry_id_value, f"{name}.entryIds[{entry_index}]", 500)
             for entry_index, entry_id_value in enumerate(_list(week.get("entryIds"), f"{name}.entryIds", 20))

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -946,7 +946,7 @@ def test_2003_backfill_ledger_reconciles_the_complete_legacy_archive_census():
     assert validated["complete"] is True
 
 
-def test_2002_backfill_ledger_accounts_for_the_partial_legacy_archive_census():
+def test_2002_backfill_ledger_preserves_partial_legacy_archive_research_debt():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2002.json").read_text())
     validated = validate_backfill_ledger(ledger, histories)
@@ -955,13 +955,13 @@ def test_2002_backfill_ledger_accounts_for_the_partial_legacy_archive_census():
     assert validated["sourceArchiveCoverage"] == "partial"
     assert len(validated["sourceArchiveErrors"]) == 4
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 51
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 33
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
-    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 0
-    assert validated["complete"] is True
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 18
+    assert validated["complete"] is False
 
 
-def test_2001_backfill_ledger_rejects_a_redundant_saturn_story():
+def test_2001_backfill_ledger_rejects_a_redundant_story_without_claiming_archive_coverage():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2001.json").read_text())
     validated = validate_backfill_ledger(ledger, histories)
@@ -970,13 +970,14 @@ def test_2001_backfill_ledger_rejects_a_redundant_saturn_story():
     assert validated["sourceArchiveCoverage"] == "unavailable"
     assert len(validated["sourceArchiveErrors"]) == 12
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 52
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 52
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
     assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 1
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 0
-    assert validated["complete"] is True
+    assert validated["complete"] is False
 
 
-def test_2000_backfill_ledger_accounts_for_the_unavailable_legacy_archive():
+def test_2000_backfill_ledger_preserves_unavailable_legacy_archive_research_debt():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2000.json").read_text())
     validated = validate_backfill_ledger(ledger, histories)
@@ -985,10 +986,10 @@ def test_2000_backfill_ledger_accounts_for_the_unavailable_legacy_archive():
     assert validated["sourceArchiveCoverage"] == "unavailable"
     assert len(validated["sourceArchiveErrors"]) == 12
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 51
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 51
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
-    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 0
-    assert validated["complete"] is True
+    assert validated["complete"] is False
 
 
 def test_1995_backfill_ledger_opens_pre_web_research_debt_without_hiding_the_recovered_story():
@@ -1004,6 +1005,18 @@ def test_1995_backfill_ledger_opens_pre_web_research_debt_without_hiding_the_rec
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
     assert validated["complete"] is False
+
+
+def test_unavailable_archive_cannot_be_recorded_as_an_explicit_gap():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2000.json").read_text())
+    dishonest = copy.deepcopy(ledger)
+    week = next(week for week in dishonest["weeks"] if week["disposition"] == "unresearched")
+    week["disposition"] = "explicit_gap"
+    week["reason"] = "No matching source card was found."
+
+    with pytest.raises(IssueValidationError, match="source archive coverage is unavailable"):
+        validate_backfill_ledger(dishonest, histories)
 
 
 def test_initial_backfill_ledger_accounts_for_every_discovery_card():


### PR DESCRIPTION
## What changed
- convert uncovered 2000 and 2001 windows from false `explicit_gap` claims to `unresearched`
- convert the eighteen 2002 windows overlapping unavailable January-April archives to `unresearched`
- mark all three ledgers incomplete until broader contemporary-source recovery happens
- make the validator reject any `explicit_gap` when annual archive coverage is unavailable
- update regression expectations and add a direct dishonest-gap rejection test

## Why
The control-plane fix correctly reports 2000 and 2001 as unavailable and 2002 as partial. The publication ledgers still encoded unavailable weeks as quiet, which made `complete: true` technically valid but epistemically false.

## Verification
- all 29 backfill ledgers validate
- 59 Gravel Weekly focused tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial metadata and validation only; no runtime publish path changes, though `complete: false` may affect downstream assumptions about year closure.
> 
> **Overview**
> **Stops backfill ledgers from treating missing legacy Cyclingnews archives as editorially quiet weeks.**
> 
> For **2000** and **2001** (`sourceArchiveCoverage: unavailable`), weeks that were labeled `explicit_gap` are now **`unresearched`** with reasons that require broader contemporary-source recovery and explicitly say not to infer quiet. **`complete`** is set to **`false`** on those years (and on **2002**, which stays `partial`). On **2002**, the eighteen Jan–Apr windows that overlap unavailable archive months get the same **`unresearched`** treatment; later weeks can still be **`explicit_gap`** where partial census applies.
> 
> **`validate_gravel_weekly_backfill.py`** now **rejects** any week with disposition **`explicit_gap`** when annual **`sourceArchiveCoverage`** is **`unavailable`**, so ledgers cannot claim a searched quiet period without archive access.
> 
> Tests for the 2000–2002 ledgers are updated to expect **`unresearched`** counts and **`complete: false`**, and a new regression test asserts that flipping an unresearched week to **`explicit_gap`** on an unavailable-archive year fails validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6685649c4be3235a1a0572c5867d1141a9461897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->