### PR TITLE
Recover 1992 Gravel Weekly ultra-endurance origin story

### DIFF
--- a/data/gravel-weekly/backfill/1992.json
+++ b/data/gravel-weekly/backfill/1992.json
@@ -1,0 +1,445 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 1992,
+  "asOf": "1992-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/89",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33186302385",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceArchiveCoverage": "unavailable",
+  "sourceArchiveErrors": [
+    "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
+  ],
+  "sourceCardCount": 0,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "1991-12-28",
+      "periodEndedAt": "1992-01-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-01-04",
+      "periodEndedAt": "1992-01-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-01-11",
+      "periodEndedAt": "1992-01-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-01-18",
+      "periodEndedAt": "1992-01-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-01-25",
+      "periodEndedAt": "1992-01-31",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-02-01",
+      "periodEndedAt": "1992-02-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-02-08",
+      "periodEndedAt": "1992-02-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-02-15",
+      "periodEndedAt": "1992-02-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-02-22",
+      "periodEndedAt": "1992-02-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-02-29",
+      "periodEndedAt": "1992-03-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-03-07",
+      "periodEndedAt": "1992-03-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-03-14",
+      "periodEndedAt": "1992-03-20",
+      "sourceCardCount": 0,
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-stamstad-did-not-do-it-alone-1992"
+      ],
+      "reason": "A recovered contemporary report supports a distinct draft about the social infrastructure behind an apparently solitary ultra-endurance performance. Human editorial approval remains required."
+    },
+    {
+      "periodStartedAt": "1992-03-21",
+      "periodEndedAt": "1992-03-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-03-28",
+      "periodEndedAt": "1992-04-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-04-04",
+      "periodEndedAt": "1992-04-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-04-11",
+      "periodEndedAt": "1992-04-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-04-18",
+      "periodEndedAt": "1992-04-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-04-25",
+      "periodEndedAt": "1992-05-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-05-02",
+      "periodEndedAt": "1992-05-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-05-09",
+      "periodEndedAt": "1992-05-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-05-16",
+      "periodEndedAt": "1992-05-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-05-23",
+      "periodEndedAt": "1992-05-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-05-30",
+      "periodEndedAt": "1992-06-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-06-06",
+      "periodEndedAt": "1992-06-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-06-13",
+      "periodEndedAt": "1992-06-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-06-20",
+      "periodEndedAt": "1992-06-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-06-27",
+      "periodEndedAt": "1992-07-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-07-04",
+      "periodEndedAt": "1992-07-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-07-11",
+      "periodEndedAt": "1992-07-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-07-18",
+      "periodEndedAt": "1992-07-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-07-25",
+      "periodEndedAt": "1992-07-31",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-08-01",
+      "periodEndedAt": "1992-08-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-08-08",
+      "periodEndedAt": "1992-08-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-08-15",
+      "periodEndedAt": "1992-08-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-08-22",
+      "periodEndedAt": "1992-08-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-08-29",
+      "periodEndedAt": "1992-09-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-09-05",
+      "periodEndedAt": "1992-09-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-09-12",
+      "periodEndedAt": "1992-09-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-09-19",
+      "periodEndedAt": "1992-09-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-09-26",
+      "periodEndedAt": "1992-10-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-10-03",
+      "periodEndedAt": "1992-10-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-10-10",
+      "periodEndedAt": "1992-10-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-10-17",
+      "periodEndedAt": "1992-10-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-10-24",
+      "periodEndedAt": "1992-10-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-10-31",
+      "periodEndedAt": "1992-11-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-11-07",
+      "periodEndedAt": "1992-11-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-11-14",
+      "periodEndedAt": "1992-11-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-11-21",
+      "periodEndedAt": "1992-11-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-11-28",
+      "periodEndedAt": "1992-12-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-12-05",
+      "periodEndedAt": "1992-12-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-12-12",
+      "periodEndedAt": "1992-12-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-12-19",
+      "periodEndedAt": "1992-12-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1992-12-26",
+      "periodEndedAt": "1993-01-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    }
+  ],
+  "updatedAt": "2026-08-28T15:40:49.000Z"
+}

--- a/data/gravel-weekly/history/1992-stamstad-did-not-do-it-alone.json
+++ b/data/gravel-weekly/history/1992-stamstad-did-not-do-it-alone.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-stamstad-did-not-do-it-alone-1992",
+  "activeFrom": "1992-03-18",
+  "activeThrough": "1992-03-31",
+  "status": "draft",
+  "headline": "John Stamstad Rode Three Hours on a Flat. He Still Did Not Do It Alone.",
+  "point": "In February 1992, John Stamstad finished third in a 190-mile Iditasport after five flat tires, including three hours riding on a dead one in temperatures reported as low as 35 below zero. The feat helped make him an ultra-endurance archetype. It was also possible because rival Carl Tobin gave him his last tube and a checkpoint mechanic glued the replacement tire to the rim. The useful origin story is not that one superhuman conquered Alaska alone. It is that off-road endurance was extreme from the start and interdependent from the start.",
+  "priorJudgment": "The foundational off-road ultra story is the lone rider proving that enough toughness can overcome distance, weather, mechanical failure, and isolation without help.",
+  "changedJudgment": "Stamstad supplied absurd physical commitment, but another competitor and a checkpoint mechanic kept his race alive. The heroism is real; the self-sufficiency is mythology added by selective memory.",
+  "stakes": "Modern gravel and bikepacking rules need hard boundaries around outside assistance, but the culture becomes dumber when unsupported is treated as a personality and accepting help as moral failure. A race can test individual agency while still depending on competitors, volunteers, mechanics, trail builders, and the people willing to rescue a bad decision.",
+  "credibleOpposition": "Iditasport was a winter mountain-bike event rather than a gravel race, and Tobin's tube did not pedal Stamstad's bike for him. The contemporary account still describes an extraordinary individual performance. One dramatic exchange cannot establish the complete assistance norms of early ultra racing, and later retellings may have elevated Stamstad's ride because his subsequent career made it look prophetic.",
+  "whatHappened": "On March 18, 1992, the Los Angeles Times reported on John Stamstad's February Iditasport, described as a 190-mile mountain-bike race across Alaskan winter terrain. Stamstad brought three tubes and suffered five flats. After the fourth, rival Carl Tobin gave him his last spare. That tube also failed, so Stamstad rode the flat wheel for more than three hours to the next checkpoint, where a mechanic glued the tire to the rim. He finished third after roughly twenty-four hours, with temperatures reported between zero and 35 below. The ride was his first major test after a September assault during training left him with a compound skull fracture and disrupted his balance, vision, endurance, and confidence for more than two months.",
+  "take": "Model draft, not Matti's approved view: Gravel likes the lonely hardman because he makes a clean poster. One rider. One wilderness. No excuses. Unfortunately, another human keeps wandering into the frame. John Stamstad arrived at the 1992 Iditasport with three tubes and somehow collected five flats. After the fourth, Carl Tobin gave the man trying to beat him his last spare. When that one failed too, Stamstad rode the flat for more than three hours until a checkpoint mechanic glued the tire to the rim. Then he finished third after roughly twenty-four hours in temperatures that reached 35 below. That is an incredible hardman story. It is also a story about receiving help. Unsupported racing needs rules or it becomes a group project with secret cars. Fine. But unsupported is a competition format, not proof that you have transcended needing other people. The original freaks were already tougher than us. They were not alone either.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The Los Angeles Times is the only recovered contemporary publisher, so this entry cannot advance beyond draft without a second contemporaneous source. Its report calls the course 190 miles; later institutional accounts describe early Iditasport distances as 170 or 160 miles, so the 190-mile figure is attributed only to the 1992 report. The story supports a judgment about this episode, not a universal claim about every early ultra's assistance rules. No canonical Iditasport race record exists in the current database, so no race mutation is proposed.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_stamstad_five_flats_1992",
+      "canonicalUrl": "https://www.latimes.com/archives/la-xpm-1992-03-18-sp-3791-story.html",
+      "publisher": "Los Angeles Times",
+      "publishedAt": "1992-03-18T00:00:00-08:00",
+      "quoteExcerpt": "He carried three spare inner tubes, but had five flat tires.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_tobin_last_spare_1992",
+      "canonicalUrl": "https://www.latimes.com/archives/la-xpm-1992-03-18-sp-3791-story.html",
+      "publisher": "Los Angeles Times",
+      "publishedAt": "1992-03-18T00:00:00-08:00",
+      "quoteExcerpt": "Tobin gave him his last spare and sped off.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T15:45:00Z",
+  "contentHash": "d490f535dd50593cfa7bcc8d0d4ab74135711d8721ab9c98dad28abcfa8e9853"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -1031,6 +1031,21 @@ def test_pre_web_backfill_ledgers_preserve_unresolved_research_debt(year):
     assert validated["complete"] is False
 
 
+def test_1992_backfill_ledger_preserves_research_debt_around_the_recovered_stamstad_story():
+    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
+    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "1992.json").read_text())
+    validated = validate_backfill_ledger(ledger, histories)
+
+    assert len(validated["weeks"]) == 53
+    assert validated["sourceArchiveCoverage"] == "unavailable"
+    assert len(validated["sourceArchiveErrors"]) == 1
+    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 52
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
+    assert validated["complete"] is False
+
+
 def test_1995_backfill_ledger_opens_pre_web_research_debt_without_hiding_the_recovered_story():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "1995.json").read_text())


### PR DESCRIPTION
## Summary
- add a fail-closed 1992 backfill ledger with 52 unresolved windows and one window covered by a draft
- recover a contemporary Los Angeles Times account of John Stamstad’s five-flat 1992 Iditasport
- stage a point-first historical chapter about the cooperation underneath the lone-hardman myth
- add a regression case preserving the year’s remaining pre-web research debt

## Editorial point
Stamstad’s performance was extraordinary, but rival Carl Tobin’s last tube and a checkpoint mechanic kept it alive. Unsupported is a competition format, not evidence that endurance athletes stop needing other people.

## Voice provenance
Canonical profile: `wattgod/writing-graph/self/voice-and-beliefs-profile.md`
Verified raw pieces read:
- `inbox/substack/suffer-kink-is-not-a-victimless-crime.md`
- `inbox/gravel-god/the-tyranny-of-irony-in-cycling.md`
- `inbox/gravel-god/the-jester-precedes-the-king.md`

## Safety and limitations
- `status: draft` and `takeProvenance: model_draft`
- `humanApprovalRequired: true`; `autoPublishAllowed: false`
- only one contemporary publisher recovered, so the entry cannot advance beyond draft
- no canonical Iditasport database record exists, so `raceImpacts` is empty rather than inventing an identity
- no public page, race mutation, or deployment

## Verification
- history and ledger validators pass
- focused Gravel Weekly suite: 65 passed
- strict writing-graph AI-writing gate: pass
- target slop dry-run found only two unrelated existing race-copy candidates
- generator emits 0 dated issues
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static editorial/backfill JSON plus a contract test; no publish path, race mutations, or runtime behavior changes.
> 
> **Overview**
> Adds **1992** to the Gravel Weekly pre-web backfill program: a new `1992.json` ledger marks archive coverage as **unavailable**, keeps the year **incomplete**, and assigns **52** weekly windows as `unresearched` while one mid-March window is `covered_by_draft` and points at a recovered story.
> 
> Stages a **draft** history entry (`history-stamstad-did-not-do-it-alone-1992`) grounded in a **1992 Los Angeles Times** report on John Stamstad’s Iditasport flats, rival Carl Tobin’s spare tube, and checkpoint help—framed as pushing back on lone-hardman mythology while keeping `takeProvenance: model_draft`, `humanApprovalRequired`, and empty `raceImpacts` (no invented Iditasport record).
> 
> Adds a regression test mirroring the **1995** pattern: the ledger must stay fail-closed (one `covered_by_draft`, no `explicit_gap` when archives are unavailable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27577443f0dfb0f6037ab36376edc716636dc9fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->