### PR TITLE
Open 1994 Gravel Weekly archival backfill

### DIFF
--- a/data/gravel-weekly/backfill/1994.json
+++ b/data/gravel-weekly/backfill/1994.json
@@ -1,0 +1,445 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 1994,
+  "asOf": "1994-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/87",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33184666798",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceArchiveCoverage": "unavailable",
+  "sourceArchiveErrors": [
+    "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
+  ],
+  "sourceCardCount": 0,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "1994-01-01",
+      "periodEndedAt": "1994-01-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-01-08",
+      "periodEndedAt": "1994-01-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-01-15",
+      "periodEndedAt": "1994-01-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-01-22",
+      "periodEndedAt": "1994-01-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-01-29",
+      "periodEndedAt": "1994-02-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-02-05",
+      "periodEndedAt": "1994-02-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-02-12",
+      "periodEndedAt": "1994-02-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-02-19",
+      "periodEndedAt": "1994-02-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-02-26",
+      "periodEndedAt": "1994-03-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-03-05",
+      "periodEndedAt": "1994-03-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-03-12",
+      "periodEndedAt": "1994-03-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-03-19",
+      "periodEndedAt": "1994-03-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-03-26",
+      "periodEndedAt": "1994-04-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-04-02",
+      "periodEndedAt": "1994-04-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-04-09",
+      "periodEndedAt": "1994-04-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-04-16",
+      "periodEndedAt": "1994-04-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-04-23",
+      "periodEndedAt": "1994-04-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-04-30",
+      "periodEndedAt": "1994-05-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-05-07",
+      "periodEndedAt": "1994-05-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-05-14",
+      "periodEndedAt": "1994-05-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-05-21",
+      "periodEndedAt": "1994-05-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-05-28",
+      "periodEndedAt": "1994-06-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-06-04",
+      "periodEndedAt": "1994-06-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-06-11",
+      "periodEndedAt": "1994-06-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-06-18",
+      "periodEndedAt": "1994-06-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-06-25",
+      "periodEndedAt": "1994-07-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-07-02",
+      "periodEndedAt": "1994-07-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-07-09",
+      "periodEndedAt": "1994-07-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-07-16",
+      "periodEndedAt": "1994-07-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-07-23",
+      "periodEndedAt": "1994-07-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-07-30",
+      "periodEndedAt": "1994-08-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-08-06",
+      "periodEndedAt": "1994-08-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-08-13",
+      "periodEndedAt": "1994-08-19",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-leadville-town-economic-engine-1994"
+      ],
+      "reason": "Manual archival recovery found the official inaugural Leadville Trail 100 MTB results and later institutional evidence of the event's town-economic purpose; the resulting draft remains unpublished pending human approval."
+    },
+    {
+      "periodStartedAt": "1994-08-20",
+      "periodEndedAt": "1994-08-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-08-27",
+      "periodEndedAt": "1994-09-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-09-03",
+      "periodEndedAt": "1994-09-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-09-10",
+      "periodEndedAt": "1994-09-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-09-17",
+      "periodEndedAt": "1994-09-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-09-24",
+      "periodEndedAt": "1994-09-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-10-01",
+      "periodEndedAt": "1994-10-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-10-08",
+      "periodEndedAt": "1994-10-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-10-15",
+      "periodEndedAt": "1994-10-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-10-22",
+      "periodEndedAt": "1994-10-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-10-29",
+      "periodEndedAt": "1994-11-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-11-05",
+      "periodEndedAt": "1994-11-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-11-12",
+      "periodEndedAt": "1994-11-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-11-19",
+      "periodEndedAt": "1994-11-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-11-26",
+      "periodEndedAt": "1994-12-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-12-03",
+      "periodEndedAt": "1994-12-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-12-10",
+      "periodEndedAt": "1994-12-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-12-17",
+      "periodEndedAt": "1994-12-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-12-24",
+      "periodEndedAt": "1994-12-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1994-12-31",
+      "periodEndedAt": "1995-01-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    }
+  ],
+  "updatedAt": "2026-08-28T15:35:00Z"
+}

--- a/data/gravel-weekly/history/1994-leadville-town-economic-engine.json
+++ b/data/gravel-weekly/history/1994-leadville-town-economic-engine.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-leadville-town-economic-engine-1994",
+  "activeFrom": "1994-08-13",
+  "activeThrough": "1994-10-31",
+  "status": "draft",
+  "headline": "Leadville Built a Bike Race Because the Town Needed a Payroll",
+  "point": "Leadville's first 100-mile mountain-bike race started on August 13, 1994, as the wheeled extension of an endurance event created after the Climax Mine closure erased roughly 3,250 jobs from a town of about 5,000. A footwear sponsor proposed the bike race, 145 riders started, and national television followed. Commercial gravel did not invent the idea that a brutal off-road event could sell a place and prop up its economy. The useful argument is not whether race money contaminates authenticity; it is who captures the money and whether the host community remains the point.",
+  "priorJudgment": "Major off-road races began as authentic sporting challenges and acquired their economic-development and sponsor logic later, when corporate owners professionalized them.",
+  "changedJudgment": "Leadville's endurance mythology and its local economic purpose were intertwined before the first mountain-bike start. The bike race came from a sponsor proposal and expanded a town-recovery project, showing that commerce can be part of a race's original social function rather than evidence of later corruption.",
+  "stakes": "Modern arguments about Life Time, destination racing, entry fees, and authenticity become less useful if every dollar is treated as contamination. The sharper test is whether an event converts visiting riders into durable local benefit, preserves community agency, and makes the sporting burden worth what the town gives up to host it.",
+  "credibleOpposition": "The mine closure and economic-revival motive belong first to the 1983 running race; the 1994 bike event was a sponsor's extension and should not be credited with rescuing Leadville by itself. The strongest economic-impact number comes from a 2012 study cited by the Hall of Fame, not from a recovered 1994 source. Later institutional histories are celebratory and may compress a complicated local economy into a founder myth.",
+  "whatHappened": "Leadville Race Series' official 1994 results record John Stamstad winning the inaugural Leadville Trail 100 MTB in 7:52:53 and Laurie Brandt as the first woman in 9:03:50. A later first-person account from Todd Murray says 142 riders started, 96 finished under the twelve-hour cutoff, and only Stamstad beat the promised eight-hour big-buckle standard, prompting organizers to change the standards to nine and twelve hours. Leadville's institutional history says the Climax Mine closed in 1982, eliminating roughly 3,250 jobs in a community of about 5,000. Ken Chlouber and Merilee Maupin launched the 100-mile run in 1983 as an economic response. In 1993, sponsor Rockport proposed a 100-mile mountain-bike race; organizers scheduled it a week before the run, and 145 entrants started on August 13, 1994. The Hall of Fame says CBS aired the race nationally that October and cites a 2012 study estimating that the race series put more than $15 million into the local economy.",
+  "take": "Model draft, not Matti's approved view: Before Life Time bought Leadville, Leadville had already invented the part of the Life Time business model that matters: make suffering portable and give people a reason to spend money in town. The Climax Mine closure wiped out roughly 3,250 jobs in a community of about 5,000. The 100-mile run was the first response. Then a shoe-company sponsor suggested doing it on mountain bikes, because apparently one municipal recovery plan can always use more hypoxia. In 1994, 145 riders started, John Stamstad was the only one under eight hours, and CBS put the thing on national television. That history does not make every modern entry fee noble. It kills the lazy argument that commerce arrived later and ruined a pure sport. Money was there near the start. The question is whether the town is still the beneficiary or merely the backdrop.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The official results PDF is a preserved event record, but its current web upload date is later than 1994; it is indexed at the documented race date because the results themselves were created by the event. Later sources disagree slightly on whether 142, 145, 148, or 150 riders started, so the entry uses 145 only when attributing the Hall of Fame account and otherwise preserves the reported range. The economic origin is well attested by organizers and the Hall of Fame but still lacks a recovered contemporaneous 1994 newspaper or municipal record. The 2012 impact figure describes the full race series, not the inaugural bike race.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_leadville_inaugural_mtb_results_1994",
+      "canonicalUrl": "https://www.leadvilleraceseries.com/wp-content/uploads/2013/12/1994-Leadville-Trail-100-MTB-Overall-Results.pdf",
+      "publisher": "Leadville Race Series",
+      "publishedAt": "1994-08-13T18:00:00-06:00",
+      "quoteExcerpt": "1 Stamstad, John 7:52:53 OH 1994 29 M",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_leadville_first_woman_result_1994",
+      "canonicalUrl": "https://www.leadvilleraceseries.com/wp-content/uploads/2013/12/1994-Leadville-Trail-100-MTB-Overall-Results.pdf",
+      "publisher": "Leadville Race Series",
+      "publishedAt": "1994-08-13T18:00:00-06:00",
+      "quoteExcerpt": "19 Brandt, Laurie 9:03:50 CO 1994 30 F",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_leadville_first_field_cutoffs_later",
+      "canonicalUrl": "https://www.leadvilleraceseries.com/todd-murrays-quest-for-25-straight-leadville-trail-100-mtbs/",
+      "publisher": "Leadville Race Series / Todd Murray",
+      "publishedAt": "2018-07-25T12:00:00-06:00",
+      "quoteExcerpt": "There were 96 finishers under the 12 hour cutoff out of 142 starters.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_leadville_mine_jobs_race_economy_later",
+      "canonicalUrl": "https://mmbhof.org/mountain-bike-hall-of-fame/2018/ken-chlouber/",
+      "publisher": "Marin Museum of Bicycling and Mountain Bike Hall of Fame",
+      "publishedAt": "2018-09-22T12:00:00-07:00",
+      "quoteExcerpt": "In that instant, 3,250 jobs were lost and in the Leadville community of about 5,000, that affected everybody.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_leadville_sponsor_mtb_proposal_later",
+      "canonicalUrl": "https://www.leadvilleraceseries.com/5017-2/",
+      "publisher": "Leadville Race Series",
+      "publishedAt": "2021-01-21T12:00:00-07:00",
+      "quoteExcerpt": "Rockport, the shoe company, entered into the Leadville sponsorship asking for Leadville to host a 100 mile mountain bike race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_leadville_founders_economic_purpose_later",
+      "canonicalUrl": "https://www.leadvilletrail100legacy.org/blog-/consideradonation",
+      "publisher": "Leadville Trail 100 Legacy Foundation / Ken Chlouber and Merilee Maupin",
+      "publishedAt": "2019-12-19T12:00:00-07:00",
+      "quoteExcerpt": "You brought economic life back to Leadville.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:leadville-100",
+      "fieldPath": "race.history",
+      "claimIds": [
+        "claim_leadville_inaugural_mtb_results_1994",
+        "claim_leadville_first_woman_result_1994",
+        "claim_leadville_first_field_cutoffs_later",
+        "claim_leadville_mine_jobs_race_economy_later",
+        "claim_leadville_sponsor_mtb_proposal_later",
+        "claim_leadville_founders_economic_purpose_later"
+      ],
+      "confidence": 0.91,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T15:35:00Z",
+  "contentHash": "c586a93d2c65ea51c660b6261306a40fdb745896e790e4574289443f1135ea23"
+}


### PR DESCRIPTION
## What changed
- add a truthful 1994 pre-web ledger tied to control-plane run 33184666798 and issue #87
- stage one hidden historical draft about Leadville's bike race inheriting a town-economic recovery mission
- bind the draft to official inaugural results and later institutional evidence
- leave the other 52 windows unresearched; no fake quiet-year claim

## Editorial point
Commercial off-road racing did not begin as a pure sport later contaminated by money. Leadville's endurance mythology and local economic purpose were intertwined before the first bike start. The useful modern test is who captures the money and whether the host community remains the point.

## Safety
- `status: draft`
- `takeProvenance: model_draft`
- `humanApprovalRequired: true`
- `autoPublishAllowed: false`
- `gravel:leadville-100` history impact is `editorial_review`; `autoFixAllowed: false`

## Verification
- new entry and ledger validate
- 62 Gravel Weekly focused tests pass
- both anti-slop detectors report zero findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static editorial/backfill JSON only, with draft status and publish gates; the Leadville race history impact is review-only and cannot auto-apply fixes.
> 
> **Overview**
> Adds **1994** to the Gravel Weekly archival backfill with a new `data/gravel-weekly/backfill/1994.json` ledger tied to control-plane issue/run links. The ledger marks automated archive coverage as **unavailable** (pre-2000 Cyclingnews), sets **`complete: false`**, and labels almost every week **`unresearched`** with explicit “do not infer quiet” reasons—only the **1994-08-13** week is **`covered_by_draft`**, pointing at a new history entry.
> 
> Introduces **`data/gravel-weekly/history/1994-leadville-town-economic-engine.json`**, a **`draft`** Gravel Weekly history piece on the inaugural Leadville Trail 100 MTB and the town’s post-mine economic recovery narrative, backed by official 1994 results receipts plus later institutional sources. Publishing stays blocked (`humanApprovalRequired`, `autoPublishAllowed: false`, `takeProvenance: model_draft`); it registers a **`raceImpacts`** hook on **`gravel:leadville-100`** `race.history` for **editorial review** only (`autoFixAllowed: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d96d9d431ee7f57a11a4aded1033f829e9cf114c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->