### PR TITLE
Open 1991 Gravel Weekly archival research ledger

### DIFF
--- a/data/gravel-weekly/backfill/1991.json
+++ b/data/gravel-weekly/backfill/1991.json
@@ -1,0 +1,443 @@
+{
+  "schemaVersion": "gravel-weekly-backfill-ledger/v1",
+  "year": 1991,
+  "asOf": "1991-12-31T23:59:59.000Z",
+  "sourceLedgerIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/90",
+  "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33186826226",
+  "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
+  "sourceArchiveCoverage": "unavailable",
+  "sourceArchiveErrors": [
+    "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
+  ],
+  "sourceCardCount": 0,
+  "complete": false,
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "weeks": [
+    {
+      "periodStartedAt": "1990-12-29",
+      "periodEndedAt": "1991-01-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-01-05",
+      "periodEndedAt": "1991-01-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-01-12",
+      "periodEndedAt": "1991-01-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-01-19",
+      "periodEndedAt": "1991-01-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-01-26",
+      "periodEndedAt": "1991-02-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-02-02",
+      "periodEndedAt": "1991-02-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-02-09",
+      "periodEndedAt": "1991-02-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-02-16",
+      "periodEndedAt": "1991-02-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-02-23",
+      "periodEndedAt": "1991-03-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-03-02",
+      "periodEndedAt": "1991-03-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-03-09",
+      "periodEndedAt": "1991-03-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-03-16",
+      "periodEndedAt": "1991-03-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-03-23",
+      "periodEndedAt": "1991-03-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-03-30",
+      "periodEndedAt": "1991-04-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-04-06",
+      "periodEndedAt": "1991-04-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-04-13",
+      "periodEndedAt": "1991-04-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-04-20",
+      "periodEndedAt": "1991-04-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-04-27",
+      "periodEndedAt": "1991-05-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-05-04",
+      "periodEndedAt": "1991-05-10",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-05-11",
+      "periodEndedAt": "1991-05-17",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-05-18",
+      "periodEndedAt": "1991-05-24",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-05-25",
+      "periodEndedAt": "1991-05-31",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-06-01",
+      "periodEndedAt": "1991-06-07",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-06-08",
+      "periodEndedAt": "1991-06-14",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-06-15",
+      "periodEndedAt": "1991-06-21",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-06-22",
+      "periodEndedAt": "1991-06-28",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-06-29",
+      "periodEndedAt": "1991-07-05",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-07-06",
+      "periodEndedAt": "1991-07-12",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-07-13",
+      "periodEndedAt": "1991-07-19",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-07-20",
+      "periodEndedAt": "1991-07-26",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-07-27",
+      "periodEndedAt": "1991-08-02",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-08-03",
+      "periodEndedAt": "1991-08-09",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-08-10",
+      "periodEndedAt": "1991-08-16",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-08-17",
+      "periodEndedAt": "1991-08-23",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-08-24",
+      "periodEndedAt": "1991-08-30",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-08-31",
+      "periodEndedAt": "1991-09-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-09-07",
+      "periodEndedAt": "1991-09-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-09-14",
+      "periodEndedAt": "1991-09-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-09-21",
+      "periodEndedAt": "1991-09-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-09-28",
+      "periodEndedAt": "1991-10-04",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-10-05",
+      "periodEndedAt": "1991-10-11",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-10-12",
+      "periodEndedAt": "1991-10-18",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-10-19",
+      "periodEndedAt": "1991-10-25",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-10-26",
+      "periodEndedAt": "1991-11-01",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-11-02",
+      "periodEndedAt": "1991-11-08",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-11-09",
+      "periodEndedAt": "1991-11-15",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-11-16",
+      "periodEndedAt": "1991-11-22",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-11-23",
+      "periodEndedAt": "1991-11-29",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-11-30",
+      "periodEndedAt": "1991-12-06",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-12-07",
+      "periodEndedAt": "1991-12-13",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-12-14",
+      "periodEndedAt": "1991-12-20",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-12-21",
+      "periodEndedAt": "1991-12-27",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    },
+    {
+      "periodStartedAt": "1991-12-28",
+      "periodEndedAt": "1992-01-03",
+      "sourceCardCount": 0,
+      "disposition": "unresearched",
+      "entryIds": [],
+      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+    }
+  ],
+  "updatedAt": "2026-08-28T15:47:22.000Z"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -1016,7 +1016,7 @@ def test_2000_backfill_ledger_preserves_unavailable_legacy_archive_research_debt
     assert validated["complete"] is False
 
 
-@pytest.mark.parametrize("year", [1999, 1997, 1996, 1993])
+@pytest.mark.parametrize("year", [1999, 1997, 1996, 1993, 1991])
 def test_pre_web_backfill_ledgers_preserve_unresolved_research_debt(year):
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / f"{year}.json").read_text())


### PR DESCRIPTION
## Summary
- add the permanent 1991 assigning ledger generated from control-plane run 33186826226
- preserve all 53 windows as unresearched at the pre-web boundary
- extend the pre-web regression case to 1991

## Editorial disposition
Wilderness 101 is a promising candidate, but the vivid origin details currently trace to an unrecovered 1991 Dirt Rag issue. A later Cyclingnews “longest-running” description and secondary summaries do not justify manufacturing the chapter. Research notes: https://github.com/wattgod/race-intelligence-control-plane/issues/90#issuecomment-5454624637

## Safety
- `complete: false`
- `humanApprovalRequired: true`
- `autoPublishAllowed: false`
- no historical entry, public page, race mutation, or deployment

## Verification
- ledger validator passes
- focused Gravel Weekly suite: 65 passed
- generator emits 0 dated issues
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds static ledger JSON and a parametrized test assertion; no runtime, publish, or race-data behavior changes.
> 
> **Overview**
> Adds **`data/gravel-weekly/backfill/1991.json`**, a permanent assigning ledger for 1991 generated from the control-plane run linked in the file. Every one of the **53** weekly windows is recorded as **`unresearched`** with zero source cards, **`sourceArchiveCoverage`: `unavailable`**, and explicit reasons not to treat missing archive data as a quiet week.
> 
> The ledger is marked **`complete: false`** with **`humanApprovalRequired: true`** and **`autoPublishAllowed: false`**—research debt only, not historical entries or publishing.
> 
> **`test_pre_web_backfill_ledgers_preserve_unresolved_research_debt`** now includes **1991** alongside 1999, 1997, 1996, and 1993 so the validator keeps enforcing that pattern for the new year file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3388451e4d61877b1fecfee5a1ffde03af779ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->