### PR TITLE
Add 2026 Crusher host-community historical draft

### DIFF
--- a/data/gravel-weekly/backfill/2026.json
+++ b/data/gravel-weekly/backfill/2026.json
@@ -261,17 +261,20 @@
       "sourceCardCount": 4,
       "disposition": "covered_by_draft",
       "entryIds": [
+        "history-crusher-host-community-2026",
         "history-life-time-admissions-office-2026"
       ],
-      "reason": "Life Time's midseason wildcard replacements advance the career-institution draft."
+      "reason": "Life Time's midseason wildcard replacements advance the career-institution draft, while Crusher's cancellation and the first quantified local business loss begin the host-community recovery draft."
     },
     {
       "periodStartedAt": "2026-07-04",
       "periodEndedAt": "2026-07-10",
       "sourceCardCount": 1,
-      "disposition": "rejected",
-      "entryIds": [],
-      "reason": "The lone card is a routine UCI Gravel World Series result with no demonstrated consequence beyond the finishing order."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-crusher-host-community-2026"
+      ],
+      "reason": "The routine World Series result remains rejected, but contemporary Beaver reporting connects Crusher's cancellation to lost hotel reservations and broader tourism-business harm, advancing the host-community recovery draft."
     },
     {
       "periodStartedAt": "2026-07-11",
@@ -313,10 +316,11 @@
       "sourceCardCount": 10,
       "disposition": "covered_by_draft",
       "entryIds": [
+        "history-crusher-host-community-2026",
         "history-leadville-category-border-2026",
         "history-life-time-admissions-office-2026"
       ],
-      "reason": "Life Time's performance-based 2027 qualifier advances the career-institution draft, while the verified Leadville reroute advances the equipment-category draft."
+      "reason": "Life Time's performance-based 2027 qualifier advances the career-institution draft, the verified Leadville reroute advances the equipment-category draft, and Beaver County's funding boundary advances the Crusher host-community recovery draft."
     },
     {
       "periodStartedAt": "2026-08-15",
@@ -324,9 +328,10 @@
       "sourceCardCount": 5,
       "disposition": "covered_by_draft",
       "entryIds": [
+        "history-crusher-host-community-2026",
         "history-leadville-category-border-2026"
       ],
-      "reason": "Post-race reporting tests the handlebar rule against the smoother wildfire-rerouted course while preserving the two-way-descent safety counterargument."
+      "reason": "Post-race reporting tests the handlebar rule against the smoother wildfire-rerouted course while preserving the two-way-descent safety counterargument; UDOT's published SR-153 closure, funding, and reconstruction timeline completes the Crusher host-community recovery mechanism."
     },
     {
       "periodStartedAt": "2026-08-22",
@@ -337,5 +342,5 @@
       "reason": "The Bonk Bros pass produced research leads, but no lead has yet cleared verification and editorial disposition."
     }
   ],
-  "updatedAt": "2026-08-28T03:25:00Z"
+  "updatedAt": "2026-08-28T16:20:00Z"
 }

--- a/data/gravel-weekly/history/2026-crusher-host-community.json
+++ b/data/gravel-weekly/history/2026-crusher-host-community.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-crusher-host-community-2026",
+  "activeFrom": "2026-06-29",
+  "activeThrough": "2026-08-17",
+  "status": "draft",
+  "headline": "Crusher Was Canceled. Beaver Could Not Cancel the Disaster.",
+  "point": "A host community is not the scenery surrounding a race. When the Cottonwood Fire canceled Crusher, damaged Eagle Point, emptied hotel rooms, hurt local businesses, and closed the event's defining road into a $50 million reconstruction, the race's relationship with Beaver became a recovery obligation rather than a venue arrangement.",
+  "priorJudgment": "Canceling an unsafe race, giving registered riders their options, and returning when the road and resort recover is a sufficient event response to a natural disaster beyond the organizer's control.",
+  "changedJudgment": "Cancellation handles the athlete transaction. It does not settle what a race owner owes the town, businesses, volunteers, roads, and identity from which the event built its product—especially when infrastructure funding cannot directly replace local business losses.",
+  "stakes": "If host communities are operating partners rather than interchangeable backdrops, disaster planning cannot end with refunds, deferrals, and a future reopening date. Event owners need a legible standard for direct recovery support, fundraising, promotion of surviving businesses, and transparent return conditions; riders need to understand that preserving a race may mean spending in and supporting the place long before another start gun.",
+  "credibleOpposition": "The wildfire and flooding were not caused by Life Time, cancellation was plainly necessary, the event page directs visitors to a local relief fund, and the available record does not establish what Life Time or its partners donated privately. Public infrastructure programs may be legally unable to pay private losses, Crusher is only one piece of Beaver's tourism economy, and an event organizer cannot repair a resort or state highway by itself.",
+  "whatHappened": "Life Time canceled the July 11 Crusher in the Tushar on June 29 because the Cottonwood Fire was affecting Beaver, Eagle Point, emergency resources, and the surrounding community; its event page linked to a fire-relief fund. FOX 13 then reported that Tucker High Adventure Tours had lost five of nine condos, canceled trips amid local event cancellations including Crusher, and expected $30,000 to $50,000 in lost revenue. Deseret News reported that tourism-dependent Beaver hotels, restaurants, and the grocery store were losing business, with travelers canceling hotel reservations and Crusher among the canceled events. On August 11, Beaver County explained that an $18 million public recovery fund would stabilize hillsides, watershed, roads, and infrastructure but would not provide direct assistance to residents, businesses, private property, or Eagle Point; a separate chamber fund would distribute money directly to affected locals and businesses. UDOT's August 17 project page said SR-153 remained closed to general traffic, recorded $50 million in initial reconstruction funding, and anticipated major permanent work beginning in spring 2027.",
+  "take": "Model draft, not Matti's approved view: Crusher riders lost a race. Beaver could not defer the disaster to 2027. The cancellation was obviously right, and Life Time's page points people to relief. But the public record makes the scale mismatch impossible to ignore: one local operator estimated $30,000 to $50,000 in lost revenue, hotels lost reservations, $18 million in public recovery specifically does not go directly to businesses or Eagle Point, and SR-153 entered a $50 million initial reconstruction with major work extending into 2027. Gravel loves to call places like Beaver the host community, which sounds warmer than scenery with a hotel block. This is when the phrase acquires a price. A race that builds its product from a town's roads, volunteers, lodging, and identity has an obligation to make the town's recovery part of the event—not merely the explanation for why registration stopped. What that obligation costs is open. That it exists is not.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources do not isolate how much of any local loss came specifically from Crusher rather than the fire, road closure, resort damage, other canceled events, or travelers' broader fears. They do not quantify Crusher's normal economic contribution, disclose any private Life Time or sponsor donations beyond the public relief link, establish a contractual duty to fund recovery, or show whether the event can return in 2027. The UDOT funding and construction schedule remain mutable. Day-level publication dates without source timestamps are normalized to midnight UTC; UDOT's page timestamp comes from its public project metadata.",
+  "editorialScore": 92,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_3b883c0cbf82862e5564e5d5",
+      "canonicalUrl": "https://tusharcrusher.com/",
+      "publisher": "Life Time Crusher in the Tushar",
+      "publishedAt": "2026-06-29T00:00:00Z",
+      "quoteExcerpt": "Crusher in the Tushar will not take place as planned this year.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_5c393512576aba502b8f1b14",
+      "canonicalUrl": "https://www.fox13now.com/news/local-news/central-utah/how-will-local-businesses-recover-after-the-cottonwood-fire",
+      "publisher": "FOX 13 News Utah",
+      "publishedAt": "2026-07-03T04:54:24Z",
+      "quoteExcerpt": "He estimates they'll lose between $30,000 and $50,000 in revenue.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_a7c0f7b65ff7ffec42376884",
+      "canonicalUrl": "https://www.deseret.com/utah/2026/07/10/beaver-community-supports-those-affected-by-cottonwood-fire/",
+      "publisher": "Deseret News",
+      "publishedAt": "2026-07-10T00:00:00Z",
+      "quoteExcerpt": "We're concerned about our hotels and the restaurants and, you know, the grocery store.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_47a247652b56d59e919ba954",
+      "canonicalUrl": "https://visitbeavercountyut.com/cottonwood-fire-information/",
+      "publisher": "Beaver County, Utah",
+      "publishedAt": "2026-08-11T00:00:00Z",
+      "quoteExcerpt": "will not provide direct financial assistance to individual residents or businesses",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_698b4800e4d5f7e3001d3616",
+      "canonicalUrl": "https://udotinput.utah.gov/v42122",
+      "publisher": "Utah Department of Transportation",
+      "publishedAt": "2026-08-17T21:03:47Z",
+      "quoteExcerpt": "will not reopen SR-153 to general public traffic at this time",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:crusher-in-the-tushar",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_3b883c0cbf82862e5564e5d5",
+        "claim_5c393512576aba502b8f1b14",
+        "claim_a7c0f7b65ff7ffec42376884",
+        "claim_47a247652b56d59e919ba954",
+        "claim_698b4800e4d5f7e3001d3616"
+      ],
+      "confidence": 0.95,
+      "owner": "Gravel God historical editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T16:20:00Z",
+  "contentHash": "44382cb1ec84929fbbefd40b98b427718e584fabb63e142b67858ef4e14d9da0"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -1170,9 +1170,9 @@ def test_2026_backfill_ledger_accounts_for_every_window_without_claiming_complet
 
     assert len(validated["weeks"]) == 35
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 230
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 22
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 23
     assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 7
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 4
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 3
     assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 1
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 1
     assert validated["complete"] is False


### PR DESCRIPTION
## Outcome

Adds a draft-only 2026 Gravel Weekly history entry for the Cottonwood Fire, Crusher cancellation, Beaver business losses, recovery-funding boundary, and SR-153 reconstruction. The story point is that cancellation resolves the athlete transaction but not the event owner’s obligation to the host community.

## Safety

- `status: draft`
- `takeProvenance: model_draft`
- `humanApprovalRequired: true`
- `autoPublishAllowed: false`
- race impact is `editorial_review` only
- public generator still emits zero dated issue pages

## Evidence

Five contemporaneous receipts: Life Time Crusher, FOX 13 Utah, Deseret News, Beaver County, and UDOT. The UDOT timestamp was corrected from the dated milestone to the page’s public `publishDate` metadata before this draft was sealed.

## Voice provenance

Canonical writing-graph profile plus raw pieces `inbox/gravel-god/listening-to-robert-in-silver-city.md` and `inbox/gravel-god/the-double-day-10-im-not-sure-what-an-18-hrv-means.md`; strict AI-writing gate passed.

## Verification

- focused Gravel Weekly suite: 66 passed
- full repository suite: 7,873 passed, 331 skipped
- history validator: 73 entries valid
- public generator: 0 dated issues
- `git diff --check`: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and backfill ledger updates only; no publish path or automated race-field changes, with existing validators and tests enforcing draft-only linkage.
> 
> **Overview**
> Adds a **draft-only** Gravel Weekly history entry (`history-crusher-host-community-2026`) arguing that canceling Crusher after the Cottonwood Fire settles the athlete transaction but not Life Time’s obligation to Beaver as a host community—backed by five contemporaneous receipts (Life Time, FOX 13, Deseret News, Beaver County, UDOT).
> 
> The **2026 backfill ledger** now routes four weekly windows through that draft (including flipping the July 4–10 window from `rejected` to `covered_by_draft`), and **tests** update expected `covered_by_draft` / `rejected` counts. Publication stays gated: `status: draft`, `takeProvenance: model_draft`, human approval required, and race impact is `editorial_review` on `race.biased_opinion` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6fd8ff095a47048d073f911fd48f58361a8b093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->