### PR TITLE
Close the 2026 historical research ledger

### DIFF
--- a/data/gravel-weekly/backfill/2026.json
+++ b/data/gravel-weekly/backfill/2026.json
@@ -6,7 +6,7 @@
   "sourceLedgerRun": "https://github.com/wattgod/race-intelligence-control-plane/actions/runs/33133357634",
   "programIssue": "https://github.com/wattgod/race-intelligence-control-plane/issues/47",
   "sourceCardCount": 230,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -100,9 +100,9 @@
       "periodStartedAt": "2026-02-28",
       "periodEndedAt": "2026-03-06",
       "sourceCardCount": 7,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The cards suggest equipment-category convergence and road riders moving into gravel, but the week lacks a verified consequence strong enough to turn that observation into a durable story."
+      "reason": "The full 2026 census never converted the week's road-gravel crossover, product coverage, and Strade Bianche material into a concrete gravel-racing consequence or changed judgment. Preserve the sources as discovery, not a historical story."
     },
     {
       "periodStartedAt": "2026-03-07",
@@ -129,9 +129,9 @@
       "periodStartedAt": "2026-03-21",
       "periodEndedAt": "2026-03-27",
       "sourceCardCount": 5,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "A road-bike gravel FKT, 32-inch-wheel speculation, and aero-wheel launches point toward an equipment arms race, but no single claim yet establishes who gained, lost, or changed course."
+      "reason": "The road-bike FKT, 32-inch-wheel show concept, and aero-wheel launches remained equipment novelty. The completed census found no verified competitive, access, safety, or labor consequence worth elevating into the season narrative."
     },
     {
       "periodStartedAt": "2026-03-28",
@@ -157,17 +157,17 @@
       "periodStartedAt": "2026-04-11",
       "periodEndedAt": "2026-04-17",
       "sourceCardCount": 9,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The cards begin an equipment-and-global-championship arc, but they do not yet clear the point, stakes, and credible-opposition gates as a standalone Current Thing."
+      "reason": "Race results, equipment galleries, contender previews, and the Worlds route page did not combine into one defensible changed judgment. The later 2026 census supplied no missing mechanism, so this remains context rather than a story."
     },
     {
       "periodStartedAt": "2026-04-18",
       "periodEndedAt": "2026-04-24",
       "sourceCardCount": 6,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "International racing and World Series coverage may advance gravel's globalization, but the present evidence is event anticipation rather than a consequential change."
+      "reason": "International results, an Unbound history page, product review, and Worlds-course anticipation documented calendar breadth but no affected party or consequential change. Globalization by accumulation is not itself a narrative point."
     },
     {
       "periodStartedAt": "2026-04-25",
@@ -193,9 +193,9 @@
       "periodStartedAt": "2026-05-09",
       "periodEndedAt": "2026-05-15",
       "sourceCardCount": 6,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "World Series previews and equipment coverage continue the global-championship arc, but a preview is not itself a season-changing event and no stronger point has cleared review."
+      "reason": "World Series results, road-star speculation, an Unbound route announcement, a wheel launch, and a Worlds-course preview remained anticipation or routine coverage. No later evidence made this week a narrative change-point."
     },
     {
       "periodStartedAt": "2026-05-16",
@@ -280,17 +280,17 @@
       "periodStartedAt": "2026-07-11",
       "periodEndedAt": "2026-07-17",
       "sourceCardCount": 5,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The cards may advance the global-series and world-championship arc, but the assigning desk still needs a concrete changed judgment rather than international-calendar aggregation."
+      "reason": "National and international results plus Worlds index pages only extended the calendar ledger. The completed census found no mechanism, credible opposition, or changed decision beyond international-calendar aggregation."
     },
     {
       "periodStartedAt": "2026-07-18",
       "periodEndedAt": "2026-07-24",
       "sourceCardCount": 4,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Global racing and adventure coverage supplies context but not yet a defensible mechanism, affected party, and consequence for a standalone historical story."
+      "reason": "A World Series result, one endurance-race account, calendar coverage, and a Worlds starter note supplied atmosphere but no defensible mechanism, affected party, or consequence. The premise did not mature later in the census."
     },
     {
       "periodStartedAt": "2026-07-25",
@@ -337,10 +337,10 @@
       "periodStartedAt": "2026-08-22",
       "periodEndedAt": "2026-08-28",
       "sourceCardCount": 13,
-      "disposition": "pending_review",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The Bonk Bros pass produced research leads, but no lead has yet cleared verification and editorial disposition."
+      "reason": "The thirteen source cards were routine results, product launches, road-gravel analysis, and Worlds anticipation. Bonk Bros supplied discovery leads, but the official Gravel Worlds rules only verify open-road responsibility and one current 75-mile route; they do not verify the alleged near misses, conflicting pre-race files, train delays, or result consequences required for a story."
     }
   ],
-  "updatedAt": "2026-08-28T16:20:00Z"
+  "updatedAt": "2026-08-28T16:56:09Z"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -1333,7 +1333,7 @@ def test_initial_backfill_ledger_preserves_partial_archive_research_debt_and_rej
         )
 
 
-def test_2026_backfill_ledger_accounts_for_every_window_without_claiming_completion():
+def test_2026_backfill_ledger_accounts_for_every_window_and_closes_research_review():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2026.json").read_text())
     validated = validate_backfill_ledger(ledger, histories)
@@ -1341,11 +1341,11 @@ def test_2026_backfill_ledger_accounts_for_every_window_without_claiming_complet
     assert len(validated["weeks"]) == 35
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 230
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 23
-    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 7
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 3
-    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 11
+    assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 1
-    assert validated["complete"] is False
+    assert validated["complete"] is True
 
     missing_window = copy.deepcopy(ledger)
     missing_window["weeks"].pop(10)
@@ -1358,7 +1358,7 @@ def test_2026_backfill_ledger_accounts_for_every_window_without_claiming_complet
         validate_backfill_ledger(dishonest_gap, histories)
 
     premature_completion = copy.deepcopy(ledger)
-    premature_completion["complete"] = True
+    premature_completion["weeks"][-1]["disposition"] = "pending_review"
     with pytest.raises(IssueValidationError, match="no weekly window remains pending"):
         validate_backfill_ledger(premature_completion, histories)
 


### PR DESCRIPTION
## Summary
- close seven weak equipment/globalization themes as documented non-stories after the complete 230-card census produced no consequential mechanism
- close the August 22–28 window after official Gravel Worlds sources confirmed only open-road rider responsibility and one current GW75 route, not the alleged incidents or conflicting pre-race files
- mark all 35 weekly windows dispositioned: 23 covered by six drafts, 11 rejected, and one explicit source gap
- preserve every historical entry as an unapproved model draft

## Boundary
Ledger completion means source-window accounting is complete. It does not mean Matti approved any Take, and it does not publish or mutate race data.

## Verification
- focused Gravel Weekly tests: 72 passed
- 2026 backfill validator: passed
- preflight quality: passed with 7 pre-existing environment/data warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial ledger JSON and test assertions only; no publish paths, race data, or approval workflows change.
> 
> **Overview**
> **Finishes the 2026 Gravel Weekly historical backfill ledger** by setting `complete` to `true` once every weekly window has a final disposition (no `held_for_evidence` or `pending_review` left).
> 
> Eight windows that were still open—seven `held_for_evidence` plus Aug 22–28 `pending_review`—are now **`rejected`**, with reasons that cite the full 230-card census and, for the last week, official Gravel Worlds rules not supporting Bonk Bros incident claims. Totals are **23** `covered_by_draft`, **11** `rejected`, **1** `explicit_gap`.
> 
> The **`test_2026_backfill_ledger_*`** contract test is renamed and updated for those counts and for asserting completion; the “premature completion” negative case now leaves the last week `pending_review` instead of flipping `complete` alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce4dec68de6794a3d324e9431634b9a771ce1abb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->