### PR TITLE
Close Gravel Weekly 2023 backfill ledger

### DIFF
--- a/data/gravel-weekly/backfill/2023.json
+++ b/data/gravel-weekly/backfill/2023.json
@@ -24,17 +24,17 @@
       "periodStartedAt": "2023-01-07",
       "periodEndedAt": "2023-01-13",
       "sourceCardCount": 3,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Hold the Dirt RAD Fest wildcard as an access-pathway lead until selection mechanics, athlete conversion, and race delivery can show whether the invitation changed opportunity rather than launch publicity."
+      "reason": "The Dirt RAD Fest 'wildcard' selected an event for the already invitation-only Life Time Grand Prix calendar, not an athlete for an access pathway. The race delivered, but adding one commercial stop without a changed admission mechanism or athlete consequence is schedule news rather than a chapter."
     },
     {
       "periodStartedAt": "2023-01-14",
       "periodEndedAt": "2023-01-20",
       "sourceCardCount": 2,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The first Canadian gravel-championship announcement is a meaningful institutional lead, but it needs delivered fields, results, qualification effects, and continuity before it can support a narrative."
+      "reason": "Canada delivered its first gravel championship and repeated it in 2024, but the reviewed evidence shows title creation and results rather than a distinctive qualification, funding, access, or career consequence. A new jersey by itself does not clear the point gate."
     },
     {
       "periodStartedAt": "2023-01-21",
@@ -48,9 +48,9 @@
       "periodStartedAt": "2023-01-28",
       "periodEndedAt": "2023-02-03",
       "sourceCardCount": 3,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The Floyd's of Leadville-ButcherBox private team could anchor a gravel-labor story, but contract terms, operating support, sponsor durability, and athlete outcomes remain necessary evidence."
+      "reason": "The Floyd's of Leadville-ButcherBox launch supplied a roster and sponsor announcement but no contract terms, operating support, sponsor durability, or attributable athlete outcome. Without the labor mechanism, 'PrivaTeam' remains branding rather than history."
     },
     {
       "periodStartedAt": "2023-02-04",
@@ -80,9 +80,9 @@
       "periodStartedAt": "2023-02-25",
       "periodEndedAt": "2023-03-03",
       "sourceCardCount": 4,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Hold the inaugural European Gravel Championships announcement for delivered field quality, course identity, broadcast, title legitimacy, and subsequent continuity."
+      "reason": "The inaugural European Gravel Championships delivered recognized winners and continued in later years, but the evidence does not reveal a distinctive access rule, economic effect, conflict, or changed institution beyond adding another title to an already proliferating championship calendar."
     },
     {
       "periodStartedAt": "2023-03-04",
@@ -279,9 +279,11 @@
       "periodStartedAt": "2023-08-05",
       "periodEndedAt": "2023-08-11",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "The Worlds-Leadville doubleheader is a credible calendar-conflict lead; hold for actual athlete choices, travel burden, series consequences, and whether the clash altered later scheduling."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-worlds-was-the-leadville-warmup-2023"
+      ],
+      "reason": "Smith's 7,221-kilometre Worlds-to-Leadville trip, fifth place at altitude, and eventual third in the Grand Prix show two uncoordinated institutions making credible claims on the same privateer's season."
     },
     {
       "periodStartedAt": "2023-08-12",
@@ -374,33 +376,37 @@
       "periodStartedAt": "2023-10-14",
       "periodEndedAt": "2023-10-20",
       "sourceCardCount": 2,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Hold the new Australian $10,000-purse race as a regional professionalization lead until delivery, field depth, payout, continuity, and athlete impact are verified."
+      "reason": "RADL GRVL delivered and continued after its A$10,000-purse announcement, but the reviewed evidence does not disclose payout depth, athlete economics, or a consequence that distinguishes it from the many new commercial races entering regional calendars."
     },
     {
       "periodStartedAt": "2023-10-21",
       "periodEndedAt": "2023-10-27",
       "sourceCardCount": 10,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "The Tour de France gravel-stage argument is a high-signal risk-versus-spectacle lead; hold the announcement, team objections, organizer rationale, and eventual stage outcome for a dedicated chapter rather than mixing them with weekly results."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-tour-borrowed-gravel-as-threat-2023"
+      ],
+      "reason": "The Tour's route reveal, organizer rationale, and team objections establish gravel as deliberately engineered uncertainty inserted to break up flat television, a thesis the delivered 2024 stage can test."
     },
     {
       "periodStartedAt": "2023-10-28",
       "periodEndedAt": "2023-11-03",
       "sourceCardCount": 2,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "Mohorič's gravel-world-champion reaction extends the Tour-stage debate and should remain linked to that held chapter pending full delivery and consequence review."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-tour-borrowed-gravel-as-threat-2023"
+      ],
+      "reason": "Gravel world champion Mohorič questioning whether puncture risk belonged in a Grand Tour sharpened the distinction between gravel skill and gravel used as classification jeopardy."
     },
     {
       "periodStartedAt": "2023-11-04",
       "periodEndedAt": "2023-11-10",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The Life Time Grand Prix expansion to 60 athletes and a $300,000 purse is a material labor-and-access lead; hold for admissions, support distribution, athlete economics, and delivered outcomes."
+      "reason": "The 60-athlete field and $300,000 purse materially enlarged Life Time's series, but they extended the selected-field mechanism already established in 2021 rather than changing it; later labor and career consequences are handled in dedicated chapters."
     },
     {
       "periodStartedAt": "2023-11-11",
@@ -416,17 +422,21 @@
       "periodStartedAt": "2023-11-18",
       "periodEndedAt": "2023-11-24",
       "sourceCardCount": 3,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "Project Echelon treating gravel as North America's classics and Pidcock reconning the Tour stage suggest road-gravel institutional convergence, but the plans require delivered programs and outcomes."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-tour-borrowed-gravel-as-threat-2023"
+      ],
+      "reason": "Pidcock's November recon shows a road team operationalizing the Tour's gravel novelty as a specialized threat. Project Echelon's separate gravel plan is useful convergence texture but adds no second chapter beyond later career-market coverage."
     },
     {
       "periodStartedAt": "2023-11-25",
       "periodEndedAt": "2023-12-01",
       "sourceCardCount": 5,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "The World Series expansion to 25 races and year-end money analysis form a global-growth lead; hold for participation, travel cost, regional access, calendar load, and series sustainability evidence."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-two-world-tours-privateer-airfare-2023"
+      ],
+      "reason": "The UCI's 25-event qualification network and contemporary reporting on privateer economics establish the split between a global-looking calendar and the riders still financing participation."
     },
     {
       "periodStartedAt": "2023-12-02",
@@ -440,9 +450,11 @@
       "periodStartedAt": "2023-12-09",
       "periodEndedAt": "2023-12-15",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "Gravel Earth's announced expansion to 20 events is a second global-growth signal; hold for delivered races, field quality, geographic access, financial continuity, and relationship to competing series."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-two-world-tours-privateer-airfare-2023"
+      ],
+      "reason": "Gravel Earth's 20-race, 13-country points series and €12,500 purse created a second global product distinct from UCI qualification, making calendar scale versus privateer support the actual story."
     },
     {
       "periodStartedAt": "2023-12-16",
@@ -469,5 +481,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T08:10:00Z"
+  "updatedAt": "2026-08-28T18:00:00Z"
 }

--- a/data/gravel-weekly/history/2023-tour-borrowed-gravel-as-threat.json
+++ b/data/gravel-weekly/history/2023-tour-borrowed-gravel-as-threat.json
@@ -1,0 +1,99 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-tour-borrowed-gravel-as-threat-2023",
+  "activeFrom": "2023-10-25",
+  "activeThrough": "2023-11-24",
+  "status": "draft",
+  "headline": "The Tour Borrowed Gravel as a Threat",
+  "point": "The Tour de France did not import gravel because it wanted to join gravel racing. It imported 32.2 kilometres of white roads because the route needed something more interesting than consecutive sprint stages. The organizer advertised tension and elimination; GC riders and even gravel world champion Matej Mohorič answered with punctures, crashes, and months of preparation lost to luck. When the stage arrived, it produced superb television and no change among the leading contenders. Gravel's most valuable export to road racing was controlled uncertainty.",
+  "priorJudgment": "When the Tour adds gravel, the surface is the sporting test: bike handling, mixed-terrain skill, and a broader definition of the complete road racer.",
+  "changedJudgment": "At the Tour, gravel was first a programming device. The route designer needed spectacle between the Alps and Massif Central, and loose roads supplied danger, tactical disorder, and television tension whether or not they changed the classification.",
+  "stakes": "This is the difference between gravel as a sport and gravel as an ingredient. Riders carry the crash and puncture risk, the Tour captures the attention, and the audience may mistake manufactured jeopardy for a meaningful test of who should win a three-week race.",
+  "credibleOpposition": "The delivered stage was not empty gimmickry. It demanded positioning, handling, team support, repeated accelerations, and tactical judgment; Tadej Pogačar attacked, Jonas Vingegaard survived a mechanical on a teammate's bike, and Anthony Turgis beat Tom Pidcock from a strong break. Road racing has always included weather, cobbles, narrow roads, and bad luck. A Tour winner can reasonably be expected to manage varied terrain, and the absence of a final GC gap does not mean the stage lacked competitive substance.",
+  "whatHappened": "The Tour unveiled its 2024 route on October 25, 2023 with a 199-kilometre ninth stage around Troyes containing 14 white-road sectors and 32.2 kilometres of gravel. Route designer Thierry Gouvenou said the race had promised not to schedule consecutive sprint stages and therefore had to invent something clever for the flat run between the Alps and stage 11. Managers Richard Plugge and Patrick Lefevere objected that gravel increased the chance of bad luck; Remco Evenepoel called it unnecessary; Tadej Pogačar called it risky; and gravel world champion Matej Mohorič said a puncture or crash could erase months of GC preparation. Tom Pidcock reconnoitred the route in November, treating the novelty as a stage-specific discipline. On July 7, 2024, Anthony Turgis won from the break ahead of Pidcock after a chaotic, attacking day. The principal GC contenders finished together and the Tour's own report recorded no change at the top of the classification. The threat worked as television even when it failed as separation.",
+  "take": "Model draft, not Matti's approved view: The Tour did not discover gravel in 2023. It discovered that flat stages were boring. Route designer Thierry Gouvenou had promised not to stack sprint days, stared at the map between the Alps and Cantal, and said they needed something clever. Gravel entered cycling's largest race as a content strategy. The managers predicted random GC death. Even Matej Mohorič—who was wearing the gravel rainbow jersey—wondered whether a puncture should erase somebody's year. Tom Pidcock went to Troyes in November to study the threat. Then the stage happened: dust, attacks, a teammate's bike under Jonas Vingegaard, Anthony Turgis beating Pidcock, excellent television, and every major GC rider on the same time. Gravel changed the mood and left the classification alone. That does not make the stage fake. It makes the product obvious. The Tour rented gravel's chaos for a day and returned it without joining the sport.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "One delivered stage cannot establish the long-run competitive effect of gravel in Grand Tours, and finishing the leading GC riders together does not measure energy cost, tactical constraints, crashes elsewhere in the field, or what a different weather pattern would have produced. The organizer's sprint-stage rationale is documented, but spectacle and sporting design are not mutually exclusive motives. The evidence supports gravel as deliberately engineered uncertainty, not a claim that the stage was fixed, unserious, or harmless.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_tour_announced_32km_white_roads_2023",
+      "canonicalUrl": "https://www.letour.fr/en/news/2024/111th-edition-a-set-of-aces-on-top-of-the-bill/1316767",
+      "publisher": "Tour de France",
+      "publishedAt": "2023-10-25T13:00:00Z",
+      "quoteExcerpt": "white roads (32.2km in total) on the Tour route",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_tour_designer_needed_sprint_stage_break_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/we-had-to-come-up-with-something-clever-why-the-2024-tour-de-france-has-a-gravel-stage/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-10-27T12:00:00Z",
+      "quoteExcerpt": "we had to come up with something clever",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_pogacar_called_tour_gravel_risky_2023",
+      "canonicalUrl": "https://velo.outsideonline.com/road/road-racing/tour-de-france/tadej-pogacar-says-gravel-in-2024-tour-de-france-is-pretty-risky/",
+      "publisher": "Velo",
+      "publishedAt": "2023-10-28T03:39:00Z",
+      "quoteExcerpt": "It's pretty risky to have this kind of stage",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_mohoric_questioned_tour_gravel_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/matej-mohoric-unsure-of-gravel-inclusion-at-2024-tour-de-france/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-11-03T12:00:00Z",
+      "quoteExcerpt": "for a puncture or a crash to ruin or limit their chances",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_pidcock_reconned_tour_gravel_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/tom-pidcock-recons-gravel-stage-of-the-2024-tour-de-france/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-11-24T12:00:00Z",
+      "quoteExcerpt": "checked out the gravel roads around Troyes",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_tour_gravel_delivered_no_gc_change_2024",
+      "canonicalUrl": "https://www.letour.fr/en/news/2024/stage-9/gravel-masterclass-gives-turgis-troyes-win/1320149",
+      "publisher": "Tour de France",
+      "publishedAt": "2024-07-07T18:16:00Z",
+      "quoteExcerpt": "no changes at the head of the general classification",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_turgis_won_tour_gravel_ahead_pidcock_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/races/tour-de-france-2024/stage-9/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-07-07T18:30:00Z",
+      "quoteExcerpt": "there were no changes to the top places in the overall classification",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T18:00:00Z",
+  "contentHash": "b52af2ff31d751be2f0fac2ba6ea5d0ab4e016ca400e9a13ef3376dd2e958ae4"
+}

--- a/data/gravel-weekly/history/2023-two-world-tours-privateer-airfare.json
+++ b/data/gravel-weekly/history/2023-two-world-tours-privateer-airfare.json
@@ -1,0 +1,147 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-two-world-tours-privateer-airfare-2023",
+  "activeFrom": "2023-11-30",
+  "activeThrough": "2023-12-18",
+  "status": "draft",
+  "headline": "Gravel Built Two World Tours for Riders Paying Their Own Airfare",
+  "point": "At the end of 2023, gravel produced two different claims to a global season. The UCI expanded a qualification network from 16 events to 25, while Gravel Earth nearly tripled to 20 races in 13 countries and added an overall points competition with a €12,500 purse. One calendar sold routes to a world title; the other sold a season championship. Both made the sport look global faster than the sport made global participation economically sane for privateers.",
+  "priorJudgment": "More international races create more access: a larger map gives more riders a nearby event, more routes into elite fields, and a healthier alternative to a sport concentrated in the United States.",
+  "changedJudgment": "A larger map can widen local access while making the imagined full season less accessible. Qualification networks and points series are different products, but both shift travel, scheduling, and financial decisions onto riders unless meaningful support grows with the calendar.",
+  "stakes": "Calendar design determines who can qualify, who can contest an overall title, which races gain international relevance, and whether a privateer can convert results into a sustainable career. Counting countries without counting rider costs turns global growth into a map graphic rather than an access measure.",
+  "credibleOpposition": "The UCI World Series was not asking riders to contest every round; its top-25-percent format deliberately created regional routes to Worlds. Gravel Earth required only selected scores plus its final and offered equal male, female, and non-binary rankings. Expansion also brought international status to existing local races rather than inventing every event from scratch. The calendars delivered substantial racing in 2024, and riders could choose selectively. The problem is not that every added race imposed another mandatory flight, but that global branding outran the financial support available to the athletes expected to animate it.",
+  "whatHappened": "On November 30, Cyclingnews reported that the Trek UCI Gravel World Series would grow from 16 events in 2023 to 25 events tied to the 2024 championship cycle. Its mechanism was qualification rather than a season title: the top 25 percent in each category at each round earned eligibility for Gravel Worlds. A year-end review published the next day described gravel as an increasingly structured business while noting that cash remained especially important for privateers. On December 14, Gravel Earth announced a different global product: 20 events in 13 countries, nearly triple its six-event debut, with the best selected results feeding a final and a €12,500 purse split equally across male, female, and non-binary top tens. Its own December 18 announcement called the series a global alternative. Both calendars substantially delivered in 2024: the UCI later counted 26 rounds, and Gravel Earth completed a 20-race, 13-country season with Migration Gravel among five higher-points Global events. Gravel Earth's subsequent contraction to 11 confirmed 2026 events is a reminder that a giant calendar is an experiment, not proof of durable demand.",
+  "take": "Model draft, not Matti's approved view: Gravel finished 2023 with two world tours and approximately zero team buses. The UCI put 25 pins on a map and sold each one as a door to Worlds. Gravel Earth put 20 races in 13 countries, added standings, and found €12,500 to divide among thirty season-end places. One system offered qualification. The other offered points and a purse. Both looked magnificent from the altitude of a press release. Down at baggage claim, a privateer still had to make the spreadsheet work. This is the trick hidden inside gravel's globalization: regional qualifiers can genuinely bring Worlds closer to more riders, while a global points chase can turn access into airfare. The sport had built the calendar architecture of professional cycling before it built the payroll. By 2026 Gravel Earth was back to 11 confirmed events. Maps expand in one click; economies do not.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed evidence does not provide comprehensive rider budgets, travel subsidies, event fees, sponsor reimbursements, participation counts for all rounds, or the share of athletes attempting multiple continents. The UCI count changed from 25 in the November announcement to 26 in its 2024 review, reflecting calendar revision rather than necessarily an error. Gravel Earth's 2026 count may change after publication. The evidence supports a mismatch between calendar scale and disclosed prize support, not a claim that every international event reduced access or lost money.",
+  "editorialScore": 97,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_uci_gravel_series_25_events_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/news/uci-gravel-world-series-expands-further-to-include-25-races-in-2024/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-11-30T12:00:00Z",
+      "quoteExcerpt": "taking the total number of events in the series ... up to 25",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_uci_series_top_25_percent_qualification_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/uci-gravel-world-series-expands-further-to-include-25-races-in-2024/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-11-30T12:00:00Z",
+      "quoteExcerpt": "top 25 per cent of riders in each category",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_cash_king_for_privateers_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/features/rocks-to-riches-global-impacts-and-impressions-from-gravel-racing-in-2023/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-12-01T12:00:00Z",
+      "quoteExcerpt": "cash is king, especially for privateers",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_earth_20_events_13_countries_12500_euros_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/gravel-earth-series-expands-to-20-events-adds-races-to-usa-and-chile-in-2024/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-12-14T12:00:00Z",
+      "quoteExcerpt": "20 across 13 countries ... €12,500 total prize purse",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_earth_global_alternative_2023",
+      "canonicalUrl": "https://gravelearthseries.com/2023/12/18/the-values-of-the-gravel-earth-series-expand-across-the-globe/",
+      "publisher": "Gravel Earth Series",
+      "publishedAt": "2023-12-18T12:00:00Z",
+      "quoteExcerpt": "20 races and 13 countries make up the calendar",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_uci_gravel_series_delivered_26_rounds_2024",
+      "canonicalUrl": "https://www.uci.org/article/trek-uci-gravel-world-series-en-route-to-flanders/1RvnZZrF4rJgkeBTgwPSzo",
+      "publisher": "UCI",
+      "publishedAt": "2024-04-05T12:00:00Z",
+      "quoteExcerpt": "11 rounds in 2022, to 16 rounds in 2023, to 26 rounds in 2024",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_migration_gravel_global_series_2024",
+      "canonicalUrl": "https://www.cyclingnews.com/races/gravel-earth-global-events-2024/migration-gravel-stage-race/results/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2024-06-22T12:00:00Z",
+      "quoteExcerpt": "one of five events on the Gravel Earth Series calendar at the Global level",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_earth_delivered_20_races_13_countries_2024",
+      "canonicalUrl": "https://gravelearthseries.com/2024/10/13/karolina-migon-and-simen-nordahl-svendsen-kings-of-the-gravel-earth-series/",
+      "publisher": "Gravel Earth Series",
+      "publishedAt": "2024-10-13T18:00:00Z",
+      "quoteExcerpt": "20 scheduled races ... 13 countries",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_gravel_earth_contracted_11_events_2026",
+      "canonicalUrl": "https://www.cyclingnews.com/pro-cycling/racing/gravel-earth-series-2026/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2026-08-07T12:00:00Z",
+      "quoteExcerpt": "11 events in six countries confirmed for 2026",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:uci-gravel-worlds",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_uci_gravel_series_25_events_2024",
+        "claim_uci_series_top_25_percent_qualification_2023",
+        "claim_cash_king_for_privateers_2023",
+        "claim_uci_gravel_series_delivered_26_rounds_2024"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    },
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:migration-gravel-race",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_gravel_earth_20_events_13_countries_12500_euros_2023",
+        "claim_gravel_earth_global_alternative_2023",
+        "claim_migration_gravel_global_series_2024",
+        "claim_gravel_earth_delivered_20_races_13_countries_2024",
+        "claim_gravel_earth_contracted_11_events_2026"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T18:00:00Z",
+  "contentHash": "855dee5bf0f2e5fb97baa76dde2ed5933a2ac51db4c9471fd273b6077a04ba2d"
+}

--- a/data/gravel-weekly/history/2023-worlds-was-the-leadville-warmup.json
+++ b/data/gravel-weekly/history/2023-worlds-was-the-leadville-warmup.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-worlds-was-the-leadville-warmup-2023",
+  "activeFrom": "2023-08-11",
+  "activeThrough": "2023-08-12",
+  "status": "draft",
+  "headline": "A Private Race Series Made Worlds the Leadville Warm-Up",
+  "point": "The 2023 Life Time Grand Prix had become important enough that athletes treated a national-team World Championship and a 7,221-kilometre trip to Leadville as consecutive obligations. Haley Smith raced Marathon Worlds in Scotland, crossed the Atlantic, and finished fifth at Leadville six days later because one race carried federation prestige while the other carried private-series points. Gravel's new career calendar did not replace the old institutions; it made riders serve both on schedules nobody had coordinated.",
+  "priorJudgment": "A World Championship is the fixed point around which a serious athlete's calendar is built, while a privately owned domestic series yields when the two create an absurd travel and recovery problem.",
+  "changedJudgment": "Prestige and livelihood can create separate mandatory calendars. Once private-series standings matter to a rider's season, Worlds may keep the flag and rainbow jersey while becoming the inconvenient race immediately before the commercial one.",
+  "stakes": "Athletes absorb the airfare, jet lag, recovery loss, altitude compromise, and performance risk created by institutional calendars that each behave as if they are the only calendar. The conflict also reveals which events actually govern a privateer's season: not necessarily the event with the grandest title, but the one with cumulative points and money attached.",
+  "credibleOpposition": "Smith described representing Canada as an honour and the World Championship experience as invaluable, so the double was not evidence that Worlds had become meaningless. Elite endurance athletes also choose difficult doubles as part of the appeal, and Leadville's date was longstanding rather than a targeted slight. The evidence shows a costly collision and a consequential athlete choice, not that either organizer deliberately manufactured the conflict or that every rider viewed the Grand Prix as more important than Worlds.",
+  "whatHappened": "On August 6, Haley Smith finished 15th for Canada in the 100-kilometre UCI Marathon Mountain Bike World Championship in Scotland. She then traveled more than 7,221 kilometres to Colorado for the August 12 Leadville Trail 100 MTB, the fourth stop of the Life Time Grand Prix, where the start sits above 10,000 feet. Smith entered the week tied for second in the women's series and acknowledged that the trip had displaced her normal Leadville preparation and altitude camp. Three men—Matthew Beers, Andrew L'Esperance, and Alex Wild—were also reported as attempting the double after Worlds. Smith completed it and finished fifth at Leadville in 7:21:26; L'Esperance finished 19th. Smith ultimately placed third in the 2023 Grand Prix. The result did not prove the double was wise. It proved the private series had accumulated enough competitive consequence that crossing an ocean between two hundred-kilometre-class efforts could look like the rational schedule.",
+  "take": "Model draft, not Matti's approved view: Cycling used to have one obvious center of gravity. You wore the national jersey at Worlds, everybody bowed toward the rainbow bands, and the rest of the calendar moved around it. In 2023 Haley Smith raced Marathon Worlds in Scotland, flew 7,221 kilometres, and six days later started Leadville above 10,000 feet because Life Time points were waiting. Worlds became the altitude camp nobody would prescribe. She finished fifth anyway. That is not evidence that athletes have discovered teleportation; it is evidence that gravel built a second power structure before anyone built a shared calendar. The federation had the flag. Life Time had the season standings. The rider got the middle seat and the sauna protocol.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The reviewed evidence does not itemize Smith's travel cost, sleep, recovery metrics, sponsor obligations, or the counterfactual Leadville result with a conventional altitude block. Reporting confirmed four intended double attempts, but the available results establish the completed outcome only for Smith and L'Esperance; it should not imply that Beers or Wild started Leadville. The evidence also does not establish whether the UCI or Life Time considered changing dates in response.",
+  "editorialScore": 95,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_worlds_leadville_7221km_double_2023",
+      "canonicalUrl": "https://www.cyclingnews.com/news/worlds-leadville-doubleheader-looms-for-life-time-grand-prix-champ-haley-smith/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2023-08-11T12:00:00Z",
+      "quoteExcerpt": "air travel distance of more than 7,221 kilometres",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_smith_fifth_leadville_2023",
+      "canonicalUrl": "https://www.webscorer.com/racealldetails?groupid=300796&pid=1&raceid=300792",
+      "publisher": "Webscorer",
+      "publishedAt": "2023-08-12T13:30:00Z",
+      "quoteExcerpt": "5 Haley Smith 7:21:26",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_lesperance_nineteenth_leadville_2023",
+      "canonicalUrl": "https://www.webscorer.com/racealldetails?groupid=300796&pid=1&raceid=300792",
+      "publisher": "Webscorer",
+      "publishedAt": "2023-08-12T13:30:00Z",
+      "quoteExcerpt": "19 Andrew L'esperance 6:40:34",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_smith_third_lifetime_grand_prix_2023",
+      "canonicalUrl": "https://www.lifetimegrandprix.com/wp-content/uploads/2023/10/LTGP2023FinalResults.pdf",
+      "publisher": "Life Time Grand Prix",
+      "publishedAt": "2023-10-22T12:00:00Z",
+      "quoteExcerpt": "3 Haley Smith 160",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:leadville-100",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_worlds_leadville_7221km_double_2023",
+        "claim_smith_fifth_leadville_2023",
+        "claim_lesperance_nineteenth_leadville_2023",
+        "claim_smith_third_lifetime_grand_prix_2023"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T18:00:00Z",
+  "contentHash": "de557239b215575c4a46d3984d5181e5755a5a48c10bb06cbec64f5e8998003d"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -835,9 +835,9 @@ def test_2023_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 218
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 4
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 16
-    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 12
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 21
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 22
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 27
     assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
     assert validated["complete"] is True
 


### PR DESCRIPTION
## What changed

- resolve all twelve remaining 2023 evidence holds
- add three draft-only historical Current Thing chapters: Worlds-to-Leadville calendar collision, Tour gravel as manufactured threat, and global calendars outrunning privateer economics
- close the 53-week ledger at 22 covered, 27 rejected, 4 explicit gaps, and 0 holds
- preserve all race implications as editorial-review-only

## Editorial safety

- every new entry remains status draft with model_draft take provenance
- human approval remains required and auto-publication remains disabled
- no race record is changed; race impacts only create review candidates

## Voice provenance

Drafts were calibrated against:
- inbox/gravel-god/i-screwed-up-sbt-grvl-so-you-dont-have-to.md
- inbox/substack/racing-is-not-for-pies.md
- inbox/gravel-god/listening-to-robert-in-silver-city.md
- wattgod/writing-graph/self/voice-and-beliefs-profile.md

## Verification

- history validators and content hashes
- 2023 backfill ledger validator
- python3 -m pytest tests/test_gravel_weekly.py -q (72 passed)
- strict AI-writing checks on all three new drafts
- private review desk render (10 drafts)
- git diff --check
- full preflight quality suite (passed with 7 known environment/backlog warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and test expectation changes only; new content stays draft with review-only race impacts and no automated publishing.
> 
> **Overview**
> **Closes the 2023 Gravel Weekly backfill ledger** by clearing all twelve `held_for_evidence` weeks: seven are **rejected** with tighter rationale (schedule news, title-only championships, insufficient labor evidence), and five are **`covered_by_draft`** and wired to new or existing history `entryIds`. The year now validates as **complete** with **22** draft-covered weeks, **27** rejected, **4** explicit gaps, and **0** holds.
> 
> **Adds three draft-only historical “Current Thing” entries** (all `model_draft`, human approval required): Worlds–Leadville calendar collision for Haley Smith / Life Time Grand Prix; Tour de France gravel as engineered TV uncertainty (route reveal through Mohorič / Pidcock recon); and parallel UCI vs Gravel Earth global calendars versus privateer economics. Two drafts attach **editorial-review-only** `raceImpacts` on canonical race IDs; nothing auto-publishes or mutates race records.
> 
> **Updates** `test_2023_backfill_ledger_starts_from_the_complete_source_census` to match the new disposition totals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f8d828d8c97f00fdd38c5ad13a1984da5d56af7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->