### PR TITLE
Close 2024 Gravel Weekly backfill ledger

### DIFF
--- a/data/gravel-weekly/backfill/2024.json
+++ b/data/gravel-weekly/backfill/2024.json
@@ -34,9 +34,9 @@
       "periodStartedAt": "2024-01-13",
       "periodEndedAt": "2024-01-19",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Classified and Ridley announced a factory gravel team, but the launch alone does not establish whether manufacturer-backed teams materially changed rider pay, race tactics, or privateer viability; hold for contracts, operating evidence, and season outcomes."
+      "reason": "Classified and Ridley's factory-team launch remained an isolated announcement: the reviewed 2024 evidence does not establish changed rider pay, race tactics, or privateer viability, and the later teamification mechanism is documented more directly in the 2026 chapter."
     },
     {
       "periodStartedAt": "2024-01-20",
@@ -62,9 +62,11 @@
       "periodStartedAt": "2024-02-03",
       "periodEndedAt": "2024-02-09",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "Phase II proposed a development path through Unbound and Big Sugar, but the announcement does not yet show who advanced, what support riders received, or whether the program changed access to professional racing; hold for participant and outcome evidence."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-gravel-career-market-2024"
+      ],
+      "reason": "Phase II supplied an expenses-paid, sponsor-supported under-23 gravel pathway and independently corroborates the career-market chapter's argument that gravel had become a development route rather than only a road-racing exit."
     },
     {
       "periodStartedAt": "2024-02-10",
@@ -256,9 +258,11 @@
       "periodStartedAt": "2024-07-06",
       "periodEndedAt": "2024-07-12",
       "sourceCardCount": 14,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "The Tour gravel stage produced a strong route-trust hypothesis, but rider and team claims that raced sectors differed from reconnaissance still lack organizer-side documentation of what changed, when, and why."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-amani-built-the-home-game-2024"
+      ],
+      "reason": "The Tour route-trust claim remains rejected for lack of organizer-side documentation, but contemporaneous East African reporting supports the stronger Team Amani chapter about home-road competition, rider support, and local development infrastructure."
     },
     {
       "periodStartedAt": "2024-07-13",
@@ -272,9 +276,11 @@
       "periodStartedAt": "2024-07-20",
       "periodEndedAt": "2024-07-26",
       "sourceCardCount": 4,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "USA Cycling's ten elite Worlds places could reveal how federation-controlled access reshaped a domestic championship, but the announcement lacks selection, participation, funding, and athlete-outcome evidence; hold rather than infer impact."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-team-usa-invitation-bill-2024"
+      ],
+      "reason": "Expanding nationals qualification from three to five elite riders per gender created the wider invitation pathway whose later self-funding requirement became the Team USA chapter's decisive access filter."
     },
     {
       "periodStartedAt": "2024-07-27",
@@ -378,9 +384,9 @@
       "periodStartedAt": "2024-10-12",
       "periodEndedAt": "2024-10-18",
       "sourceCardCount": 7,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Life Time moved money from the series purse to Unbound, Big Sugar, and Leadville, a potentially meaningful incentive redesign; hold until organizer rationale, athlete reaction, field effects, and later purse outcomes can establish the point rather than merely repeat the announcement."
+      "reason": "Life Time delivered the announced shift from a $300,000 series purse to a $200,000 series purse plus $30,000 at each race, but the reviewed evidence does not show a distinct field or athlete-decision consequence beyond the stronger 2025 wildcard chapter."
     },
     {
       "periodStartedAt": "2024-10-19",
@@ -394,17 +400,19 @@
       "periodStartedAt": "2024-10-26",
       "periodEndedAt": "2024-11-01",
       "sourceCardCount": 3,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "The announced five-race junior series could represent a real youth-access pathway, but the launch supplies no participant, cost, safeguarding, retention, or inaugural-season outcome evidence; hold for delivery rather than treating intent as impact."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-junior-gravel-road-camp-2024"
+      ],
+      "reason": "The five-race junior series explicitly routed winners into road talent identification, then delivered the camp for four inaugural champions and expanded in 2026; that outcome clears the announcement-only hold."
     },
     {
       "periodStartedAt": "2024-11-02",
       "periodEndedAt": "2024-11-08",
       "sourceCardCount": 4,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The Team Amani fundraiser may belong to a larger East African access and representation story, but the window otherwise contains career-market corroboration and series announcements; hold the Amani lead for participant voices, program economics, and observed outcomes."
+      "reason": "The fundraiser is a call for support rather than independent evidence of program delivery; the Amani infrastructure chapter is grounded instead in rider testimony, camp reporting, race evidence, and later outcomes."
     },
     {
       "periodStartedAt": "2024-11-09",
@@ -444,9 +452,11 @@
       "periodStartedAt": "2024-12-07",
       "periodEndedAt": "2024-12-13",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "The Team Amani feature suggests an important East African agency, access, and representation story, but one outsider-led feature cannot establish the program's economics, riders' own framing, or durable consequences; hold for first-party and longitudinal evidence."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-amani-built-the-home-game-2024"
+      ],
+      "reason": "The Iten camp account now sits beside East African rider testimony, race evidence, and later Continental-team and Black Mambas outcomes, supporting a bounded infrastructure story without treating one outsider feature as sufficient."
     },
     {
       "periodStartedAt": "2024-12-14",

--- a/data/gravel-weekly/history/2024-amani-built-the-home-game.json
+++ b/data/gravel-weekly/history/2024-amani-built-the-home-game.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-amani-built-the-home-game-2024",
+  "activeFrom": "2024-07-09",
+  "activeThrough": "2024-12-11",
+  "status": "draft",
+  "headline": "Team Amani Built a Cycling Center Where the Riders Already Lived",
+  "point": "By 2024, Team Amani's East African gravel project had grown beyond bringing international racers to Kenya. It paired home-road competition with a training center, coaching, equipment, financial support, nutrition practice, and a development squad, shifting more of the professional pathway toward the riders instead of requiring the riders to solve Europe first.",
+  "priorJudgment": "A promising East African cyclist became visible by leaving home, joining a European development structure, and learning professional cycling inside institutions concentrated elsewhere.",
+  "changedJudgment": "A development program could place serious training and international competition around East African riders, then use travel selectively as the next step rather than the admission price for being noticed. The system remained sponsor-dependent and expensive, but the center of gravity had moved.",
+  "stakes": "The model affected who paid for visibility, whether riders could develop near their communities, whether women received a credible route into professional cycling, whether Kenyan races were sporting institutions or adventure products, and whether East African talent retained agency inside a sponsor-funded international project.",
+  "credibleOpposition": "Team Amani still depended on foreign sponsors, expensive imported equipment, visas, and international media. The claim that 90 percent of participants were African came from a race co-organizer, and named successes do not measure broad access. A training center and development squad cannot by themselves fix weak domestic race calendars, gender barriers, travel constraints, or the economics of professional cycling.",
+  "whatHappened": "A July report from Kenya described more than 500 combined riders at Migration Gravel and Safari Gravel, with organizer Mikel Delagrange saying 90 percent were African. Team Amani fielded eight East African riders; at Safari Gravel, its riders placed fourth and fifth in the men's race and second in the women's race. Ethiopian former WorldTour rider Tsgabu Grmay had joined as a rider and coach of the Black Mambas development squad. Congolese rider Joel Kyaviro said the team taught discipline, nutrition, and professionalism while supplying financial means he otherwise lacked. The program had installed a training center in Iten in 2023. In December, a separate camp account described 45 Team Amani and Black Mamba riders, including nine women, training with improvised weights and working through equipment, water, fueling, and women's-health constraints. The infrastructure kept producing consequences: Team Amani announced Africa's first women's UCI Continental team in 2025, and Black Mambas riders swept the men's Migration Gravel podium on home roads in 2026.",
+  "take": "Model draft, not Matti's approved view: The important Team Amani story was not that Europeans discovered Kenyan gravel and found the scenery moving. Kenya did not need a visiting cyclist to notice the roads. The important move was building more of the job where the riders already lived: races that brought an international field to them, a training center in Iten, a development squad, coaching, equipment, nutrition practice, and money that let Joel Kyaviro train like the professional he was trying to become. None of this makes the access problem disappear. Bikes are expensive, visas remain an obstacle, sponsors still hold leverage, and nine women in a 45-rider camp is not equality. But this was infrastructure, not a donation photo. The Black Mambas later swept Migration's men's podium, and Amani launched an African women's Continental team. Cycling's usual pathway tells the rider to leave home before anyone will take the talent seriously. Amani's better idea was to move more of the serious cycling first.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources establish named riders, race results, a training center, development-squad coaching, financial support described by one rider, the size and gender composition of one camp, and later team and race outcomes. They do not disclose budgets, salaries, sponsor control, complete athlete selection criteria, retention rates, visa outcomes, or how benefits were distributed. The 90-percent participation figure is an organizer statement reported by Le Monde. Later success demonstrates persistence, not that Team Amani created equal access across East African cycling.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_amani_home_races_majority_african_2024",
+      "canonicalUrl": "https://www.lemonde.fr/afrique/article/2024/07/09/l-afrique-de-l-est-s-emballe-pour-le-velo-gravel_6248251_3212.html",
+      "publisher": "Le Monde",
+      "publishedAt": "2024-07-09T16:00:00Z",
+      "quoteExcerpt": "90 % des participants sont des coureurs africains",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_amani_not_charity_high_performance_2024",
+      "canonicalUrl": "https://www.lemonde.fr/afrique/article/2024/07/09/l-afrique-de-l-est-s-emballe-pour-le-velo-gravel_6248251_3212.html",
+      "publisher": "Le Monde",
+      "publishedAt": "2024-07-09T16:00:00Z",
+      "quoteExcerpt": "Il ne s'agit pas d'un projet marketing, humanitaire ou d'une initiative de dons de vélos",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_amani_rider_training_and_financial_support_2024",
+      "canonicalUrl": "https://www.lemonde.fr/afrique/article/2024/07/09/l-afrique-de-l-est-s-emballe-pour-le-velo-gravel_6248251_3212.html",
+      "publisher": "Le Monde",
+      "publishedAt": "2024-07-09T16:00:00Z",
+      "quoteExcerpt": "Team Amani m'apprend la rigueur, la nutrition, le professionnalisme",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_amani_iten_camp_women_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/features/lauren-de-crescenzo-team-amani-gravel-riders-redefine-whats-possible-in-africa/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-12-11T18:20:10Z",
+      "quoteExcerpt": "Connecting with the 45 riders of Team Amani and their Black Mamba Development squad",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_amani_training_resource_constraints_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/features/lauren-de-crescenzo-team-amani-gravel-riders-redefine-whats-possible-in-africa/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-12-11T18:20:10Z",
+      "quoteExcerpt": "with concrete slabs doubling as weights",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_amani_first_african_womens_continental_team_2025",
+      "canonicalUrl": "https://www.cyclingweekly.com/news/the-potential-is-enormous-team-amani-launches-first-ever-womens-uci-continental-cycling-team-from-africa",
+      "publisher": "Cycling Weekly",
+      "publishedAt": "2025-11-13T00:00:00Z",
+      "quoteExcerpt": "the first women's UCI Continental Cycling Team from Africa",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_black_mambas_migration_podium_sweep_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/gravel-earth-series-kenyan-riders-sweep-mens-podium-while-swedish-national-champion-nathalie-eklund-earns-womens-title-at-migration-gravel-race/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-06-23T00:00:00Z",
+      "quoteExcerpt": "the Black Mambas Development Squad swept the men's podium",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:migration-gravel-race",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_amani_home_races_majority_african_2024",
+        "claim_amani_not_charity_high_performance_2024",
+        "claim_amani_rider_training_and_financial_support_2024",
+        "claim_amani_iten_camp_women_2024",
+        "claim_amani_training_resource_constraints_2024",
+        "claim_amani_first_african_womens_continental_team_2025",
+        "claim_black_mambas_migration_podium_sweep_2026"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T17:25:12Z",
+  "contentHash": "06d2e36bd60280b34ff2a9d5307abfb891095e708398018b1b429f64776c7a0c"
+}

--- a/data/gravel-weekly/history/2024-gravel-career-market.json
+++ b/data/gravel-weekly/history/2024-gravel-career-market.json
@@ -10,7 +10,7 @@
   "changedJudgment": "Gravel could now function as refuge, proving ground, independent career, and route back into a WorldTour team. The traffic moved both directions, even though income and support remained far less standardized than on a salaried road team.",
   "stakes": "The shift changed how young riders could build résumés, how displaced veterans could preserve careers, what sponsors bought when backing a privateer, and whether gravel specialists were athletes in a durable profession or participants in road cycling's afterlife.",
   "credibleOpposition": "The examples were unusually talented and do not prove a stable labor market for the median rider. Road fame still made sponsorship easier, young riders such as Andy Lydic described an ambition rather than a completed promotion, and privateering transferred logistics and financial risk from teams to athletes. Romain Bardet's planned move also retained support from his road organization rather than demonstrating independent viability.",
-  "whatHappened": "In January, Lawrence Naesen lost his Decathlon AG2R contract, joined roughly two dozen WorldTour professionals reported without 2024 teams, and assembled sponsor support for a private gravel program. In February, 22-year-old Colorado rider Andy Lydic described gravel in the opposite direction: a platform for results he hoped would lead to a professional or WorldTour team after a poor experience in the amateur road pipeline. In June, former Giro stage winner Chad Haga finished second in his first Unbound 200 and said the result helped prove he was not a road rider using gravel as retirement; he called it the start of a new career. Ten days later, DSM announced that Tour de France podium finisher Romain Bardet would end his road career in 2025 but continue with team support in gravel, targeting the UCI Gravel World Championships. Later in 2024, Unbound winner and full-time PhD student Rosa Klöser signed a two-year Canyon-SRAM road deal while retaining gravel privateering, Peter Stetina left the Life Time Grand Prix without leaving professional gravel, and Haga committed to a full privateer operation for 2025.",
+  "whatHappened": "In January, Lawrence Naesen lost his Decathlon AG2R contract, joined roughly two dozen WorldTour professionals reported without 2024 teams, and assembled sponsor support for a private gravel program. In February, 22-year-old Colorado rider Andy Lydic described gravel in the opposite direction: a platform for results he hoped would lead to a professional or WorldTour team after a poor experience in the amateur road pipeline. Alexey Vermeulen's Phase II project made that route less hypothetical by offering two under-23 riders an expenses-paid camp, sponsor support, mentorship, and starts at Unbound 100, Crusher in the Tushar, and Big Sugar. In June, former Giro stage winner Chad Haga finished second in his first Unbound 200 and said the result helped prove he was not a road rider using gravel as retirement; he called it the start of a new career. Ten days later, DSM announced that Tour de France podium finisher Romain Bardet would end his road career in 2025 but continue with team support in gravel, targeting the UCI Gravel World Championships. Later in 2024, Unbound winner and full-time PhD student Rosa Klöser signed a two-year Canyon-SRAM road deal while retaining gravel privateering, Peter Stetina left the Life Time Grand Prix without leaving professional gravel, and Haga committed to a full privateer operation for 2025.",
   "take": "Model draft, not Matti's approved view: Road racing used to send riders to gravel with a cardboard box and a euphemism. Congratulations on your retirement; here is a flannel shirt and an Instagram deliverable. Then 2024 broke the conveyor belt. Lawrence Naesen came in because the WorldTour had no chair for him. Andy Lydic tried to use gravel as the staircase back up. Chad Haga finished second at Unbound and informed everybody that he was starting a career, not embalming one. Romain Bardet planned his road retirement around a gravel world title, while Rosa Klöser won Unbound during a PhD and somehow left with both a WorldTour contract and her privateer identity. That is not a retirement home. It is a labor market—an unstable, sponsor-dependent, assemble-your-own-health-insurance labor market, but one with doors on both sides. The sport became real when riders could enter it for different reasons and still argue about which job was better.",
   "takeProvenance": "model_draft",
   "uncertainty": "The reviewed sources do not disclose salaries, sponsorship values, benefits, contract guarantees, or the share of riders who could support themselves through gravel. Lydic's WorldTour pathway was an expressed goal, not a documented contract outcome. Naesen's ability to secure several recognizable sponsors may reflect prior WorldTour visibility. Haga's results validated competitiveness but did not remove family-income risk, and Bardet's planned transition had not occurred during the active period. The later cases show additional career structures, not that gravel had achieved broad economic stability.",
@@ -38,6 +38,15 @@
       "publisher": "Cyclingnews",
       "publishedAt": "2024-02-02T00:00:00Z",
       "quoteExcerpt": "My whole mission is to use gravel as a platform to professional cycling",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_phase_two_private_gravel_pathway_2024",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/gravel-racing/rethinking-the-domestic-development-pathway-with-alexey-vermeulens-phase-ii-project/",
+      "publisher": "Velo",
+      "publishedAt": "2024-02-05T16:45:27Z",
+      "quoteExcerpt": "hoping to make the jump from the junior to the pro ranks",
       "transcriptStartSeconds": null,
       "transcriptEndSeconds": null
     },
@@ -108,6 +117,6 @@
   "autoPublishAllowed": false,
   "editorialApproval": null,
   "publishedAt": null,
-  "updatedAt": "2026-08-28T10:45:00Z",
-  "contentHash": "03bfd8874f33394764e050d1349ff4f3b3c7e11965ea3d863dc54f5cf4f5c806"
+  "updatedAt": "2026-08-28T17:25:12Z",
+  "contentHash": "25097807cc10d336d50b78e47a651292f313732d3259db1957d2b02bc36ad401"
 }

--- a/data/gravel-weekly/history/2024-junior-gravel-road-camp.json
+++ b/data/gravel-weekly/history/2024-junior-gravel-road-camp.json
@@ -1,0 +1,101 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-junior-gravel-road-camp-2024",
+  "activeFrom": "2024-10-28",
+  "activeThrough": "2024-10-30",
+  "status": "draft",
+  "headline": "Gravel Built a Junior League. The Prize Was Road Camp.",
+  "point": "USA Cycling used five prominent gravel races to build a national junior series, then made its most valuable reward an invitation to a road-development camp. The program treated gravel as a talent-identification surface for American cycling rather than a self-contained discipline with its own professional destination.",
+  "priorJudgment": "Junior gravel was an event category attached to adult race weekends, while serious federation development still began in road, track, cyclocross, or mountain bike programs with established national-team pathways.",
+  "changedJudgment": "Gravel had become organized enough to operate as a national scouting system. Its major events could identify young riders across regions, but the pathway still pointed the winners toward an Olympic road program rather than toward a durable junior-to-professional gravel structure.",
+  "stakes": "The design affected who could afford three qualifying weekends, which races became youth-development institutions, whether gravel retained the riders it discovered, and whether a new discipline built its own career ladder or supplied talent to older ones.",
+  "credibleOpposition": "Road camp offered testing, coaching, mentorship, and an Olympic pathway that gravel could not provide. Cross-discipline development is useful for young athletes, and the inaugural winners actually attended the camp before the series expanded. The series also offered registration credits and used existing events rather than inventing a costly separate calendar. None of that establishes participation depth, geographic equity, retention, or professional outcomes.",
+  "whatHappened": "On October 28, USA Cycling announced a five-race Junior Gravel National Series for riders ages 15 through 18. Valley of Tears, Sea Otter, Unbound, SBT GRVL, and the national championship supplied the calendar; riders needed three starts, and their best three finishes set the standings. Top finishers received registration credits, while the four category leaders earned invitations to an October 2025 Junior Talent Identification Camp described by USA Cycling as a pathway into elite road racing and an Olympic discipline. An independent Cyclingnews report made the cross-discipline purpose explicit: the federation intended to discover talent for road and other Olympic cycling. The promise survived delivery. Four inaugural champions attended a week of testing, training, and mentorship in Colorado Springs in October 2025, and USA Cycling expanded the 2026 series to ten events.",
+  "take": "Model draft, not Matti's approved view: Gravel finally got a national junior league and immediately handed the winners directions to road camp. That is funny because it is also a useful confession. USA Cycling looked at five gravel weekends, recognized a functioning talent-identification system, and used it to find riders for an Olympic discipline. The kids still got a real series, real races, benchmark testing, coaching, and a week at the Olympic Training Center. Good. The inaugural winners actually attended, and the next calendar doubled to ten events. This was not brochure vapor. But the prize tells you where the institution thought a serious cycling career still lived. Gravel had become credible enough to scout the talent and not yet complete enough to keep it. That is a development pathway, but it is also a feeder road with excellent dust control.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The announcement and follow-up establish the five-race design, eligibility rules, promised road-development invitation, four inaugural winners' attendance, and the later ten-event expansion. They do not report total starters, category field sizes, family travel costs, socioeconomic or geographic representation, safeguarding operations, rider retention, or subsequent contracts. Camp attendance proves the pathway operated once; it does not establish that it produced elite road or gravel careers.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_junior_gravel_road_talent_pathway_2024",
+      "canonicalUrl": "https://usacycling.org/article/usa-cycling-announces-new-junior-gravel-national-series-for-2025-2",
+      "publisher": "USA Cycling",
+      "publishedAt": "2024-10-28T14:24:00Z",
+      "quoteExcerpt": "a dedicated pathway into elite-level road racing and an Olympic discipline",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_junior_gravel_five_race_series_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/unbound-gravel-sbt-grvl-among-five-events-in-new-junior-gravel-series-in-us/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-10-30T00:00:00Z",
+      "quoteExcerpt": "receive invitations to a USA Cycling Junior Talent Identification Camp in October 2025",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_inaugural_junior_gravel_champions_attended_road_camp_2025",
+      "canonicalUrl": "https://usacycling.org/article/usa-cycling-announces-2025-junior-gravel-national-series-winners-and-2026-series-updates",
+      "publisher": "USA Cycling",
+      "publishedAt": "2025-11-03T07:00:00Z",
+      "quoteExcerpt": "All four racers gathered in Colorado Springs October 12-18 for a week of testing, training, and mentorship.",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_junior_gravel_expanded_ten_events_2026",
+      "canonicalUrl": "https://usacycling.org/article/usa-cycling-announces-expanded-junior-gravel-national-series-schedule-for-2026",
+      "publisher": "USA Cycling",
+      "publishedAt": "2026-02-02T15:00:00Z",
+      "quoteExcerpt": "expanding to a 10-event series calendar",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:unbound-200",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_junior_gravel_road_talent_pathway_2024",
+        "claim_junior_gravel_five_race_series_2024",
+        "claim_inaugural_junior_gravel_champions_attended_road_camp_2025",
+        "claim_junior_gravel_expanded_ten_events_2026"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:steamboat-gravel",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_junior_gravel_road_talent_pathway_2024",
+        "claim_junior_gravel_five_race_series_2024",
+        "claim_inaugural_junior_gravel_champions_attended_road_camp_2025",
+        "claim_junior_gravel_expanded_ten_events_2026"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T17:25:12Z",
+  "contentHash": "e5f7279e3a317bb75c924066fab46cb3c1d855d30bad886ad3f319e2899cc698"
+}

--- a/data/gravel-weekly/history/2024-team-usa-invitation-bill.json
+++ b/data/gravel-weekly/history/2024-team-usa-invitation-bill.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "gravel-weekly-history-entry/v1",
   "entryId": "history-team-usa-invitation-bill-2024",
-  "activeFrom": "2024-09-25",
+  "activeFrom": "2024-07-25",
   "activeThrough": "2024-10-03",
   "status": "draft",
   "headline": "Team USA Sent Gravel Riders an Invitation and a Bill",
@@ -10,7 +10,7 @@
   "changedJudgment": "For a privateer, selection without funding is permission rather than support. Prestige can lose rationally to course fit, sponsor exposure, recovery, and races that keep the career solvent, even when the athlete genuinely values the national jersey.",
   "stakes": "The funding model affected which athletes represented the United States, whether Gravel Worlds could claim the strongest specialist field, which careers benefited from federation selection, and whether personal wealth or sponsor backing became an unofficial final selection criterion.",
   "credibleOpposition": "USA Cycling disclosed the financial terms, faced exceptional Olympic-year costs without government funding, and could not fund every athlete qualifying through gravel's unusually open pathways. Some riders considered self-funding a worthwhile career investment or national-team duty, while course suitability and the crowded calendar—not money alone—also drove withdrawals.",
-  "whatHappened": "USA Cycling's 2024 elite selection criteria said its primary objective was a cohesive, medal-capable team, then stated that automatically invited and discretionary athletes were responsible for the event's full expense and that the federation would assume no financial responsibility. Keegan Swenson, Paige Onweller, Russell Finsterwald, Lauren De Crescenzo, Alexis Skarda, and Argentina's US-based Sofia Gomez Villafañe were among prominent North American specialists reported as skipping Belgium. Worlds offered no prize money; riders faced airfare, lodging, bike transport, national kit, ground logistics, and limited on-site support. The timing put Worlds one week after The Rad Dirt Fest and two weeks before Big Sugar, the final events deciding a $300,000 Life Time Grand Prix purse. Onweller, second in the series, said a 20th at Worlds would do little for her or her sponsors compared with winning the Grand Prix. De Crescenzo wrote that the unsupported point-to-point trip did not make financial or competitive sense and chose domestic series points instead. USA Cycling said Olympic-year costs and insufficient offsetting revenue constrained support. John Borstelmann and Andy Lydic made the opposite choice, treating the trip as duty, content, or an investment and setting aside or redirecting money to attend.",
+  "whatHappened": "USA Cycling's 2024 elite selection criteria said its primary objective was a cohesive, medal-capable team, then stated that automatically invited and discretionary athletes were responsible for the event's full expense and that the federation would assume no financial responsibility. In July, the federation expanded automatic Worlds qualification at the national championship from the top three elite men and women to the top five, creating ten direct places before the September race. That wider front door did not pay for the trip behind it. Keegan Swenson, Paige Onweller, Russell Finsterwald, Lauren De Crescenzo, Alexis Skarda, and Argentina's US-based Sofia Gomez Villafañe were among prominent North American specialists reported as skipping Belgium. Worlds offered no prize money; riders faced airfare, lodging, bike transport, national kit, ground logistics, and limited on-site support. The timing put Worlds one week after The Rad Dirt Fest and two weeks before Big Sugar, the final events deciding a $300,000 Life Time Grand Prix purse. Onweller, second in the series, said a 20th at Worlds would do little for her or her sponsors compared with winning the Grand Prix. De Crescenzo wrote that the unsupported point-to-point trip did not make financial or competitive sense and chose domestic series points instead. USA Cycling said Olympic-year costs and insufficient offsetting revenue constrained support. John Borstelmann and Andy Lydic made the opposite choice, treating the trip as duty, content, or an investment and setting aside or redirecting money to attend.",
   "take": "Model draft, not Matti's approved view: Team USA picked a gravel team and then slid the dinner check across the table. Congratulations on being medal-capable. Airfare is over there. Your bike is enormous luggage. You may need to buy the national kit. Also, Worlds pays nothing, Life Time has $300,000 across the ocean, and your sponsors know where the cameras are. The privateers who stayed home did not disrespect the rainbow jersey; they respected arithmetic. USA Cycling's Olympic-year constraints were real and disclosed, but transparency does not make the sporting filter disappear. A self-funded World Championship does not assemble only the best riders. It assembles the best riders who can afford to treat international uncertainty as a career investment—and then acts surprised when a domestic paycheck wins the sprint.",
   "takeProvenance": "model_draft",
   "uncertainty": "The reviewed sources do not provide itemized budgets for each rider, and no athlete described cost as the sole reason for declining. Course fit, UCI starting position, recovery, existing sponsor obligations, and the Life Time calendar were material. Some athletes reached Worlds through UCI automatic qualification rather than federation discretion, although the published USA Cycling criteria assigned both groups full financial responsibility. The evidence cannot establish how the absent riders would have performed or whether additional funding would have changed every decision. Later 2025 evidence shows recurrence, not that the 2024 controversy caused subsequent choices.",
@@ -29,6 +29,15 @@
       "publisher": "USA Cycling",
       "publishedAt": "2024-04-03T14:03:11Z",
       "quoteExcerpt": "USA Cycling will not assume any financial responsibility for athletes",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_us_nationals_ten_worlds_spots_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/us-gravel-nationals-add-enticement-of-10-elite-spots-for-uci-world-championships-to-hefty-prize-purse/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-07-25T00:00:00Z",
+      "quoteExcerpt": "automatic qualifications for the UCI Gravel World Championships will be expanded to the top five",
       "transcriptStartSeconds": null,
       "transcriptEndSeconds": null
     },
@@ -114,6 +123,7 @@
       "fieldPath": "race.biased_opinion",
       "claimIds": [
         "claim_usac_worlds_full_financial_responsibility_2024",
+        "claim_us_nationals_ten_worlds_spots_2024",
         "claim_us_specialists_declined_worlds_2024",
         "claim_worlds_no_prize_or_us_travel_support_2024",
         "claim_onweller_sponsor_series_tradeoff_2024",
@@ -129,6 +139,6 @@
   "autoPublishAllowed": false,
   "editorialApproval": null,
   "publishedAt": null,
-  "updatedAt": "2026-08-28T08:05:00Z",
-  "contentHash": "f8e2071d31e83302a0a8d72c3046f8d7ee3c5b096e5662333a6e3f2fe2e0dfe3"
+  "updatedAt": "2026-08-28T17:25:12Z",
+  "contentHash": "9bcf00aae40bf60dc989afe4c76047b6f2c6012f653d9a9385289e3472a49926"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -820,9 +820,9 @@ def test_2024_backfill_ledger_accounts_for_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 239
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 2
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 17
-    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 8
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 26
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 22
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 29
     assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
     assert validated["complete"] is True
 


### PR DESCRIPTION
## What changed
- closed all eight remaining 2024 research holds across the 53-week, 239-card census
- added draft-only chapters for the Junior Gravel National Series road-development pathway and Team Amani's East African training infrastructure
- folded Phase II and the expanded Team USA qualification pathway into existing career-market and self-funding chapters
- rejected announcement-only claims that did not establish a consequential story
- preserved all publication and race-database changes behind human editorial review

## Voice provenance
- `inbox/gravel-god/i-screwed-up-sbt-grvl-so-you-dont-have-to.md`
- `inbox/substack/racing-is-not-for-pies.md`
- `inbox/gravel-god/listening-to-robert-in-silver-city.md`
- `voice-and-beliefs-profile.md`

## Verification
- `python3 scripts/validate_gravel_weekly_history.py ...`
- `python3 scripts/validate_gravel_weekly_backfill.py data/gravel-weekly/backfill/2024.json`
- `python3 -m pytest tests/test_gravel_weekly.py -q` (72 passed)
- strict AI-writing check on all four changed history drafts
- `python3 scripts/preflight_quality.py`
- private 2024 review desk rendered with eight drafts

## Safety boundary
All entries remain `draft` with model-draft provenance, human approval required, auto-publication disabled, and no editorial approval or publication timestamp. Race impacts are review-only with `autoFixAllowed: false`; this PR does not publish history or mutate race records.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and test assertions only; content stays draft with human approval and no auto-publish or race-record writes.
> 
> **Overview**
> **Finishes the 2024 Gravel Weekly research ledger** by resolving every remaining `held_for_evidence` week across the 53-week / 239-card census. Weeks now map to draft chapters (`covered_by_draft` rises 17→22), get explicit rejections with updated rationales (`rejected` 26→29), or stay gaps—**no pending holds** (`held_for_evidence` 8→0).
> 
> **Adds two new draft history entries:** Team Amani’s East African training/infrastructure story and USA Cycling’s junior gravel series whose top prize is road talent-ID camp (with later delivery evidence). **Extends existing drafts:** Phase II under-23 pathway in the career-market chapter; July expansion of nationals Worlds auto-qualifiers (top five per gender) and receipts in the Team USA self-funding chapter.
> 
> **Tests** lock the new 2024 disposition totals. All touched entries remain `draft` / `model_draft` with human approval required and review-only race impacts—no publication or auto race mutations in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 724ac2b9b576ce3ecfcb8aed11d3f2d2dc3eed24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->