### PR TITLE
Gate Gravel Weekly publication against AI slop

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,25 @@
+# Third-party notices
+
+## no-ai-slop
+
+The Gravel Weekly prose gate is adapted from
+[petergyang/no-ai-slop](https://github.com/petergyang/no-ai-slop), revision
+`d30eddb9e04562234f2070b5ee63ca4649d9a05e`.
+
+Copyright (c) 2026 Peter Yang
+
+Licensed under the MIT License. Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom
+the Software is furnished to do so, subject to the conditions in the upstream
+[license](https://github.com/petergyang/no-ai-slop/blob/d30eddb9e04562234f2070b5ee63ca4649d9a05e/LICENSE).
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/no_ai_slop.py
+++ b/scripts/no_ai_slop.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Deterministic No-AI-slop audit for exact Gravel Weekly publication copy."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Mapping
+
+SOURCE_URL = "https://github.com/petergyang/no-ai-slop"
+SOURCE_REVISION = "d30eddb9e04562234f2070b5ee63ca4649d9a05e"
+
+RULES = (
+    ("banned_word", r"\b(?:delve|foster|leverage|utilize|facilitate|empower|streamline|robust|cutting-edge|paradigm shift|game changer|this is huge|this changes everything|tapestry|realm|beacon|multifaceted|meticulous|intricate|paramount|transformative|elevate|embark|supercharge|harness|ever-evolving)\b"),
+    ("empty_opener", r"\b(?:here(?:’|')s the thing|here(?:’|')s what i mean|let me be clear|i(?:’|')ll be honest|the uncomfortable truth is|it(?:’|')s worth noting|it(?:’|')s important to note|let(?:’|')s dive in)\b"),
+    ("faux_insight", r"\b(?:what (?:most people|nobody) (?:get wrong|tell you)|the part (?:everyone|most people) (?:miss|skip)|here(?:’|')s what nobody tells you)\b"),
+    ("binary_contrast", r"(?:\bit(?:’|')s|\b(?:it|this|that|the (?:question|point|story)) (?:is|was))(?:n(?:’|')t| not) [^.!?\n]{1,120}[,.]?\s+(?:it(?:’|')s|(?:it|this|that) (?:is|was))\b"),
+    ("binary_contrast", r"\bnot just\b[^.!?\n]{1,120}\bbut\b"),
+    ("colon_reveal", r"\b(?:best|hard|funny|interesting|important|key|real|wild) (?:part|thing|detail|point|problem|truth):\s+[a-z]"),
+    ("superficial_analysis", r",\s+(?:highlighting|underscoring|reflecting|showcasing)\b"),
+    ("importance_puffery", r"\b(?:stands as a testament|marks a pivotal moment|plays a vital role|solidifies (?:its|the) position|underscores (?:its|the) significance)\b"),
+    ("interpretive_metadiscourse", r"\b(?:that last part matters more than it sounds|the key point is|as you can see|this distinction matters|in other words)\b"),
+    ("weasel_attribution", r"\b(?:experts agree|industry reports suggest|many argue|widely regarded as|studies show)\b"),
+    ("fake_strong_verb", r"\b(?:serves|acts|stands) as (?:a|an|the)\b"),
+    ("negative_listing", r"(?:^|[.!?]\s+)not (?:a|an|the) [^.!?]{1,80}\.\s+not (?:a|an|the) [^.!?]{1,80}\."),
+    ("dramatic_fragment", r"\bthat(?:’|')s it\.\s+that(?:’|')s the whole thing\b"),
+    ("rhetorical_setup", r"\b(?:what if i told you|think about it|plot twist)\s*[:?]"),
+    ("fake_profound_kicker", r"\bthe future (?:isn(?:’|')t|is not) coming\.\s+it(?:’|')s already here\.?\s*$"),
+    ("summary_recap", r"(?:^|\n)\s*(?:in conclusion|ultimately|overall)\b"),
+)
+
+
+def _excerpt(text: str, start: int, length: int) -> str:
+    return re.sub(r"\s+", " ", text[max(0, start - 35):start + length + 35]).strip()
+
+
+def audit_no_ai_slop(fields: Mapping[str, str]) -> dict[str, object]:
+    entries = sorted((name, value) for name, value in fields.items() if isinstance(value, str) and value.strip())
+    findings: list[dict[str, str]] = []
+    for field, value in entries:
+        for pattern, expression in RULES:
+            match = re.search(expression, value, re.IGNORECASE)
+            if match:
+                findings.append({"pattern": pattern, "field": field, "excerpt": _excerpt(value, match.start(), len(match.group(0)))})
+        em_dash_count = value.count("—")
+        allowed = 0 if len(value) < 500 else 2
+        if em_dash_count > allowed:
+            findings.append({
+                "pattern": "em_dash_cluster",
+                "field": field,
+                "excerpt": f"{em_dash_count} em dashes in {'short' if len(value) < 500 else 'long'} copy",
+            })
+    checked_text_hash = hashlib.sha256(
+        json.dumps(entries, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return {
+        "schemaVersion": "no-ai-slop-gate/v1",
+        "sourceUrl": SOURCE_URL,
+        "sourceRevision": SOURCE_REVISION,
+        "checkedTextHash": checked_text_hash,
+        "verdict": "fail" if findings else "pass",
+        "findings": findings,
+        "humanChecks": [
+            "Preserve Matti's vocabulary, cadence, bluntness, humor, uncertainty, and useful rough edges.",
+            "Cut portable filler; keep concrete facts, mechanisms, consequences, and judgments.",
+            "Read aloud for robotic symmetry, synonym cycling, fake profundity, and flattened voice.",
+        ],
+        "humanApprovalRequired": True,
+        "autoPublishAllowed": False,
+    }

--- a/scripts/validate_gravel_weekly.py
+++ b/scripts/validate_gravel_weekly.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
+from no_ai_slop import audit_no_ai_slop
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 ISSUE_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "issues"
 
@@ -135,6 +137,11 @@ def _retrospective(value: Any, name: str, *, status: str) -> dict[str, Any]:
         raise IssueValidationError(f"{name}.assessment requires human-approved provenance")
     if status != "draft" and re.search(r"model draft|not matti(?:’|')s approved", assessment, re.IGNORECASE):
         raise IssueValidationError(f"{name}.assessment still contains model-draft language")
+    if status != "draft":
+        prose_gate = audit_no_ai_slop({"retrospective": f"{item['headline']}\n{item['whatChanged']}\n{assessment}"})
+        if prose_gate["verdict"] != "pass":
+            patterns = ", ".join(finding["pattern"] for finding in prose_gate["findings"])
+            raise IssueValidationError(f"{name} fails the no-ai-slop gate: {patterns}")
     receipts = _list(item.get("receipts"), f"{name}.receipts", 100)
     if not receipts:
         raise IssueValidationError(f"{name}.receipts must not be empty")
@@ -183,14 +190,14 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
         story = _record(raw_story, f"stories[{index}]")
         story_id = _text(story.get("candidateId"), f"stories[{index}].candidateId", 500)
         story_ids.append(story_id)
-        _text(story.get("headline"), f"stories[{index}].headline", 300)
-        _text(story.get("dek"), f"stories[{index}].dek", 600)
+        headline = _text(story.get("headline"), f"stories[{index}].headline", 300)
+        dek = _text(story.get("dek"), f"stories[{index}].dek", 600)
         if story.get("storyKind") not in STORY_KINDS:
             raise IssueValidationError(f"stories[{index}].storyKind is invalid")
         score = story.get("score")
         if not isinstance(score, int) or isinstance(score, bool) or not 70 <= score <= 100:
             raise IssueValidationError(f"stories[{index}].score must be 70 to 100")
-        _text(story.get("whatHappened"), f"stories[{index}].whatHappened", 2_000)
+        what_happened = _text(story.get("whatHappened"), f"stories[{index}].whatHappened", 2_000)
         take = _text(story.get("take"), f"stories[{index}].take", 8_000)
         provenance = story.get("takeProvenance")
         if provenance not in {"model_draft", "human_approved"}:
@@ -199,6 +206,11 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
             raise IssueValidationError(f"stories[{index}].take requires human-approved provenance")
         if status != "draft" and re.search(r"model draft|not matti(?:’|')s approved", take, re.IGNORECASE):
             raise IssueValidationError(f"stories[{index}].take still contains model-draft language")
+        if status != "draft":
+            prose_gate = audit_no_ai_slop({"headline": headline, "dek": dek, "what_happened": what_happened, "take": take})
+            if prose_gate["verdict"] != "pass":
+                findings = ", ".join(f"{finding['field']}:{finding['pattern']}" for finding in prose_gate["findings"])
+                raise IssueValidationError(f"stories[{index}] fails the no-ai-slop gate: {findings}")
         receipts = _list(story.get("receipts"), f"stories[{index}].receipts", 100)
         if not receipts:
             raise IssueValidationError(f"stories[{index}].receipts must not be empty")

--- a/scripts/validate_gravel_weekly_history.py
+++ b/scripts/validate_gravel_weekly_history.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from validate_gravel_weekly import IssueValidationError, _impact, _iso, _list, _receipt, _record, _text
+from no_ai_slop import audit_no_ai_slop
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 HISTORY_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "history"
@@ -81,7 +82,7 @@ def validate_history_entry(value: Any, *, verify_hash: bool = True) -> dict[str,
     _text(entry.get("changedJudgment"), "changedJudgment", 1_000)
     _text(entry.get("stakes"), "stakes", 1_500)
     _text(entry.get("credibleOpposition"), "credibleOpposition", 1_000)
-    _text(entry.get("whatHappened"), "whatHappened", 3_000)
+    what_happened = _text(entry.get("whatHappened"), "whatHappened", 3_000)
     take = _text(entry.get("take"), "take", 8_000)
     _text(entry.get("uncertainty"), "uncertainty", 2_000)
     score = entry.get("editorialScore")
@@ -96,6 +97,11 @@ def validate_history_entry(value: Any, *, verify_hash: bool = True) -> dict[str,
         raise IssueValidationError("historical take still contains model-draft language")
     if status != "draft" and re.search(r"model draft|not matti(?:’|')s approved", headline, re.IGNORECASE):
         raise IssueValidationError("historical headline still contains model-draft language")
+    if status != "draft":
+        prose_gate = audit_no_ai_slop({"headline": headline, "what_happened": what_happened, "take": take})
+        if prose_gate["verdict"] != "pass":
+            findings = ", ".join(f"{finding['field']}:{finding['pattern']}" for finding in prose_gate["findings"])
+            raise IssueValidationError(f"historical entry fails the no-ai-slop gate: {findings}")
     gates = _record(entry.get("editorialGates"), "editorialGates")
     if set(gates) != PASSING_GATES:
         raise IssueValidationError("editorialGates must contain the five historical gates")

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -32,6 +32,7 @@ from seal_gravel_weekly_history import (  # noqa: E402
 )
 from validate_gravel_weekly_history_decisions import validate_history_decision  # noqa: E402
 from validate_gravel_weekly_backfill import validate_backfill_ledger  # noqa: E402
+from no_ai_slop import audit_no_ai_slop  # noqa: E402
 from prepare_gravel_weekly_backfill_ledger import build_initial_backfill_ledger  # noqa: E402
 from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
 from prepare_gravel_weekly_issue import prepare_issue  # noqa: E402
@@ -261,6 +262,35 @@ def test_issue_contract_requires_receipts_approval_and_hash():
     model_copy["stories"][0]["take"] = "Editable model draft, not Matti's approved view."
     with pytest.raises(IssueValidationError, match="model-draft"):
         validate_issue(model_copy, verify_hash=False)
+
+    slopped = copy.deepcopy(issue)
+    slopped["stories"][0]["take"] = "The future isn't coming. It's already here."
+    with pytest.raises(IssueValidationError, match="no-ai-slop gate.*fake_profound_kicker"):
+        validate_issue(slopped, verify_hash=False)
+
+
+def test_no_ai_slop_audit_names_patterns_without_guessing_authorship():
+    clean = audit_no_ai_slop({
+        "headline": "Gravel Worlds Moved Lunch Forty Miles",
+        "take": "Bring another bottle and stop pretending total mileage is the useful number.",
+    })
+    assert clean["verdict"] == "pass"
+    assert clean["findings"] == []
+    assert clean["humanApprovalRequired"] is True
+    assert clean["autoPublishAllowed"] is False
+
+    failed = audit_no_ai_slop({
+        "headline": "This Changes Everything",
+        "take": "Here's the thing: it's not a race update. It's a transformative paradigm shift.",
+    })
+    assert failed["verdict"] == "fail"
+    assert {finding["pattern"] for finding in failed["findings"]} >= {
+        "banned_word", "empty_opener", "binary_contrast",
+    }
+    assert len(failed["checkedTextHash"]) == 64
+
+    factual_pair = audit_no_ai_slop({"what_happened": "Selection considered not only results but also interest in the series."})
+    assert factual_pair["verdict"] == "pass"
 
 
 def test_review_prepares_a_draft_but_cannot_imply_approval():
@@ -616,6 +646,11 @@ def test_historical_current_thing_requires_contemporary_corroboration_and_human_
     model_take["takeProvenance"] = "model_draft"
     with pytest.raises(IssueValidationError, match="human-approved provenance"):
         validate_history_entry(model_take, verify_hash=False)
+
+    slopped = copy.deepcopy(entry)
+    slopped["take"] = "Here's what nobody tells you: this changes everything."
+    with pytest.raises(IssueValidationError, match="no-ai-slop gate"):
+        validate_history_entry(slopped, verify_hash=False)
 
 
 def test_historical_approval_is_hash_bound_copy_limited_and_non_public(tmp_path):


### PR DESCRIPTION
## What changed\n- add a pinned, deterministic audit adapted from petergyang/no-ai-slop\n- rerun it on exact approved/published live story copy and retrospective copy\n- rerun it on exact approved/published historical headline, factual narrative, and Take\n- keep drafts editable; no draft is surfaced publicly\n- include the upstream MIT notice\n\n## Backfill impact\n- 82 historical drafts audited\n- 69 pass unchanged\n- 13 require edits before approval: 12 binary-contrast findings, one interpretive-metadiscourse finding, and one banned-word finding (one entry has two findings)\n\n## Verification\n- Gravel Weekly tests: 75/75 passing\n- full repository: 7,883 passed, 331 skipped, 26 existing warnings\n- git diff --check\n\nNo issue or historical entry is approved or published by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New fail-closed checks block approval/publish when copy matches heuristic slop patterns; legitimate phrasing (e.g. “not only … but”) may need edits, and 13 historical drafts are flagged per the PR description.
> 
> **Overview**
> Adds a **deterministic “no-ai-slop” prose gate** (adapted from upstream `no-ai-slop`, pinned revision) plus MIT attribution in `THIRD_PARTY_NOTICES.md`.
> 
> For **non-draft** Gravel Weekly issues, validation now runs `audit_no_ai_slop` on each story’s headline/dek/what-happened/take and on retrospective headline/what-changed/assessment; failures raise `IssueValidationError` with named pattern IDs. Historical Current Thing entries get the same check on headline, what-happened, and take. **Drafts are unchanged** and still skip the gate.
> 
> The audit returns pass/fail, regex-based findings (banned phrases, binary contrasts, em-dash limits, etc.), a content hash, and explicit flags that **human approval is still required** and auto-publish is not allowed. Tests cover the auditor and validation failures on slopgy copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a202ec00039244cf2a3025e916280ed1d4fc298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->