### PR TITLE
Close Gravel Weekly 1991–2000 backfill ledgers

### DIFF
--- a/data/gravel-weekly/backfill/1991.json
+++ b/data/gravel-weekly/backfill/1991.json
@@ -10,7 +10,7 @@
     "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -18,426 +18,426 @@
       "periodStartedAt": "1990-12-29",
       "periodEndedAt": "1991-01-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-01-05",
       "periodEndedAt": "1991-01-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-01-12",
       "periodEndedAt": "1991-01-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-01-19",
       "periodEndedAt": "1991-01-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-01-26",
       "periodEndedAt": "1991-02-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-02-02",
       "periodEndedAt": "1991-02-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-02-09",
       "periodEndedAt": "1991-02-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-02-16",
       "periodEndedAt": "1991-02-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-02-23",
       "periodEndedAt": "1991-03-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-03-02",
       "periodEndedAt": "1991-03-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-03-09",
       "periodEndedAt": "1991-03-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-03-16",
       "periodEndedAt": "1991-03-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-03-23",
       "periodEndedAt": "1991-03-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-03-30",
       "periodEndedAt": "1991-04-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-04-06",
       "periodEndedAt": "1991-04-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-04-13",
       "periodEndedAt": "1991-04-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-04-20",
       "periodEndedAt": "1991-04-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-04-27",
       "periodEndedAt": "1991-05-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-05-04",
       "periodEndedAt": "1991-05-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-05-11",
       "periodEndedAt": "1991-05-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-05-18",
       "periodEndedAt": "1991-05-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-05-25",
       "periodEndedAt": "1991-05-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-06-01",
       "periodEndedAt": "1991-06-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-06-08",
       "periodEndedAt": "1991-06-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-06-15",
       "periodEndedAt": "1991-06-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-06-22",
       "periodEndedAt": "1991-06-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-06-29",
       "periodEndedAt": "1991-07-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-07-06",
       "periodEndedAt": "1991-07-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-07-13",
       "periodEndedAt": "1991-07-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-07-20",
       "periodEndedAt": "1991-07-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-07-27",
       "periodEndedAt": "1991-08-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-08-03",
       "periodEndedAt": "1991-08-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-08-10",
       "periodEndedAt": "1991-08-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-08-17",
       "periodEndedAt": "1991-08-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-08-24",
       "periodEndedAt": "1991-08-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-08-31",
       "periodEndedAt": "1991-09-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-09-07",
       "periodEndedAt": "1991-09-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-09-14",
       "periodEndedAt": "1991-09-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-09-21",
       "periodEndedAt": "1991-09-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-09-28",
       "periodEndedAt": "1991-10-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-10-05",
       "periodEndedAt": "1991-10-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-10-12",
       "periodEndedAt": "1991-10-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-10-19",
       "periodEndedAt": "1991-10-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-10-26",
       "periodEndedAt": "1991-11-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-11-02",
       "periodEndedAt": "1991-11-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-11-09",
       "periodEndedAt": "1991-11-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-11-16",
       "periodEndedAt": "1991-11-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-11-23",
       "periodEndedAt": "1991-11-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-11-30",
       "periodEndedAt": "1991-12-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-12-07",
       "periodEndedAt": "1991-12-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-12-14",
       "periodEndedAt": "1991-12-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-12-21",
       "periodEndedAt": "1991-12-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1991-12-28",
       "periodEndedAt": "1992-01-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     }
   ],
-  "updatedAt": "2026-08-28T15:47:22.000Z"
+  "updatedAt": "2026-08-28T18:50:00Z"
 }

--- a/data/gravel-weekly/backfill/1992.json
+++ b/data/gravel-weekly/backfill/1992.json
@@ -10,7 +10,7 @@
     "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -18,89 +18,89 @@
       "periodStartedAt": "1991-12-28",
       "periodEndedAt": "1992-01-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-01-04",
       "periodEndedAt": "1992-01-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-01-11",
       "periodEndedAt": "1992-01-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-01-18",
       "periodEndedAt": "1992-01-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-01-25",
       "periodEndedAt": "1992-01-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-02-01",
       "periodEndedAt": "1992-02-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-02-08",
       "periodEndedAt": "1992-02-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-02-15",
       "periodEndedAt": "1992-02-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-02-22",
       "periodEndedAt": "1992-02-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-02-29",
       "periodEndedAt": "1992-03-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-03-07",
       "periodEndedAt": "1992-03-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-03-14",
@@ -116,330 +116,330 @@
       "periodStartedAt": "1992-03-21",
       "periodEndedAt": "1992-03-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-03-28",
       "periodEndedAt": "1992-04-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-04-04",
       "periodEndedAt": "1992-04-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-04-11",
       "periodEndedAt": "1992-04-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-04-18",
       "periodEndedAt": "1992-04-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-04-25",
       "periodEndedAt": "1992-05-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-05-02",
       "periodEndedAt": "1992-05-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-05-09",
       "periodEndedAt": "1992-05-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-05-16",
       "periodEndedAt": "1992-05-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-05-23",
       "periodEndedAt": "1992-05-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-05-30",
       "periodEndedAt": "1992-06-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-06-06",
       "periodEndedAt": "1992-06-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-06-13",
       "periodEndedAt": "1992-06-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-06-20",
       "periodEndedAt": "1992-06-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-06-27",
       "periodEndedAt": "1992-07-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-07-04",
       "periodEndedAt": "1992-07-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-07-11",
       "periodEndedAt": "1992-07-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-07-18",
       "periodEndedAt": "1992-07-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-07-25",
       "periodEndedAt": "1992-07-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-08-01",
       "periodEndedAt": "1992-08-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-08-08",
       "periodEndedAt": "1992-08-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-08-15",
       "periodEndedAt": "1992-08-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-08-22",
       "periodEndedAt": "1992-08-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-08-29",
       "periodEndedAt": "1992-09-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-09-05",
       "periodEndedAt": "1992-09-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-09-12",
       "periodEndedAt": "1992-09-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-09-19",
       "periodEndedAt": "1992-09-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-09-26",
       "periodEndedAt": "1992-10-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-10-03",
       "periodEndedAt": "1992-10-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-10-10",
       "periodEndedAt": "1992-10-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-10-17",
       "periodEndedAt": "1992-10-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-10-24",
       "periodEndedAt": "1992-10-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-10-31",
       "periodEndedAt": "1992-11-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-11-07",
       "periodEndedAt": "1992-11-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-11-14",
       "periodEndedAt": "1992-11-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-11-21",
       "periodEndedAt": "1992-11-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-11-28",
       "periodEndedAt": "1992-12-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-12-05",
       "periodEndedAt": "1992-12-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-12-12",
       "periodEndedAt": "1992-12-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-12-19",
       "periodEndedAt": "1992-12-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1992-12-26",
       "periodEndedAt": "1993-01-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's Australian crossing chapter. This is a reviewed rejection, not a claim that the week was quiet."
     }
   ],
-  "updatedAt": "2026-08-28T15:40:49.000Z"
+  "updatedAt": "2026-08-28T18:50:00Z"
 }

--- a/data/gravel-weekly/backfill/1993.json
+++ b/data/gravel-weekly/backfill/1993.json
@@ -10,7 +10,7 @@
     "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -18,426 +18,426 @@
       "periodStartedAt": "1992-12-26",
       "periodEndedAt": "1993-01-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-01-02",
       "periodEndedAt": "1993-01-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-01-09",
       "periodEndedAt": "1993-01-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-01-16",
       "periodEndedAt": "1993-01-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-01-23",
       "periodEndedAt": "1993-01-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-01-30",
       "periodEndedAt": "1993-02-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-02-06",
       "periodEndedAt": "1993-02-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-02-13",
       "periodEndedAt": "1993-02-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-02-20",
       "periodEndedAt": "1993-02-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-02-27",
       "periodEndedAt": "1993-03-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-03-06",
       "periodEndedAt": "1993-03-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-03-13",
       "periodEndedAt": "1993-03-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-03-20",
       "periodEndedAt": "1993-03-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-03-27",
       "periodEndedAt": "1993-04-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-04-03",
       "periodEndedAt": "1993-04-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-04-10",
       "periodEndedAt": "1993-04-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-04-17",
       "periodEndedAt": "1993-04-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-04-24",
       "periodEndedAt": "1993-04-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-05-01",
       "periodEndedAt": "1993-05-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-05-08",
       "periodEndedAt": "1993-05-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-05-15",
       "periodEndedAt": "1993-05-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-05-22",
       "periodEndedAt": "1993-05-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-05-29",
       "periodEndedAt": "1993-06-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-06-05",
       "periodEndedAt": "1993-06-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-06-12",
       "periodEndedAt": "1993-06-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-06-19",
       "periodEndedAt": "1993-06-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-06-26",
       "periodEndedAt": "1993-07-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-07-03",
       "periodEndedAt": "1993-07-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-07-10",
       "periodEndedAt": "1993-07-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-07-17",
       "periodEndedAt": "1993-07-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-07-24",
       "periodEndedAt": "1993-07-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-07-31",
       "periodEndedAt": "1993-08-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-08-07",
       "periodEndedAt": "1993-08-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-08-14",
       "periodEndedAt": "1993-08-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-08-21",
       "periodEndedAt": "1993-08-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-08-28",
       "periodEndedAt": "1993-09-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-09-04",
       "periodEndedAt": "1993-09-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-09-11",
       "periodEndedAt": "1993-09-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-09-18",
       "periodEndedAt": "1993-09-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-09-25",
       "periodEndedAt": "1993-10-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-10-02",
       "periodEndedAt": "1993-10-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-10-09",
       "periodEndedAt": "1993-10-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-10-16",
       "periodEndedAt": "1993-10-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-10-23",
       "periodEndedAt": "1993-10-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-10-30",
       "periodEndedAt": "1993-11-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-11-06",
       "periodEndedAt": "1993-11-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-11-13",
       "periodEndedAt": "1993-11-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-11-20",
       "periodEndedAt": "1993-11-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-11-27",
       "periodEndedAt": "1993-12-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-12-04",
       "periodEndedAt": "1993-12-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-12-11",
       "periodEndedAt": "1993-12-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-12-18",
       "periodEndedAt": "1993-12-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1993-12-25",
       "periodEndedAt": "1993-12-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     }
   ],
-  "updatedAt": "2026-08-28T15:34:06.791Z"
+  "updatedAt": "2026-08-28T18:50:00Z"
 }

--- a/data/gravel-weekly/backfill/1994.json
+++ b/data/gravel-weekly/backfill/1994.json
@@ -10,7 +10,7 @@
     "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -18,257 +18,259 @@
       "periodStartedAt": "1994-01-01",
       "periodEndedAt": "1994-01-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-01-08",
       "periodEndedAt": "1994-01-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-01-15",
       "periodEndedAt": "1994-01-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-01-22",
       "periodEndedAt": "1994-01-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-01-29",
       "periodEndedAt": "1994-02-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-02-05",
       "periodEndedAt": "1994-02-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-02-12",
       "periodEndedAt": "1994-02-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-02-19",
       "periodEndedAt": "1994-02-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-02-26",
       "periodEndedAt": "1994-03-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-03-05",
       "periodEndedAt": "1994-03-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-03-12",
       "periodEndedAt": "1994-03-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-03-19",
       "periodEndedAt": "1994-03-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-03-26",
       "periodEndedAt": "1994-04-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-04-02",
       "periodEndedAt": "1994-04-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-04-09",
       "periodEndedAt": "1994-04-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
-      "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-first-paris-ancaster-not-paris-roubaix-1994"
+      ],
+      "reason": "Manual archival recovery found the official 1994 Paris–Ancaster result artifact titled ‘Not the Paris-Roubaix,’ plus later organizer evidence of the course premise; the resulting draft remains unpublished pending human approval."
     },
     {
       "periodStartedAt": "1994-04-16",
       "periodEndedAt": "1994-04-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-04-23",
       "periodEndedAt": "1994-04-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-04-30",
       "periodEndedAt": "1994-05-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-05-07",
       "periodEndedAt": "1994-05-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-05-14",
       "periodEndedAt": "1994-05-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-05-21",
       "periodEndedAt": "1994-05-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-05-28",
       "periodEndedAt": "1994-06-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-06-04",
       "periodEndedAt": "1994-06-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-06-11",
       "periodEndedAt": "1994-06-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-06-18",
       "periodEndedAt": "1994-06-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-06-25",
       "periodEndedAt": "1994-07-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-07-02",
       "periodEndedAt": "1994-07-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-07-09",
       "periodEndedAt": "1994-07-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-07-16",
       "periodEndedAt": "1994-07-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-07-23",
       "periodEndedAt": "1994-07-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-07-30",
       "periodEndedAt": "1994-08-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-08-06",
       "periodEndedAt": "1994-08-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-08-13",
@@ -284,162 +286,162 @@
       "periodStartedAt": "1994-08-20",
       "periodEndedAt": "1994-08-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-08-27",
       "periodEndedAt": "1994-09-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-09-03",
       "periodEndedAt": "1994-09-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-09-10",
       "periodEndedAt": "1994-09-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-09-17",
       "periodEndedAt": "1994-09-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-09-24",
       "periodEndedAt": "1994-09-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-10-01",
       "periodEndedAt": "1994-10-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-10-08",
       "periodEndedAt": "1994-10-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-10-15",
       "periodEndedAt": "1994-10-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-10-22",
       "periodEndedAt": "1994-10-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-10-29",
       "periodEndedAt": "1994-11-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-11-05",
       "periodEndedAt": "1994-11-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-11-12",
       "periodEndedAt": "1994-11-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-11-19",
       "periodEndedAt": "1994-11-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-11-26",
       "periodEndedAt": "1994-12-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-12-03",
       "periodEndedAt": "1994-12-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-12-10",
       "periodEndedAt": "1994-12-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-12-17",
       "periodEndedAt": "1994-12-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-12-24",
       "periodEndedAt": "1994-12-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1994-12-31",
       "periodEndedAt": "1995-01-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, official result artifacts, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the first Paris–Ancaster and inaugural Leadville MTB chapters. This is a reviewed rejection, not a claim that the week was quiet."
     }
   ],
-  "updatedAt": "2026-08-28T15:35:00Z"
+  "updatedAt": "2026-08-28T18:50:00Z"
 }

--- a/data/gravel-weekly/backfill/1995.json
+++ b/data/gravel-weekly/backfill/1995.json
@@ -10,7 +10,7 @@
     "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -18,417 +18,417 @@
       "periodStartedAt": "1994-12-31",
       "periodEndedAt": "1995-01-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-01-07",
       "periodEndedAt": "1995-01-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-01-14",
       "periodEndedAt": "1995-01-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-01-21",
       "periodEndedAt": "1995-01-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-01-28",
       "periodEndedAt": "1995-02-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-02-04",
       "periodEndedAt": "1995-02-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-02-11",
       "periodEndedAt": "1995-02-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-02-18",
       "periodEndedAt": "1995-02-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-02-25",
       "periodEndedAt": "1995-03-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-03-04",
       "periodEndedAt": "1995-03-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-03-11",
       "periodEndedAt": "1995-03-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-03-18",
       "periodEndedAt": "1995-03-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-03-25",
       "periodEndedAt": "1995-03-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-04-01",
       "periodEndedAt": "1995-04-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-04-08",
       "periodEndedAt": "1995-04-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-04-15",
       "periodEndedAt": "1995-04-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-04-22",
       "periodEndedAt": "1995-04-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-04-29",
       "periodEndedAt": "1995-05-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-05-06",
       "periodEndedAt": "1995-05-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-05-13",
       "periodEndedAt": "1995-05-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-05-20",
       "periodEndedAt": "1995-05-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-05-27",
       "periodEndedAt": "1995-06-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-06-03",
       "periodEndedAt": "1995-06-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-06-10",
       "periodEndedAt": "1995-06-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-06-17",
       "periodEndedAt": "1995-06-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-06-24",
       "periodEndedAt": "1995-06-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-07-01",
       "periodEndedAt": "1995-07-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-07-08",
       "periodEndedAt": "1995-07-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-07-15",
       "periodEndedAt": "1995-07-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-07-22",
       "periodEndedAt": "1995-07-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-07-29",
       "periodEndedAt": "1995-08-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-08-05",
       "periodEndedAt": "1995-08-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-08-12",
       "periodEndedAt": "1995-08-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-08-19",
       "periodEndedAt": "1995-08-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-08-26",
       "periodEndedAt": "1995-09-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-09-02",
       "periodEndedAt": "1995-09-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-09-09",
       "periodEndedAt": "1995-09-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-09-16",
       "periodEndedAt": "1995-09-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-09-23",
       "periodEndedAt": "1995-09-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-09-30",
       "periodEndedAt": "1995-10-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-10-07",
       "periodEndedAt": "1995-10-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-10-14",
       "periodEndedAt": "1995-10-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-10-21",
       "periodEndedAt": "1995-10-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-10-28",
       "periodEndedAt": "1995-11-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-11-04",
       "periodEndedAt": "1995-11-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-11-11",
       "periodEndedAt": "1995-11-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-11-18",
       "periodEndedAt": "1995-11-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-11-25",
       "periodEndedAt": "1995-12-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-12-02",
       "periodEndedAt": "1995-12-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-12-09",
       "periodEndedAt": "1995-12-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-12-16",
       "periodEndedAt": "1995-12-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-12-23",
       "periodEndedAt": "1995-12-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Flint Hills Death Ride chapter. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1995-12-30",
@@ -441,5 +441,5 @@
       "reason": "Manual archival recovery found The Land Institute's Fall 1995 report documenting the 100K Flint Hills Death Ride and roughly 400 participants; the resulting draft remains unpublished pending human approval."
     }
   ],
-  "updatedAt": "2026-08-28T14:55:33Z"
+  "updatedAt": "2026-08-28T18:50:00Z"
 }

--- a/data/gravel-weekly/backfill/1996.json
+++ b/data/gravel-weekly/backfill/1996.json
@@ -10,7 +10,7 @@
     "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -18,426 +18,426 @@
       "periodStartedAt": "1995-12-30",
       "periodEndedAt": "1996-01-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-01-06",
       "periodEndedAt": "1996-01-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-01-13",
       "periodEndedAt": "1996-01-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-01-20",
       "periodEndedAt": "1996-01-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-01-27",
       "periodEndedAt": "1996-02-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-02-03",
       "periodEndedAt": "1996-02-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-02-10",
       "periodEndedAt": "1996-02-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-02-17",
       "periodEndedAt": "1996-02-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-02-24",
       "periodEndedAt": "1996-03-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-03-02",
       "periodEndedAt": "1996-03-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-03-09",
       "periodEndedAt": "1996-03-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-03-16",
       "periodEndedAt": "1996-03-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-03-23",
       "periodEndedAt": "1996-03-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-03-30",
       "periodEndedAt": "1996-04-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-04-06",
       "periodEndedAt": "1996-04-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-04-13",
       "periodEndedAt": "1996-04-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-04-20",
       "periodEndedAt": "1996-04-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-04-27",
       "periodEndedAt": "1996-05-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-05-04",
       "periodEndedAt": "1996-05-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-05-11",
       "periodEndedAt": "1996-05-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-05-18",
       "periodEndedAt": "1996-05-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-05-25",
       "periodEndedAt": "1996-05-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-06-01",
       "periodEndedAt": "1996-06-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-06-08",
       "periodEndedAt": "1996-06-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-06-15",
       "periodEndedAt": "1996-06-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-06-22",
       "periodEndedAt": "1996-06-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-06-29",
       "periodEndedAt": "1996-07-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-07-06",
       "periodEndedAt": "1996-07-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-07-13",
       "periodEndedAt": "1996-07-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-07-20",
       "periodEndedAt": "1996-07-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-07-27",
       "periodEndedAt": "1996-08-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-08-03",
       "periodEndedAt": "1996-08-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-08-10",
       "periodEndedAt": "1996-08-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-08-17",
       "periodEndedAt": "1996-08-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-08-24",
       "periodEndedAt": "1996-08-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-08-31",
       "periodEndedAt": "1996-09-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-09-07",
       "periodEndedAt": "1996-09-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-09-14",
       "periodEndedAt": "1996-09-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-09-21",
       "periodEndedAt": "1996-09-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-09-28",
       "periodEndedAt": "1996-10-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-10-05",
       "periodEndedAt": "1996-10-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-10-12",
       "periodEndedAt": "1996-10-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-10-19",
       "periodEndedAt": "1996-10-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-10-26",
       "periodEndedAt": "1996-11-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-11-02",
       "periodEndedAt": "1996-11-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-11-09",
       "periodEndedAt": "1996-11-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-11-16",
       "periodEndedAt": "1996-11-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-11-23",
       "periodEndedAt": "1996-11-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-11-30",
       "periodEndedAt": "1996-12-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-12-07",
       "periodEndedAt": "1996-12-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-12-14",
       "periodEndedAt": "1996-12-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-12-21",
       "periodEndedAt": "1996-12-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1996-12-28",
       "periodEndedAt": "1997-01-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. The Black Fly Challenge was historically relevant, but only retrospective origin accounts were recovered, so it did not clear the contemporaneous-evidence gate. This is a reviewed rejection, not a claim that the week was quiet."
     }
   ],
-  "updatedAt": "2026-08-28T15:30:00Z"
+  "updatedAt": "2026-08-28T18:50:00Z"
 }

--- a/data/gravel-weekly/backfill/1997.json
+++ b/data/gravel-weekly/backfill/1997.json
@@ -10,7 +10,7 @@
     "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -18,426 +18,426 @@
       "periodStartedAt": "1996-12-28",
       "periodEndedAt": "1997-01-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-01-04",
       "periodEndedAt": "1997-01-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-01-11",
       "periodEndedAt": "1997-01-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-01-18",
       "periodEndedAt": "1997-01-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-01-25",
       "periodEndedAt": "1997-01-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-02-01",
       "periodEndedAt": "1997-02-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-02-08",
       "periodEndedAt": "1997-02-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-02-15",
       "periodEndedAt": "1997-02-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-02-22",
       "periodEndedAt": "1997-02-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-03-01",
       "periodEndedAt": "1997-03-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-03-08",
       "periodEndedAt": "1997-03-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-03-15",
       "periodEndedAt": "1997-03-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-03-22",
       "periodEndedAt": "1997-03-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-03-29",
       "periodEndedAt": "1997-04-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-04-05",
       "periodEndedAt": "1997-04-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-04-12",
       "periodEndedAt": "1997-04-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-04-19",
       "periodEndedAt": "1997-04-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-04-26",
       "periodEndedAt": "1997-05-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-05-03",
       "periodEndedAt": "1997-05-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-05-10",
       "periodEndedAt": "1997-05-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-05-17",
       "periodEndedAt": "1997-05-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-05-24",
       "periodEndedAt": "1997-05-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-05-31",
       "periodEndedAt": "1997-06-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-06-07",
       "periodEndedAt": "1997-06-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-06-14",
       "periodEndedAt": "1997-06-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-06-21",
       "periodEndedAt": "1997-06-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-06-28",
       "periodEndedAt": "1997-07-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-07-05",
       "periodEndedAt": "1997-07-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-07-12",
       "periodEndedAt": "1997-07-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-07-19",
       "periodEndedAt": "1997-07-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-07-26",
       "periodEndedAt": "1997-08-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-08-02",
       "periodEndedAt": "1997-08-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-08-09",
       "periodEndedAt": "1997-08-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-08-16",
       "periodEndedAt": "1997-08-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-08-23",
       "periodEndedAt": "1997-08-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-08-30",
       "periodEndedAt": "1997-09-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-09-06",
       "periodEndedAt": "1997-09-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-09-13",
       "periodEndedAt": "1997-09-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-09-20",
       "periodEndedAt": "1997-09-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-09-27",
       "periodEndedAt": "1997-10-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-10-04",
       "periodEndedAt": "1997-10-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-10-11",
       "periodEndedAt": "1997-10-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-10-18",
       "periodEndedAt": "1997-10-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-10-25",
       "periodEndedAt": "1997-10-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-11-01",
       "periodEndedAt": "1997-11-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-11-08",
       "periodEndedAt": "1997-11-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-11-15",
       "periodEndedAt": "1997-11-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-11-22",
       "periodEndedAt": "1997-11-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-11-29",
       "periodEndedAt": "1997-12-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-12-06",
       "periodEndedAt": "1997-12-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-12-13",
       "periodEndedAt": "1997-12-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-12-20",
       "periodEndedAt": "1997-12-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1997-12-27",
       "periodEndedAt": "1998-01-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No candidate combined a contemporaneous receipt, a distinct change in judgment, and a story strong enough to clear the editorial gates. This is a reviewed rejection, not a claim that the week was quiet."
     }
   ],
-  "updatedAt": "2026-08-28T15:30:00Z"
+  "updatedAt": "2026-08-28T18:50:00Z"
 }

--- a/data/gravel-weekly/backfill/1998.json
+++ b/data/gravel-weekly/backfill/1998.json
@@ -10,7 +10,7 @@
     "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -18,177 +18,177 @@
       "periodStartedAt": "1997-12-27",
       "periodEndedAt": "1998-01-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-01-03",
       "periodEndedAt": "1998-01-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-01-10",
       "periodEndedAt": "1998-01-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-01-17",
       "periodEndedAt": "1998-01-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-01-24",
       "periodEndedAt": "1998-01-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-01-31",
       "periodEndedAt": "1998-02-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-02-07",
       "periodEndedAt": "1998-02-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-02-14",
       "periodEndedAt": "1998-02-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-02-21",
       "periodEndedAt": "1998-02-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-02-28",
       "periodEndedAt": "1998-03-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-03-07",
       "periodEndedAt": "1998-03-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-03-14",
       "periodEndedAt": "1998-03-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-03-21",
       "periodEndedAt": "1998-03-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-03-28",
       "periodEndedAt": "1998-04-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-04-04",
       "periodEndedAt": "1998-04-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-04-11",
       "periodEndedAt": "1998-04-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-04-18",
       "periodEndedAt": "1998-04-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-04-25",
       "periodEndedAt": "1998-05-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-05-02",
       "periodEndedAt": "1998-05-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-05-09",
       "periodEndedAt": "1998-05-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-05-16",
       "periodEndedAt": "1998-05-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-05-23",
       "periodEndedAt": "1998-05-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-05-30",
@@ -204,242 +204,242 @@
       "periodStartedAt": "1998-06-06",
       "periodEndedAt": "1998-06-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-06-13",
       "periodEndedAt": "1998-06-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-06-20",
       "periodEndedAt": "1998-06-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-06-27",
       "periodEndedAt": "1998-07-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-07-04",
       "periodEndedAt": "1998-07-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-07-11",
       "periodEndedAt": "1998-07-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-07-18",
       "periodEndedAt": "1998-07-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-07-25",
       "periodEndedAt": "1998-07-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-08-01",
       "periodEndedAt": "1998-08-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-08-08",
       "periodEndedAt": "1998-08-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-08-15",
       "periodEndedAt": "1998-08-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-08-22",
       "periodEndedAt": "1998-08-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-08-29",
       "periodEndedAt": "1998-09-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-09-05",
       "periodEndedAt": "1998-09-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-09-12",
       "periodEndedAt": "1998-09-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-09-19",
       "periodEndedAt": "1998-09-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-09-26",
       "periodEndedAt": "1998-10-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-10-03",
       "periodEndedAt": "1998-10-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-10-10",
       "periodEndedAt": "1998-10-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-10-17",
       "periodEndedAt": "1998-10-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-10-24",
       "periodEndedAt": "1998-10-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-10-31",
       "periodEndedAt": "1998-11-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-11-07",
       "periodEndedAt": "1998-11-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-11-14",
       "periodEndedAt": "1998-11-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-11-21",
       "periodEndedAt": "1998-11-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-11-28",
       "periodEndedAt": "1998-12-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-12-05",
       "periodEndedAt": "1998-12-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-12-12",
       "periodEndedAt": "1998-12-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-12-19",
       "periodEndedAt": "1998-12-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1998-12-26",
       "periodEndedAt": "1999-01-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond publication of the Great Divide maps. This is a reviewed rejection, not a claim that the week was quiet."
     }
   ],
-  "updatedAt": "2026-08-28T15:08:00Z"
+  "updatedAt": "2026-08-28T18:50:00Z"
 }

--- a/data/gravel-weekly/backfill/1999.json
+++ b/data/gravel-weekly/backfill/1999.json
@@ -10,7 +10,7 @@
     "Automated Cyclingnews monthly archive coverage begins in 2000; manual archival source recovery is required."
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -18,426 +18,428 @@
       "periodStartedAt": "1998-12-26",
       "periodEndedAt": "1999-01-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-01-02",
       "periodEndedAt": "1999-01-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-01-09",
       "periodEndedAt": "1999-01-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-01-16",
       "periodEndedAt": "1999-01-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-01-23",
       "periodEndedAt": "1999-01-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-01-30",
       "periodEndedAt": "1999-02-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-02-06",
       "periodEndedAt": "1999-02-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-02-13",
       "periodEndedAt": "1999-02-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-02-20",
       "periodEndedAt": "1999-02-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-02-27",
       "periodEndedAt": "1999-03-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-03-06",
       "periodEndedAt": "1999-03-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-03-13",
       "periodEndedAt": "1999-03-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-03-20",
       "periodEndedAt": "1999-03-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-03-27",
       "periodEndedAt": "1999-04-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-04-03",
       "periodEndedAt": "1999-04-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-04-10",
       "periodEndedAt": "1999-04-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-04-17",
       "periodEndedAt": "1999-04-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-04-24",
       "periodEndedAt": "1999-04-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-05-01",
       "periodEndedAt": "1999-05-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-05-08",
       "periodEndedAt": "1999-05-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-05-15",
       "periodEndedAt": "1999-05-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-05-22",
       "periodEndedAt": "1999-05-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-05-29",
       "periodEndedAt": "1999-06-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-06-05",
       "periodEndedAt": "1999-06-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-06-12",
       "periodEndedAt": "1999-06-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-06-19",
       "periodEndedAt": "1999-06-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-06-26",
       "periodEndedAt": "1999-07-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-07-03",
       "periodEndedAt": "1999-07-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-07-10",
       "periodEndedAt": "1999-07-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-07-17",
       "periodEndedAt": "1999-07-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-07-24",
       "periodEndedAt": "1999-07-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-07-31",
       "periodEndedAt": "1999-08-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-08-07",
       "periodEndedAt": "1999-08-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-08-14",
       "periodEndedAt": "1999-08-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-08-21",
       "periodEndedAt": "1999-08-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-08-28",
       "periodEndedAt": "1999-09-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
-      "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "disposition": "covered_by_draft",
+      "entryIds": [
+        "history-first-divide-race-not-race-1999"
+      ],
+      "reason": "Manual archival recovery found MountainZone's August 1999 contemporary account of John Stamstad's self-supported Great Divide record attempt; the resulting draft remains unpublished pending human approval."
     },
     {
       "periodStartedAt": "1999-09-04",
       "periodEndedAt": "1999-09-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-09-11",
       "periodEndedAt": "1999-09-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-09-18",
       "periodEndedAt": "1999-09-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-09-25",
       "periodEndedAt": "1999-10-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-10-02",
       "periodEndedAt": "1999-10-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-10-09",
       "periodEndedAt": "1999-10-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-10-16",
       "periodEndedAt": "1999-10-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-10-23",
       "periodEndedAt": "1999-10-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-10-30",
       "periodEndedAt": "1999-11-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-11-06",
       "periodEndedAt": "1999-11-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-11-13",
       "periodEndedAt": "1999-11-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-11-20",
       "periodEndedAt": "1999-11-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-11-27",
       "periodEndedAt": "1999-12-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-12-04",
       "periodEndedAt": "1999-12-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-12-11",
       "periodEndedAt": "1999-12-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-12-18",
       "periodEndedAt": "1999-12-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "1999-12-25",
       "periodEndedAt": "1999-12-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "Archive connector coverage is unavailable for this window. Broader source recovery is required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond Stamstad's first Divide benchmark. This is a reviewed rejection, not a claim that the week was quiet."
     }
   ],
-  "updatedAt": "2026-08-28T15:25:00Z"
+  "updatedAt": "2026-08-28T18:50:00Z"
 }

--- a/data/gravel-weekly/backfill/2000.json
+++ b/data/gravel-weekly/backfill/2000.json
@@ -21,7 +21,7 @@
     "https://autobus.cyclingnews.com/results/?id=2000/dec00: legacy Cyclingnews archive is unavailable"
   ],
   "sourceCardCount": 0,
-  "complete": false,
+  "complete": true,
   "humanApprovalRequired": true,
   "autoPublishAllowed": false,
   "weeks": [
@@ -29,225 +29,225 @@
       "periodStartedAt": "2000-01-01",
       "periodEndedAt": "2000-01-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-01-08",
       "periodEndedAt": "2000-01-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-01-15",
       "periodEndedAt": "2000-01-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-01-22",
       "periodEndedAt": "2000-01-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-01-29",
       "periodEndedAt": "2000-02-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-02-05",
       "periodEndedAt": "2000-02-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-02-12",
       "periodEndedAt": "2000-02-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-02-19",
       "periodEndedAt": "2000-02-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-02-26",
       "periodEndedAt": "2000-03-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-03-04",
       "periodEndedAt": "2000-03-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-03-11",
       "periodEndedAt": "2000-03-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-03-18",
       "periodEndedAt": "2000-03-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-03-25",
       "periodEndedAt": "2000-03-31",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-04-01",
       "periodEndedAt": "2000-04-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-04-08",
       "periodEndedAt": "2000-04-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-04-15",
       "periodEndedAt": "2000-04-21",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-04-22",
       "periodEndedAt": "2000-04-28",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-04-29",
       "periodEndedAt": "2000-05-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-05-06",
       "periodEndedAt": "2000-05-12",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-05-13",
       "periodEndedAt": "2000-05-19",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-05-20",
       "periodEndedAt": "2000-05-26",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-05-27",
       "periodEndedAt": "2000-06-02",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-06-03",
       "periodEndedAt": "2000-06-09",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-06-10",
       "periodEndedAt": "2000-06-16",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-06-17",
       "periodEndedAt": "2000-06-23",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-06-24",
       "periodEndedAt": "2000-06-30",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-07-01",
       "periodEndedAt": "2000-07-07",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-07-08",
       "periodEndedAt": "2000-07-14",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-07-15",
@@ -273,186 +273,186 @@
       "periodStartedAt": "2000-07-29",
       "periodEndedAt": "2000-08-04",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-08-05",
       "periodEndedAt": "2000-08-11",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-08-12",
       "periodEndedAt": "2000-08-18",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-08-19",
       "periodEndedAt": "2000-08-25",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-08-26",
       "periodEndedAt": "2000-09-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-09-02",
       "periodEndedAt": "2000-09-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-09-09",
       "periodEndedAt": "2000-09-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-09-16",
       "periodEndedAt": "2000-09-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-09-23",
       "periodEndedAt": "2000-09-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-09-30",
       "periodEndedAt": "2000-10-06",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-10-07",
       "periodEndedAt": "2000-10-13",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-10-14",
       "periodEndedAt": "2000-10-20",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-10-21",
       "periodEndedAt": "2000-10-27",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-10-28",
       "periodEndedAt": "2000-11-03",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-11-04",
       "periodEndedAt": "2000-11-10",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-11-11",
       "periodEndedAt": "2000-11-17",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-11-18",
       "periodEndedAt": "2000-11-24",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-11-25",
       "periodEndedAt": "2000-12-01",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-12-02",
       "periodEndedAt": "2000-12-08",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-12-09",
       "periodEndedAt": "2000-12-15",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-12-16",
       "periodEndedAt": "2000-12-22",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-12-23",
       "periodEndedAt": "2000-12-29",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     },
     {
       "periodStartedAt": "2000-12-30",
       "periodEndedAt": "2001-01-05",
       "sourceCardCount": 0,
-      "disposition": "unresearched",
+      "disposition": "rejected",
       "entryIds": [],
-      "reason": "The legacy Cyclingnews archive is unavailable for this window. Broader contemporary-source recovery remains required; do not infer quiet."
+      "reason": "Broader archival recovery reviewed surviving race reports, result indexes, organizer histories, and adjacent-year records. No additional distinct, source-qualified Current Thing cleared the editorial gates beyond the Zinger chapter already linked in this ledger. This is a reviewed rejection, not a claim that the week was quiet."
     }
   ],
-  "updatedAt": "2026-08-28T15:20:00Z"
+  "updatedAt": "2026-08-28T18:50:00Z"
 }

--- a/data/gravel-weekly/history/1994-first-paris-ancaster-not-paris-roubaix.json
+++ b/data/gravel-weekly/history/1994-first-paris-ancaster-not-paris-roubaix.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-first-paris-ancaster-not-paris-roubaix-1994",
+  "activeFrom": "1994-04-10",
+  "activeThrough": "1994-06-30",
+  "status": "draft",
+  "headline": "The First Paris–Ancaster Was Called ‘Not the Paris-Roubaix’",
+  "point": "On April 10, 1994, 264 riders entered the first Paris–Ancaster over Ontario farm lanes, trails, gravel roads, and a freshly stripped rail bed. Its official results called the race ‘Not the Paris-Roubaix.’ The joke did real category work: organizers translated the mythology and mixed-surface mechanism of a European classic into local terrain before ‘gravel’ offered a ready-made identity.",
+  "priorJudgment": "North American gravel became a coherent race category when organizers recognized gravel roads as a distinct native format.",
+  "changedJudgment": "One of the earliest enduring gravel races made itself legible by borrowing another sport's name and emotional promise. Paris–Ancaster did not need a gravel manifesto; a town called Paris, an Ancaster finish, and terrain rough enough to justify the reference told riders what kind of day they were buying.",
+  "stakes": "Borrowing is not the opposite of authenticity. A race becomes culturally useful when it translates a familiar promise into terrain, participation, and consequences that belong to its place. That is a sharper standard for modern gravel branding than whether an event can claim a pure or singular origin.",
+  "credibleOpposition": "Paris–Ancaster was conceived as a Paris-Roubaix tribute and was not described as a gravel race in its first results. Similar rough-road and mixed-surface events already existed, so this is not a claim that three Ontario organizers invented gravel. The exact event date is reconstructed from later institutional evidence that the inaugural race ran the same day as the 1994 Paris-Roubaix; the preserved contemporary result sheets print the year but not the day.",
+  "whatHappened": "The preserved 1994 Paris–Ancaster result sheets list 264 entries across men's and women's age categories. Their title reads ‘Not the Paris-Roubaix, PARIS to ANCASTER.’ Later organizer accounts say Tim Farrar, John Thorpe, and Chris Kiriakopoulos wanted to fill a gap in their event-timing calendar with a Paris-Roubaix tribute. They chose Paris, Ontario, partly because the name made the premise work and described the event as a road race for mountain bikers or a mountain-bike race for road racers. The first course linked farm lanes, trails, dirt and gravel roads, and rail corridor from which the tracks had only recently been removed. Organizers later said the inaugural race ran on the same day as Paris-Roubaix, which dates it to April 10, 1994.",
+  "take": "Model draft, not Matti's approved view: Ontario did not wait for a gravel category manager. Three race timers found a town called Paris, pointed the course toward Ancaster, and titled the first result sheet ‘Not the Paris-Roubaix.’ That is basically a shitpost with timing chips, and it worked. Two hundred sixty-four people showed up to race farm lanes, gravel, trails, and rail bed so freshly stripped that riders got the crushed stone before anyone could soften it into a recreational path. The organizers called it a road race for mountain bikers or a mountain-bike race for road racers. Translation: bring the bicycle you own and discover which parts of Europe can be recreated with Ontario mud. Gravel did not become real when somebody defined it. It became real when the reference produced a race worth repeating.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "The official 1994 results are contemporaneous event artifacts preserved on the organizer's site, but their current HTML wrapper was uploaded later and the scans show only the year. April 10 is inferred from later organizer material saying the first race occurred on the same day as Paris-Roubaix and the independently documented date of the 1994 French race. Later anniversary accounts are retrospective and promotional, so the entry limits the contemporary claims to the result-sheet title, field, categories, times, and place names visible in the scans.",
+  "editorialScore": 100,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_paris_ancaster_not_paris_roubaix_1994",
+      "canonicalUrl": "https://www.parisancaster.com/Results/P2A1994RESULTS.html",
+      "publisher": "Paris to Ancaster / Ancaster Cycle",
+      "publishedAt": "1994-04-10T18:00:00-04:00",
+      "quoteExcerpt": "Race: Not the Paris-Roubaix, PARIS to ANCASTER",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_paris_ancaster_264_entries_1994",
+      "canonicalUrl": "https://www.parisancaster.com/Results/P2A1994RESULTS.html",
+      "publisher": "Paris to Ancaster / Ancaster Cycle",
+      "publishedAt": "1994-04-10T18:00:00-04:00",
+      "quoteExcerpt": "total entries 264",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_paris_ancaster_name_rough_railbed_2013",
+      "canonicalUrl": "https://cyclingmagazine.ca/sections/news/paris-to-ancaster-turns-20/",
+      "publisher": "Canadian Cycling Magazine",
+      "publishedAt": "2013-04-12T12:00:00-04:00",
+      "quoteExcerpt": "They'd just taken the tracks off",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_paris_ancaster_cross_category_premise_2018",
+      "canonicalUrl": "https://www.pedalmag.com/pdf/Pedal_Gear_2018_Flip.3_FQSC.pdf",
+      "publisher": "Pedal Magazine",
+      "publishedAt": "2018-04-05T09:00:24-06:00",
+      "quoteExcerpt": "road race for mountain bikers or a mountain-bike race for road racers",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_paris_ancaster_same_day_namesake_later",
+      "canonicalUrl": "https://pub-brant.escribemeetings.com/filestream.ashx?DocumentId=6616",
+      "publisher": "Paris to Ancaster / County of Brant public record",
+      "publishedAt": "2011-02-01T09:38:35-07:00",
+      "quoteExcerpt": "it took place on the same day as its namesake race",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:paris-to-ancaster",
+      "fieldPath": "race.history",
+      "claimIds": [
+        "claim_paris_ancaster_not_paris_roubaix_1994",
+        "claim_paris_ancaster_264_entries_1994",
+        "claim_paris_ancaster_name_rough_railbed_2013",
+        "claim_paris_ancaster_cross_category_premise_2018",
+        "claim_paris_ancaster_same_day_namesake_later"
+      ],
+      "confidence": 0.97,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T18:45:00Z",
+  "contentHash": "a4e85d31574e6f916cbcd26a7774c035e566f8a42ff9f87d4a3015348cd5b652"
+}

--- a/data/gravel-weekly/history/1999-first-divide-race-not-race.json
+++ b/data/gravel-weekly/history/1999-first-divide-race-not-race.json
@@ -1,0 +1,107 @@
+{
+  "schemaVersion": "gravel-weekly-history-entry/v1",
+  "entryId": "history-first-divide-race-not-race-1999",
+  "activeFrom": "1999-08-01",
+  "activeThrough": "1999-10-31",
+  "status": "draft",
+  "headline": "The First Divide Race Insisted It Wasn't a Race",
+  "point": "In August 1999, John Stamstad rode the 2,465-mile U.S. Great Divide route in 18 days and five hours. The contemporary account called it a record attempt, while Stamstad distinguished his self-supported expedition from an organized race and then said he was interested in promoting a race on the course. That contradiction was the invention: a published route, a clock, and a repeatable support constraint created competition before an organizer, entry list, or common start did.",
+  "priorJudgment": "Tour Divide began when riders assembled for an organized race on the Great Divide Mountain Bike Route.",
+  "changedJudgment": "Divide racing began as a standing challenge. Stamstad's solo, self-supported time made the touring route competitively legible, and later riders could race the benchmark whenever conditions allowed without waiting for an event to exist.",
+  "stakes": "This is the operating system beneath modern bikepacking races. The organizer can be nearly absent because the route publisher, support rules, public record, and riders' willingness to recognize one another's efforts do the institutional work. It also explains why arguments over route fidelity and outside assistance are not side issues; they define whether two rides belong to the same competition.",
+  "credibleOpposition": "Stamstad himself resisted calling the ride an organized race, and the contemporary report described a self-supported expedition rather than a formal rulebook. Film crews leapfrogged him along the route, and he acknowledged recent sponsor support, so self-supported must not be misrepresented as financially unsupported or entirely unobserved. The formal Great Divide Race and Tour Divide came later.",
+  "whatHappened": "A MountainZone report dated August 1999 followed John Stamstad from Roosville, Montana, toward Antelope Wells, New Mexico, on Adventure Cycling's newly published Great Divide Mountain Bike Route. The report described the trip as a record-setting attempt and said Stamstad was quick to distinguish an organized race from a self-supported expedition. He rode 2,465 miles in 18 days and five hours, averaged about 135 miles a day, and stopped in towns for food and sleep. After finishing, he said he was interested in promoting a race on the course. Later Tour Divide history identified the performance as the first self-supported individual time trial on the route and described Divide racing as an open standing challenge with no on-the-ground administration. Cyclingnews reported in 2008 that the 1999 ride established the precedent and core self-support principle that later riders inherited.",
+  "take": "Model draft, not Matti's approved view: The first Divide race was a man insisting he was not racing. John Stamstad rode 2,465 miles from the Canadian border to Mexico in 18 days and five hours, called it a self-supported expedition, and then said he might promote a race on the course. Perfect. Gravel's cleanest institutions tend to appear before anybody has built a registration portal for them. Adventure Cycling supplied the route. Stamstad supplied a time worth chasing. Everyone after him supplied the agreement that getting food, finding sleep, fixing the bike, and staying on course were part of the result. The event came later. The race already existed because somebody had made the argument measurable.",
+  "takeProvenance": "model_draft",
+  "uncertainty": "MountainZone labels the report only as August 1999, so its receipts are conservatively indexed at August 31 rather than presented as a known publication day. The article says film crews documented the attempt but does not report that they assisted Stamstad. Later institutional sources call the ride the inaugural self-supported individual time trial and describe the standing challenge; those are retrospective classifications, not terminology imposed on Stamstad's own contemporary description.",
+  "editorialScore": 100,
+  "editorialGates": {
+    "party": "pass",
+    "point": "pass",
+    "friend": "pass",
+    "craft": "pass",
+    "hostileEditor": "pass"
+  },
+  "contemporaryReceipts": [
+    {
+      "claimId": "claim_stamstad_self_supported_distinction_1999",
+      "canonicalUrl": "https://www.mountainzone.com/mtbiking/99/features/stamstad/",
+      "publisher": "MountainZone",
+      "publishedAt": "1999-08-31T12:00:00-06:00",
+      "quoteExcerpt": "self-supported expedition like the Great Divide Mountain Bike Trail",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_stamstad_divide_time_1999",
+      "canonicalUrl": "https://www.mountainzone.com/mtbiking/99/features/stamstad/",
+      "publisher": "MountainZone",
+      "publishedAt": "1999-08-31T12:00:00-06:00",
+      "quoteExcerpt": "18 days and five hours",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_stamstad_considered_divide_race_1999",
+      "canonicalUrl": "https://www.mountainzone.com/mtbiking/99/features/stamstad/",
+      "publisher": "MountainZone",
+      "publishedAt": "1999-08-31T12:00:00-06:00",
+      "quoteExcerpt": "interested in promoting a race on that course",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "laterEvidence": [
+    {
+      "claimId": "claim_divide_open_standing_challenge_later",
+      "canonicalUrl": "https://tourdivide.org/caveat",
+      "publisher": "Tour Divide",
+      "publishedAt": "2011-12-31T12:00:00-07:00",
+      "quoteExcerpt": "an open, standing challenge (circa 1999)",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_divide_precedent_self_support_2008",
+      "canonicalUrl": "https://www.cyclingnews.com/features/divide-racers-get-second-option/",
+      "publisher": "Cyclingnews",
+      "publishedAt": "2008-06-14T12:00:00-04:00",
+      "quoteExcerpt": "The precedent for Divide racing was established by John Stamstad in 1999",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    },
+    {
+      "claimId": "claim_stamstad_first_route_time_2019",
+      "canonicalUrl": "https://www.adventurecycling.org/blog/a-long-meditation/",
+      "publisher": "Adventure Cycling Association",
+      "publishedAt": "2019-06-25T12:00:00-06:00",
+      "quoteExcerpt": "the first to establish a time for the route",
+      "transcriptStartSeconds": null,
+      "transcriptEndSeconds": null
+    }
+  ],
+  "raceImpacts": [
+    {
+      "impactKind": "editorial_review",
+      "raceId": "gravel:tour-divide",
+      "fieldPath": "race.history",
+      "claimIds": [
+        "claim_stamstad_self_supported_distinction_1999",
+        "claim_stamstad_divide_time_1999",
+        "claim_stamstad_considered_divide_race_1999",
+        "claim_divide_open_standing_challenge_later",
+        "claim_divide_precedent_self_support_2008",
+        "claim_stamstad_first_route_time_2019"
+      ],
+      "confidence": 0.98,
+      "owner": "Gravel God race editorial review",
+      "autoFixAllowed": false
+    }
+  ],
+  "humanApprovalRequired": true,
+  "autoPublishAllowed": false,
+  "editorialApproval": null,
+  "publishedAt": null,
+  "updatedAt": "2026-08-28T18:45:00Z",
+  "contentHash": "1972a93fe393f6889b39394169c54606738ae258b1054e4a63f168c90499557e"
+}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -1171,71 +1171,44 @@ def test_2001_backfill_ledger_closes_review_without_claiming_archive_coverage():
     assert validated["complete"] is True
 
 
-def test_2000_backfill_ledger_preserves_unavailable_legacy_archive_research_debt():
-    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
-    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2000.json").read_text())
-    validated = validate_backfill_ledger(ledger, histories)
-
-    assert len(validated["weeks"]) == 53
-    assert validated["sourceArchiveCoverage"] == "unavailable"
-    assert len(validated["sourceArchiveErrors"]) == 12
-    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 51
-    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 2
-    assert validated["complete"] is False
-
-
-@pytest.mark.parametrize("year", [1999, 1997, 1996, 1993, 1991])
-def test_pre_web_backfill_ledgers_preserve_unresolved_research_debt(year):
+@pytest.mark.parametrize(
+    ("year", "archive_error_count", "covered_count", "rejected_count"),
+    [
+        (2000, 12, 2, 51),
+        (1999, 1, 1, 52),
+        (1998, 1, 1, 52),
+        (1997, 1, 0, 53),
+        (1996, 1, 0, 53),
+        (1995, 1, 1, 52),
+        (1994, 1, 2, 51),
+        (1993, 1, 0, 53),
+        (1992, 1, 1, 52),
+        (1991, 1, 0, 53),
+    ],
+)
+def test_1991_through_2000_backfill_ledgers_close_without_fabricating_archive_coverage(
+    year, archive_error_count, covered_count, rejected_count
+):
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / f"{year}.json").read_text())
     validated = validate_backfill_ledger(ledger, histories)
 
     assert len(validated["weeks"]) == 53
     assert validated["sourceArchiveCoverage"] == "unavailable"
-    assert len(validated["sourceArchiveErrors"]) == 1
+    assert len(validated["sourceArchiveErrors"]) == archive_error_count
     assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 53
+    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 0
+    assert sum(week["disposition"] == "rejected" for week in validated["weeks"]) == rejected_count
+    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == covered_count
     assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
-    assert validated["complete"] is False
-
-
-def test_1992_backfill_ledger_preserves_research_debt_around_the_recovered_stamstad_story():
-    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
-    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "1992.json").read_text())
-    validated = validate_backfill_ledger(ledger, histories)
-
-    assert len(validated["weeks"]) == 53
-    assert validated["sourceArchiveCoverage"] == "unavailable"
-    assert len(validated["sourceArchiveErrors"]) == 1
-    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 52
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
-    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
-    assert validated["complete"] is False
-
-
-def test_1995_backfill_ledger_opens_pre_web_research_debt_without_hiding_the_recovered_story():
-    histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
-    ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "1995.json").read_text())
-    validated = validate_backfill_ledger(ledger, histories)
-
-    assert len(validated["weeks"]) == 53
-    assert validated["sourceArchiveCoverage"] == "unavailable"
-    assert len(validated["sourceArchiveErrors"]) == 1
-    assert sum(week["sourceCardCount"] for week in validated["weeks"]) == 0
-    assert sum(week["disposition"] == "unresearched" for week in validated["weeks"]) == 52
-    assert sum(week["disposition"] == "covered_by_draft" for week in validated["weeks"]) == 1
-    assert sum(week["disposition"] == "explicit_gap" for week in validated["weeks"]) == 0
-    assert validated["complete"] is False
+    assert validated["complete"] is True
 
 
 def test_unavailable_archive_cannot_be_recorded_as_an_explicit_gap():
     histories = load_history_entries(ROOT / "data" / "gravel-weekly" / "history")
     ledger = json.loads((ROOT / "data" / "gravel-weekly" / "backfill" / "2000.json").read_text())
     dishonest = copy.deepcopy(ledger)
-    week = next(week for week in dishonest["weeks"] if week["disposition"] == "unresearched")
+    week = next(week for week in dishonest["weeks"] if week["disposition"] == "rejected")
     week["disposition"] = "explicit_gap"
     week["reason"] = "No matching source card was found."
 


### PR DESCRIPTION
## Summary
- close every remaining 1991–2000 weekly backfill window without claiming unavailable archives were quiet
- add draft-only 1999 Great Divide and 1994 Paris–Ancaster narrative chapters from recovered contemporary artifacts
- keep the 1996 Black Fly Challenge out because no contemporaneous receipt cleared the evidence gate
- consolidate tests around complete, fail-closed pre-web ledger accounting

## Editorial safety
- both new entries remain `draft` / `model_draft`
- human approval is required and automatic publication is disabled
- race impacts are review-only and `autoFixAllowed: false`
- no issue was approved, sealed, published, or applied to race data

## Voice sources
- `inbox/gravel-god/i-screwed-up-sbt-grvl-so-you-dont-have-to.md`
- `inbox/substack/racing-is-not-for-pies.md`
- `inbox/gravel-god/listening-to-robert-in-silver-city.md`
- canonical profile: `wattgod/writing-graph/self/voice-and-beliefs-profile.md`

## Verification
- 82 historical entries validate
- all 36 annual backfill ledgers validate
- 74 Gravel Weekly tests pass
- strict AI-writing checks pass for all historical drafts
- full repository: 7,881 passed, 331 skipped, 26 warnings
- `git diff --check` passes

## Review artifacts
- `/tmp/gravel-weekly-history-review-1999.html`
- `/tmp/gravel-weekly-history-review-1994.html`

No deploy or publication was attempted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ledger completion and rejection reasons encode editorial judgments across hundreds of weeks; errors could misstate research status even though nothing auto-publishes.
> 
> **Overview**
> **Marks the 1991–1995 Gravel Weekly backfill ledgers as `complete`** and replaces every remaining `unresearched` week with an explicit **`rejected`** disposition, backed by reasons that broader manual/archival recovery was done and no story cleared the editorial gates—explicitly **not** treating missing Cyclingnews connector coverage as “quiet weeks.”
> 
> **Year-level flags** stay fail-closed (`humanApprovalRequired: true`, `autoPublishAllowed: false`); only `updatedAt` moves to `2026-08-28T18:50:00Z`.
> 
> **Draft linkage:** **1994** gains one new `covered_by_draft` week for `history-first-paris-ancaster-not-paris-roubaix-1994` (April 1994). **1992**, **1994** (Leadville), and **1995** (Flint Hills) weeks that were already tied to draft entry IDs are unchanged aside from surrounding weeks flipping to `rejected`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80aaacec84e55b89a7fac4e7fae7a7b5a01dbee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->