### PR TITLE
Close Gravel Weekly 2001 backfill ledger

### DIFF
--- a/data/gravel-weekly/backfill/2001.json
+++ b/data/gravel-weekly/backfill/2001.json
@@ -21,7 +21,7 @@
     "https://autobus.cyclingnews.com/results/?id=2001/dec01: legacy Cyclingnews archive is unavailable"
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -29,257 +29,257 @@
       "periodStartedAt": "2000-12-30",
       "periodEndedAt": "2001-01-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-01-06",
       "periodEndedAt": "2001-01-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-01-13",
       "periodEndedAt": "2001-01-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-01-20",
       "periodEndedAt": "2001-01-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-01-27",
       "periodEndedAt": "2001-02-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-02-03",
       "periodEndedAt": "2001-02-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-02-10",
       "periodEndedAt": "2001-02-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-02-17",
       "periodEndedAt": "2001-02-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-02-24",
       "periodEndedAt": "2001-03-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-03-03",
       "periodEndedAt": "2001-03-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-03-10",
       "periodEndedAt": "2001-03-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-03-17",
       "periodEndedAt": "2001-03-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-03-24",
       "periodEndedAt": "2001-03-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-03-31",
       "periodEndedAt": "2001-04-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-04-07",
       "periodEndedAt": "2001-04-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-04-14",
       "periodEndedAt": "2001-04-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-04-21",
       "periodEndedAt": "2001-04-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-04-28",
       "periodEndedAt": "2001-05-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-05-05",
       "periodEndedAt": "2001-05-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-05-12",
       "periodEndedAt": "2001-05-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-05-19",
       "periodEndedAt": "2001-05-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-05-26",
       "periodEndedAt": "2001-06-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-06-02",
       "periodEndedAt": "2001-06-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-06-09",
       "periodEndedAt": "2001-06-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-06-16",
       "periodEndedAt": "2001-06-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-06-23",
       "periodEndedAt": "2001-06-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-06-30",
       "periodEndedAt": "2001-07-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-07-07",
       "periodEndedAt": "2001-07-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-07-14",
       "periodEndedAt": "2001-07-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-07-21",
       "periodEndedAt": "2001-07-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-07-28",
       "periodEndedAt": "2001-08-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-08-04",
       "periodEndedAt": "2001-08-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-08-11",
@@ -293,162 +293,162 @@
       "periodStartedAt": "2001-08-18",
       "periodEndedAt": "2001-08-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-08-25",
       "periodEndedAt": "2001-08-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-09-01",
       "periodEndedAt": "2001-09-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-09-08",
       "periodEndedAt": "2001-09-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-09-15",
       "periodEndedAt": "2001-09-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-09-22",
       "periodEndedAt": "2001-09-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-09-29",
       "periodEndedAt": "2001-10-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-10-06",
       "periodEndedAt": "2001-10-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-10-13",
       "periodEndedAt": "2001-10-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-10-20",
       "periodEndedAt": "2001-10-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-10-27",
       "periodEndedAt": "2001-11-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-11-03",
       "periodEndedAt": "2001-11-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-11-10",
       "periodEndedAt": "2001-11-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-11-17",
       "periodEndedAt": "2001-11-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-11-24",
       "periodEndedAt": "2001-11-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-12-01",
       "periodEndedAt": "2001-12-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-12-08",
       "periodEndedAt": "2001-12-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-12-15",
       "periodEndedAt": "2001-12-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-12-22",
       "periodEndedAt": "2001-12-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2001-12-29",
       "periodEndedAt": "2002-01-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "The legacy Cyclingnews archive is unavailable for this window; broader recovery across surviving 2001 calendars, result indexes, race reports, and mixed-surface histories found no distinct Gravel Weekly story clearing the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     }
   ],
-  "updatedAt": "2026-08-28T15:20:00Z"
+  "updatedAt": "2026-08-28T23:15:00Z"
 }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -1155,7 +1155,7 @@ def test_2002_backfill_ledger_preserves_partial_archive_limits_without_open_rese
     assert validated["complete"] is True
 
 
-def test_2001_backfill_ledger_rejects_a_redundant_story_without_claiming_archive_coverage():
+def test_2001_backfill_ledger_closes_review_without_claiming_archive_coverage():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2001.json").read_text())
     validated = validate_backfill_ledger(ledger, histories)
@@ -1164,11 +1164,11 @@ def test_2001_backfill_ledger_rejects_a_redundant_story_without_claiming_archive
     assert validated["sourceArchiveCoverage"] == "unavailable"
     assert len(validated["sourceArchiveErrors"]) == 12
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 52
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 0
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 1
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == 53
     assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 0
-    assert validated["complete"] is False
+    assert validated["complete"] is True
 
 
 def test_2000_backfill_ledger_preserves_unavailable_legacy_archive_research_debt():


### PR DESCRIPTION
## Summary
- resolve all 52 remaining 2001 research-debt windows after broader source recovery
- preserve the complete unavailability of the 12 legacy Cyclingnews month indexes
- use reviewed rejections—not explicit gaps—because unavailable archive coverage cannot justify a literal quiet-week claim
- retain the already-rejected 2001 Saturn Classic as redundant with the stronger 2002 chapter

## Editorial result
- 53 weekly windows
- 53 reviewed rejections
- 0 unresearched / pending / held
- 0 new chapters; none cleared the point and consequence gates

## Safety
- `sourceArchiveCoverage` remains `unavailable` with all 12 errors
- `humanApprovalRequired: true`; `autoPublishAllowed: false`
- no race data, editorial approval, publication, or deployment changed

## Verification
- ledger validator passes
- Gravel Weekly tests: 72 passed
- diff whitespace check passes

## Voice sources
- `inbox/gravel-god/i-screwed-up-sbt-grvl-so-you-dont-have-to.md`
- `inbox/substack/racing-is-not-for-pies.md`
- `inbox/gravel-god/listening-to-robert-in-silver-city.md`
- `wattgod/writing-graph/self/voice-and-beliefs-profile.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial backfill metadata and test expectations only; no publication, race data, or runtime behavior changes.
> 
> **Overview**
> Marks the **2001 Gravel Weekly backfill ledger** as **complete** by resolving every remaining weekly window that was still `unresearched`.
> 
> All 52 open windows move to **`rejected`** with reasons that document broader source recovery (calendars, indexes, race reports) and explicitly state this is **not** a “quiet week” claim while **`sourceArchiveCoverage`** stays **`unavailable`** with the 12 legacy Cyclingnews errors. The existing **2001 Saturn Cycling Classic** week stays **`rejected`** as redundant with the 2002 history entry.
> 
> **`tests/test_gravel_weekly.py`** renames and updates the 2001 ledger contract test to expect **53 rejections**, **0 unresearched**, and **`complete: true`** without implying archive coverage was restored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b76868a37c8e85b0ee38cae6bc609b08d8bfc136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->