### PR TITLE
Fix race rating copy hierarchy

### DIFF
--- a/race-data/unbound-200.json
+++ b/race-data/unbound-200.json
@@ -80,15 +80,15 @@
     "biased_opinion_ratings": {
       "logistics": {
         "score": 4,
-        "explanation": "Four thousand riders, lottery entry, and professional wave starts manage the chaos effectively. Amy Charity describes the surprisingly intense beginning: \"It felt like a criterium. I was 30 miles into the race and my heart rate must have been in the 180s.\" Brian McCulloch experienced last-minute adaptability when \"torrential rain for two days forced a last-minute course change and re-route.\""
+        "explanation": "Four thousand riders, lottery entry, and professional wave starts turn Emporia into controlled chaos. The opening can feel \"like a criterium\" even 30 miles into a 200-mile day. When two days of torrential rain force a late reroute, the operation is big enough to absorb it."
       },
       "length": {
         "score": 5,
-        "explanation": "SomeMayoPlease positioned strategically early, marking \"Mile 28 as the first important point on the course\" where the field of 1,100 riders thinned to \"fewer than 50.\" Two hundred miles with 20.5-hour cutoff transforms routine terrain into endurance warfare. Winners finish around 10 hours while mid-pack riders face potential 3:00 AM cutoffs in darkness."
+        "explanation": "Two hundred miles with a 20.5-hour cutoff turns ordinary Flint Hills rollers into a full-day durability test. Mile 28 can already cut a field of 1,100 to \"fewer than 50\" at the front. Winners need roughly 10 hours; the back of the race can still be working at 3:00 AM."
       },
       "technicality": {
         "score": 4,
-        "explanation": "Chunky flint rock roads demand equipment survival over bike handling skills. At Kaw Reserve Road, minidini10 found it \"rough and rocky\" with \"bottles everywhere and people pulled over to fix their bikes.\" Bertn05 avoided crashes when riders around him went down: \"3 times I avoided these\" on technical sections."
+        "explanation": "This is not singletrack, but chunky flint makes equipment survival part of the handling test. Kaw Reserve Road gets \"rough and rocky,\" with \"bottles everywhere and people pulled over to fix their bikes.\" The course punishes bad lines and fragile setups more than it rewards bike-park skill."
       },
       "elevation": {
         "score": 5,
@@ -96,7 +96,7 @@
       },
       "climate": {
         "score": 5,
-        "explanation": "Kansas June weather swings from disaster to paradise within hours. Brian McCulloch experienced the lottery: \"Friday evening the weather forecast was calling for clear conditions... two hours later we would be riding through some of the worst rain I have ever pedaled through.\" The 2024 edition brought relief with minidini10 enjoying \"a cool 65 degrees.\""
+        "explanation": "Kansas June weather can move from a clear forecast to \"some of the worst rain I have ever pedaled through\" in two hours. Other editions deliver a merciful \"cool 65 degrees.\" Heat, wind, storms, and wheel-stopping mud all belong in the plan."
       },
       "altitude": {
         "score": 1,
@@ -104,35 +104,35 @@
       },
       "adventure": {
         "score": 5,
-        "explanation": "Remote ranch roads where support crews reach only four spots across 200 miles. When conditions deteriorate, riders face true isolation - minidini10 witnessed \"lots of people pulled over in the shade trying to rest or shake out cramps\" during the heat. Course changes and weather create unpredictable challenges in cattle country solitude."
+        "explanation": "Support crews can reach only four spots across 200 miles of remote ranch roads. When the heat lands, there are \"lots of people pulled over in the shade trying to rest or shake out cramps.\" Cattle country, weather, and distance create real isolation without pretending the course is wilderness singletrack."
       },
       "prestige": {
         "score": 5,
-        "explanation": "Amy Charity discovered what elite-level gravel racing demands when running with \"the top women\" required criterium-level intensity 30 miles in with 170 miles remaining. Her heart rate \"must have been in the 180s\" just to stay with the lead group. The belt buckle remains gravel racing's most coveted amateur prize."
+        "explanation": "This is the race that makes criterium intensity 30 miles in feel normal, with 170 miles still to go. Staying with \"the top women\" can mean a heart rate \"in the 180s\" before the day has properly started. The belt buckle remains gravel racing's defining amateur prize."
       },
       "race_quality": {
         "score": 5,
-        "explanation": "Lifetime runs professional operations handling 4,000+ riders with wave starts and checkpoint cutoffs. Even when weather forces last-minute changes, organization adapts seamlessly. The field management from neutral rollout through 3:00 AM finish cutoffs maintains safety protocols throughout the night finish window."
+        "explanation": "Lifetime runs professional operations handling 4,000+ riders with wave starts and checkpoint cutoffs. Even when weather forces last-minute changes, the operation absorbs the hit. The field management from neutral rollout through 3:00 AM finish cutoffs maintains safety protocols throughout the night finish window."
       },
       "experience": {
         "score": 5,
-        "explanation": "The defining gravel experience from sunrise start through potential night riding. Richard at SILCA captures it: \"This race is special period and what I consider to be the best riding on earth... that coin flip of beauty and brutality is what keeps people coming back.\" Finishers earn medals, pint glasses, and lifetime stories."
+        "explanation": "Sunrise start, potential night finish, and a course that can flip from beauty to brutality in one weather system. \"The best riding on earth\" is a huge claim; on the right day in the Flint Hills, it does not sound ridiculous. The medal and pint glass are souvenirs. The day is the thing."
       },
       "community": {
         "score": 5,
-        "explanation": "Emporia becomes 'Gravel City' as locals embrace the cycling invasion. minidini10 found residents at Lake Kahola \"having a block party\" during the race. Richard at SILCA notes how the \"rugged, vast\" Flint Hills create shared suffering bonds: \"That coin flip of beauty and brutality\" drives continued community growth."
+        "explanation": "Emporia becomes Gravel City for a week, and the support reaches well beyond Commercial Street. Residents at Lake Kahola are out \"having a block party\" while riders pass. The \"coin flip of beauty and brutality\" gives strangers something immediate to share."
       },
       "field_depth": {
         "score": 5,
-        "explanation": "Elite depth spans from Amy Charity pushing criterium pace early to recreational riders grinding through technical sections. Brennan Wertz emphasizes tactical complexity: \"The biggest mistake almost EVERY racer makes, even pros, is going out too hard.\" SomeMayoPlease's strategy of leading 1,100 riders into rough doubletrack demonstrates the field's competitive sophistication."
+        "explanation": "The front includes the best gravel racers in the world; behind them, thousands are managing the same roads on very different clocks. \"The biggest mistake almost EVERY racer makes, even pros, is going out too hard.\" A field this deep makes positioning tactical long before fitness settles the result."
       },
       "value": {
         "score": 4,
-        "explanation": "At $345 entry, Richard at SILCA's assessment rings true: \"the best riding on earth\" through the \"rugged, vast\" Flint Hills. The lottery system and week-long festival atmosphere justify premium pricing. The experience and prestige provide value beyond typical race entry fees for most participants."
+        "explanation": "$345 is premium race entry, and the lottery means money alone cannot buy a start. What you get is a week-long gravel festival and a day across the \"rugged, vast\" Flint Hills that riders call \"the best riding on earth.\" Expensive, yes. Overpriced, no."
       },
       "expenses": {
         "score": 4,
-        "explanation": "Beyond $345 entry, participants face Kansas logistics costs plus specialized equipment. Elite setups like SomeMayoPlease's Continental Race Kings and Mettle Cycling's tire pressure strategies (\"17.5 / 19.5 but as the day got warmer, the pressure also increased to 19.5 / 21\") show equipment investment needs. Budget $1,000+ for full race week experience."
+        "explanation": "The $345 entry is only the opening bill. Travel, scarce lodging, tires, spares, and a week in Emporia can push the full trip past $1,000. Even tire pressure becomes an all-day equipment decision as heat moves a setup from \"17.5 / 19.5\" to \"19.5 / 21.\""
       }
     },
     "biased_opinion": {

--- a/scripts/batch_enrich.py
+++ b/scripts/batch_enrich.py
@@ -285,6 +285,10 @@ Rules:
 - Keep the existing scores — don't change them
 - Each explanation: 2-4 sentences, specific, Matti voice
 - Reference specific course features, weather data, logistics details from research
+- Lead with Gravel God's judgment. Never narrate the research process with "according to",
+  "X notes/reports/describes/captures", "X's assessment rings true", or "As X puts it"
+- Keep memorable source language in quotation marks; the profile's citation section owns
+  source provenance, so the explanation should not read like a research handoff
 - No generic filler ("amazing experience", "world-class")
 - If research lacks detail for a criterion, say what you know honestly
 - Output ONLY the JSON object, no markdown, no code blocks"""
@@ -384,9 +388,12 @@ VOICE AND TONE:
 
 QUOTE RULES:
 - Prefer direct rider quotes over your own paraphrasing. A quote in their words beats your summary.
-- Every rider name you mention MUST be paired with something specific they said or did.
-  GOOD: "Bobby Kennedy describes 'riding on the moon' through volcanic moondust terrain."
-  BAD: "Riders like Josh Spector and Coach Dandelion gather annually in tiny Laona." (name-stuffing — names without substance)
+- Lead with the Gravel God judgment, then use the quote. Do not make the source the
+  grammatical subject of the explanation or narrate how the quote was found.
+  GOOD: "Volcanic moondust makes this feel like 'riding on the moon.'"
+  BAD: "Bobby Kennedy describes 'riding on the moon' through volcanic moondust terrain."
+- Never use "according to", "X notes/reports/describes/captures", "X's assessment rings
+  true", or "As X puts it". Citations and source labels already appear below the profile.
 - If a rider said something vivid, use their exact words in quotes. That's the whole point.
 - Prioritize quotes with sensory detail, concrete specifics, or surprise. A quote about 'chains chewed,
   derailleurs gargled and spat' is worth ten quotes about 'great event, well organized.'
@@ -422,8 +429,8 @@ Output ONLY valid JSON:
 Rules:
 - Keep the existing scores — don't change them
 - Beat the previous explanation on every criterion — more specific, more community-sourced
-- You MUST use rider names and terrain features from the COMMUNITY FACT SHEET
-- Reference specific rider names, course features, weather data from the research
+- You MUST use distinct rider evidence and terrain features from the COMMUNITY FACT SHEET
+- Reference specific course features, weather data, and direct quoted language from the research
 - No generic filler ("amazing experience", "world-class", "the fact that")
 - No fake uncertainty ("zero rider reports") when the FACT SHEET lists real riders
 - Output ONLY the JSON object, no markdown, no code blocks"""
@@ -474,6 +481,9 @@ Rules:
 - Keep the existing scores — don't change them
 - Each explanation: 2-4 sentences, specific, Matti voice
 - Reference specific course features, weather data, logistics details from research
+- Lead with Gravel God's judgment. Never narrate the research process with "according to",
+  "X notes/reports/describes/captures", "X's assessment rings true", or "As X puts it"
+- Keep memorable source language in quotation marks; citations stay in the dedicated source list
 - No generic filler ("amazing experience", "world-class")
 - If research lacks detail for a criterion, say what you know honestly
 - Output ONLY the JSON object, no markdown, no code blocks"""

--- a/tests/test_neo_brutalist.py
+++ b/tests/test_neo_brutalist.py
@@ -25,6 +25,8 @@ from generate_neo_brutalist import (
     TRAINING_PLANS_URL,
     US_STATES,
     _build_race_name_map,
+    _editorialize_rating_explanation,
+    _rating_bumper,
     _safe_json_for_script,
     build_course_overview,
     build_course_route,
@@ -878,6 +880,55 @@ class TestSections:
         assert html.count('class="gg-rating-tile"') == 14
         assert "gg-rating-explanation" in html
         assert "gg-accordion" not in html
+
+    def test_ratings_lead_with_group_verdicts_not_first_criterion(self, normalized_data):
+        html = build_ratings(normalized_data)
+        assert "Course verdict" in html
+        assert "Rolling Kansas gravel through the Flint Hills." in html
+        assert "Editorial verdict" in html
+        assert "A solid Kansas gravel event." in html
+        assert 'aria-pressed="true"' not in html
+        assert html.count('class="gg-rating-explanation"') == 2
+        assert html.count('aria-live="polite" hidden') == 2
+
+    def test_rating_bumper_keeps_short_opening_with_followup(self):
+        assert _rating_bumper(
+            "Relentless. Not one killer climb, but 200 miles of attrition. Extra detail."
+        ) == "Relentless. Not one killer climb, but 200 miles of attrition."
+
+    def test_rating_copy_removes_research_voice_but_keeps_quotes(self):
+        copy = (
+            'At $345 entry, Richard at SILCA\'s assessment rings true: '
+            '"the best riding on earth" through the "rugged, vast" Flint Hills. '
+            'As Jane Rider puts it: "I would race it again." [1][2]'
+        )
+        cleaned = _editorialize_rating_explanation(copy)
+        assert "Richard at SILCA" not in cleaned
+        assert "assessment rings true" not in cleaned
+        assert "As Jane Rider puts it" not in cleaned
+        assert "the best riding on earth" in cleaned
+        assert "I would race it again" in cleaned
+        assert "[1]" not in cleaned
+
+    def test_catalog_rating_copy_contract(self):
+        banned = re.compile(
+            r"according to|assessment rings true|"
+            r"\bAs\s+[^,:]{1,100}\s+(?:puts it|notes?|reports?|describes?|captures?)[,:]",
+            re.IGNORECASE,
+        )
+        violations = []
+        root = Path(__file__).resolve().parents[1] / "race-data"
+        for path in root.glob("*.json"):
+            rd = normalize_race_data(json.loads(path.read_text()))
+            for group, summary in rd["rating_summaries"].items():
+                if not summary or len(summary) > 220:
+                    violations.append(f"{path.stem}.{group} summary length={len(summary)}")
+                if banned.search(summary):
+                    violations.append(f"{path.stem}.{group} summary narrates source process")
+            for dim, entry in rd["explanations"].items():
+                if banned.search(entry["explanation"]):
+                    violations.append(f"{path.stem}.{dim} narrates source process")
+        assert not violations, "\n".join(violations[:30])
 
     def test_ratings_has_tabbed_radar_charts(self, normalized_data):
         html = build_ratings(normalized_data)

--- a/wordpress/generate_neo_brutalist.py
+++ b/wordpress/generate_neo_brutalist.py
@@ -438,6 +438,123 @@ def _normalize_surface_breakdown(raw: Any) -> dict:
     }
 
 
+def _rating_bumper(text: str, *, min_chars: int = 48, max_chars: int = 220) -> str:
+    """Return a compact, complete-sentence verdict from existing profile copy."""
+    clean = re.sub(r'\s+', ' ', str(text or '')).strip()
+    if not clean:
+        return ''
+    if clean.startswith('['):
+        return ''
+
+    sentences = re.split(r'(?<=[.!?])\s+', clean)
+    chosen = []
+    for sentence in sentences:
+        candidate = ' '.join(chosen + [sentence]).strip()
+        if chosen and len(candidate) > max_chars:
+            break
+        chosen.append(sentence)
+        if len(candidate) >= min_chars:
+            break
+    bumper = ' '.join(chosen).strip()
+    if len(bumper) <= max_chars:
+        return bumper
+    candidate = bumper[:max_chars + 1]
+    clause_break = max(candidate.rfind(mark) for mark in ('; ', ' — ', ', '))
+    if clause_break >= min_chars:
+        return candidate[:clause_break].rstrip(' ,;:—-') + '.'
+    word_break = candidate.rfind(' ')
+    return candidate[:word_break].rstrip(' ,;:—-') + '…'
+
+
+def _editorialize_rating_explanation(text: str) -> str:
+    """Remove research-process scaffolding while preserving facts and quotes.
+
+    Citations remain in the dedicated Sources & Citations section. Rating cards
+    should sound like the publication's judgment, not a research handoff.
+    """
+    clean = re.sub(r'\s+', ' ', str(text or '')).strip()
+    if not clean:
+        return ''
+
+    # Inline research-footnote markers belong in the citation section below.
+    clean = re.sub(r'(?<!\w)\[\d+\](?:\[\d+\])*', '', clean)
+
+    clean = re.sub(
+        r'\bthe\s+(?:event|official|race)\s+(?:page|site)\s+calls?\s+the\s+'
+        r'(course|route|event)\s+([^,.;]+)',
+        lambda match: f"The {match.group(1)} is {match.group(2)}",
+        clean,
+        flags=re.IGNORECASE,
+    )
+
+    # Keep the quoted words; remove the clunky narration of how we found them.
+    clean = re.sub(
+        r'\bAs\s+[^,:]{1,100}\s+(?:puts it|notes?|reports?|describes?|captures?)[,:]\s*',
+        '',
+        clean,
+        flags=re.IGNORECASE,
+    )
+    clean = re.sub(
+        r"\b[A-Z][^.!?]{0,80}?[’']s\s+(?:assessment|description|account|take|verdict)\s+"
+        r'(?:rings true|is apt|is accurate):\s*',
+        '',
+        clean,
+    )
+    clean = re.sub(
+        r'\baccording to\s+[^,.;:]{1,80}(?=[,.;:])',
+        '',
+        clean,
+        flags=re.IGNORECASE,
+    )
+
+    # Source-led sentences are a recurring enrichment artifact: "X notes...",
+    # "X describes...", "the event page calls...". Remove the throat-clearing
+    # and leave the sourced fact or quotation to do the work.
+    source_subject = (
+        r'(?:[A-Z][\w@.\-’\']*(?:\s+(?:at|from|of|the|&|[A-Z][\w@.\-’\']*)){0,6}'
+        r'|[a-z][A-Za-z0-9_\-]{2,}'
+        r'|[Tt]he\s+(?:event|official|race|organizer|municipal|local)\s+(?:page|site|report|reporting)'
+        r'|[Tt]he\s+organizer(?:-linked)?\s+(?:route|page|site)'
+        r'|[Tt]he\s+organizers?)'
+    )
+    sentence_boundary = r'(^|(?<=[.!?])\s+|(?<=[.!?]["”\'])\s+)'
+    reporting_verb = (
+        r'(?i:notes?|noted|reports?|reported|says?|said|observes?|observed|recalls?|recalled|'
+        r'writes?|wrote|explains?|explained|emphasizes?|emphasized|acknowledges?|acknowledged|'
+        r'argues?|argued)'
+    )
+    clean = re.sub(
+        rf'{sentence_boundary}{source_subject}\s+{reporting_verb}\s+(?:that\s+|how\s+|it:?\s+)?',
+        r'\1',
+        clean,
+    )
+    clean = re.sub(
+        rf'{sentence_boundary}{source_subject}\s+(?i:describes?|described)\s+'
+        r'(?=(?:the|a|an)\b|["“\'])',
+        r'\1',
+        clean,
+    )
+    clean = re.sub(
+        rf'{sentence_boundary}{source_subject}\s+(?i:calls?|called|captures?|captured)\s+'
+        r'(?:it:?\s+|(?=["“\']))',
+        r'\1',
+        clean,
+    )
+
+    clean = re.sub(r'\s+([,.;:!?])', r'\1', clean)
+    clean = re.sub(r'\s{2,}', ' ', clean).strip(' ,;')
+    clean = re.sub(
+        r'(^|[.!?](?:["”\'])?\s+)([a-z])',
+        lambda match: match.group(1) + match.group(2).upper(),
+        clean,
+    )
+
+    # Mechanical removals can expose a lowercase first word.
+    if clean and clean[0].islower():
+        clean = clean[0].upper() + clean[1:]
+    return clean
+
+
 def normalize_race_data(data: dict) -> dict:
     """Normalize race data from new-format JSON into a consistent shape
     with all fields the generator expects. Computes derived fields if missing."""
@@ -471,14 +588,40 @@ def normalize_race_data(data: dict) -> dict:
     course_profile = sum(rating.get(d, 0) for d in COURSE_DIMS)
     opinion_total = sum(rating.get(d, 0) for d in OPINION_DIMS)
 
-    # Build explanations dict from biased_opinion_ratings
+    # Build display explanations from biased_opinion_ratings. The source data
+    # retains its full research provenance; the public page gets editorial copy.
     explanations = {}
     for dim in ALL_DIMS:
         entry = bor.get(dim, {})
         explanations[dim] = {
             'score': entry.get('score', rating.get(dim, 0)),
-            'explanation': entry.get('explanation', ''),
+            'explanation': _editorialize_rating_explanation(entry.get('explanation', '')),
         }
+
+    explicit_summaries = race.get('rating_summaries', {})
+    course_summary = next((
+        summary for source in (
+            explicit_summaries.get('course'),
+            course.get('character'),
+            course.get('summary'),
+            course.get('overview'),
+            race.get('tagline', ''),
+        ) if (summary := _rating_bumper(_editorialize_rating_explanation(source)))
+    ), '')
+    editorial_summary = next((
+        summary for source in (
+            explicit_summaries.get('editorial'),
+            final_verdict.get('one_liner'),
+            bo.get('bottom_line'),
+            bo.get('summary'),
+            race.get('tagline', ''),
+        ) if (summary := _rating_bumper(_editorialize_rating_explanation(source)))
+    ), '')
+    race_name = race.get('display_name') or race.get('name', 'This race')
+    if not course_summary:
+        course_summary = f"{race_name} scores {course_profile}/35 for course demands."
+    if not editorial_summary:
+        editorial_summary = f"{race_name} scores {opinion_total}/35 on the editorial card."
 
     # Extract date with year from date_specific like "2026: June 6" -> "June 6, 2026"
     raw_date_specific = vitals.get('date_specific', '')
@@ -546,6 +689,10 @@ def normalize_race_data(data: dict) -> dict:
         'opinion_total': opinion_total,
         'rating': rating,
         'explanations': explanations,
+        'rating_summaries': {
+            'course': course_summary,
+            'editorial': editorial_summary,
+        },
         'vitals': {
             'distance': f"{vitals.get('distance_mi', '--')} mi" if vitals.get('distance_mi') else '--',
             'distance_mi': vitals.get('distance_mi', 0),
@@ -816,21 +963,15 @@ def _radar_svg(dims: list, explanations: dict, color_fill: str, color_stroke: st
 
 
 def _build_rating_tiles(dims: list, explanations: dict, group_id: str) -> str:
-    """Build keyboard-operable score tiles and one shared explanation region."""
+    """Build score tiles plus a detail region revealed after selection."""
     tiles = []
-    first_label = ''
-    first_score = 0
-    first_explanation = ''
-    for i, dim in enumerate(dims):
+    for dim in dims:
         entry = explanations.get(dim, {})
         label = DIM_LABELS.get(dim, dim.replace('_', ' ').title())
         score = max(0, min(5, _parse_score(entry.get('score', 0))))
         score_label = f'{score:g}'
         explanation = entry.get('explanation', '').strip() or 'No written explanation is available yet.'
-        if i == 0:
-            first_label, first_score, first_explanation = label, score, explanation
-        pressed = 'true' if i == 0 else 'false'
-        tiles.append(f'''<button type="button" class="gg-rating-tile" data-rating-group="{group_id}" data-rating-key="{esc(dim)}" aria-pressed="{pressed}">
+        tiles.append(f'''<button type="button" class="gg-rating-tile" data-rating-group="{group_id}" data-rating-key="{esc(dim)}" aria-pressed="false">
           <span class="gg-rating-tile-label">{esc(label)}</span>
           <span class="gg-rating-tile-score">{score_label}<span>/5</span></span>
           <span class="gg-rating-source" hidden>{esc(explanation)}</span>
@@ -839,17 +980,23 @@ def _build_rating_tiles(dims: list, explanations: dict, group_id: str) -> str:
     return f'''<div class="gg-rating-breakdown" aria-label="{esc(group_id.title())} score breakdown">
         {''.join(tiles)}
       </div>
-      <div class="gg-rating-explanation" id="gg-rating-detail-{group_id}" role="status" aria-live="polite">
+      <div class="gg-rating-explanation" id="gg-rating-detail-{group_id}" role="status" aria-live="polite" hidden>
         <div class="gg-rating-explanation-head">
-          <span class="gg-rating-explanation-label">{esc(first_label)}</span>
-          <span class="gg-rating-explanation-score">{first_score:g}/5</span>
+          <span class="gg-rating-explanation-label"></span>
+          <span class="gg-rating-explanation-score"></span>
         </div>
-        <p>{esc(first_explanation)}</p>
+        <p></p>
       </div>'''
 
 
-def build_radar_charts(explanations: dict, course_total: int, opinion_total: int) -> str:
+def build_radar_charts(
+    explanations: dict,
+    course_total: int,
+    opinion_total: int,
+    summaries: Optional[dict] = None,
+) -> str:
     """Build tabbed, click-to-explain Course and Editorial radar charts."""
+    summaries = summaries or {}
     course_chart = _radar_svg(COURSE_DIMS, explanations,
                               COLORS['teal'], COLORS['teal'],
                               'Course Profile', course_total, 35, group_id='course')
@@ -864,10 +1011,18 @@ def build_radar_charts(explanations: dict, course_total: int, opinion_total: int
         <button type="button" id="gg-rating-tab-editorial" role="tab" aria-selected="false" aria-controls="gg-rating-panel-editorial" tabindex="-1">Editorial <span>{esc(opinion_total)}/35</span></button>
       </div>
       <div id="gg-rating-panel-course" class="gg-rating-panel" role="tabpanel" aria-labelledby="gg-rating-tab-course" data-rating-group="course">
+        <div class="gg-rating-summary">
+          <span>Course verdict</span>
+          <p>{esc(summaries.get('course', ''))}</p>
+        </div>
         {course_chart}
         {course_tiles}
       </div>
       <div id="gg-rating-panel-editorial" class="gg-rating-panel" role="tabpanel" aria-labelledby="gg-rating-tab-editorial" data-rating-group="editorial" hidden>
+        <div class="gg-rating-summary">
+          <span>Editorial verdict</span>
+          <p>{esc(summaries.get('editorial', ''))}</p>
+        </div>
         {editorial_chart}
         {editorial_tiles}
       </div>
@@ -977,6 +1132,7 @@ def build_inline_js() -> str:
     var detail = document.getElementById('gg-rating-detail-' + group);
     var source = tile.querySelector('.gg-rating-source');
     if (detail && source) {
+      detail.hidden = false;
       detail.querySelector('.gg-rating-explanation-label').textContent = tile.querySelector('.gg-rating-tile-label').textContent;
       detail.querySelector('.gg-rating-explanation-score').textContent = tile.querySelector('.gg-rating-tile-score').textContent;
       detail.querySelector('p').textContent = source.textContent;
@@ -2936,7 +3092,12 @@ def build_from_the_field(rd: dict) -> str:
 
 def build_ratings(rd: dict) -> str:
     """Build the centerpiece tabbed Course/Opinion rating component."""
-    radar = build_radar_charts(rd['explanations'], rd['course_profile'], rd['opinion_total'])
+    radar = build_radar_charts(
+        rd['explanations'],
+        rd['course_profile'],
+        rd['opinion_total'],
+        rd.get('rating_summaries'),
+    )
 
     return f'''<section id="ratings" class="gg-section gg-section--teal-accent gg-fade-section" data-measure-section="rating">
     <div class="gg-section-header gg-section-header--dark">
@@ -6053,8 +6214,11 @@ body {{ margin: 0; background: var(--gg-color-warm-paper); }}
 .gg-neo-brutalist-page .gg-rating-tablist button:last-child {{ border-right: 0; }}
 .gg-neo-brutalist-page .gg-rating-tablist button[aria-selected="true"] {{ background: var(--gg-color-sand); color: var(--gg-color-dark-brown); border-bottom: 3px solid var(--gg-color-gold); }}
 .gg-neo-brutalist-page .gg-rating-tablist button span {{ color: var(--gg-color-teal); }}
-.gg-neo-brutalist-page .gg-rating-panel {{ display: grid; grid-template-columns: minmax(300px, 1.1fr) minmax(260px, .9fr); grid-template-areas: 'radar tiles' 'radar detail'; gap: 16px; padding-top: 20px; }}
+.gg-neo-brutalist-page .gg-rating-panel {{ display: grid; grid-template-columns: minmax(300px, 1.1fr) minmax(260px, .9fr); grid-template-areas: 'summary summary' 'radar tiles' 'radar detail'; gap: 16px; padding-top: 20px; }}
 .gg-neo-brutalist-page .gg-rating-panel[hidden] {{ display: none; }}
+.gg-neo-brutalist-page .gg-rating-summary {{ grid-area: summary; padding: 18px 20px; border: 1px solid var(--gg-color-gold); background: var(--gg-color-sand); }}
+.gg-neo-brutalist-page .gg-rating-summary span {{ display: block; font-family: var(--gg-font-data); font-size: 10px; font-weight: 700; letter-spacing: var(--gg-letter-spacing-ultra-wide); text-transform: uppercase; color: var(--gg-color-teal); }}
+.gg-neo-brutalist-page .gg-rating-summary p {{ max-width: 72ch; margin: 7px 0 0; font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-md); font-weight: 650; line-height: 1.45; color: var(--gg-color-dark-brown); }}
 .gg-neo-brutalist-page .gg-radar-chart {{ grid-area: radar; border: var(--gg-border-subtle); background: var(--gg-color-warm-paper); padding: 12px 8px; text-align: center; }}
 .gg-neo-brutalist-page .gg-radar-svg {{ width: 100%; height: auto; display: block; margin: 0 auto; }}
 .gg-neo-brutalist-page .gg-radar-label {{ font-family: var(--gg-font-data); font-size: var(--gg-font-size-2xs); font-weight: 700; text-transform: uppercase; letter-spacing: var(--gg-letter-spacing-wider); color: var(--gg-color-secondary-brown); margin-top: var(--gg-spacing-2xs); }}
@@ -6462,7 +6626,7 @@ body {{ margin: 0; background: var(--gg-color-warm-paper); }}
   .gg-neo-brutalist-page .gg-stat-grid {{ grid-template-columns: repeat(2, 1fr); }}
   .gg-neo-brutalist-page .gg-verdict-grid {{ grid-template-columns: 1fr; }}
   .gg-neo-brutalist-page .gg-logistics-grid {{ grid-template-columns: 1fr; }}
-  .gg-neo-brutalist-page .gg-rating-panel {{ grid-template-columns: 1fr; grid-template-areas: 'radar' 'tiles' 'detail'; }}
+  .gg-neo-brutalist-page .gg-rating-panel {{ grid-template-columns: 1fr; grid-template-areas: 'summary' 'radar' 'tiles' 'detail'; }}
   .gg-neo-brutalist-page .gg-training-secondary {{ flex-direction: column; text-align: center; }}
   .gg-neo-brutalist-page .gg-pack-demand-label {{ font-size: 11px; }}
   .gg-neo-brutalist-page .gg-pack-workout-header {{ flex-wrap: wrap; }}


### PR DESCRIPTION
## What changed\n- Lead Course and Editorial panels with a compact overall verdict.\n- Keep every criterion collapsed until the reader selects it.\n- Remove known research-process scaffolding from displayed legacy explanations while preserving quotes and the Sources & Citations section.\n- Rewrite the Unbound 200 rating copy in the Gravel God voice.\n- Prevent future enrichment from generating source-handoff prose.\n\n## Verification\n- 7,353 tests passed; 298 skipped.\n- 201 rating-generator tests passed.\n- 384 generated pages passed the spine catalog audit.\n- Strict AI-writing check passed for the rewritten Unbound rating copy.\n- Desktop and mobile visual checks passed, including Editorial to Value interaction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly presentation and copy normalization on race pages plus prompt rules; no auth, payments, or critical runtime paths.
> 
> **Overview**
> Race profile **ratings** now open with compact **Course** and **Editorial verdict** blurbs instead of auto-expanding the first criterion. Criterion tiles stay collapsed until the reader picks one; the detail panel is hidden until then.
> 
> **Display copy** is normalized at page build time: `_editorialize_rating_explanation` strips research-handoff phrasing ("according to", "X describes", inline `[1]` markers) while keeping quoted rider language; `_rating_bumper` trims summaries to a short, complete-sentence lead. Source JSON keeps full provenance; the public page reads like Gravel God's judgment.
> 
> **Unbound 200** `biased_opinion_ratings` explanations were rewritten in that voice. **Batch enrichment** prompts now forbid the same patterns so new profiles do not regress.
> 
> Tests cover bumper/editorialize helpers, the new ratings HTML contract, and a **catalog-wide** check that normalized summaries and explanations stay under length limits and avoid banned narration patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b17bbd7018041727f9913922d431a4e53b754e8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->