### PR TITLE
Normalize Gravel Weekly historical race identity

### DIFF
--- a/data/gravel-weekly/history/2012-rusch-nearly-won-whole-thing.json
+++ b/data/gravel-weekly/history/2012-rusch-nearly-won-whole-thing.json
@@ -73,7 +73,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_dirty_kanza_breakout_field_2012",
@@ -92,5 +92,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T15:00:00Z",
-  "contentHash": "dc80a7942cc405ecdb4fd12da345cbfc3e8414460f14618d2f7f4d342551b4d5"
+  "contentHash": "827d6cb7b486aa934715142fc53c8a1b1fc957c1bbe0f4c65569fe165b883cc4"
 }

--- a/data/gravel-weekly/history/2013-gravel-race-bike-before-rulebook.json
+++ b/data/gravel-weekly/history/2013-gravel-race-bike-before-rulebook.json
@@ -74,7 +74,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_warbird_owner_dirty_kanza_and_odin_2013",
@@ -102,5 +102,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T14:15:00Z",
-  "contentHash": "de500e9f5d96d71344801f35a81a1ec289b58b57b98ede97a10fbbabcd77f2f9"
+  "contentHash": "51525067d9c0cfa19e4206406f34dba9b80231cc8a52d4eebb5f4f1a216ef1da"
 }

--- a/data/gravel-weekly/history/2014-rusch-built-gravel-home-game.json
+++ b/data/gravel-weekly/history/2014-rusch-built-gravel-home-game.json
@@ -65,7 +65,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_dirty_kanza_scale_rusch_overall_2014",
@@ -93,5 +93,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T13:25:00Z",
-  "contentHash": "415a91523fb298753dff2ec3dd641d7df8e3b77752e5ec7386deb5ca3a7ac65b"
+  "contentHash": "49e74296fdc5d07bf7efe245b1fd0ab4d67cf2cf6aaf3a901a7e04f12e1441db"
 }

--- a/data/gravel-weekly/history/2016-ted-king-prototyped-gravel-pro.json
+++ b/data/gravel-weekly/history/2016-ted-king-prototyped-gravel-pro.json
@@ -65,7 +65,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_king_first_dirty_kanza_self_support_2016",
@@ -83,5 +83,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T12:45:00Z",
-  "contentHash": "3df436ff5b5991598938aa48a4247a82e0e9b055fc510b48a036e63a0b4a9463"
+  "contentHash": "163bd47583b3e57f802269c0c51fc8bce6008cb561c4f7db841756c81398904e"
 }

--- a/data/gravel-weekly/history/2017-gravel-got-huge-before-important.json
+++ b/data/gravel-weekly/history/2017-gravel-got-huge-before-important.json
@@ -64,7 +64,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_dirty_kanza_economic_scale_2017",
@@ -82,5 +82,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T12:25:00Z",
-  "contentHash": "8c7b0fd51eb589396b85a803c6fbd2641d80fdfb7424a81f05bb462d728ed4b2"
+  "contentHash": "a7ff82ac4ddf52e2456eef56f45005251a709cf11de1aa10ab36d951879c9ffb"
 }

--- a/data/gravel-weekly/history/2019-gravel-became-economy-before-league.json
+++ b/data/gravel-weekly/history/2019-gravel-became-economy-before-league.json
@@ -55,7 +55,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_stetina_left_worldtour_for_gravel_2019",
@@ -67,7 +67,7 @@
     },
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:big-sugar-gravel",
+      "raceId": "gravel:big-sugar",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_life_time_launched_big_sugar_2019"
@@ -82,5 +82,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T12:15:00Z",
-  "contentHash": "a2f9a3f5b42cd415858c779f4e7f39387d2284164523c90fac845bf431af760d"
+  "contentHash": "b14970353617823b47e82bd557b0af416982f63aad6c2bfadc75ee35b62d4eab"
 }

--- a/data/gravel-weekly/history/2019-gravel-got-own-department.json
+++ b/data/gravel-weekly/history/2019-gravel-got-own-department.json
@@ -46,7 +46,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_shimano_launched_dedicated_grx_2019",
@@ -62,5 +62,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T12:15:00Z",
-  "contentHash": "0b0621fbb2b073dd05c3e81abb9a1a345f17dd94d4abc033c4b86d3a98e096e7"
+  "contentHash": "1e23d8516c820ec9f9803ba5f3ad3bc4612e7e72f5356d407336112a8aa883c6"
 }

--- a/data/gravel-weekly/history/2020-gravel-became-pro-cycling-exit-interview.json
+++ b/data/gravel-weekly/history/2020-gravel-became-pro-cycling-exit-interview.json
@@ -83,7 +83,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_stetina_leaves_worldtour_in_prime_2020",
@@ -102,5 +102,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T19:30:00Z",
-  "contentHash": "2784f0d91868090c5fe59f57c616c96c8a899c9a7269615706af9094e4099dbe"
+  "contentHash": "be053c7e4392a66621e218d26bfc9fc9bc2583c8cd1c0a423e45694f45c89d14"
 }

--- a/data/gravel-weekly/history/2020-gravel-world-championship-before-government.json
+++ b/data/gravel-weekly/history/2020-gravel-world-championship-before-government.json
@@ -101,7 +101,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_morton_dirty_kanza_existing_worlds_2020",
@@ -136,5 +136,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T19:00:00Z",
-  "contentHash": "dd688bd0aa076416b95f57ab3913f16b002c9abbe68bb79c59dedef2c25a2a4f"
+  "contentHash": "36b80a260216ab27d66deb5af9c1b6b7c1f9f95448cd0e63ecd6927d88abaa1a"
 }

--- a/data/gravel-weekly/history/2020-heritage-not-consent.json
+++ b/data/gravel-weekly/history/2020-heritage-not-consent.json
@@ -55,7 +55,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_kaw_nation_requested_name_connection_end_2020",
@@ -72,5 +72,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T20:15:00Z",
-  "contentHash": "7fd9e6bad741171db1921e3100db902645a497fafffe1e3cb947e819822f1cb7"
+  "contentHash": "3ef545f87c5e976c69e55f1dc84e96703eb07acd7927b9ee10424804098915cf"
 }

--- a/data/gravel-weekly/history/2020-race-cancelled-gravel-everywhere.json
+++ b/data/gravel-weekly/history/2020-race-cancelled-gravel-everywhere.json
@@ -82,7 +82,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:sbt-grvl",
+      "raceId": "gravel:steamboat-gravel",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_sbt_cancelled_and_launched_vrtl_2020"
@@ -93,7 +93,7 @@
     },
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_dirty_kanzelled_distributed_substitute_2020",
@@ -111,5 +111,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T20:15:00Z",
-  "contentHash": "42553fc4ab0b7d9b76c907f1d898167745e188414dc54686c1c0c60b49ef7088"
+  "contentHash": "f7f8df73f2799717550fdc2aba42644403eb49d3fbc54f251495a7c8e6d1d8c6"
 }

--- a/data/gravel-weekly/history/2021-gravel-opened-transfer-window.json
+++ b/data/gravel-weekly/history/2021-gravel-opened-transfer-window.json
@@ -83,7 +83,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:sbt-grvl",
+      "raceId": "gravel:steamboat-gravel",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_cromwell_executes_gravel_debut_2021"
@@ -98,5 +98,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T12:30:00Z",
-  "contentHash": "31a99187d5a35bde6568f3062cbc1193f321c22bafcfd7e82efb69e749e9821c"
+  "contentHash": "98a2bbf886d23a0acb8fdb6fbb3eadfbf6476b70568aa4623fb317f6fd8a5a54"
 }

--- a/data/gravel-weekly/history/2021-lifetime-invented-admissions.json
+++ b/data/gravel-weekly/history/2021-lifetime-invented-admissions.json
@@ -83,7 +83,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_lifetime_launches_selected_250k_series_2021",
@@ -103,5 +103,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T10:05:50Z",
-  "contentHash": "3ffe81da09a098c98f41efa78fe9237bb20fcc5952a03bd8f628d17338297efd"
+  "contentHash": "6be12f66344701ef5a363b4a4dff1db043ef3654998fae61418a7ddccc0bf685"
 }

--- a/data/gravel-weekly/history/2021-unbound-became-super-bowl.json
+++ b/data/gravel-weekly/history/2021-unbound-became-super-bowl.json
@@ -110,7 +110,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_unbound_first_us_national_gravel_stream_2021",
@@ -130,5 +130,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T13:15:00Z",
-  "contentHash": "1ada8531f92235d54c34215f8edaa93aae45858b4c709e27020f294ca841f493"
+  "contentHash": "e2a3a767bf0f643d7051591b12ccdce95389664de4a5397f39f446927198691c"
 }

--- a/data/gravel-weekly/history/2021-unwritten-rules-failed-women.json
+++ b/data/gravel-weekly/history/2021-unwritten-rules-failed-women.json
@@ -101,7 +101,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_allison_says_rules_allowed_unequal_male_support_2021",
@@ -118,7 +118,7 @@
     },
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:sbt-grvl",
+      "raceId": "gravel:steamboat-gravel",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_cinch_tactics_legal_and_changed_sbt_field_2021",
@@ -137,5 +137,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T10:12:52Z",
-  "contentHash": "ff9b3cc1fa82075a40b1342fa2cf5325559622d51f1737a3ffe7004fa6744d77"
+  "contentHash": "d87bec48c2cc521980ef300c951e2f034ce1c065850bd0f68afbb664a391e271"
 }

--- a/data/gravel-weekly/history/2022-gravel-spirit-hr-job.json
+++ b/data/gravel-weekly/history/2022-gravel-spirit-hr-job.json
@@ -110,7 +110,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_unbound_aerobar_collective_action_2022",
@@ -132,5 +132,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T16:00:00Z",
-  "contentHash": "54a1bb74759de687d1905e96e1042e52f4ac6dd9df7945bb9fec7ea67d3719f9"
+  "contentHash": "ec7deda9450224ca9a95ac60abdef426de9df6bd33de5821ee35934edc9deea0"
 }

--- a/data/gravel-weekly/history/2022-gravel-worlds-road-settings.json
+++ b/data/gravel-weekly/history/2022-gravel-worlds-road-settings.json
@@ -119,7 +119,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:uci-gravel-world-championships",
+      "raceId": "gravel:uci-gravel-worlds",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_worlds_road_privateer_field_and_course_2022",
@@ -143,5 +143,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T15:25:00Z",
-  "contentHash": "57796d3b4c940a2079ac58f43bdf705f5d9f3b3ffbe85f92e98c8766c954491c"
+  "contentHash": "42cf3e828a354f0e8994d966080ad060625a08d8146cd39c87dcbc37475aed55"
 }

--- a/data/gravel-weekly/history/2022-life-time-tv-series.json
+++ b/data/gravel-weekly/history/2022-life-time-tv-series.json
@@ -92,7 +92,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_lifetime_grand_prix_launch_and_broadcast_promise_2022",
@@ -119,7 +119,7 @@
     },
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:big-sugar-gravel",
+      "raceId": "gravel:big-sugar",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_lifetime_broadcasts_ended_midseason_2022",
@@ -135,5 +135,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T16:35:00Z",
-  "contentHash": "52c6a4ee3f2de5f3d538d36b0d0d8c645a5ab603fbfca8db2896ba8a5227df8e"
+  "contentHash": "30da896ea73ec35e905fbbb3697868aff2654861ba5affbb840dc7df7366265b"
 }

--- a/data/gravel-weekly/history/2022-nannup-built-worlds.json
+++ b/data/gravel-weekly/history/2022-nannup-built-worlds.json
@@ -99,7 +99,7 @@
     },
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:uci-gravel-world-championships",
+      "raceId": "gravel:uci-gravel-worlds",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_nannup_awarded_2026_worlds_2022",
@@ -116,5 +116,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T20:05:00Z",
-  "contentHash": "5a8da75f8bbe2e3955d55b2be3a6c28caa917be38b97e2e0e5e3a0fe880d9547"
+  "contentHash": "b395e5d6e9580b8d54713ff275454becced1717a3ffa0cfdf07ccbcbc54ab070"
 }

--- a/data/gravel-weekly/history/2022-onweller-career-bet.json
+++ b/data/gravel-weekly/history/2022-onweller-career-bet.json
@@ -74,7 +74,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:big-sugar-gravel",
+      "raceId": "gravel:big-sugar",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_onweller_big_sugar_win_and_payout_2022",
@@ -93,5 +93,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T19:05:00Z",
-  "contentHash": "3acfabc749df4f31dc0895470104f1c0b7a94587e61fcc7ac0f6d5c1fb2a4373"
+  "contentHash": "1c0c34b3c1cd1ffa44a6dd2e72077aa14f990d5adfd4652d636ba111fe08ca73"
 }

--- a/data/gravel-weekly/history/2022-season-stops-for-mo-wilson.json
+++ b/data/gravel-weekly/history/2022-season-stops-for-mo-wilson.json
@@ -110,7 +110,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_wilson_rise_full_time_plan_and_tributes_2022",
@@ -127,5 +127,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T18:00:00Z",
-  "contentHash": "a89bb248324f02b9b3e2ba6b29f620ca946835314f8aae89bd0c37b8c3a75dc6"
+  "contentHash": "6923f0418f94d306d05f2b8117b9550cde92d1840c2185c30c429c4173e0cb8f"
 }

--- a/data/gravel-weekly/history/2022-worlds-qualifying-before-address.json
+++ b/data/gravel-weekly/history/2022-worlds-qualifying-before-address.json
@@ -110,7 +110,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:uci-gravel-world-championships",
+      "raceId": "gravel:uci-gravel-worlds",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_world_series_calendar_leaked_2022",
@@ -133,5 +133,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T18:30:00Z",
-  "contentHash": "0caf7f791c8299a7cde278bee76ec74e605350bdbeaff7030a6503ebaa9f24c3"
+  "contentHash": "5ccdf2e0a953799270a6d56ac4eaea5758c8528f1a3963f33ebe2dca084ba932"
 }

--- a/data/gravel-weekly/history/2023-gravel-locos-spirit-of-racing.json
+++ b/data/gravel-weekly/history/2023-gravel-locos-spirit-of-racing.json
@@ -64,7 +64,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:gravel-locos-150",
+      "raceId": "gravel:gravel-locos",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_gravel_locos_roberge_result_2023",
@@ -82,5 +82,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T07:55:00Z",
-  "contentHash": "18d2d576531e282cd7953711679f38774857bd4df9612f4e0cb93be92e9a544d"
+  "contentHash": "5daed857056ba6109ccaa0eae14123a0dd058329fb140666b234a584f5c64d72"
 }

--- a/data/gravel-weekly/history/2023-gravel-retirement-plan.json
+++ b/data/gravel-weekly/history/2023-gravel-retirement-plan.json
@@ -95,7 +95,7 @@
     },
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_haga_next_thing_gravel_2023",
@@ -112,5 +112,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T12:00:00Z",
-  "contentHash": "a0e3ce6ec556e38de64a16d0818e38f1525bade44f6f003ef1cc3959309e06ba"
+  "contentHash": "6ab822f6f4ee422857cbea1e78eaa1a3fc114df95ad7b0866c0afc6f1f289750"
 }

--- a/data/gravel-weekly/history/2023-gravel-worlds-still-in-beta.json
+++ b/data/gravel-weekly/history/2023-gravel-worlds-still-in-beta.json
@@ -15,26 +15,122 @@
   "takeProvenance": "model_draft",
   "uncertainty": "The reviewed evidence does not disclose the complete contractual dispute, the UCI's internal timeline, the organizers' budget, or the exact date every route file reached athletes. Contemporary reporting describes the venue and organizer change as occurring seven weeks out, while the first public report reviewed here appeared a little more than six weeks before racing. Road content was disputed, but no independently audited surface breakdown is available here, and the UCI described substantial gravel and technical climbing. The evidence supports late organizational and route certainty plus first-race winners; it does not prove that planning instability caused the results or that road riders were structurally guaranteed to win.",
   "editorialScore": 98,
-  "editorialGates": {"party": "pass", "point": "pass", "friend": "pass", "craft": "pass", "hostileEditor": "pass"},
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
   "contemporaryReceipts": [
-    {"claimId": "claim_gravel_worlds_organizer_changed_six_weeks_out_2023", "canonicalUrl": "https://www.cyclingnews.com/news/late-changes-afoot-for-2023-uci-gravel-world-championships/", "publisher": "Cyclingnews", "publishedAt": "2023-08-24T00:00:00Z", "quoteExcerpt": "change to the organiser of the rainbow jersey event", "transcriptStartSeconds": null, "transcriptEndSeconds": null},
-    {"claimId": "claim_gravel_worlds_locations_before_full_route_2023", "canonicalUrl": "https://www.cyclingnews.com/news/uci-gravel-world-championships-moved-to-treviso-wait-for-full-route-detail-continues/", "publisher": "Cyclingnews", "publishedAt": "2023-09-10T00:00:00Z", "quoteExcerpt": "Race distances and full race routes have still to be revealed", "transcriptStartSeconds": null, "transcriptEndSeconds": null},
-    {"claimId": "claim_uci_gravel_worlds_full_course_released_2023", "canonicalUrl": "https://www.uci.org/pressrelease/2023-uci-gravel-world-championships-course-details-revealed/59DmS6oxuW2ygkGKhnrfth", "publisher": "UCI", "publishedAt": "2023-09-20T00:00:00Z", "quoteExcerpt": "Men Elite race covers 169km, while the Women Elite race spans 140km", "transcriptStartSeconds": null, "transcriptEndSeconds": null},
-    {"claimId": "claim_gravel_worlds_elevation_and_course_identity_debate_2023", "canonicalUrl": "https://www.cyclingnews.com/news/elevation-gain-doubled-in-uci-gravel-world-championships-routes-in-2023/", "publisher": "Cyclingnews", "publishedAt": "2023-09-20T18:09:46Z", "quoteExcerpt": "Elevation gain doubled in UCI Gravel World Championships routes in 2023", "transcriptStartSeconds": null, "transcriptEndSeconds": null},
-    {"claimId": "claim_gravel_worlds_grid_and_late_course_effects_2023", "canonicalUrl": "https://www.cyclingnews.com/news/start-grid-slots-key-as-team-usa-shapes-gravel-world-championships-strategies/", "publisher": "Cyclingnews", "publishedAt": "2023-10-05T00:00:00Z", "quoteExcerpt": "they just released the course a couple of weeks ago", "transcriptStartSeconds": null, "transcriptEndSeconds": null},
-    {"claimId": "claim_niewiadoma_mohoric_gravel_world_titles_2023", "canonicalUrl": "https://www.uci.org/article/uci-gravel-world-championships-niewiadoma-and-mohoric-claim-the-rainbow/2GcrMNspMDxwpRTcsOTG1y", "publisher": "UCI", "publishedAt": "2023-10-08T18:00:00Z", "quoteExcerpt": "crowned Kasia Niewiadoma and Matej Mohorič", "transcriptStartSeconds": null, "transcriptEndSeconds": null},
-    {"claimId": "claim_gravel_worlds_first_race_winners_2023", "canonicalUrl": "https://www.uci.org/article/uci-gravel-world-championships-road-stars-tamemaster-the-gravel-races/5FZrEskGPZkxMJCAQ01V1x", "publisher": "UCI", "publishedAt": "2023-10-10T00:00:00Z", "quoteExcerpt": "It was my first gravel race", "transcriptStartSeconds": null, "transcriptEndSeconds": null},
-    {"claimId": "claim_gravel_worlds_test_event_and_support_imbalance_2023", "canonicalUrl": "https://www.cyclingnews.com/features/2023-uci-gravel-world-championships-conclusions/", "publisher": "Cyclingnews", "publishedAt": "2023-10-09T12:00:00Z", "quoteExcerpt": "arguably improvised test events for the years to come", "transcriptStartSeconds": null, "transcriptEndSeconds": null},
-    {"claimId": "claim_gravel_worlds_2024_course_known_earlier_2023", "canonicalUrl": "https://www.cyclingnews.com/features/2023-uci-gravel-world-championships-conclusions/", "publisher": "Cyclingnews", "publishedAt": "2023-10-09T12:00:00Z", "quoteExcerpt": "far more is known about the course for 2024", "transcriptStartSeconds": null, "transcriptEndSeconds": null}
+    {
+      "claimId": "claim_gravel_worlds_organizer_changed_six_weeks_out_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/late-changes-afoot-for-2023-uci-gravel-world-championships/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-08-24T00:00:00Z",
+      "quoteExcerpt": "change to the organiser of the rainbow jersey event",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_worlds_locations_before_full_route_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/uci-gravel-world-championships-moved-to-treviso-wait-for-full-route-detail-continues/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-09-10T00:00:00Z",
+      "quoteExcerpt": "Race distances and full race routes have still to be revealed",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_uci_gravel_worlds_full_course_released_2023",
+      "canonicalUrl": "https://www.uci.org/pressrelease/2023-uci-gravel-world-championships-course-details-revealed/59DmS6oxuW2ygkGKhnrfth",
+      "publisher": "UCI",
+      "publishedAt": "2023-09-20T00:00:00Z",
+      "quoteExcerpt": "Men Elite race covers 169km, while the Women Elite race spans 140km",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_worlds_elevation_and_course_identity_debate_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/elevation-gain-doubled-in-uci-gravel-world-championships-routes-in-2023/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-09-20T18:09:46Z",
+      "quoteExcerpt": "Elevation gain doubled in UCI Gravel World Championships routes in 2023",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_worlds_grid_and_late_course_effects_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/start-grid-slots-key-as-team-usa-shapes-gravel-world-championships-strategies/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-10-05T00:00:00Z",
+      "quoteExcerpt": "they just released the course a couple of weeks ago",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_niewiadoma_mohoric_gravel_world_titles_2023",
+      "canonicalUrl": "https://www.uci.org/article/uci-gravel-world-championships-niewiadoma-and-mohoric-claim-the-rainbow/2GcrMNspMDxwpRTcsOTG1y",
+      "publisher": "UCI",
+      "publishedAt": "2023-10-08T18:00:00Z",
+      "quoteExcerpt": "crowned Kasia Niewiadoma and Matej Mohorič",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_worlds_first_race_winners_2023",
+      "canonicalUrl": "https://www.uci.org/article/uci-gravel-world-championships-road-stars-tamemaster-the-gravel-races/5FZrEskGPZkxMJCAQ01V1x",
+      "publisher": "UCI",
+      "publishedAt": "2023-10-10T00:00:00Z",
+      "quoteExcerpt": "It was my first gravel race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_worlds_test_event_and_support_imbalance_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/features/2023-uci-gravel-world-championships-conclusions/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-10-09T12:00:00Z",
+      "quoteExcerpt": "arguably improvised test events for the years to come",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_worlds_2024_course_known_earlier_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/features/2023-uci-gravel-world-championships-conclusions/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-10-09T12:00:00Z",
+      "quoteExcerpt": "far more is known about the course for 2024",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
   ],
   "laterEvidence": [],
   "raceImpacts": [
-    {"impactKind": "editorial_review", "raceId": "gravel:uci-gravel-world-championships", "fieldPath": "race.biased_opinion", "claimIds": ["claim_gravel_worlds_organizer_changed_six_weeks_out_2023", "claim_gravel_worlds_locations_before_full_route_2023", "claim_uci_gravel_worlds_full_course_released_2023", "claim_gravel_worlds_elevation_and_course_identity_debate_2023", "claim_gravel_worlds_grid_and_late_course_effects_2023", "claim_niewiadoma_mohoric_gravel_world_titles_2023", "claim_gravel_worlds_first_race_winners_2023", "claim_gravel_worlds_test_event_and_support_imbalance_2023", "claim_gravel_worlds_2024_course_known_earlier_2023"], "confidence": 0.97, "owner": "Gravel God race editorial review", "autoFixAllowed": false}
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-worlds",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_gravel_worlds_organizer_changed_six_weeks_out_2023",
+        "claim_gravel_worlds_locations_before_full_route_2023",
+        "claim_uci_gravel_worlds_full_course_released_2023",
+        "claim_gravel_worlds_elevation_and_course_identity_debate_2023",
+        "claim_gravel_worlds_grid_and_late_course_effects_2023",
+        "claim_niewiadoma_mohoric_gravel_world_titles_2023",
+        "claim_gravel_worlds_first_race_winners_2023",
+        "claim_gravel_worlds_test_event_and_support_imbalance_2023",
+        "claim_gravel_worlds_2024_course_known_earlier_2023"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
   ],
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T08:10:00Z",
-  "contentHash": "951e4bdd8f792036539600eb5881bd82fc5e311062c993a8e2503cf60c057537"
+  "contentHash": "536c19964aec6a113df61eb62bfa4c1f324190cde31e5a3da5aabee42b7855c9"
 }

--- a/data/gravel-weekly/history/2023-unbound-aerobar-workaround.json
+++ b/data/gravel-weekly/history/2023-unbound-aerobar-workaround.json
@@ -82,7 +82,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_unbound_safety_rationale_and_aerobar_ban_2023",
@@ -102,5 +102,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T07:25:00Z",
-  "contentHash": "97f8286c2c9d0220680bc0a90d21a64cf1ad47efc7695d9098246147ec39f291"
+  "contentHash": "f72281746e52688ba224f8f4cd354457bcce0dd452980015ddc0f943a83c5aee"
 }

--- a/data/gravel-weekly/history/2023-unbound-mud-mythology.json
+++ b/data/gravel-weekly/history/2023-unbound-mud-mythology.json
@@ -101,7 +101,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_unbound_dhill_backup_not_used_2023",
@@ -122,5 +122,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T13:00:00Z",
-  "contentHash": "de0394f834f6731faddcb391ee5324aa97b3351afb3a5c7f5fafed287876dd2d"
+  "contentHash": "a2f7bb61150f6f8a42ddaee22b58780090feb73da8ed980884958c93cfec5e85"
 }

--- a/data/gravel-weekly/history/2023-us-gravel-nationals-material-jersey.json
+++ b/data/gravel-weekly/history/2023-us-gravel-nationals-material-jersey.json
@@ -92,7 +92,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:usa-cycling-gravel-national-championships",
+      "raceId": "gravel:usa-cycling-gravel-nationals",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_usac_announced_first_gravel_nationals_purse_2023",
@@ -113,5 +113,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T07:40:00Z",
-  "contentHash": "1b618b874031fbdcdd69e911f85d60aac2b8bb1690b4394f0e96a74a65c04a9e"
+  "contentHash": "d611f21fb1fc6f57d73f064a2cd3b7e76e1c49f3054e06514055c3ac92fe77d8"
 }

--- a/data/gravel-weekly/history/2023-womens-worlds-off-camera.json
+++ b/data/gravel-weekly/history/2023-womens-worlds-off-camera.json
@@ -92,7 +92,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:uci-gravel-world-championships",
+      "raceId": "gravel:uci-gravel-worlds",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_worlds_women_no_broadcast_men_90_minutes_2023",
@@ -113,5 +113,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T07:10:00Z",
-  "contentHash": "7dadbd84e1cfd8d085be8307270b1be19926475269756171fb44e01db388cee9"
+  "contentHash": "479525e24f7129a17d1ca834103a36fb320a5bd48fd5e16c74bf8fe6be78a615"
 }

--- a/data/gravel-weekly/history/2024-gravel-career-market.json
+++ b/data/gravel-weekly/history/2024-gravel-career-market.json
@@ -92,7 +92,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_haga_gravel_new_career_2024",
@@ -109,5 +109,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T10:45:00Z",
-  "contentHash": "b1e6f5c47094cab09dd093b00b4fc1bc4f61f7f458585dae3dfcec6e12913ce0"
+  "contentHash": "03bfd8874f33394764e050d1349ff4f3b3c7e11965ea3d863dc54f5cf4f5c806"
 }

--- a/data/gravel-weekly/history/2024-gravel-worlds-road-skill-test.json
+++ b/data/gravel-weekly/history/2024-gravel-worlds-road-skill-test.json
@@ -82,7 +82,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:uci-gravel-world-championships",
+      "raceId": "gravel:uci-gravel-worlds",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_worlds_course_road_finish_2024",
@@ -102,5 +102,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T09:10:00Z",
-  "contentHash": "34031ac2b5e729d78c038ad65aa164dbb505825b6a479f518f6f3aad7448a32b"
+  "contentHash": "967eaafbcc0b44b9ca0f3f9899a7e6f8f99a35d66d1403ef62700501666a8802"
 }

--- a/data/gravel-weekly/history/2024-team-usa-invitation-bill.json
+++ b/data/gravel-weekly/history/2024-team-usa-invitation-bill.json
@@ -110,7 +110,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:uci-gravel-world-championships",
+      "raceId": "gravel:uci-gravel-worlds",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_usac_worlds_full_financial_responsibility_2024",
@@ -130,5 +130,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T08:05:00Z",
-  "contentHash": "105dcea1543820301dd0bfe9f82f1003a153c2260e8b15d33fc2a48e211426ca"
+  "contentHash": "f8e2071d31e83302a0a8d72c3046f8d7ee3c5b096e5662333a6e3f2fe2e0dfe3"
 }

--- a/data/gravel-weekly/history/2024-unbound-qualifier-access.json
+++ b/data/gravel-weekly/history/2024-unbound-qualifier-access.json
@@ -101,7 +101,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_unbound_main_lottery_and_fees_2024",
@@ -122,5 +122,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T10:05:00Z",
-  "contentHash": "1c62aa697dda2d2c6cf4f15b31f648c72f4f8577a3b58fd302a723827bf2e4a0"
+  "contentHash": "19c3eadb9e7a32f48457f496ba2ccabbcc67414edc702ae80265bd9e652d859e"
 }

--- a/data/gravel-weekly/history/2024-unbound-womens-start-gap.json
+++ b/data/gravel-weekly/history/2024-unbound-womens-start-gap.json
@@ -137,7 +137,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_unbound_2023_gap_failed_2024",
@@ -158,5 +158,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T10:05:00Z",
-  "contentHash": "dee9c20190f62fb82d618fa4a83c65930e5eee9a7979e88edaa54a4601f1583a"
+  "contentHash": "120c9901c2b787cb7d5dba1d7b16e198808d168a3fdc14b87bcdcabe9f0d4993"
 }

--- a/data/gravel-weekly/history/2024-vos-gravaa-proof-market.json
+++ b/data/gravel-weekly/history/2024-vos-gravaa-proof-market.json
@@ -92,7 +92,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:uci-gravel-world-championships",
+      "raceId": "gravel:uci-gravel-worlds",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_gravaa_returned_at_worlds_2024",
@@ -111,5 +111,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T07:35:00Z",
-  "contentHash": "3a06d2d2d97211a0be852f539b70589b9e92104377518fabe743548131b2c8ad"
+  "contentHash": "465b2673bda40dfb1825bcebee9972c60d193ada8f2a85f8076ea7f1f1c78f5d"
 }

--- a/data/gravel-weekly/history/2025-life-time-cross-category-drafting.json
+++ b/data/gravel-weekly/history/2025-life-time-cross-category-drafting.json
@@ -101,7 +101,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_lifetime_drafting_huge_impact_2025",
@@ -120,5 +120,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T04:35:00Z",
-  "contentHash": "7ddff7a0882861baeb04e852f72825d890889fabb26ab46caf479b13a7f285c2"
+  "contentHash": "99be550f06ec7abb2cfc2ce1e5697087a4bcf5df6f9686015b83110db22a0c5a"
 }

--- a/data/gravel-weekly/history/2025-unbound-live-broadcast.json
+++ b/data/gravel-weekly/history/2025-unbound-live-broadcast.json
@@ -101,7 +101,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_2022_grand_prix_broadcast_ended_early",
@@ -121,5 +121,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T04:24:00Z",
-  "contentHash": "cecf8a8e5da21dbe7e5a3e7d125f6f3b5f38442c44b8618a7850b89f62735824"
+  "contentHash": "9c89235c44e1a519a4ca81c1360c518ad866260be9f423e64d5e992d612bb8ab"
 }

--- a/data/gravel-weekly/history/2025-unbound-pit-crews.json
+++ b/data/gravel-weekly/history/2025-unbound-pit-crews.json
@@ -119,7 +119,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_unbound_routes_shared_checkpoint_2025",
@@ -143,5 +143,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T06:15:00Z",
-  "contentHash": "b0c3d9d6b3da6da55a47f8c9ae706132c65aa5968346d2e4936cf34d428325ee"
+  "contentHash": "f4a1bc1eb386b550f0f871f4a0f9f7f0dfb3ff299a897e454ecbaa940ecba1c4"
 }

--- a/data/gravel-weekly/history/2025-wildcard-won-series.json
+++ b/data/gravel-weekly/history/2025-wildcard-won-series.json
@@ -91,7 +91,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:unbound-gravel-200",
+      "raceId": "gravel:unbound-200",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_lifetime_2025_wildcard_structure_announced",
@@ -105,7 +105,7 @@
     },
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:big-sugar-gravel",
+      "raceId": "gravel:big-sugar",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_jones_little_sugar_moved_within_one_point_2025",
@@ -122,5 +122,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T04:50:00Z",
-  "contentHash": "8cdd9f93d3bdcc5a12969723b3f4b858646a5d4f686a1e8bc15ebf72b14057ab"
+  "contentHash": "977170b6f07d011e57577d46f56174e966548b9db850091fcc4fac60af88f44e"
 }

--- a/data/gravel-weekly/history/2025-worlds-cost-of-showing-up.json
+++ b/data/gravel-weekly/history/2025-worlds-cost-of-showing-up.json
@@ -91,7 +91,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:uci-gravel-world-championships",
+      "raceId": "gravel:uci-gravel-worlds",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_usac_gravel_worlds_self_funded_2025",
@@ -112,5 +112,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T04:40:00Z",
-  "contentHash": "1f9383cabdb49a59a3569da3a6a949b663f25413708334c24831645420391f47"
+  "contentHash": "75e63a0b50bcaef1ae721d938a40239026cb99e92c2b2511dd2c9a0912a706d5"
 }

--- a/data/gravel-weekly/history/2025-worlds-host-rescue.json
+++ b/data/gravel-weekly/history/2025-worlds-host-rescue.json
@@ -101,7 +101,7 @@
   "raceImpacts": [
     {
       "impactKind": "editorial_review",
-      "raceId": "gravel:uci-gravel-world-championships",
+      "raceId": "gravel:uci-gravel-worlds",
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_nice_awarded_gravel_worlds_2022",
@@ -123,5 +123,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T05:00:00Z",
-  "contentHash": "6283d6d68c8f0fddc0affe56d7f98bb23721c64baff9f052c5f9363b6f0f9846"
+  "contentHash": "5c1632f31b1fc129059477c26fef48f7cd6852bc493c65c231f00d81499ddaa6"
 }

--- a/data/gravel-weekly/history/2026-life-time-admissions-office.json
+++ b/data/gravel-weekly/history/2026-life-time-admissions-office.json
@@ -99,20 +99,16 @@
   "laterEvidence": [],
   "raceImpacts": [
     {
-      "impactKind": "no_change",
-      "raceId": "gravel:unbound-gravel-200",
-      "fieldPath": null,
-      "claimIds": [],
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-200",
+      "fieldPath": "race.history",
+      "claimIds": [
+        "claim_ltgp_wildcard_audition_pool_2026",
+        "claim_ltgp_selection_consequences_2025",
+        "claim_ltgp_u23_pathway_visible_result_2026",
+        "claim_ltgp_2027_qualifier_2026"
+      ],
       "confidence": 0.95,
-      "owner": "Gravel God historical editorial review",
-      "autoFixAllowed": false
-    },
-    {
-      "impactKind": "no_change",
-      "raceId": "gravel:rad-dirt-fest",
-      "fieldPath": null,
-      "claimIds": [],
-      "confidence": 0.9,
       "owner": "Gravel God historical editorial review",
       "autoFixAllowed": false
     }
@@ -122,5 +118,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T03:25:00Z",
-  "contentHash": "aeaca309dcf601dd4aa212bd4caec421961229809e9c980d6c8d435ce6e3aed9"
+  "contentHash": "500befbc6801a56d2c3ce995dc3f0f6519a29d72cef4c03a41ced64fab834669"
 }

--- a/scripts/validate_gravel_weekly_history.py
+++ b/scripts/validate_gravel_weekly_history.py
@@ -16,6 +16,16 @@ from validate_gravel_weekly import IssueValidationError, _impact, _iso, _list, _
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 HISTORY_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "history"
 PASSING_GATES = {"party", "point", "friend", "craft", "hostileEditor"}
+DEPRECATED_HISTORICAL_RACE_IDS = {
+    "gravel:big-sugar-gravel": "gravel:big-sugar",
+    "gravel:gravel-locos-150": "gravel:gravel-locos",
+    "gravel:rad-dirt-fest": "gravel:the-rad",
+    "gravel:sbt-grvl": "gravel:steamboat-gravel",
+    "gravel:uci-gravel-world-championships": "gravel:uci-gravel-worlds",
+    "gravel:unbound-gravel": "gravel:unbound-200",
+    "gravel:unbound-gravel-200": "gravel:unbound-200",
+    "gravel:usa-cycling-gravel-national-championships": "gravel:usa-cycling-gravel-nationals",
+}
 
 
 def _day(value: Any, name: str) -> str:
@@ -125,6 +135,13 @@ def validate_history_entry(value: Any, *, verify_hash: bool = True) -> dict[str,
 
     for index, impact_value in enumerate(_list(entry.get("raceImpacts"), "raceImpacts", 100)):
         impact = _impact(impact_value, f"raceImpacts[{index}]")
+        if impact["impactKind"] != "editorial_review":
+            raise IssueValidationError("historical race impacts must be editorial_review")
+        replacement = DEPRECATED_HISTORICAL_RACE_IDS.get(impact["raceId"])
+        if replacement:
+            raise IssueValidationError(
+                f"raceImpacts[{index}].raceId is deprecated; use {replacement}"
+            )
         missing = set(impact["claimIds"]) - claim_ids
         if missing:
             raise IssueValidationError(f"raceImpacts[{index}] references claims without historical receipts: {sorted(missing)}")

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -580,6 +580,30 @@ def test_historical_current_thing_requires_contemporary_corroboration_and_human_
         validate_history_entry(model_take, verify_hash=False)
 
 
+def test_historical_race_impacts_are_review_only_and_use_canonical_race_ids():
+    entry = sample_history_entry()
+    entry["raceImpacts"] = [{
+        "impactKind": "no_change",
+        "raceId": "gravel:unbound-200",
+        "fieldPath": None,
+        "claimIds": [],
+        "confidence": 0.9,
+        "owner": "Gravel God historical editorial review",
+        "autoFixAllowed": False,
+    }]
+    with pytest.raises(IssueValidationError, match="must be editorial_review"):
+        validate_history_entry(entry, verify_hash=False)
+
+    entry["raceImpacts"][0].update({
+        "impactKind": "editorial_review",
+        "raceId": "gravel:unbound-gravel-200",
+        "fieldPath": "race.history",
+        "claimIds": ["claim_team_1"],
+    })
+    with pytest.raises(IssueValidationError, match="deprecated; use gravel:unbound-200"):
+        validate_history_entry(entry, verify_hash=False)
+
+
 def test_historical_drafts_never_cross_the_public_loader(tmp_path):
     approved = sample_history_entry()
     draft = copy.deepcopy(approved)


### PR DESCRIPTION
## What changed
- normalize eight deprecated historical race-ID aliases to the owning publication slugs
- enforce canonical IDs for future history entries
- require every historical race impact to be `editorial_review`
- replace the 2026 admissions chapter's empty `no_change` record with one receipt-bound Unbound history review
- remove its unsupported Rad Dirt Fest link
- recompute every affected immutable content hash

## Canonicalization
- Big Sugar → `gravel:big-sugar`
- Gravel Locos → `gravel:gravel-locos`
- The Rad → `gravel:the-rad`
- SBT GRVL → `gravel:steamboat-gravel`
- UCI Gravel Worlds → `gravel:uci-gravel-worlds`
- Unbound aliases → `gravel:unbound-200`
- USA Cycling Gravel Nationals → `gravel:usa-cycling-gravel-nationals`

## Verification
- 71 historical entries validate
- 33 annual ledgers validate
- 81 impacts: zero non-review kinds, zero deprecated IDs, zero auto-fix authority
- 63 focused Gravel Weekly tests pass
- local render succeeds and still emits zero dated issues because all history remains draft-only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Draft-only JSON and validator/test changes; wrong IDs would fail validation rather than silently publishing bad race links.
> 
> **Overview**
> **Normalizes Gravel Weekly history** so `raceImpacts` point at canonical publication slugs (e.g. `gravel:unbound-200`, `gravel:steamboat-gravel`, `gravel:uci-gravel-worlds`) instead of legacy aliases like `gravel:unbound-gravel`, `gravel:sbt-grvl`, or `gravel:unbound-gravel-200`. Every touched history JSON gets an updated **`contentHash`**.
> 
> **Validation is tightened** in `validate_gravel_weekly_history.py`: historical impacts must be **`editorial_review` only**, and deprecated `raceId` values fail with a pointer to the replacement map. Tests cover both rules.
> 
> The **2026 Life Time admissions** chapter drops empty `no_change` / Rad Dirt links and adds one receipt-bound **`editorial_review`** on Unbound targeting `race.history`. One worlds entry also gets JSON formatting-only cleanup alongside the ID fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adeebab9842446c1bfc4d854c4885b6b70079173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->