### PR TITLE
Add fail-closed historical editorial approval workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ data/gravel-weekly/drafts/
 # Human-approved snapshots remain local until an explicit sealing action moves
 # an immutable copy into data/gravel-weekly/issues/.
 data/gravel-weekly/approved/
+# Historical approval artifacts stay local until an explicit sealing action
+# replaces the reviewed draft with its immutable published snapshot.
+data/gravel-weekly/history-staged/
+# Generated private editorial desks are neither deployable site output nor
+# canonical publication data.
+data/gravel-weekly/history-review/
 
 # Database backups
 *.json.bak

--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -89,3 +89,45 @@ Render a local draft for review without making it public:
 python3 wordpress/generate_gravel_weekly.py \
   --preview-draft data/gravel-weekly/drafts/2026-08-28.json
 ```
+
+## Historical narrative review
+
+Historical Current Thing entries are narrative reconstructions, not fabricated
+old weekly issues. Drafts live in `history/`, but the public loader excludes
+them. Build a private, read-only desk for one year:
+
+```bash
+python3 scripts/render_gravel_weekly_history_review.py --year 2026
+```
+
+The desk puts the point, prior and changed judgments, model Take, uncertainty,
+contemporary receipts, later evidence, gates, and review-only race implications
+in one place. A story is marked ready only when all five editorial gates pass
+and at least two contemporary publishers corroborate it.
+
+Apply one explicit decision using `gravel-weekly-history-approval/v1`:
+
+```bash
+python3 scripts/approve_gravel_weekly_history.py \
+  data/gravel-weekly/history/2026-example.json APPROVAL.json
+```
+
+The packet must identify the exact reviewed `contentHash`. Approval may change
+only the headline and Take, records the edit summary, and stages the result and
+decision under ignored `history-staged/`. Rejection records a reason but creates
+no approved entry. A stale hash, held gate, single-publisher premise, factual
+edit, or copy that still claims to be a model draft fails closed.
+
+Only after a separate explicit publication instruction may the staged entry be
+sealed:
+
+```bash
+python3 scripts/seal_gravel_weekly_history.py \
+  data/gravel-weekly/history-staged/history-example.approved.json \
+  --published-at 2026-08-28T16:05:00Z
+```
+
+Sealing verifies the decision against the unchanged canonical draft, replaces
+that draft with the published immutable snapshot, and writes its durable
+decision under `history-decisions/`. It does not deploy the site, and race
+impacts remain editorial-review proposals with `autoFixAllowed: false`.

--- a/scripts/approve_gravel_weekly_history.py
+++ b/scripts/approve_gravel_weekly_history.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Apply one explicit, hash-bound human decision to a historical draft.
+
+Approval stages human-owned headline and Take copy outside the public history
+directory. Rejection writes only a durable local decision. Neither path can
+publish an entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from validate_gravel_weekly_history import compute_history_content_hash, validate_history_entry
+from validate_gravel_weekly_history_decisions import DECISION_SCHEMA, validate_history_decision
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+STAGED_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "history-staged"
+APPROVAL_SCHEMA = "gravel-weekly-history-approval/v1"
+APPROVAL_KEYS = {
+    "schemaVersion",
+    "entryId",
+    "reviewedDraftContentHash",
+    "decision",
+    "approver",
+    "decidedAt",
+    "headline",
+    "take",
+    "editSummary",
+    "reason",
+}
+
+
+def _record(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be an object")
+    return value
+
+
+def _text(value: Any, name: str, maximum: int) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} is required")
+    if len(value) > maximum:
+        raise ValueError(f"{name} exceeds {maximum} characters")
+    return value.strip()
+
+
+def apply_history_decision(
+    draft_value: Any, approval_value: Any
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Return a non-public approved entry, if any, and its decision receipt."""
+    draft = validate_history_entry(draft_value)
+    if draft["status"] != "draft":
+        raise ValueError("historical approval requires a status=draft entry")
+    approval = _record(approval_value, "historical approval")
+    unknown = set(approval) - APPROVAL_KEYS
+    if unknown:
+        raise ValueError(f"historical approval has unsupported fields: {sorted(unknown)}")
+    if approval.get("schemaVersion") != APPROVAL_SCHEMA:
+        raise ValueError("unsupported Gravel Weekly historical approval schema")
+    if approval.get("entryId") != draft["entryId"]:
+        raise ValueError("approval.entryId must match the historical draft")
+    if approval.get("reviewedDraftContentHash") != draft["contentHash"]:
+        raise ValueError("approval.reviewedDraftContentHash must match the exact reviewed draft")
+    verdict = approval.get("decision")
+    if verdict not in {"approve", "reject"}:
+        raise ValueError("approval.decision must be approve or reject")
+    approver = _text(approval.get("approver"), "approval.approver", 300)
+    decided_at = _text(approval.get("decidedAt"), "approval.decidedAt", 100)
+
+    if verdict == "reject":
+        reason = _text(approval.get("reason"), "approval.reason", 2_000)
+        for field in ("headline", "take", "editSummary"):
+            if approval.get(field) is not None:
+                raise ValueError(f"rejected historical approval cannot set {field}")
+        approved = None
+        approved_headline = None
+        approved_take = None
+        edit_summary = None
+    else:
+        if approval.get("reason") is not None:
+            raise ValueError("approved historical approval cannot set reason")
+        approved_headline = _text(approval.get("headline"), "approval.headline", 300)
+        approved_take = _text(approval.get("take"), "approval.take", 8_000)
+        edit_summary = _text(approval.get("editSummary"), "approval.editSummary", 2_000)
+        reason = "Approved for the Gravel Weekly historical timeline."
+        approved = {
+            **draft,
+            "status": "approved",
+            "headline": approved_headline,
+            "take": approved_take,
+            "takeProvenance": "human_approved",
+            "editorialApproval": {"approver": approver, "approvedAt": decided_at},
+            "publishedAt": None,
+            "updatedAt": decided_at,
+            "contentHash": "pending",
+        }
+        approved["contentHash"] = compute_history_content_hash(approved)
+        approved = validate_history_entry(approved)
+
+    receipt = {
+        "schemaVersion": DECISION_SCHEMA,
+        "entryId": draft["entryId"],
+        "reviewedDraftContentHash": draft["contentHash"],
+        "decision": verdict,
+        "reason": reason,
+        "decidedBy": approver,
+        "decidedAt": decided_at,
+        "suggestedHeadline": draft["headline"],
+        "approvedHeadline": approved_headline,
+        "suggestedTake": draft["take"],
+        "approvedTake": approved_take,
+        "editSummary": edit_summary,
+    }
+    return approved, validate_history_decision(receipt, approved)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("draft", type=Path)
+    parser.add_argument("approval", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--decision-output", type=Path)
+    args = parser.parse_args()
+    draft = json.loads(args.draft.read_text(encoding="utf-8"))
+    approval = json.loads(args.approval.read_text(encoding="utf-8"))
+    approved, receipt = apply_history_decision(draft, approval)
+    entry_id = receipt["entryId"]
+    decision_output = args.decision_output or STAGED_DIR / f"{entry_id}.decision.json"
+    decision_output.parent.mkdir(parents=True, exist_ok=True)
+    decision_output.write_text(f"{json.dumps(receipt, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
+    if approved is None:
+        print(f"Rejected and recorded without publication: {decision_output}")
+        return 0
+    output = args.output or STAGED_DIR / f"{entry_id}.approved.json"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(f"{json.dumps(approved, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
+    print(f"Approved but not published: {output}")
+    print(f"Hash-bound decision staged: {decision_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_gravel_weekly_history_review.py
+++ b/scripts/render_gravel_weekly_history_review.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Render a private, read-only editorial desk for historical narrative drafts."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "wordpress"))
+
+from brand_tokens import get_tokens_css  # noqa: E402
+from validate_gravel_weekly_history import HISTORY_DIR, load_history_entries  # noqa: E402
+
+
+def esc(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def paragraphs(value: str) -> str:
+    return "".join(
+        f"<p>{esc(block.strip())}</p>"
+        for block in value.split("\n\n")
+        if block.strip()
+    )
+
+
+def approval_holds(entry: dict[str, Any]) -> list[str]:
+    holds = [name for name, verdict in entry["editorialGates"].items() if verdict != "pass"]
+    publishers = {
+        receipt["publisher"].strip().casefold()
+        for receipt in entry["contemporaryReceipts"]
+    }
+    if len(publishers) < 2:
+        holds.append("two-publisher corroboration")
+    return holds
+
+
+def _receipt_list(receipts: list[dict[str, Any]]) -> str:
+    if not receipts:
+        return '<p class="empty">None.</p>'
+    rows = []
+    for receipt in receipts:
+        published = datetime.fromisoformat(receipt["publishedAt"].replace("Z", "+00:00"))
+        rows.append(
+            '<li><a href="{url}" rel="noopener" target="_blank">{publisher} · {date}</a>'
+            '<blockquote>{excerpt}</blockquote><code>{claim}</code></li>'.format(
+                url=esc(receipt["canonicalUrl"]),
+                publisher=esc(receipt["publisher"]),
+                date=published.strftime("%b %-d, %Y"),
+                excerpt=esc(receipt["quoteExcerpt"]),
+                claim=esc(receipt["claimId"]),
+            )
+        )
+    return f'<ol class="receipts">{"".join(rows)}</ol>'
+
+
+def _impact_list(impacts: list[dict[str, Any]]) -> str:
+    if not impacts:
+        return '<p class="empty">No race-profile implication proposed.</p>'
+    return '<ul class="impacts">{}</ul>'.format(
+        "".join(
+            "<li><b>{race}</b> · {field} · editorial review only · no auto-fix</li>".format(
+                race=esc(impact["raceId"]),
+                field=esc(impact.get("fieldPath") or "unspecified field"),
+            )
+            for impact in impacts
+        )
+    )
+
+
+def _card(entry: dict[str, Any]) -> str:
+    holds = approval_holds(entry)
+    readiness = (
+        '<span class="ready">READY FOR MATTI</span>'
+        if not holds
+        else f'<span class="hold">HOLD · {esc(", ".join(holds))}</span>'
+    )
+    gate_rows = "".join(
+        f"<li><b>{esc(name)}</b><span>{esc(verdict.upper())}</span></li>"
+        for name, verdict in entry["editorialGates"].items()
+    )
+    decision_instruction = (
+        f'Tell Codex <q>approve {esc(entry["entryId"])}</q>, '
+        '<q>reject … because …</q>, or give an edited headline/Take.'
+        if not holds
+        else "Resolve the named hold or reject this premise. Approval fails closed while any hold remains."
+    )
+    return f'''<article class="story" id="{esc(entry['entryId'])}">
+      <header>
+        <div class="eyebrow">{esc(entry['activeFrom'])} → {esc(entry['activeThrough'])} · SCORE {entry['editorialScore']}</div>
+        <h2>{esc(entry['headline'])}</h2>
+        <div class="status">{readiness}<code>{esc(entry['entryId'])}</code></div>
+      </header>
+      <section class="point"><h3>THE POINT</h3>{paragraphs(entry['point'])}</section>
+      <div class="judgment">
+        <section><h3>BEFORE</h3>{paragraphs(entry['priorJudgment'])}</section>
+        <section><h3>AFTER</h3>{paragraphs(entry['changedJudgment'])}</section>
+      </div>
+      <section><h3>WHAT HAPPENED</h3>{paragraphs(entry['whatHappened'])}</section>
+      <section class="take"><h3>THE TAKE · MODEL DRAFT</h3>{paragraphs(entry['take'])}</section>
+      <div class="judgment">
+        <section><h3>STAKES</h3>{paragraphs(entry['stakes'])}</section>
+        <section><h3>CREDIBLE OPPOSITION</h3>{paragraphs(entry['credibleOpposition'])}</section>
+      </div>
+      <section><h3>UNCERTAINTY</h3>{paragraphs(entry['uncertainty'])}</section>
+      <details open><summary>CONTEMPORARY RECEIPTS ({len(entry['contemporaryReceipts'])})</summary>{_receipt_list(entry['contemporaryReceipts'])}</details>
+      <details><summary>LATER EVIDENCE ({len(entry['laterEvidence'])})</summary>{_receipt_list(entry['laterEvidence'])}</details>
+      <details><summary>GATES &amp; RACE INTELLIGENCE</summary><ul class="gates">{gate_rows}</ul>{_impact_list(entry['raceImpacts'])}</details>
+      <footer>
+        <p><b>DECIDE:</b> {decision_instruction} Any decision binds to this exact draft hash and still does not publish.</p>
+        <code>{esc(entry['contentHash'])}</code>
+      </footer>
+    </article>'''
+
+
+def render_history_review(entries: list[dict[str, Any]], year: int) -> str:
+    selected = [
+        entry for entry in entries
+        if entry["activeFrom"] <= f"{year}-12-31" and entry["activeThrough"] >= f"{year}-01-01"
+    ]
+    drafts = [entry for entry in selected if entry["status"] == "draft"]
+    ready = sum(not approval_holds(entry) for entry in drafts)
+    held = len(drafts) - ready
+    cards = "".join(_card(entry) for entry in drafts)
+    return f'''<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex,nofollow"><title>Gravel Weekly {year} Historical Review</title>
+<style>
+{get_tokens_css()}
+* {{ box-sizing: border-box; }}
+body {{ margin: 0; background: var(--gg-color-sand); color: var(--gg-color-near-black); font-family: var(--gg-font-data); }}
+main {{ width: min(1120px, calc(100% - 32px)); margin: 32px auto 80px; }}
+.desk-head {{ border: var(--gg-border-heavy); background: var(--gg-color-gold); padding: var(--gg-spacing-lg); }}
+.desk-head h1 {{ margin: 0; font-size: clamp(2.4rem, 8vw, 6rem); line-height: .85; }}
+.desk-head p {{ max-width: 800px; font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-lg); }}
+.summary {{ display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }}
+.summary b, .ready, .hold {{ border: var(--gg-border-standard); padding: 6px 10px; background: var(--gg-color-warm-paper); }}
+.hold {{ background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }}
+.story {{ margin-top: 32px; border: var(--gg-border-heavy); background: var(--gg-color-warm-paper); }}
+.story > header, .story > section, .story > div, .story > details, .story > footer {{ padding: var(--gg-spacing-lg); border-top: var(--gg-border-standard); }}
+.story > header {{ border-top: 0; background: var(--gg-color-white); }}
+.story h2 {{ margin: 8px 0 16px; max-width: 900px; font-family: var(--gg-font-editorial); font-size: clamp(2rem, 6vw, 4rem); line-height: .95; }}
+.story h3 {{ margin: 0 0 8px; letter-spacing: var(--gg-letter-spacing-wide); }}
+.story p {{ max-width: 900px; font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-md); line-height: var(--gg-line-height-relaxed); }}
+.status {{ display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }}
+.judgment {{ display: grid; grid-template-columns: 1fr 1fr; padding: 0 !important; }}
+.judgment section {{ padding: var(--gg-spacing-lg); }} .judgment section + section {{ border-left: var(--gg-border-standard); }}
+.point {{ background: var(--gg-color-gold); }} .take {{ background: var(--gg-color-sand); }}
+summary {{ cursor: pointer; font-weight: var(--gg-font-weight-black); }}
+.receipts li {{ margin: 16px 0; }} blockquote {{ margin: 8px 0; font-family: var(--gg-font-editorial); }}
+.gates {{ max-width: 520px; padding: 0; list-style: none; }} .gates li {{ display: flex; justify-content: space-between; border-bottom: var(--gg-border-subtle); padding: 8px 0; }}
+code {{ overflow-wrap: anywhere; }} footer {{ background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }} footer code {{ color: var(--gg-color-light-gold); }}
+@media (max-width: 700px) {{ .judgment {{ grid-template-columns: 1fr; }} .judgment section + section {{ border-left: 0; border-top: var(--gg-border-standard); }} main {{ width: min(100% - 16px, 1120px); margin-top: 8px; }} }}
+</style></head><body><main>
+  <header class="desk-head"><div class="eyebrow">PRIVATE EDITORIAL DESK · NOT PUBLIC</div><h1>{year}<br>THE SEASON<br>AS A STORY</h1>
+  <p>This queue contains narrative change-points, not one required story per week. Review the point first, then the Take. Receipts from the active period are separated from evidence learned later.</p>
+  <div class="summary"><b>{len(drafts)} DRAFTS</b><b>{ready} READY FOR HUMAN DECISION</b><b>{held} HELD BY EVIDENCE OR EDITORIAL GATES</b></div></header>
+  {cards or '<section class="story"><header><h2>No draft historical entries for this year.</h2></header></section>'}
+</main></body></html>'''
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--year", required=True, type=int)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    output = args.output or (
+        PROJECT_ROOT / "data" / "gravel-weekly" / "history-review" / f"{args.year}.html"
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    entries = load_history_entries(HISTORY_DIR)
+    output.write_text(render_history_review(entries, args.year), encoding="utf-8")
+    selected = [
+        entry for entry in entries
+        if entry["activeFrom"] <= f"{args.year}-12-31"
+        and entry["activeThrough"] >= f"{args.year}-01-01"
+        and entry["status"] == "draft"
+    ]
+    print(f"Rendered {len(selected)} private historical drafts: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/seal_gravel_weekly_history.py
+++ b/scripts/seal_gravel_weekly_history.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Seal a staged historical approval as an immutable public snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from validate_gravel_weekly_history import (
+    HISTORY_DIR,
+    compute_history_content_hash,
+    validate_history_entry,
+)
+from validate_gravel_weekly_history_decisions import validate_history_decision
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DECISION_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "history-decisions"
+
+
+def _timestamp(value: str, name: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{name} must include a timezone")
+    return parsed
+
+
+def seal_history_entry(approved_value: Any, published_at: str) -> dict[str, Any]:
+    approved = validate_history_entry(approved_value)
+    if approved["status"] != "approved":
+        raise ValueError("historical sealing requires a status=approved entry")
+    published_time = _timestamp(published_at, "publishedAt")
+    approved_time = _timestamp(
+        approved["editorialApproval"]["approvedAt"], "editorialApproval.approvedAt"
+    )
+    if published_time < approved_time:
+        raise ValueError("publishedAt cannot precede historical editorial approval")
+    sealed = {
+        **approved,
+        "status": "published",
+        "publishedAt": published_at,
+        "updatedAt": published_at,
+        "contentHash": "pending",
+    }
+    sealed["contentHash"] = compute_history_content_hash(sealed)
+    return validate_history_entry(sealed)
+
+
+def _find_reviewed_draft(entry_id: str) -> Path:
+    matches: list[Path] = []
+    for path in sorted(HISTORY_DIR.glob("*.json")):
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if value.get("entryId") == entry_id:
+            matches.append(path)
+    if len(matches) != 1:
+        raise SystemExit(
+            f"Expected exactly one canonical draft for {entry_id}; found {len(matches)}"
+        )
+    return matches[0]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("approved", type=Path)
+    parser.add_argument("--published-at", required=True)
+    parser.add_argument("--decision", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--decision-output", type=Path)
+    args = parser.parse_args()
+    approved = json.loads(args.approved.read_text(encoding="utf-8"))
+    sealed = seal_history_entry(approved, args.published_at)
+    decision_input = args.decision or args.approved.with_name(
+        f"{sealed['entryId']}.decision.json"
+    )
+    if not decision_input.exists():
+        raise SystemExit(f"Historical decision not found: {decision_input}")
+    decision = validate_history_decision(
+        json.loads(decision_input.read_text(encoding="utf-8")), sealed
+    )
+    output = args.output or _find_reviewed_draft(sealed["entryId"])
+    decision_output = args.decision_output or DECISION_DIR / f"{sealed['entryId']}.json"
+
+    if output.exists():
+        current = validate_history_entry(json.loads(output.read_text(encoding="utf-8")))
+        if current["status"] != "draft":
+            raise SystemExit(f"Refusing to replace non-draft historical snapshot: {output}")
+        if current["entryId"] != sealed["entryId"]:
+            raise SystemExit(f"Refusing to replace a different historical entry: {output}")
+        if current["contentHash"] != decision["reviewedDraftContentHash"]:
+            raise SystemExit("Canonical historical draft changed after review; approval is stale")
+        if current["headline"] != decision["suggestedHeadline"] or current["take"] != decision["suggestedTake"]:
+            raise SystemExit("Historical decision does not preserve the exact reviewed draft copy")
+    if decision_output.exists():
+        raise SystemExit(f"Refusing to replace immutable historical decision: {decision_output}")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    decision_output.parent.mkdir(parents=True, exist_ok=True)
+    decision_output.write_text(f"{json.dumps(decision, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
+    output.write_text(f"{json.dumps(sealed, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
+    print(f"Sealed published historical snapshot: {output}")
+    print(f"Sealed immutable historical decision: {decision_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_gravel_weekly_history.py
+++ b/scripts/validate_gravel_weekly_history.py
@@ -75,7 +75,7 @@ def validate_history_entry(value: Any, *, verify_hash: bool = True) -> dict[str,
     status = entry.get("status")
     if status not in {"draft", "approved", "published"}:
         raise IssueValidationError("history status is invalid")
-    _text(entry.get("headline"), "headline", 300)
+    headline = _text(entry.get("headline"), "headline", 300)
     _text(entry.get("point"), "point", 1_000)
     _text(entry.get("priorJudgment"), "priorJudgment", 1_000)
     _text(entry.get("changedJudgment"), "changedJudgment", 1_000)
@@ -94,6 +94,8 @@ def validate_history_entry(value: Any, *, verify_hash: bool = True) -> dict[str,
         raise IssueValidationError("approved historical takes require human-approved provenance")
     if status != "draft" and re.search(r"model draft|not matti(?:’|')s approved", take, re.IGNORECASE):
         raise IssueValidationError("historical take still contains model-draft language")
+    if status != "draft" and re.search(r"model draft|not matti(?:’|')s approved", headline, re.IGNORECASE):
+        raise IssueValidationError("historical headline still contains model-draft language")
     gates = _record(entry.get("editorialGates"), "editorialGates")
     if set(gates) != PASSING_GATES:
         raise IssueValidationError("editorialGates must contain the five historical gates")

--- a/scripts/validate_gravel_weekly_history_decisions.py
+++ b/scripts/validate_gravel_weekly_history_decisions.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Validate a hash-bound human decision for one historical narrative entry."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import re
+from typing import Any
+
+from validate_gravel_weekly_history import validate_history_entry
+
+DECISION_SCHEMA = "gravel-weekly-history-decision/v1"
+DECISION_KEYS = {
+    "schemaVersion",
+    "entryId",
+    "reviewedDraftContentHash",
+    "decision",
+    "reason",
+    "decidedBy",
+    "decidedAt",
+    "suggestedHeadline",
+    "approvedHeadline",
+    "suggestedTake",
+    "approvedTake",
+    "editSummary",
+}
+
+
+def _record(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be an object")
+    return value
+
+
+def _text(value: Any, name: str, maximum: int) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} is required")
+    if len(value) > maximum:
+        raise ValueError(f"{name} exceeds {maximum} characters")
+    return value.strip()
+
+
+def _optional_text(value: Any, name: str, maximum: int) -> str | None:
+    if value is None:
+        return None
+    return _text(value, name, maximum)
+
+
+def _timestamp(value: Any, name: str) -> str:
+    raw = _text(value, name, 100)
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{name} must include a timezone")
+    return raw
+
+
+def validate_history_decision(value: Any, approved_value: Any | None = None) -> dict[str, Any]:
+    """Validate a decision and, for approvals, bind it to the staged entry."""
+    decision = _record(value, "historical decision")
+    unknown = set(decision) - DECISION_KEYS
+    missing = DECISION_KEYS - set(decision)
+    if unknown or missing:
+        raise ValueError(
+            f"historical decision fields mismatch; missing={sorted(missing)}, extra={sorted(unknown)}"
+        )
+    if decision.get("schemaVersion") != DECISION_SCHEMA:
+        raise ValueError("unsupported Gravel Weekly historical decision schema")
+    _text(decision.get("entryId"), "entryId", 500)
+    reviewed_hash = _text(decision.get("reviewedDraftContentHash"), "reviewedDraftContentHash", 64)
+    if not re.fullmatch(r"[0-9a-f]{64}", reviewed_hash):
+        raise ValueError("reviewedDraftContentHash must be a SHA-256 hex digest")
+    verdict = decision.get("decision")
+    if verdict not in {"approve", "reject"}:
+        raise ValueError("decision must be approve or reject")
+    _text(decision.get("reason"), "reason", 2_000)
+    _text(decision.get("decidedBy"), "decidedBy", 300)
+    _timestamp(decision.get("decidedAt"), "decidedAt")
+    _text(decision.get("suggestedHeadline"), "suggestedHeadline", 300)
+    _text(decision.get("suggestedTake"), "suggestedTake", 8_000)
+
+    approved_headline = _optional_text(decision.get("approvedHeadline"), "approvedHeadline", 300)
+    approved_take = _optional_text(decision.get("approvedTake"), "approvedTake", 8_000)
+    edit_summary = _optional_text(decision.get("editSummary"), "editSummary", 2_000)
+    if verdict == "approve" and not all((approved_headline, approved_take, edit_summary)):
+        raise ValueError("approved historical decisions require approved copy and an edit summary")
+    if verdict == "reject" and any((approved_headline, approved_take, edit_summary)):
+        raise ValueError("rejected historical decisions cannot carry approved copy")
+
+    if approved_value is not None:
+        approved = validate_history_entry(approved_value)
+        if verdict != "approve":
+            raise ValueError("a staged approved entry requires an approve decision")
+        if approved["status"] not in {"approved", "published"}:
+            raise ValueError("decision binding requires an approved or published history entry")
+        if decision["entryId"] != approved["entryId"]:
+            raise ValueError("historical decision entryId does not match the approved entry")
+        if approved_headline != approved["headline"]:
+            raise ValueError("approved headline does not match the approved entry")
+        if approved_take != approved["take"]:
+            raise ValueError("approved take does not match the approved entry")
+        approval = approved["editorialApproval"]
+        if decision["decidedBy"] != approval["approver"] or decision["decidedAt"] != approval["approvedAt"]:
+            raise ValueError("historical decision identity does not match editorial approval")
+    return decision

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -24,6 +24,13 @@ from validate_gravel_weekly_history import (  # noqa: E402
     load_public_history_entries,
     validate_history_entry,
 )
+from approve_gravel_weekly_history import apply_history_decision  # noqa: E402
+from render_gravel_weekly_history_review import render_history_review  # noqa: E402
+from seal_gravel_weekly_history import (  # noqa: E402
+    main as seal_history_main,
+    seal_history_entry,
+)
+from validate_gravel_weekly_history_decisions import validate_history_decision  # noqa: E402
 from validate_gravel_weekly_backfill import validate_backfill_ledger  # noqa: E402
 from prepare_gravel_weekly_backfill_ledger import build_initial_backfill_ledger  # noqa: E402
 from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
@@ -127,6 +134,37 @@ def sample_history_entry():
     }
     entry["contentHash"] = compute_history_content_hash(entry)
     return entry
+
+
+def sample_history_draft():
+    entry = sample_history_entry()
+    entry.update({
+        "status": "draft",
+        "headline": "MODEL DRAFT: The privateer became gravel's control group",
+        "take": "Model draft, not Matti's approved view: Gravel installed a backstage entrance.",
+        "takeProvenance": "model_draft",
+        "editorialApproval": None,
+        "publishedAt": None,
+        "updatedAt": "2026-08-27T17:00:00Z",
+    })
+    entry["contentHash"] = compute_history_content_hash(entry)
+    return entry
+
+
+def sample_history_approval(draft=None):
+    draft = draft or sample_history_draft()
+    return {
+        "schemaVersion": "gravel-weekly-history-approval/v1",
+        "entryId": draft["entryId"],
+        "reviewedDraftContentHash": draft["contentHash"],
+        "decision": "approve",
+        "approver": "Matti Rowe",
+        "decidedAt": "2026-08-28T16:00:00Z",
+        "headline": "The privateer became gravel's control group",
+        "take": "Gravel kept the front door open and installed a backstage entrance.",
+        "editSummary": "Removed the model label and tightened the judgment.",
+        "reason": None,
+    }
 
 
 def passing_editorial_gate():
@@ -578,6 +616,138 @@ def test_historical_current_thing_requires_contemporary_corroboration_and_human_
     model_take["takeProvenance"] = "model_draft"
     with pytest.raises(IssueValidationError, match="human-approved provenance"):
         validate_history_entry(model_take, verify_hash=False)
+
+
+def test_historical_approval_is_hash_bound_copy_limited_and_non_public(tmp_path):
+    draft = sample_history_draft()
+    approved, decision = apply_history_decision(draft, sample_history_approval(draft))
+
+    assert approved is not None
+    assert approved["status"] == "approved"
+    assert approved["publishedAt"] is None
+    assert approved["headline"] == "The privateer became gravel's control group"
+    assert approved["take"] == "Gravel kept the front door open and installed a backstage entrance."
+    assert approved["takeProvenance"] == "human_approved"
+    assert approved["editorialApproval"] == {
+        "approver": "Matti Rowe", "approvedAt": "2026-08-28T16:00:00Z",
+    }
+    for field in (
+        "point", "priorJudgment", "changedJudgment", "stakes", "credibleOpposition",
+        "whatHappened", "uncertainty", "editorialScore", "editorialGates",
+        "contemporaryReceipts", "laterEvidence", "raceImpacts",
+    ):
+        assert approved[field] == draft[field]
+    assert decision["reviewedDraftContentHash"] == draft["contentHash"]
+    assert validate_history_decision(decision, approved) == decision
+
+    (tmp_path / "draft.json").write_text(json.dumps(draft))
+    assert load_public_history_entries(tmp_path) == []
+
+    stale = sample_history_approval(draft)
+    stale["reviewedDraftContentHash"] = "0" * 64
+    with pytest.raises(ValueError, match="exact reviewed draft"):
+        apply_history_decision(draft, stale)
+
+    factual_edit = sample_history_approval(draft)
+    factual_edit["whatHappened"] = "Silently replace the sourced account."
+    with pytest.raises(ValueError, match="unsupported fields"):
+        apply_history_decision(draft, factual_edit)
+
+
+def test_historical_rejection_records_the_reason_without_approved_copy():
+    draft = sample_history_draft()
+    rejection = sample_history_approval(draft)
+    rejection.update({
+        "decision": "reject",
+        "headline": None,
+        "take": None,
+        "editSummary": None,
+        "reason": "The changed judgment is still too obvious to publish.",
+    })
+    approved, decision = apply_history_decision(draft, rejection)
+
+    assert approved is None
+    assert decision["decision"] == "reject"
+    assert decision["reason"] == "The changed judgment is still too obvious to publish."
+    assert decision["approvedHeadline"] is None
+    assert decision["approvedTake"] is None
+    assert validate_history_decision(decision) == decision
+
+
+def test_historical_approval_cannot_rescue_a_held_editorial_gate():
+    draft = sample_history_draft()
+    draft["editorialGates"]["hostileEditor"] = "hold"
+    draft["contentHash"] = compute_history_content_hash(draft)
+    with pytest.raises(IssueValidationError, match="every editorial gate"):
+        apply_history_decision(draft, sample_history_approval(draft))
+
+
+def test_historical_sealing_is_separate_and_preserves_approved_copy():
+    draft = sample_history_draft()
+    approved, decision = apply_history_decision(draft, sample_history_approval(draft))
+    assert approved is not None
+    sealed = seal_history_entry(approved, "2026-08-28T16:05:00Z")
+
+    assert sealed["status"] == "published"
+    assert sealed["publishedAt"] == "2026-08-28T16:05:00Z"
+    assert sealed["headline"] == approved["headline"]
+    assert sealed["take"] == approved["take"]
+    assert validate_history_decision(decision, sealed) == decision
+
+    with pytest.raises(ValueError, match="status=approved"):
+        seal_history_entry(draft, "2026-08-28T16:05:00Z")
+    with pytest.raises(ValueError, match="cannot precede"):
+        seal_history_entry(approved, "2026-08-28T15:59:59Z")
+
+
+def test_historical_seal_refuses_a_canonical_draft_changed_after_review(tmp_path, monkeypatch):
+    draft = sample_history_draft()
+    approved, decision = apply_history_decision(draft, sample_history_approval(draft))
+    assert approved is not None
+    changed = copy.deepcopy(draft)
+    changed["point"] = "A newly revised point after Matti reviewed the earlier draft."
+    changed["contentHash"] = compute_history_content_hash(changed)
+    approved_path = tmp_path / "approved.json"
+    decision_path = tmp_path / "decision.json"
+    canonical_path = tmp_path / "canonical.json"
+    decision_output = tmp_path / "canonical-decision.json"
+    approved_path.write_text(json.dumps(approved))
+    decision_path.write_text(json.dumps(decision))
+    canonical_path.write_text(json.dumps(changed))
+    monkeypatch.setattr(sys, "argv", [
+        "seal_gravel_weekly_history.py", str(approved_path),
+        "--published-at", "2026-08-28T16:05:00Z",
+        "--decision", str(decision_path),
+        "--output", str(canonical_path),
+        "--decision-output", str(decision_output),
+    ])
+
+    with pytest.raises(SystemExit, match="approval is stale"):
+        seal_history_main()
+    assert json.loads(canonical_path.read_text())["contentHash"] == changed["contentHash"]
+    assert not decision_output.exists()
+
+
+def test_private_historical_review_desk_separates_evidence_and_approval_state():
+    draft = sample_history_draft()
+    held = copy.deepcopy(draft)
+    held["entryId"] = "history-held-2026"
+    held["headline"] = "A held premise"
+    held["editorialGates"]["friend"] = "hold"
+    held["contentHash"] = compute_history_content_hash(held)
+    page = render_history_review([draft, held], 2026)
+
+    assert "PRIVATE EDITORIAL DESK · NOT PUBLIC" in page
+    assert "2 DRAFTS" in page
+    assert "1 READY FOR HUMAN DECISION" in page
+    assert "1 HELD BY EVIDENCE OR EDITORIAL GATES" in page
+    assert "THE TAKE · MODEL DRAFT" in page
+    assert "CONTEMPORARY RECEIPTS (2)" in page
+    assert "LATER EVIDENCE (1)" in page
+    assert "any decision binds to this exact draft hash" in page.lower()
+    assert "approval fails closed while any hold remains" in page.lower()
+    assert draft["contentHash"] in page
+    assert "noindex,nofollow" in page
 
 
 def test_historical_race_impacts_are_review_only_and_use_canonical_race_ids():


### PR DESCRIPTION
## Summary
- add a private yearly historical review desk that separates contemporary receipts from later evidence and identifies held premises
- add hash-bound approve/reject decisions that can edit only the human-owned headline and Take, staged outside the public loader
- add a separate seal step that refuses stale drafts and preserves an immutable decision receipt
- document the workflow and harden approved headlines against model-draft labels

## Safety
- no historical entry was approved, sealed, published, deployed, or used to edit a race profile
- held editorial gates and single-publisher drafts cannot be approved
- the canonical draft hash must still match at seal time

## Verification
- focused Gravel Weekly tests: 72 passed
- full repository tests: 7,339 passed, 331 skipped
- preflight quality: passed with 7 pre-existing environment/data warnings
- historical validator: 73 entries valid
- desktop and 390px local-browser review: 6 drafts, 5 ready, 1 held, no horizontal overflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes govern what can become published historical editorial content and replace canonical `history/` JSON on seal; fail-closed checks limit blast radius, but mistakes at seal time are hard to undo.
> 
> **Overview**
> Adds a **three-step editorial pipeline** for Gravel Weekly **historical Current Thing** narratives (draft → hash-bound human decision → explicit seal), modeled on the weekly issue flow but kept off the public loader until sealing.
> 
> A new **`render_gravel_weekly_history_review.py`** builds a private, noindex HTML desk per year: contemporary vs later evidence, gate status, two-publisher readiness, and race impacts marked review-only. **`approve_gravel_weekly_history.py`** accepts `gravel-weekly-history-approval/v1` packets tied to the reviewed draft **`contentHash`**, allows edits only to **headline** and **Take**, stages approved entries and decision receipts under ignored **`history-staged/`**, and records rejections without creating approved copy. **`seal_gravel_weekly_history.py`** promotes staged approvals to **`published`**, refuses stale or mutated canonical drafts, and persists immutable decisions under **`history-decisions/`**—still no deploy or race-profile auto-fix.
> 
> **`validate_gravel_weekly_history_decisions.py`** defines decision receipt validation; **`validate_gravel_weekly_history.py`** now rejects **model-draft language in headlines** for non-draft entries. **`.gitignore`** and **`data/gravel-weekly/README.md`** document the workflow. **`tests/test_gravel_weekly.py`** adds contract tests for approval, rejection, held gates, sealing, stale-hash refusal, and the review desk output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6dd98684fb6ed8ab17df414d8fd35b81e114387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->