### PR TITLE
Close Gravel Weekly 2022 backfill ledger

### DIFF
--- a/data/gravel-weekly/backfill/2022.json
+++ b/data/gravel-weekly/backfill/2022.json
@@ -22,9 +22,11 @@
       "periodStartedAt": "2022-01-08",
       "periodEndedAt": "2022-01-14",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "The Utah race announcement may mark a durable event origin, but a single launch story cannot establish the event's eventual identity, field, or consequence."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-tour-of-utah-winner-built-gravel-race-2022"
+      ],
+      "reason": "Louder's move from a shrinking domestic road program into Wasatch All-Road revealed that gravel inherited road cycling's abandoned institutional expertise and converted it into an open participant event."
     },
     {
       "periodStartedAt": "2022-01-15",
@@ -46,9 +48,9 @@
       "periodStartedAt": "2022-01-29",
       "periodEndedAt": "2022-02-04",
       "sourceCardCount": 2,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "A new Spanish pro race and Haas's move from the WorldTour signal geographic and career migration, but launch announcements alone do not establish what either changed."
+      "reason": "Haas's career migration is already resolved in the dedicated 2022 and later career-market chapters, while Clásica Jaén repeats the road-race spectacle mechanism covered by the road-risk chapter without adding a distinct consequence."
     },
     {
       "periodStartedAt": "2022-02-05",
@@ -405,41 +407,43 @@
       "periodStartedAt": "2022-10-29",
       "periodEndedAt": "2022-11-04",
       "sourceCardCount": 2,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Dirty Warrny's launch may support a race-origin and longevity story, but the announcement needs longitudinal evidence covering its interruptions and promised return."
+      "reason": "Dirty Warrny launched and delivered a race, then later entered a hiatus with a promised return; that event chronology does not establish a changed judgment or consequence distinct enough for a historical chapter."
     },
     {
       "periodStartedAt": "2022-11-05",
       "periodEndedAt": "2022-11-11",
       "sourceCardCount": 2,
-      "disposition": "held_for_evidence",
-      "entryIds": [],
-      "reason": "Fahringer's concussion recovery could support a careful health and career-transition chapter, but it needs primary corroboration; the Wilson legal update is not a standalone gravel story."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-fahringer-new-finish-line-not-protocol-2022"
+      ],
+      "reason": "Fahringer's own account, contemporary race recap, and independent reporting support a careful chapter separating gravel's value as a new competitive path from the medical ambiguity of concussion return-to-play; the Wilson legal update remains contextual rather than standalone."
     },
     {
       "periodStartedAt": "2022-11-12",
       "periodEndedAt": "2022-11-18",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The Grand Prix expansion from six to seven races and 60 to 70 riders is a useful scale marker, but not a story until linked to athlete access, media, or competitive outcomes."
+      "reason": "The Grand Prix's move from six to seven races and 60 to 70 riders is a scale marker for the selected-field mechanism already established in 2021 and expanded in later chapters, not an independent story."
     },
     {
       "periodStartedAt": "2022-11-19",
       "periodEndedAt": "2022-11-25",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The early 2024 Worlds start-and-finish announcement is valuable longitudinal evidence for institutional lead time, but the update alone does not support another chapter."
+      "reason": "The early 2024 Worlds start-and-finish announcement remains useful longitudinal evidence of institutional lead time, but it does not contain a conflict, outcome, or changed judgment sufficient for another chapter."
     },
     {
       "periodStartedAt": "2022-11-26",
       "periodEndedAt": "2022-12-02",
       "sourceCardCount": 3,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The Gravel Earth Series launch may mark an independent global counterweight, while Smith's recommitment may illuminate the Grand Prix labor market; both require outcome evidence."
+      "reason": "Gravel Earth's launch and Smith's Grand Prix recommitment are announcements whose eventual calendar and labor consequences are handled with delivered evidence in the 2023 global-calendar chapter."
     },
     {
       "periodStartedAt": "2022-12-03",
@@ -455,17 +459,17 @@
       "periodStartedAt": "2022-12-10",
       "periodEndedAt": "2022-12-16",
       "sourceCardCount": 2,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Cyclocross survival and the 2023 Grand Prix roster suggest a cross-discipline calendar story, but the two announcements do not yet establish a consequence or changed judgment."
+      "reason": "Cyclocross survival and the 2023 Grand Prix roster show cross-discipline continuity but supply no independent consequence beyond the existing career and private-series chapters."
     },
     {
       "periodStartedAt": "2022-12-17",
       "periodEndedAt": "2022-12-23",
       "sourceCardCount": 1,
-      "disposition": "held_for_evidence",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Expansion to 17 World Series rounds is a meaningful scale marker retained for a later growth-versus-quality analysis, not a sufficient story by itself."
+      "reason": "Expansion to 17 World Series rounds is retained as a scale marker, while the delivered consequences of competing global calendars are covered in the 2023 chapter; the announcement alone is not a story."
     },
     {
       "periodStartedAt": "2022-12-24",
@@ -484,5 +488,5 @@
       "reason": "Cyclingnews exposed no matching source card; preserve the quiet window."
     }
   ],
-  "updatedAt": "2026-08-28T20:30:00Z"
+  "updatedAt": "2026-08-28T21:30:00Z"
 }

--- a/data/gravel-weekly/history/2022-fahringer-new-finish-line-not-protocol.json
+++ b/data/gravel-weekly/history/2022-fahringer-new-finish-line-not-protocol.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-fahringer-new-finish-line-not-protocol-2022",
+  "activeFrom": "2022-10-17",
+  "activeThrough": "2022-11-08",
+  "status": "draft",
+  "headline": "Gravel Gave Fahringer a New Finish Line, Not a Concussion Protocol",
+  "point": "Rebecca Fahringer's 2022 move toward gravel is a recovery story with an institutional indictment inside it. After two concussions, persistent symptoms, and what she described as yellow and green signals but no red light on racing, gravel gave her room to change expectations, rediscover competition, and win again. It did not solve the medical ambiguity that allowed her to keep racing while symptomatic. A new discipline can preserve a career; it cannot substitute for a return-to-play system.",
+  "priorJudgment": "A successful switch from cyclocross to gravel after injury is evidence of athlete resilience and the career flexibility created by a growing discipline.",
+  "changedJudgment": "The flexibility mattered, but the more consequential fact was why Fahringer needed it. Her account separates an athlete's ability to construct a new competitive identity from a sport's responsibility to provide decisive, medically governed stop and return criteria after brain injury.",
+  "stakes": "Fahringer's long-term health and agency, how cycling describes comeback stories, whether athletes must interpret ambiguous medical signals while their identity and income reward continued racing, and whether gravel is credited for offering an alternative without being falsely presented as concussion treatment.",
+  "credibleOpposition": "Fahringer did see a concussion specialist, chose to enter the Life Time Grand Prix, adjusted her own expectations, and described genuine enjoyment and improvement in gravel. The evidence does not identify a single governing body, clinician, team, or race organizer as legally responsible for her decisions, nor does it establish that gravel was inherently safer than cyclocross. Her return should not be recast as either helplessness or proof that one universal protocol would have produced a simple recovery.",
+  "whatHappened": "Fahringer sustained a concussion in a November 2020 cyclocross crash, returned after missing two races, and finished that season with only two top tens in 22 starts. Early in the 2021–22 cyclocross season she crashed again and sustained another concussion. She later wrote that she received many yellow lights and some green lights but no red light on racing, then continued through ten more races with headaches and disorientation before stopping screens, driving, exercise, and social activity. In February 2022 she entered the invitation-only Life Time Grand Prix while still recovering and expected to contend for its prize payout. Her season instead included 23rd of 36 at Sea Otter, a COVID-related Unbound DNS, and mid-pack series results. She deliberately lowered the stakes she attached to results and began enjoying racing again. On October 16, she won Belgian Waffle Ride Kansas and wrote that the previous month was the first time her familiar racing sensations had returned since the September 2021 concussion. Cyclingnews reported on November 8 that she would not return to cyclocross that season and planned more gravel and mountain-bike racing. Later reporting showed that symptoms still shaped her discipline choices and that the economic precarity of racing remained unresolved.",
+  "take": "Model draft, not Matti's approved view: Rebecca Fahringer won BWR Kansas in October 2022, and the easy headline is that gravel saved her career. It is also the wrong headline. Gravel gave her someplace to race where a bad result did not have to confirm that the cyclocross version of her was gone. She could change the stakes, use the skills she still had, enjoy a bike race, and eventually feel the old sensations again. That matters. But her account also includes two concussions, lingering headaches and disorientation, ten more races, and a medical landscape she described as yellow lights and green lights with nobody willing to put up a red one. Gravel was a new finish line. It was not a neurologist, a protocol, or permission to turn brain injury into inspirational content. The good part of this story is not that she proved toughness. Professional cyclists arrive pre-overqualified in toughness. It is that she found another way to be an athlete while the sport around her failed to make stopping feel as clear as starting.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The record is based substantially on Fahringer's own retrospective account as reported by Cyclingnews, Velo, BWR, and Brown Alumni Magazine. It does not include medical records, clinician interviews, diagnostic imaging, contractual obligations, or a complete chronology of medical advice. The sources differ slightly in how they date or describe the crashes, and the chapter should preserve Fahringer's words rather than infer negligence or assign legal responsibility. Her later preference for gravel and mountain biking does not establish that either discipline is generally safer for concussion recovery.",
+  "editorialScore": 98,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_fahringer_bwr_kansas_win_sensations_2022",
+      "canonicalUrl": "https://www.belgianwaffleride.bike/blogs/news/2022-bwr-kansas-results",
+      "publisher": "Belgian Waffle Ride",
+      "publishedAt": "2022-10-17T08:00:00Z",
+      "quoteExcerpt": "the first time 'ze sensations' have been there since I had my concussion",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_fahringer_persistent_symptoms_grand_prix_2022",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/becca-fahringer-is-back-to-winning-races/",
+      "publisher": "Velo",
+      "publishedAt": "2022-10-18T08:10:50Z",
+      "quoteExcerpt": "persistent symptoms from a head injury she sustained in September of 2021",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_fahringer_yellow_lights_no_red_light_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/features/fahringer-crosses-to-gravel-after-two-years-of-concussion-setbacks/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-11-08T21:24:23Z",
+      "quoteExcerpt": "a lot of yellow lights and a few green lights, but no one put the red light on racing",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_fahringer_lingering_effects_and_career_2024",
+      "canonicalUrl": "https://www.brownalumnimagazine.com/articles/2024-08-22/true-grit-gravel-bike-racing-Rebecca-Fahringer",
+      "publisher": "Brown Alumni Magazine",
+      "publishedAt": "2024-08-22T12:00:00Z",
+      "quoteExcerpt": "Even now, Fahringer is still feeling the lingering effects",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:belgian-waffle-ride-kansas",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_fahringer_bwr_kansas_win_sensations_2022",
+        "claim_fahringer_persistent_symptoms_grand_prix_2022",
+        "claim_fahringer_yellow_lights_no_red_light_2022",
+        "claim_fahringer_lingering_effects_and_career_2024"
+      ],
+      "confidence": 0.94,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T21:30:00Z",
+  "contentHash": "15dd9d9f6f888454102d865a784ee2696247ea0ba1c2b8706c13218acd225fe7"
+}

--- a/data/gravel-weekly/history/2022-tour-of-utah-winner-built-gravel-race.json
+++ b/data/gravel-weekly/history/2022-tour-of-utah-winner-built-gravel-race.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-tour-of-utah-winner-built-gravel-race-2022",
+  "activeFrom": "2022-01-14",
+  "activeThrough": "2022-06-02",
+  "status": "draft",
+  "headline": "When the Tour of Utah Died, Its Winner Built a Gravel Race",
+  "point": "Gravel did not merely inherit riders from a collapsing American road calendar. It absorbed the people who knew how to build the sport. When the Tour of Utah disappeared and domestic opportunities shrank, its 2008 winner Jeff Louder left a development-team director role to grow Wasatch All-Road: an open mass-participation race where 650 riders had already shared the course with professionals. Road racing lost an institution; gravel repurposed its human infrastructure.",
+  "priorJudgment": "American gravel grew because riders wanted adventure, open entry, and an alternative to the formal rules and closed hierarchy of road racing.",
+  "changedJudgment": "Gravel's rise also depended on institutional migration. As American road events vanished, experienced racers, directors, coaches, organizers, sponsors, and venues carried their operating knowledge into a format that let amateurs and professionals occupy the same event.",
+  "stakes": "The transfer changed who could enter a serious race, where cycling-industry expertise went after domestic road contraction, which communities retained major events, and whether gravel's apparent spontaneity concealed a large inheritance from the institutions it was replacing.",
+  "credibleOpposition": "Wasatch All-Road began in 2021, before Louder left Hagens Berman Axeon, and the reviewed sources do not prove that the Tour of Utah's disappearance directly caused the new event. Louder also cited family, coaching, and a desire to work closer to home. One organizer cannot establish a national labor migration by himself, and an open start does not make a difficult, fee-based race universally accessible. The evidence supports a revealing transfer of expertise, not a claim that gravel single-handedly rescued American cycling.",
+  "whatHappened": "On January 14, Jeff Louder announced that he was leaving Hagens Berman Axeon after five years as a director to focus on coaching and Wasatch All-Road. The domestic road calendar had contracted to a handful of UCI races during the pandemic, while the Tour of Utah—an event Louder won in 2008—had been cancelled again with little prospect of returning. Wasatch had already drawn more than 650 riders to its inaugural 2021 edition. For 2022, Louder and his partners moved the event to Soldier Hollow, retained an open mass-participation format, offered 100-, 65-, and 35-mile options, and split a $10,000 professional purse equally between women and men. The long course promised roughly 75 percent gravel and a 12-mile climb to 10,000 feet. Louder contrasted this with closed professional sport: most people cannot play on Michael Jordan's court, but gravel riders could ride the champions' route. The second edition happened in August. Local reporting counted about 420 registrations before the deadline, and Velo reported completed men's and women's races on the 100-mile course. Official Utah Gravel Series records later listed Wasatch All-Road results for 2025.",
+  "take": "Model draft, not Matti's approved view: The Tour of Utah disappeared, and its 2008 winner did not spend the rest of his life explaining to people under forty that American stage racing used to exist. Jeff Louder took the useful parts—the course knowledge, the event work, the sponsors, the appetite for a properly hard bike race—and put them into Wasatch All-Road. More than 650 people showed up the first year. The long course offered 100 miles, 12,000 feet of climbing, equal prize money, and no requirement that a team director first decide you belonged there. This is how gravel actually ate American road racing. It did not just collect retired pros like novelty jerseys. It hired the abandoned institutional memory and changed the front door. The Tour of Utah had barriers, caravans, and a professional field you watched. Wasatch had a former Tour of Utah winner building a course you could enter. Same mountains. Different ownership of the experience.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The sources do not provide the race's operating budget, entry fees, sponsor values, complete participant demographics, or the causal counterfactual in which the Tour of Utah survived. The January article called the inaugural event a success largely through Louder's own assessment. The June source is an organizer press release. Later independent reporting confirms that the 2022 race drew hundreds of riders and produced results, while official records confirm a 2025 edition; neither proves uninterrupted annual operation or broad affordability. The chapter should not imply that Louder alone created the event or that every road-cycling worker made the same transition.",
+  "editorialScore": 96,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_louder_left_axeon_for_wasatch_2022",
+      "canonicalUrl": "https://www.cyclingnews.com/news/jeff-louder-exits-hagens-berman-axeon-to-nurture-new-gravel-race-in-utah/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2022-01-14T15:47:25Z",
+      "quoteExcerpt": "focus on a new role as race director for The Wasatch All-Road gravel race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_wasatch_2022_venue_distances_and_purse",
+      "canonicalUrl": "https://www.endurancesportswire.com/the-wasatch-all-road-bicycle-race/",
+      "publisher": "Endurance Sportswire",
+      "publishedAt": "2022-06-02T11:58:06Z",
+      "quoteExcerpt": "There will be a $10,000 prize purse divided evenly between men and women",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_wasatch_2022_registration_and_tour_inspiration",
+      "canonicalUrl": "https://www.kpcw.org/wasatch-county/2022-08-23/hundreds-of-cyclists-to-race-at-soldier-hollow-in-wasatch-all-road",
+      "publisher": "KPCW",
+      "publishedAt": "2022-08-23T23:15:00Z",
+      "quoteExcerpt": "About 420 riders have registered",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_wasatch_2022_race_delivered",
+      "canonicalUrl": "https://velo.outsideonline.com/gravel/the-wasatch-all-road-griffin-easter-tops-tight-mens-race-while-newcomer-chelsea-bolton-soloes-to-the-win/",
+      "publisher": "Velo",
+      "publishedAt": "2022-08-29T17:15:00Z",
+      "quoteExcerpt": "Griffin Easter and Chelsea Bolton winning the 100-mile Full Yeti course",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_wasatch_official_2025_results",
+      "canonicalUrl": "https://utahgravelseries.com/results",
+      "publisher": "Utah Gravel Series",
+      "publishedAt": "2025-12-31T23:59:59Z",
+      "quoteExcerpt": "2025 Wasatch All-Road Results",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:wasatch-all-road",
+      "fieldPath": "race.biased_opinion",
+      "claimIds": [
+        "claim_louder_left_axeon_for_wasatch_2022",
+        "claim_wasatch_2022_venue_distances_and_purse",
+        "claim_wasatch_2022_registration_and_tour_inspiration",
+        "claim_wasatch_2022_race_delivered",
+        "claim_wasatch_official_2025_results"
+      ],
+      "confidence": 0.96,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T21:30:00Z",
+  "contentHash": "f5103557bdad7b467dea7222a12047d3dea59ec7fd6d7ec5372e494ac4816e1c"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -850,9 +850,9 @@ def test_2022_backfill_ledger_starts_from_the_complete_source_census():
     assert len(validated["weeks"]) == 53
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 173
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 6
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 23
-    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 9
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 15
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 25
+    assert sum(week["disposition"] == "held_for_evidence" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 22
     assert sum(week["disposition"] == "pending_review" for week in validated["weeks"]) == 0
     assert validated["complete"] is True
 


### PR DESCRIPTION
## Summary
- resolve all nine held 2022 weekly windows
- add two evidence-grounded, draft-only historical chapters
- preserve review-only race impacts and the human publication boundary

## Editorial result
- 53 weekly windows / 173 source cards
- 25 covered by drafts
- 22 explicitly rejected
- 6 explicit source gaps
- 0 held / 0 pending

## Safety
- both entries remain `status: draft` and `takeProvenance: model_draft`
- `humanApprovalRequired: true`; `autoPublishAllowed: false`
- race impacts are `editorial_review` with `autoFixAllowed: false`
- no race data, editorial approval, publication, or deployment changed

## Verification
- history and ledger validators pass
- Gravel Weekly tests: 72 passed
- strict AI-writing checks: pass
- full pytest: 7,339 passed / 331 skipped
- full preflight reaches an existing local artifact failure because ignored `wordpress/output/blog` and recap HTML are absent; no deploy attempted

## Voice sources
- `inbox/gravel-god/i-screwed-up-sbt-grvl-so-you-dont-have-to.md`
- `inbox/substack/racing-is-not-for-pies.md`
- `inbox/gravel-god/listening-to-robert-in-silver-city.md`
- `wattgod/writing-graph/self/voice-and-beliefs-profile.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial JSON and test assertions only; new content stays draft and does not auto-publish or mutate race data.
> 
> **Overview**
> **Finishes the 2022 Gravel Weekly backfill ledger** by clearing all nine `held_for_evidence` weekly windows: two become `covered_by_draft` with linked history entries, and the rest are explicitly `rejected` with reasons that point to existing chapters or insufficient standalone consequence. The ledger now shows **25 draft-covered / 22 rejected / 6 explicit gaps / 0 held**, with `complete: true`.
> 
> Adds two **draft-only** `gravel-weekly-history-entry` files: **Wasatch All-Road / Jeff Louder** (road institutional expertise moving into open-entry gravel) and **Rebecca Fahringer** (gravel as a new competitive path vs. concussion return-to-play ambiguity). Both keep `model_draft` takes, `humanApprovalRequired`, and review-only `raceImpacts` with `autoFixAllowed: false`.
> 
> Updates `test_2022_backfill_ledger_starts_from_the_complete_source_census` to match the new disposition totals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6983c31e417534a01f09cfb47292d3c3d35e3a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->