### PR TITLE
Close 2025 historical research ledger

### DIFF
--- a/data/gravel-weekly/backfill/2025.json
+++ b/data/gravel-weekly/backfill/2025.json
@@ -22,9 +22,9 @@
       "periodStartedAt": "2025-01-04",
       "periodEndedAt": "2025-01-10",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The Michaela Thompson profile may establish a before-and-after for Life Time's U23 pathway, but a retrospective athlete profile alone does not prove the program's access or development consequences."
+      "reason": "The Michaela Thompson profile remained a retrospective account of one athlete before Life Time's U23 program. Later selection rules and inaugural titles showed that the program operated, but did not convert this profile into a distinct access or development consequence worth retelling."
     },
     {
       "periodStartedAt": "2025-01-11",
@@ -62,17 +62,17 @@
       "periodStartedAt": "2025-02-08",
       "periodEndedAt": "2025-02-14",
       "sourceCardCount": 5,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Morton's international calendar, Klöser's WorldTour move, PAS's roster, and Van Aert's interest suggest gravel-road convergence, but the cards do not yet establish a shared mechanism or consequence."
+      "reason": "Morton's calendar, Klöser's WorldTour move, the PAS roster, bike coverage, and Van Aert's interest remained separate examples of gravel-road crossover. The full census produced no shared mechanism or 2025 judgment change beyond the already preserved gravel career-market story."
     },
     {
       "periodStartedAt": "2025-02-15",
       "periodEndedAt": "2025-02-21",
       "sourceCardCount": 8,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The Castelli roster, road-retiree crossover, BMC recall, and new U23 qualifiers expose several possible professionalization arcs, but none clears every story gate from this mixed evidence set."
+      "reason": "The Castelli roster, one road-retiree transition, a product recall, results, equipment coverage, and U23 selection rules point in different directions. No focused premise survived the party, point, friend, evidence, and hostile-editor gates."
     },
     {
       "periodStartedAt": "2025-02-22",
@@ -88,9 +88,9 @@
       "periodStartedAt": "2025-03-01",
       "periodEndedAt": "2025-03-07",
       "sourceCardCount": 7,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Unbound and Lauf's 1,000-women commitment may support a participation-and-access story, but registration goals and road-race gravel coverage do not yet prove durable participation or retention."
+      "reason": "Unbound and Gravel Worlds announced a 1,000-women participation goal, but the source set supplied no verified delivery, retention, field-composition change, or access mechanism. The remaining cards concern road racing, results, and products rather than the claimed participation consequence."
     },
     {
       "periodStartedAt": "2025-03-08",
@@ -157,17 +157,17 @@
       "periodStartedAt": "2025-04-19",
       "periodEndedAt": "2025-04-25",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The announcement of Australia's first national gravel championship may begin an institutional-growth arc, but a proposed event alone cannot establish delivery, legitimacy, or consequence."
+      "reason": "The sole source announced Australia's first national gravel championship. The following week confirmed that the event occurred, but neither week established a durable participation, funding, selection, or labor consequence beyond creation of another title."
     },
     {
       "periodStartedAt": "2025-04-26",
       "periodEndedAt": "2025-05-02",
       "sourceCardCount": 11,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Australia's first elite national titles and the international race cluster may advance gravel's formalization, but the mixed results and personality pieces lack a focused changed judgment."
+      "reason": "Australia awarded its first elite gravel titles, while the other cards were routine results, previews, products, and personality pieces. A new championship is a fact for the calendar; this evidence did not supply a focused changed judgment for the historical narrative."
     },
     {
       "periodStartedAt": "2025-05-03",
@@ -314,9 +314,9 @@
       "periodStartedAt": "2025-08-23",
       "periodEndedAt": "2025-08-29",
       "sourceCardCount": 4,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Carolin Schiff ending her season over bone-density and RED-S concerns may support a professional-gravel health story, but one athlete account cannot establish prevalence, incentives, or systemic responsibility."
+      "reason": "Carolin Schiff's decision to end her season over bone-density and RED-S concerns is important athlete testimony, but the census supplied no corroborated prevalence, gravel-specific incentive, responsible institution, or changed policy. Do not turn one person's health account into a systemic claim."
     },
     {
       "periodStartedAt": "2025-08-30",
@@ -393,9 +393,9 @@
       "periodStartedAt": "2025-10-25",
       "periodEndedAt": "2025-10-31",
       "sourceCardCount": 5,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Life Time's $590,000 purse expansion and first U23 titles may support a paid-pathway story, but announced money and inaugural titles need recipient, access, and livelihood consequences before publication."
+      "reason": "Life Time announced a $590,000 2026 purse structure and awarded its first U23 titles, but the evidence did not yet show who could build a livelihood, which access barrier changed, or whether the development pathway produced durable careers. Preserve the facts without promoting the announcement into a story."
     },
     {
       "periodStartedAt": "2025-11-01",
@@ -409,9 +409,9 @@
       "periodStartedAt": "2025-11-08",
       "periodEndedAt": "2025-11-14",
       "sourceCardCount": 6,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The top three Gravel Earth women entering Life Time and the public selection reactions may reveal a cross-series talent pipeline, but roster announcements alone do not prove access or competitive effects."
+      "reason": "Life Time selected the top three Gravel Earth women and published reactions exposed the emotional stakes of selection, but roster announcements alone did not prove that one series had become a talent pipeline or establish competitive effects. The 2026 admissions draft retains the broader gatekeeping question."
     },
     {
       "periodStartedAt": "2025-11-15",
@@ -425,17 +425,17 @@
       "periodStartedAt": "2025-11-22",
       "periodEndedAt": "2025-11-28",
       "sourceCardCount": 2,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The UCI series expansion to 45 events may support a globalization or dilution story, but the announcement does not yet establish participation quality, organizer burden, or championship effects."
+      "reason": "The UCI announced a 45-event 2026 Gravel World Series calendar. Without evidence of field quality, organizer burden, qualification effects, participation change, or dilution, calendar expansion remained an administrative fact rather than a narrative change-point."
     },
     {
       "periodStartedAt": "2025-11-29",
       "periodEndedAt": "2025-12-05",
       "sourceCardCount": 2,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Oceania's first continental gravel title may extend the institutional-growth arc, but a future-event announcement cannot prove delivery, field quality, or regional consequence."
+      "reason": "The first Oceania gravel championship was still a future-event announcement in this window. Its later delivery did not establish field quality, regional participation, funding, or qualification consequences sufficient for a separate 2025 story."
     },
     {
       "periodStartedAt": "2025-12-06",
@@ -449,9 +449,9 @@
       "periodStartedAt": "2025-12-13",
       "periodEndedAt": "2025-12-19",
       "sourceCardCount": 3,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "De Gendt building a gravel team may advance the teamification arc and the Bianchi recall raises safety stakes, but the mixed cards do not yet support one focused 2025 judgment change."
+      "reason": "De Gendt's team launch is a prelude to the separately preserved 2026 teamification mechanism; the Bianchi recall is a product-safety action; the third card is a bike review. Combining them would manufacture coherence rather than recover a 2025 judgment change."
     },
     {
       "periodStartedAt": "2025-12-20",
@@ -465,10 +465,10 @@
       "periodStartedAt": "2025-12-27",
       "periodEndedAt": "2026-01-02",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Swenson joining Specialized is a credible prelude to 2026 teamification, but the signing itself had not yet produced the tactical or competitive consequence documented the following season."
+      "reason": "Swenson joining Specialized is preserved as discovery context for the 2026 teamification story. The signing alone had not produced the wheel sacrifice, coordinated restraint, integrated development, or result consequence that later changed the judgment."
     }
   ],
-  "updatedAt": "2026-08-28T06:15:00Z"
+  "updatedAt": "2026-08-28T17:08:00Z"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -807,8 +807,8 @@ def test_2025_backfill_ledger_preserves_the_complete_assigning_desk_review():
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 5
     assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 15
-    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 13
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 20
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 33
     assert validated["complete"] is True
 
 


### PR DESCRIPTION
## Summary
- close all 13 evidence-held 2025 windows after full source-census editorial audit
- record specific non-story reasons instead of manufacturing weak narratives
- preserve the seven existing history drafts and five explicit source gaps
- update regression counts for a fully adjudicated 53-week, 255-card ledger

## Safety boundary
- no history entry is approved, sealed, or published
- no race record is changed
- `complete` means research accounting is complete only

## Verification
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2025.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q` (72 passed)
- `git diff --check`
- `python3 scripts/preflight_quality.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial metadata and test expectations only; no publish path, race records, or history entry status changes.
> 
> **Overview**
> Finishes **2025 historical research accounting** on the Gravel Weekly backfill ledger: all **13** weeks that were `held_for_evidence` are now **`rejected`**, with rewritten `reason` text that records why a full source census did not support a standalone “Current Thing” (weak mechanism, duplication with existing drafts, announcement-only facts, or prelude material reserved for other years).
> 
> **Unchanged adjudication** stays explicit: **15** `covered_by_draft` weeks, **5** `explicit_gap` quiet windows, **255** source cards across **53** weeks, and `complete: true` with **zero** `pending_review` or `held_for_evidence`. This is research closure only—no history entries are approved, sealed, or published.
> 
> Regression test `test_2025_backfill_ledger_preserves_the_complete_assigning_desk_review` now expects **0** held / **33** rejected weeks and `updatedAt` on `2025.json` is bumped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4268afc3d82a216734158338a5647b3c14b7d53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->