### PR TITLE
Close Gravel Weekly 2002 backfill ledger

### DIFF
--- a/data/gravel-weekly/backfill/2002.json
+++ b/data/gravel-weekly/backfill/2002.json
@@ -13,7 +13,7 @@
     "https://autobus.cyclingnews.com/results/?id=2002/apr02: legacy Cyclingnews archive is unavailable"
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -21,145 +21,145 @@
       "periodStartedAt": "2001-12-29",
       "periodEndedAt": "2002-01-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-01-05",
       "periodEndedAt": "2002-01-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-01-12",
       "periodEndedAt": "2002-01-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-01-19",
       "periodEndedAt": "2002-01-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-01-26",
       "periodEndedAt": "2002-02-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-02-02",
       "periodEndedAt": "2002-02-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-02-09",
       "periodEndedAt": "2002-02-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-02-16",
       "periodEndedAt": "2002-02-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-02-23",
       "periodEndedAt": "2002-03-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-03-02",
       "periodEndedAt": "2002-03-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-03-09",
       "periodEndedAt": "2002-03-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-03-16",
       "periodEndedAt": "2002-03-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-03-23",
       "periodEndedAt": "2002-03-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-03-30",
       "periodEndedAt": "2002-04-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-04-06",
       "periodEndedAt": "2002-04-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-04-13",
       "periodEndedAt": "2002-04-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-04-20",
       "periodEndedAt": "2002-04-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-04-27",
       "periodEndedAt": "2002-05-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "explicit_gap",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for at least part of this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The partial legacy Cyclingnews archive remains unavailable for this window; broader contemporary race, results, and mixed-surface history recovery found no story that cleared the editorial gates, so this is a researched coverage gap rather than inferred quiet."
     },
     {
       "periodStartedAt": "2002-05-04",
@@ -446,5 +446,5 @@
       "reason": "The partial legacy Cyclingnews archive census found no matching source card; broader contemporary-source recovery found no story that cleared the editorial gates."
     }
   ],
-  "updatedAt": "2026-08-28T15:20:00Z"
+  "updatedAt": "2026-08-28T22:30:00Z"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -1140,7 +1140,7 @@ def test_2003_backfill_ledger_reconciles_the_complete_legacy_archive_census():
     assert validated["complete"] is True
 
 
-def test_2002_backfill_ledger_preserves_partial_legacy_archive_research_debt():
+def test_2002_backfill_ledger_preserves_partial_archive_limits_without_open_research_debt():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2002.json").read_text())
     validated = validate_backfill_ledger(ledger, histories)
@@ -1149,10 +1149,10 @@ def test_2002_backfill_ledger_preserves_partial_legacy_archive_research_debt():
     assert validated["sourceArchiveCoverage"] == "partial"
     assert len(validated["sourceArchiveErrors"]) == 4
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 33
+    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 51
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
-    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 18
-    assert validated["complete"] is False
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 0
+    assert validated["complete"] is True
 
 
 def test_2001_backfill_ledger_rejects_a_redundant_story_without_claiming_archive_coverage():


### PR DESCRIPTION
## Summary
- resolve the 18 remaining January–April 2002 research-debt windows
- preserve the four unavailable legacy Cyclingnews archive indexes as an explicit partial-coverage limitation
- classify each window as a researched coverage gap after broader contemporary race/results and mixed-surface recovery produced no story clearing the editorial gates

## Editorial result
- 53 weekly windows
- 2 covered by the existing Saturn Cycling Classic draft
- 51 explicit researched gaps
- 0 unresearched / pending / held

## Safety
- the existing chapter remains `status: draft` and `takeProvenance: model_draft`
- `humanApprovalRequired: true`; `autoPublishAllowed: false`
- no race data, editorial approval, publication, or deployment changed

## Verification
- history and ledger validators pass
- Gravel Weekly tests: 72 passed
- strict AI-writing check: pass
- private one-draft review desk rendered

## Voice sources
- `inbox/gravel-god/i-screwed-up-sbt-grvl-so-you-dont-have-to.md`
- `inbox/substack/racing-is-not-for-pies.md`
- `inbox/gravel-god/listening-to-robert-in-silver-city.md`
- `wattgod/writing-graph/self/voice-and-beliefs-profile.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only backfill ledger and test expectation updates; no publication, approval, or runtime behavior changes.
> 
> **Overview**
> **Closes the 2002 Gravel Weekly backfill ledger** by reclassifying the remaining January–April weekly windows from `unresearched` to **`explicit_gap`**, with reasons that document broader contemporary recovery and no stories clearing editorial gates (not inferred quiet).
> 
> Sets ledger **`complete: true`** while keeping **`sourceArchiveCoverage: partial`** and the four legacy Cyclingnews archive errors unchanged. Editorial posture stays the same: two weeks **`covered_by_draft`** (Saturn Cycling Classic), 51 explicit gaps, zero open research debt; **`humanApprovalRequired`** / **`autoPublishAllowed`** unchanged.
> 
> Updates **`test_2002_backfill_ledger_preserves_partial_archive_limits_without_open_research_debt`** to assert the new disposition counts and completion flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95b1dac9c9ab36ec55a7964e558085fe56be278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->