### PR TITLE
Preserve numbered inline citations in rating copy

### DIFF
--- a/race-data/unbound-200.json
+++ b/race-data/unbound-200.json
@@ -116,7 +116,7 @@
       },
       "experience": {
         "score": 5,
-        "explanation": "Sunrise start, potential night finish, and a course that can flip from beauty to brutality in one weather system. \"The best riding on earth\" is a huge claim; on the right day in the Flint Hills, it does not sound ridiculous. The medal and pint glass are souvenirs. The day is the thing."
+        "explanation": "Sunrise start, potential night finish, and a course that can flip from beauty to brutality in one weather system. \"The best riding on earth\" is a huge claim; on the right day in the Flint Hills, it does not sound ridiculous.[6] The medal and pint glass are souvenirs. The day is the thing."
       },
       "community": {
         "score": 5,
@@ -128,11 +128,11 @@
       },
       "value": {
         "score": 4,
-        "explanation": "$345 is premium race entry, and the lottery means money alone cannot buy a start. What you get is a week-long gravel festival and a day across the \"rugged, vast\" Flint Hills that riders call \"the best riding on earth.\" Expensive, yes. Overpriced, no."
+        "explanation": "$345 is premium race entry, and the lottery means money alone cannot buy a start.[15] What you get is a week-long gravel festival and a day across the \"rugged, vast\" Flint Hills that riders call \"the best riding on earth.\"[6] Expensive, yes. Overpriced, no."
       },
       "expenses": {
         "score": 4,
-        "explanation": "The $345 entry is only the opening bill. Travel, scarce lodging, tires, spares, and a week in Emporia can push the full trip past $1,000. Even tire pressure becomes an all-day equipment decision as heat moves a setup from \"17.5 / 19.5\" to \"19.5 / 21.\""
+        "explanation": "The $345 entry is only the opening bill.[15] Travel, scarce lodging, tires, spares, and a week in Emporia can push the full trip past $1,000. Even tire pressure becomes an all-day equipment decision as heat moves a setup from \"17.5 / 19.5\" to \"19.5 / 21.\"[9]"
       }
     },
     "biased_opinion": {

--- a/scripts/batch_enrich.py
+++ b/scripts/batch_enrich.py
@@ -287,8 +287,9 @@ Rules:
 - Reference specific course features, weather data, logistics details from research
 - Lead with Gravel God's judgment. Never narrate the research process with "according to",
   "X notes/reports/describes/captures", "X's assessment rings true", or "As X puts it"
-- Keep memorable source language in quotation marks; the profile's citation section owns
-  source provenance, so the explanation should not read like a research handoff
+- Keep memorable source language in quotation marks; preserve numbered inline citation
+  markers like [1] on factual claims so they map to the profile's citation list. Never
+  invent a citation number. The explanation should not read like a research handoff
 - No generic filler ("amazing experience", "world-class")
 - If research lacks detail for a criterion, say what you know honestly
 - Output ONLY the JSON object, no markdown, no code blocks"""
@@ -483,7 +484,8 @@ Rules:
 - Reference specific course features, weather data, logistics details from research
 - Lead with Gravel God's judgment. Never narrate the research process with "according to",
   "X notes/reports/describes/captures", "X's assessment rings true", or "As X puts it"
-- Keep memorable source language in quotation marks; citations stay in the dedicated source list
+- Keep memorable source language in quotation marks; preserve numbered inline citation markers
+  like [1] on factual claims so they map to the dedicated source list. Never invent a number
 - No generic filler ("amazing experience", "world-class")
 - If research lacks detail for a criterion, say what you know honestly
 - Output ONLY the JSON object, no markdown, no code blocks"""

--- a/tests/test_neo_brutalist.py
+++ b/tests/test_neo_brutalist.py
@@ -28,6 +28,7 @@ from generate_neo_brutalist import (
     _editorialize_rating_explanation,
     _rating_bumper,
     _safe_json_for_script,
+    build_citations_section,
     build_course_overview,
     build_course_route,
     build_email_capture,
@@ -902,13 +903,29 @@ class TestSections:
             '"the best riding on earth" through the "rugged, vast" Flint Hills. '
             'As Jane Rider puts it: "I would race it again." [1][2]'
         )
-        cleaned = _editorialize_rating_explanation(copy)
+        cleaned = _editorialize_rating_explanation(copy, citation_count=2)
         assert "Richard at SILCA" not in cleaned
         assert "assessment rings true" not in cleaned
         assert "As Jane Rider puts it" not in cleaned
         assert "the best riding on earth" in cleaned
         assert "I would race it again" in cleaned
-        assert "[1]" not in cleaned
+        assert "[1][2]" in cleaned
+
+    def test_rating_copy_drops_only_unresolved_citation_markers(self):
+        cleaned = _editorialize_rating_explanation(
+            "Supported claim.[1][3]", citation_count=2
+        )
+        assert cleaned == "Supported claim.[1]"
+
+    def test_citation_list_order_matches_inline_marker_numbers(self):
+        html = build_citations_section({
+            "citations": [
+                {"url": "https://example.com/first", "label": "First", "category": "other"},
+                {"url": "https://example.com/second", "label": "Second", "category": "official"},
+            ]
+        })
+        assert html.index('id="gg-citation-1"') < html.index('id="gg-citation-2"')
+        assert html.index(">First</a>") < html.index(">Second</a>")
 
     def test_catalog_rating_copy_contract(self):
         banned = re.compile(

--- a/wordpress/generate_neo_brutalist.py
+++ b/wordpress/generate_neo_brutalist.py
@@ -466,18 +466,26 @@ def _rating_bumper(text: str, *, min_chars: int = 48, max_chars: int = 220) -> s
     return candidate[:word_break].rstrip(' ,;:—-') + '…'
 
 
-def _editorialize_rating_explanation(text: str) -> str:
-    """Remove research-process scaffolding while preserving facts and quotes.
+def _editorialize_rating_explanation(text: str, citation_count: int | None = None) -> str:
+    """Remove research-process scaffolding while preserving facts, quotes, and citations.
 
-    Citations remain in the dedicated Sources & Citations section. Rating cards
-    should sound like the publication's judgment, not a research handoff.
+    Numbered inline markers connect factual claims to the dedicated Sources &
+    Citations section. Rating cards should sound like the publication's
+    judgment, not a research handoff.
     """
     clean = re.sub(r'\s+', ' ', str(text or '')).strip()
     if not clean:
         return ''
 
-    # Inline research-footnote markers belong in the citation section below.
-    clean = re.sub(r'(?<!\w)\[\d+\](?:\[\d+\])*', '', clean)
+    # Keep only markers that resolve to a source on this profile. With no
+    # citation context (for example, unit tests), preserve every marker.
+    if citation_count is not None:
+        clean = re.sub(
+            r'(?<!\w)\[(\d+)\]',
+            lambda match: match.group(0)
+            if 1 <= int(match.group(1)) <= citation_count else '',
+            clean,
+        )
 
     clean = re.sub(
         r'\bthe\s+(?:event|official|race)\s+(?:page|site)\s+calls?\s+the\s+'
@@ -560,6 +568,7 @@ def normalize_race_data(data: dict) -> dict:
     with all fields the generator expects. Computes derived fields if missing."""
     race = data.get('race', data)
     slug = race.get('slug', '(unknown)')
+    citation_count = len(race.get('citations', []))
 
     rating = race.get('gravel_god_rating', {})
     bor = race.get('biased_opinion_ratings', {})
@@ -595,7 +604,9 @@ def normalize_race_data(data: dict) -> dict:
         entry = bor.get(dim, {})
         explanations[dim] = {
             'score': entry.get('score', rating.get(dim, 0)),
-            'explanation': _editorialize_rating_explanation(entry.get('explanation', '')),
+            'explanation': _editorialize_rating_explanation(
+                entry.get('explanation', ''), citation_count
+            ),
         }
 
     explicit_summaries = race.get('rating_summaries', {})
@@ -606,7 +617,9 @@ def normalize_race_data(data: dict) -> dict:
             course.get('summary'),
             course.get('overview'),
             race.get('tagline', ''),
-        ) if (summary := _rating_bumper(_editorialize_rating_explanation(source)))
+        ) if (summary := _rating_bumper(
+            _editorialize_rating_explanation(source, citation_count)
+        ))
     ), '')
     editorial_summary = next((
         summary for source in (
@@ -615,7 +628,9 @@ def normalize_race_data(data: dict) -> dict:
             bo.get('bottom_line'),
             bo.get('summary'),
             race.get('tagline', ''),
-        ) if (summary := _rating_bumper(_editorialize_rating_explanation(source)))
+        ) if (summary := _rating_bumper(
+            _editorialize_rating_explanation(source, citation_count)
+        ))
     ), '')
     race_name = race.get('display_name') or race.get('name', 'This race')
     if not course_summary:
@@ -5709,46 +5724,37 @@ def build_citations_section(rd: dict) -> str:
     if not citations:
         return ''
 
-    # Group by category
-    categories = {}
-    for c in citations:
-        cat = c.get('category', 'other')
-        categories.setdefault(cat, []).append(c)
-
-    # Category display order and labels
-    cat_order = [
-        ('official', 'Official'),
-        ('route', 'Route Maps'),
-        ('media', 'Media & Press'),
-        ('community', 'Community'),
-        ('video', 'Video'),
-        ('registration', 'Registration'),
-        ('social', 'Social'),
-        ('tracking', 'Live Tracking'),
-        ('reference', 'Reference'),
-        ('activity', 'Activity'),
-        ('other', 'Other Sources'),
-    ]
+    category_labels = {
+        'official': 'Official',
+        'route': 'Route Maps',
+        'media': 'Media & Press',
+        'community': 'Community',
+        'video': 'Video',
+        'registration': 'Registration',
+        'social': 'Social',
+        'tracking': 'Live Tracking',
+        'reference': 'Reference',
+        'activity': 'Activity',
+        'other': 'Other Sources',
+    }
 
     items = []
-    for cat_key, cat_label in cat_order:
-        if cat_key not in categories:
-            continue
-        for c in categories[cat_key]:
-            url = c.get('url', '')
-            label = c.get('label', 'Source')
-            # Truncate long URLs for display
-            display_url = url.replace('https://', '').replace('http://', '')
-            if len(display_url) > 60:
-                display_url = display_url[:57] + '...'
-            items.append(
-                f'<li class="gg-citation-item">'
-                f'<span class="gg-citation-cat">{esc(cat_label)}</span> '
-                f'<a href="{esc(url)}" target="_blank" rel="noopener noreferrer" '
-                f'class="gg-citation-link">{esc(label)}</a>'
-                f'<span class="gg-citation-url">{esc(display_url)}</span>'
-                f'</li>'
-            )
+    for index, c in enumerate(citations, start=1):
+        cat_label = category_labels.get(c.get('category', 'other'), 'Other Sources')
+        url = c.get('url', '')
+        label = c.get('label', 'Source')
+        # Preserve source-array order so an inline [n] always resolves to item n.
+        display_url = url.replace('https://', '').replace('http://', '')
+        if len(display_url) > 60:
+            display_url = display_url[:57] + '...'
+        items.append(
+            f'<li class="gg-citation-item" id="gg-citation-{index}">'
+            f'<span class="gg-citation-cat">{esc(cat_label)}</span> '
+            f'<a href="{esc(url)}" target="_blank" rel="noopener noreferrer" '
+            f'class="gg-citation-link">{esc(label)}</a>'
+            f'<span class="gg-citation-url">{esc(display_url)}</span>'
+            f'</li>'
+        )
 
     if not items:
         return ''


### PR DESCRIPTION
## Summary
- preserve valid `[n]` claim markers while removing research-process narration
- keep the source list in stable numerical order
- restore markers on the rewritten Unbound copy
- require future enrichment to preserve, not invent, source numbers

## Validation
- `203 passed` in `tests/test_neo_brutalist.py`
- generated all 384 race pages
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes citation list ordering and rating copy across all generated race pages; mismatched or invented `[n]` in source data could show wrong or missing footnotes until profiles are corrected.
> 
> **Overview**
> Rating cards and summaries **keep numbered inline markers** like `[6]` on factual claims while still stripping research-process narration (“according to”, “X’s assessment rings true”, etc.). Invalid markers outside the profile’s citation count are dropped; with no count (e.g. unit tests), all markers are left as-is.
> 
> The **Sources & Citations** block now lists entries in **`race.citations` array order** (with `gg-citation-1`, `gg-citation-2`, …) instead of grouping by category, so inline `[n]` always points at the *n*th source. `normalize_race_data` passes citation length into `_editorialize_rating_explanation` for rating tiles and bumper summaries.
> 
> **Enrichment prompts** in `batch_enrich.py` now require preserving existing citation numbers and forbid inventing new ones. **Unbound 200** sample JSON regains markers on experience/value/expenses copy.
> 
> Tests cover marker retention, partial stripping of out-of-range numbers, and list order vs. marker indices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85ca6be20a35ac06688d49251f8a6e579c12d206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->