### PR TITLE
Record 1999 to 1996 historical research debt

### DIFF
--- a/data/gravel-weekly/backfill/1996.json
+++ b/data/gravel-weekly/backfill/1996.json
@@ -1,0 +1,443 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 1996,
+  "asOf": "1996-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/86",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33184355913",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceArchiveCoverage": "unavailable",
+  "sourceArchiveErrors": [
+    "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
+  ],
+  "sourceCardCount": 0,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "1995-12-30",
+      "periodEndedAt": "1996-01-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-01-06",
+      "periodEndedAt": "1996-01-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-01-13",
+      "periodEndedAt": "1996-01-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-01-20",
+      "periodEndedAt": "1996-01-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-01-27",
+      "periodEndedAt": "1996-02-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-02-03",
+      "periodEndedAt": "1996-02-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-02-10",
+      "periodEndedAt": "1996-02-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-02-17",
+      "periodEndedAt": "1996-02-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-02-24",
+      "periodEndedAt": "1996-03-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-03-02",
+      "periodEndedAt": "1996-03-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-03-09",
+      "periodEndedAt": "1996-03-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-03-16",
+      "periodEndedAt": "1996-03-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-03-23",
+      "periodEndedAt": "1996-03-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-03-30",
+      "periodEndedAt": "1996-04-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-04-06",
+      "periodEndedAt": "1996-04-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-04-13",
+      "periodEndedAt": "1996-04-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-04-20",
+      "periodEndedAt": "1996-04-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-04-27",
+      "periodEndedAt": "1996-05-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-05-04",
+      "periodEndedAt": "1996-05-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-05-11",
+      "periodEndedAt": "1996-05-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-05-18",
+      "periodEndedAt": "1996-05-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-05-25",
+      "periodEndedAt": "1996-05-31",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-06-01",
+      "periodEndedAt": "1996-06-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-06-08",
+      "periodEndedAt": "1996-06-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-06-15",
+      "periodEndedAt": "1996-06-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-06-22",
+      "periodEndedAt": "1996-06-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-06-29",
+      "periodEndedAt": "1996-07-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-07-06",
+      "periodEndedAt": "1996-07-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-07-13",
+      "periodEndedAt": "1996-07-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-07-20",
+      "periodEndedAt": "1996-07-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-07-27",
+      "periodEndedAt": "1996-08-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-08-03",
+      "periodEndedAt": "1996-08-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-08-10",
+      "periodEndedAt": "1996-08-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-08-17",
+      "periodEndedAt": "1996-08-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-08-24",
+      "periodEndedAt": "1996-08-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-08-31",
+      "periodEndedAt": "1996-09-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-09-07",
+      "periodEndedAt": "1996-09-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-09-14",
+      "periodEndedAt": "1996-09-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-09-21",
+      "periodEndedAt": "1996-09-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-09-28",
+      "periodEndedAt": "1996-10-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-10-05",
+      "periodEndedAt": "1996-10-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-10-12",
+      "periodEndedAt": "1996-10-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-10-19",
+      "periodEndedAt": "1996-10-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-10-26",
+      "periodEndedAt": "1996-11-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-11-02",
+      "periodEndedAt": "1996-11-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-11-09",
+      "periodEndedAt": "1996-11-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-11-16",
+      "periodEndedAt": "1996-11-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-11-23",
+      "periodEndedAt": "1996-11-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-11-30",
+      "periodEndedAt": "1996-12-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-12-07",
+      "periodEndedAt": "1996-12-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-12-14",
+      "periodEndedAt": "1996-12-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-12-21",
+      "periodEndedAt": "1996-12-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1996-12-28",
+      "periodEndedAt": "1997-01-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    }
+  ],
+  "updatedAt": "2026-08-28T15:30:00Z"
+}

--- a/data/gravel-weekly/backfill/1997.json
+++ b/data/gravel-weekly/backfill/1997.json
@@ -1,0 +1,443 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 1997,
+  "asOf": "1997-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/85",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33184353351",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceArchiveCoverage": "unavailable",
+  "sourceArchiveErrors": [
+    "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
+  ],
+  "sourceCardCount": 0,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "1996-12-28",
+      "periodEndedAt": "1997-01-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-01-04",
+      "periodEndedAt": "1997-01-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-01-11",
+      "periodEndedAt": "1997-01-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-01-18",
+      "periodEndedAt": "1997-01-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-01-25",
+      "periodEndedAt": "1997-01-31",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-02-01",
+      "periodEndedAt": "1997-02-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-02-08",
+      "periodEndedAt": "1997-02-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-02-15",
+      "periodEndedAt": "1997-02-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-02-22",
+      "periodEndedAt": "1997-02-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-03-01",
+      "periodEndedAt": "1997-03-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-03-08",
+      "periodEndedAt": "1997-03-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-03-15",
+      "periodEndedAt": "1997-03-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-03-22",
+      "periodEndedAt": "1997-03-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-03-29",
+      "periodEndedAt": "1997-04-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-04-05",
+      "periodEndedAt": "1997-04-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-04-12",
+      "periodEndedAt": "1997-04-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-04-19",
+      "periodEndedAt": "1997-04-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-04-26",
+      "periodEndedAt": "1997-05-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-05-03",
+      "periodEndedAt": "1997-05-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-05-10",
+      "periodEndedAt": "1997-05-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-05-17",
+      "periodEndedAt": "1997-05-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-05-24",
+      "periodEndedAt": "1997-05-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-05-31",
+      "periodEndedAt": "1997-06-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-06-07",
+      "periodEndedAt": "1997-06-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-06-14",
+      "periodEndedAt": "1997-06-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-06-21",
+      "periodEndedAt": "1997-06-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-06-28",
+      "periodEndedAt": "1997-07-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-07-05",
+      "periodEndedAt": "1997-07-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-07-12",
+      "periodEndedAt": "1997-07-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-07-19",
+      "periodEndedAt": "1997-07-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-07-26",
+      "periodEndedAt": "1997-08-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-08-02",
+      "periodEndedAt": "1997-08-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-08-09",
+      "periodEndedAt": "1997-08-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-08-16",
+      "periodEndedAt": "1997-08-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-08-23",
+      "periodEndedAt": "1997-08-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-08-30",
+      "periodEndedAt": "1997-09-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-09-06",
+      "periodEndedAt": "1997-09-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-09-13",
+      "periodEndedAt": "1997-09-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-09-20",
+      "periodEndedAt": "1997-09-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-09-27",
+      "periodEndedAt": "1997-10-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-10-04",
+      "periodEndedAt": "1997-10-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-10-11",
+      "periodEndedAt": "1997-10-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-10-18",
+      "periodEndedAt": "1997-10-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-10-25",
+      "periodEndedAt": "1997-10-31",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-11-01",
+      "periodEndedAt": "1997-11-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-11-08",
+      "periodEndedAt": "1997-11-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-11-15",
+      "periodEndedAt": "1997-11-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-11-22",
+      "periodEndedAt": "1997-11-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-11-29",
+      "periodEndedAt": "1997-12-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-12-06",
+      "periodEndedAt": "1997-12-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-12-13",
+      "periodEndedAt": "1997-12-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-12-20",
+      "periodEndedAt": "1997-12-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1997-12-27",
+      "periodEndedAt": "1998-01-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    }
+  ],
+  "updatedAt": "2026-08-28T15:30:00Z"
+}

--- a/data/gravel-weekly/backfill/1999.json
+++ b/data/gravel-weekly/backfill/1999.json
@@ -1,0 +1,443 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 1999,
+  "asOf": "1999-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/82",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33182221701",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceArchiveCoverage": "unavailable",
+  "sourceArchiveErrors": [
+    "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
+  ],
+  "sourceCardCount": 0,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "1998-12-26",
+      "periodEndedAt": "1999-01-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-01-02",
+      "periodEndedAt": "1999-01-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-01-09",
+      "periodEndedAt": "1999-01-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-01-16",
+      "periodEndedAt": "1999-01-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-01-23",
+      "periodEndedAt": "1999-01-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-01-30",
+      "periodEndedAt": "1999-02-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-02-06",
+      "periodEndedAt": "1999-02-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-02-13",
+      "periodEndedAt": "1999-02-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-02-20",
+      "periodEndedAt": "1999-02-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-02-27",
+      "periodEndedAt": "1999-03-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-03-06",
+      "periodEndedAt": "1999-03-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-03-13",
+      "periodEndedAt": "1999-03-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-03-20",
+      "periodEndedAt": "1999-03-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-03-27",
+      "periodEndedAt": "1999-04-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-04-03",
+      "periodEndedAt": "1999-04-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-04-10",
+      "periodEndedAt": "1999-04-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-04-17",
+      "periodEndedAt": "1999-04-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-04-24",
+      "periodEndedAt": "1999-04-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-05-01",
+      "periodEndedAt": "1999-05-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-05-08",
+      "periodEndedAt": "1999-05-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-05-15",
+      "periodEndedAt": "1999-05-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-05-22",
+      "periodEndedAt": "1999-05-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-05-29",
+      "periodEndedAt": "1999-06-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-06-05",
+      "periodEndedAt": "1999-06-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-06-12",
+      "periodEndedAt": "1999-06-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-06-19",
+      "periodEndedAt": "1999-06-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-06-26",
+      "periodEndedAt": "1999-07-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-07-03",
+      "periodEndedAt": "1999-07-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-07-10",
+      "periodEndedAt": "1999-07-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-07-17",
+      "periodEndedAt": "1999-07-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-07-24",
+      "periodEndedAt": "1999-07-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-07-31",
+      "periodEndedAt": "1999-08-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-08-07",
+      "periodEndedAt": "1999-08-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-08-14",
+      "periodEndedAt": "1999-08-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-08-21",
+      "periodEndedAt": "1999-08-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-08-28",
+      "periodEndedAt": "1999-09-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-09-04",
+      "periodEndedAt": "1999-09-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-09-11",
+      "periodEndedAt": "1999-09-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-09-18",
+      "periodEndedAt": "1999-09-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-09-25",
+      "periodEndedAt": "1999-10-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-10-02",
+      "periodEndedAt": "1999-10-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-10-09",
+      "periodEndedAt": "1999-10-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-10-16",
+      "periodEndedAt": "1999-10-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-10-23",
+      "periodEndedAt": "1999-10-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-10-30",
+      "periodEndedAt": "1999-11-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-11-06",
+      "periodEndedAt": "1999-11-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-11-13",
+      "periodEndedAt": "1999-11-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-11-20",
+      "periodEndedAt": "1999-11-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-11-27",
+      "periodEndedAt": "1999-12-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-12-04",
+      "periodEndedAt": "1999-12-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-12-11",
+      "periodEndedAt": "1999-12-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-12-18",
+      "periodEndedAt": "1999-12-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1999-12-25",
+      "periodEndedAt": "1999-12-31",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    }
+  ],
+  "updatedAt": "2026-08-28T15:25:00Z"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -992,6 +992,21 @@ def test_2000_backfill_ledger_preserves_unavailable_legacy_archive_research_debt
     assert validated["complete"] is False
 
 
+@pytest.mark.parametrize("year", [1999, 1997, 1996])
+def test_pre_web_backfill_ledgers_preserve_unresolved_research_debt(year):
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / f"{year}.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert validated["sourceArchiveCoverage"] == "unavailable"
+    assert len(validated["sourceArchiveErrors"]) == 1
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 53
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
+    assert validated["complete"] is False
+
+
 def test_1995_backfill_ledger_opens_pre_web_research_debt_without_hiding_the_recovered_story():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "1995.json").read_text())


### PR DESCRIPTION
## What changed
- add truthful pre-web annual ledgers for 1999, 1997, and 1996 from control-plane runs 33182221701, 33184353351, and 33184355913
- keep all 159 weekly windows `unresearched`, not quiet or complete
- bind each ledger to its assigning-desk issue and the program issue
- regression-test that all three years remain unavailable, incomplete, and free of false explicit gaps

## Editorial disposition
- 1999 John Stamstad/Great Divide is supporting chronology for the stronger 1998 route-publication and 2008 Tour Divide equipment chapters, not a third duplicate story
- the proposed 1999 D2R2 precursor remains held until contemporary evidence is recovered
- 1997 route research completion and 1996 half-mapped status support the 1998 chapter but do not independently clear the party/friend gate

## Verification
- all 32 backfill ledgers validate
- 62 Gravel Weekly focused tests pass
- no historical entry, publication authority, or race mutation is added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static JSON metadata and test assertions only; no runtime, auth, or publish-path changes.
> 
> **Overview**
> Adds **annual backfill ledgers** for **1996**, **1997**, and **1999** under `data/gravel-weekly/backfill/`, wired to control-plane ledger issues and workflow runs. Each year is marked **`sourceArchiveCoverage: unavailable`** (Cyclingnews automation starts in 2000), **`complete: false`**, and **`humanApprovalRequired`** with **no auto-publish**.
> 
> Every weekly window (**53 per year**) is **`unresearched`** with zero source cards and explicit reasons not to treat missing archive coverage as quiet weeks or **`explicit_gap`**. No new history entries or published content are introduced.
> 
> A **parametrized regression test** (`test_pre_web_backfill_ledgers_preserve_unresolved_research_debt`) asserts those three ledgers stay unavailable, incomplete, fully unresearched, and free of false explicit gaps after `validate_backfill_ledger`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 845561816293d11c023cd8caef1e82e8d675c77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->