### PR TITLE
Fix legal links and sitemap indexability

### DIFF
--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -24,6 +24,30 @@ SITE_BASE_URL = "https://gravelgodcycling.com"
 # recaps/previews pulled 2026-07-22 (WS5 Option A); roundups indexable only
 # via the owner-approved allowlist in config/indexable-roundups.json.
 INDEXABLE_BLOG_CATEGORIES = frozenset({"roundup", "article"})
+INDEXABLE_WORDPRESS_PAGES = (
+    "/coaching/",
+    "/the-assessment-aerobic-6/",
+    "/the-anaerobic-assessment-2/",
+    "/articles/",
+    "/resources/",
+    "/trainingpeaks-athlete-user-guide/",
+    "/trainingpeaks-athlete-user-guide-2/",
+    "/training-plans-faq/",
+    "/is-coaching-worth-it/",
+    "/custom-training-plans/",
+    "/how-much-faster-could-you-be/",
+    "/how-and-why-to-set-your-training-zones-in-trainingpeaks/",
+    "/the-big-three-frequency-duration-and-intensity/",
+    "/how-to-improve-at-anything/",
+    "/the-aerobic-endurance-test/",
+    "/how-to-make-sure-training-doesnt-destroy-your-relationship/",
+    "/popular-training-plans/",
+    "/gravel-god-cycling-values/",
+    "/articles-2/",
+    "/products/training-plans/",
+    "/the-ultimate-gravel-guide/",
+    "/contact/",
+)
 INDEXABLE_ROUNDUPS = frozenset(
     __import__("json").loads(
         (Path(__file__).resolve().parent.parent / "config" / "indexable-roundups.json")
@@ -210,6 +234,16 @@ def generate_sitemap(race_index: list, output_path: Path, data_dir: Path = None,
     SubElement(url, 'lastmod').text = today
     SubElement(url, 'changefreq').text = 'monthly'
     SubElement(url, 'priority').text = '0.8'
+
+    # Indexable WordPress pages previously came from AIOSEO's page sitemap,
+    # which also advertised intentionally noindex account and checkout pages.
+    # Keep the public routes explicit and source-controlled instead.
+    for path in INDEXABLE_WORDPRESS_PAGES:
+        url = SubElement(urlset, 'url')
+        SubElement(url, 'loc').text = f"{SITE_BASE_URL}{path}"
+        SubElement(url, 'lastmod').text = today
+        SubElement(url, 'changefreq').text = 'monthly'
+        SubElement(url, 'priority').text = '0.6'
 
     # Tier hub pages
     for t in [1, 2, 3, 4]:
@@ -482,7 +516,7 @@ def main():
     course_slugs = load_course_slugs(project_root)
     course_url_count = (1 + len(course_slugs)) if course_slugs else 0
     guide_cluster_count = 10  # pillar + 8 chapters + configurator
-    total_urls = (7 + guide_cluster_count + len(series_slugs) + len(vs_slugs) + len(state_slugs)
+    total_urls = (7 + len(INDEXABLE_WORDPRESS_PAGES) + guide_cluster_count + len(series_slugs) + len(vs_slugs) + len(state_slugs)
                   + len(special_slugs) + len(plan_slugs) + len(tire_slugs)
                   + len(tire_page_slugs) + len(tire_vs_slugs) + course_url_count + len(race_index))
     print(f"Generated sitemap: {output_path} ({total_urls} URLs)")

--- a/scripts/push_wordpress.py
+++ b/scripts/push_wordpress.py
@@ -2000,13 +2000,35 @@ def sync_redirects():
         return False
 
 
+def build_sitemap_index(today: str, has_blog_sitemap: bool) -> str:
+    """Build the root index from known-indexable sitemap files only."""
+    entries = ["race-sitemap.xml"]
+    if has_blog_sitemap:
+        entries.append("blog-sitemap.xml")
+    entries.append("post-sitemap.xml")
+
+    sitemap_entries = "".join(
+        f"""  <sitemap>
+    <loc>https://gravelgodcycling.com/{filename}</loc>
+    <lastmod>{today}</lastmod>
+  </sitemap>
+"""
+        for filename in entries
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{sitemap_entries}</sitemapindex>
+"""
+
+
 def sync_sitemap():
     """Deploy race-sitemap.xml and a sitemap index to the server.
 
     Uploads the generated race sitemap as race-sitemap.xml, then creates a
-    sitemap index at sitemap.xml that references race-sitemap.xml plus
-    AIOSEO-generated sitemaps (post-sitemap.xml, page-sitemap.xml,
-    category-sitemap.xml).
+    sitemap index at sitemap.xml that references the generated race/blog
+    sitemaps plus the live indexable post sitemap. Indexable WordPress pages
+    are emitted by the generated race sitemap; noindex page and category
+    sitemaps are deliberately excluded.
     """
     ssh = get_ssh_credentials()
     if not ssh:
@@ -2062,34 +2084,9 @@ def sync_sitemap():
             print(f"  WARN: Failed to upload blog-sitemap.xml: {e}")
             has_blog_sitemap = False
 
-    # 2. Create sitemap index referencing all sub-sitemaps
-    blog_sitemap_entry = ""
-    if has_blog_sitemap:
-        blog_sitemap_entry = f"""  <sitemap>
-    <loc>https://gravelgodcycling.com/blog-sitemap.xml</loc>
-    <lastmod>{today}</lastmod>
-  </sitemap>
-"""
-    sitemap_index = f"""<?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <sitemap>
-    <loc>https://gravelgodcycling.com/race-sitemap.xml</loc>
-    <lastmod>{today}</lastmod>
-  </sitemap>
-{blog_sitemap_entry}  <sitemap>
-    <loc>https://gravelgodcycling.com/post-sitemap.xml</loc>
-    <lastmod>{today}</lastmod>
-  </sitemap>
-  <sitemap>
-    <loc>https://gravelgodcycling.com/page-sitemap.xml</loc>
-    <lastmod>{today}</lastmod>
-  </sitemap>
-  <sitemap>
-    <loc>https://gravelgodcycling.com/category-sitemap.xml</loc>
-    <lastmod>{today}</lastmod>
-  </sitemap>
-</sitemapindex>
-"""
+    # 2. Create an index without the AIOSEO page/category sitemaps. Those
+    # advertise pages carrying noindex, which violates sitemap parity.
+    sitemap_index = build_sitemap_index(today, has_blog_sitemap)
 
     # 3. Upload sitemap index as sitemap.xml
     try:
@@ -2120,8 +2117,6 @@ def sync_sitemap():
         if has_blog_sitemap:
             print("  → blog-sitemap.xml (blog content)")
         print("  → post-sitemap.xml (AIOSEO blog posts)")
-        print("  → page-sitemap.xml (AIOSEO WP pages)")
-        print("  → category-sitemap.xml (AIOSEO categories)")
         return True
     except Exception as e:
         print(f"✗ Failed to upload sitemap.xml: {e}")

--- a/tests/test_sitemap_index.py
+++ b/tests/test_sitemap_index.py
@@ -1,0 +1,43 @@
+"""Regression tests for indexability-safe sitemap composition."""
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+from generate_sitemap import INDEXABLE_WORDPRESS_PAGES, generate_sitemap  # noqa: E402
+from push_wordpress import build_sitemap_index  # noqa: E402
+
+
+def _locations(xml: str) -> list[str]:
+    root = ElementTree.fromstring(xml)
+    return [node.text for node in root.iter() if node.tag.endswith("loc")]
+
+
+def test_root_index_omits_noindex_page_and_category_sitemaps() -> None:
+    locations = _locations(build_sitemap_index("2026-08-28", True))
+    assert locations == [
+        "https://gravelgodcycling.com/race-sitemap.xml",
+        "https://gravelgodcycling.com/blog-sitemap.xml",
+        "https://gravelgodcycling.com/post-sitemap.xml",
+    ]
+
+
+def test_generated_sitemap_owns_indexable_wordpress_pages(tmp_path: Path) -> None:
+    output = tmp_path / "web" / "sitemap.xml"
+    generate_sitemap([], output)
+    locations = _locations(output.read_text(encoding="utf-8"))
+    for path in INDEXABLE_WORDPRESS_PAGES:
+        assert f"https://gravelgodcycling.com{path}" in locations
+
+    for excluded_path in (
+        "/questionnaire/",
+        "/cart/",
+        "/instructor-registration/",
+        "/student-registration/",
+        "/dashboard/",
+    ):
+        assert f"https://gravelgodcycling.com{excluded_path}" not in locations

--- a/tests/test_utility_legal_links.py
+++ b/tests/test_utility_legal_links.py
@@ -1,0 +1,36 @@
+"""Regression guards for legal links on custom utility-page footers."""
+
+import sys
+from pathlib import Path
+
+
+WORDPRESS_DIR = Path(__file__).resolve().parents[1] / "wordpress"
+sys.path.insert(0, str(WORDPRESS_DIR))
+
+from generate_methodology import build_footer  # noqa: E402
+from generate_tier_hubs import build_hub_page  # noqa: E402
+from generate_vs_pages import build_vs_page  # noqa: E402
+
+
+def _assert_legal_links(html: str) -> None:
+    assert 'href="/privacy/"' in html
+    assert 'href="/terms/"' in html
+
+
+def test_methodology_footer_links_to_both_legal_pages() -> None:
+    _assert_legal_links(build_footer())
+
+
+def test_tier_hub_footer_links_to_both_legal_pages() -> None:
+    race = {"slug": "test-race", "name": "Test Race", "score": 80, "tier": 1,
+            "location": "Colorado", "month": "June", "tagline": "A real race."}
+    _assert_legal_links(build_hub_page(1, [race], [race]))
+
+
+def test_comparison_footer_links_to_both_legal_pages() -> None:
+    race_a = {"slug": "race-a", "name": "Race A", "score": 80, "tier": 1,
+              "location": "Colorado", "month": "June", "tagline": "Race A."}
+    race_b = {"slug": "race-b", "name": "Race B", "score": 70, "tier": 2,
+              "location": "Utah", "month": "July", "tagline": "Race B."}
+    full = {"race": {"course": {}, "experience": {}, "logistics": {}}}
+    _assert_legal_links(build_vs_page(race_a, race_b, full, full))

--- a/wordpress/generate_methodology.py
+++ b/wordpress/generate_methodology.py
@@ -284,6 +284,7 @@ def build_faq() -> str:
 def build_footer() -> str:
     return '''<div class="gg-footer">
     <p class="gg-footer-disclaimer">This methodology page describes our scoring system. All ratings, opinions, and assessments represent our editorial views based on publicly available information and community research. We are not affiliated with, endorsed by, or officially connected to any race organizer, event, or governing body.</p>
+    <p class="gg-footer-disclaimer"><a href="/privacy/">Privacy</a> &middot; <a href="/terms/">Terms</a></p>
   </div>'''
 
 

--- a/wordpress/generate_tier_hubs.py
+++ b/wordpress/generate_tier_hubs.py
@@ -465,7 +465,9 @@ def build_hub_page(tier: int, races: list, all_races: list) -> str:
   <footer class="gg-hub-footer">
     <a href="/">Gravel God</a> &middot; {len(all_races)} races rated &middot;
     <a href="/gravel-races/">Search All</a> &middot;
-    <a href="/race/methodology/">Methodology</a>
+    <a href="/race/methodology/">Methodology</a> &middot;
+    <a href="/privacy/">Privacy</a> &middot;
+    <a href="/terms/">Terms</a>
   </footer>
 
 </div>

--- a/wordpress/generate_vs_pages.py
+++ b/wordpress/generate_vs_pages.py
@@ -1008,7 +1008,9 @@ body {{ margin: 0; background: var(--gg-color-warm-paper); }}
   <footer class="gg-vs-footer">
     <a href="/">Gravel God</a> &middot;
     <a href="/gravel-races/">Search All Races</a> &middot;
-    <a href="/race/methodology/">Methodology</a>
+    <a href="/race/methodology/">Methodology</a> &middot;
+    <a href="/privacy/">Privacy</a> &middot;
+    <a href="/terms/">Terms</a>
   </footer>
 
 </div>


### PR DESCRIPTION
## What changed
- add Privacy and Terms links to comparison, tier, and methodology footers
- move indexable WordPress pages into the source-controlled sitemap
- stop advertising noindex page and category sitemaps
- add regression tests for legal-link and sitemap parity

## Validation
- 42 focused tests passed
- full live pre-fix crawl: canonical and SSR gates passed; 16 sitemap URLs carried noindex and are removed by this change
- git diff --check passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live SEO sitemap composition and which URLs search engines discover; mis-updating the allowlist could drop or over-expose pages, though tests reduce regression risk.
> 
> **Overview**
> Fixes **sitemap indexability** by taking control of which WordPress routes are advertised to crawlers, and adds **Privacy / Terms** links on several generated utility footers.
> 
> The generated race sitemap now includes a source-controlled **`INDEXABLE_WORDPRESS_PAGES`** allowlist (coaching, articles, contact, training-plan product page, etc.) so public WP pages stay discoverable without pulling in AIOSEO’s page sitemap. Deploy **`build_sitemap_index`** only lists `race-sitemap.xml`, optional `blog-sitemap.xml`, and `post-sitemap.xml`—**`page-sitemap.xml` and `category-sitemap.xml` are dropped** because they surfaced URLs that carry `noindex` (e.g. cart, dashboard, questionnaire).
> 
> **`generate_methodology`**, **tier hub**, and **vs comparison** footers gain links to `/privacy/` and `/terms/`. New regression tests lock in root index composition, allowlisted WP URLs in the generated sitemap (and exclusion of known junk paths), and legal links in those footers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd705f4a35bce9c6947eb9d9d15ce7bac9be31f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->