### PR TITLE
fix(legal): cover shared privacy footer surfaces

### DIFF
--- a/tests/test_cookie_consent.py
+++ b/tests/test_cookie_consent.py
@@ -114,6 +114,11 @@ class TestBannerStructure:
         assert 'id="gg-privacy-choices"' in banner
         assert ">Privacy choices<" in banner
 
+    def test_footer_has_legal_links(self, banner):
+        assert '<footer class="gg-privacy-choices-footer"' in banner
+        assert 'href="/privacy/"' in banner
+        assert 'href="/terms/"' in banner
+
     def test_no_border_radius(self, css):
         assert "border-radius" not in css
 

--- a/tests/test_cookie_consent_mu_plugin.py
+++ b/tests/test_cookie_consent_mu_plugin.py
@@ -144,6 +144,12 @@ class TestConsentMode:
         """Banner in footer at high priority to be last element."""
         assert "gg_cookie_consent_banner', 99" in php_source
 
+    def test_footer_has_legal_links(self, php_source):
+        banner = _extract_php_banner(php_source)
+        assert '<footer class="gg-privacy-choices-footer"' in banner
+        assert 'href="/privacy/"' in banner
+        assert 'href="/terms/"' in banner
+
     def test_consent_defaults_has_all_types(self, php_source):
         defaults = _extract_php_consent_defaults(php_source)
         assert "'analytics_storage'" in defaults

--- a/wordpress/cookie_consent.py
+++ b/wordpress/cookie_consent.py
@@ -147,7 +147,7 @@ def get_consent_banner_html() -> str:
     Place this right before </body> on every page.
     """
     return '''<style>
-.gg-privacy-choices-footer{padding:8px 16px;text-align:center;background:#59473c;font-family:'Sometype Mono',monospace}
+.gg-privacy-choices-footer{padding:8px 16px;background:#59473c;font-family:'Sometype Mono',monospace;display:flex;justify-content:center;gap:12px;flex-wrap:wrap}
 .gg-privacy-choices{color:#d4c5b9;font-size:10px;letter-spacing:1px;text-transform:uppercase;text-decoration:underline;text-underline-offset:3px}
 .gg-privacy-choices:hover{color:#ffffff}
 .gg-privacy-choices:focus-visible{outline:2px solid #4ECDC4;outline-offset:2px}
@@ -165,7 +165,7 @@ def get_consent_banner_html() -> str:
 @media(max-width:600px){.gg-consent-banner{padding:10px 16px;gap:10px}.gg-consent-text{font-size:11px;text-align:center}.gg-consent-btn{padding:6px 14px;font-size:11px}}
 @media(prefers-reduced-motion:reduce){.gg-consent-btn{transition:none}}
 </style>
-<div class="gg-privacy-choices-footer"><a class="gg-privacy-choices" id="gg-privacy-choices" href="/cookies/#privacy-choices">Privacy choices</a></div>
+<footer class="gg-privacy-choices-footer" aria-label="Legal"><a class="gg-privacy-choices" id="gg-privacy-choices" href="/cookies/#privacy-choices">Privacy choices</a><a class="gg-privacy-choices" href="/privacy/">Privacy</a><a class="gg-privacy-choices" href="/terms/">Terms</a></footer>
 <div class="gg-consent-banner" id="gg-consent-banner" role="dialog" aria-label="Cookie consent" aria-describedby="gg-consent-desc">
   <p class="gg-consent-text" id="gg-consent-desc">We use cookies for analytics to improve this site. No ads, no tracking across sites. <a href="/cookies/">Learn more</a>.</p>
   <button class="gg-consent-btn gg-consent-accept" id="gg-consent-accept">Accept</button>

--- a/wordpress/mu-plugins/gg-cookie-consent.php
+++ b/wordpress/mu-plugins/gg-cookie-consent.php
@@ -57,7 +57,7 @@ function gg_cookie_consent_banner() {
     if ( current_user_can( 'edit_posts' ) ) return;
     ?>
 <style>
-.gg-privacy-choices-footer{padding:8px 16px;text-align:center;background:#59473c;font-family:'Sometype Mono',monospace}
+.gg-privacy-choices-footer{padding:8px 16px;background:#59473c;font-family:'Sometype Mono',monospace;display:flex;justify-content:center;gap:12px;flex-wrap:wrap}
 .gg-privacy-choices{color:#d4c5b9;font-size:10px;letter-spacing:1px;text-transform:uppercase;text-decoration:underline;text-underline-offset:3px}
 .gg-privacy-choices:hover{color:#ffffff}
 .gg-privacy-choices:focus-visible{outline:2px solid #4ECDC4;outline-offset:2px}
@@ -75,7 +75,7 @@ function gg_cookie_consent_banner() {
 @media(max-width:600px){.gg-consent-banner{padding:10px 16px;gap:10px}.gg-consent-text{font-size:11px;text-align:center}.gg-consent-btn{padding:6px 14px;font-size:11px}}
 @media(prefers-reduced-motion:reduce){.gg-consent-btn{transition:none}}
 </style>
-<div class="gg-privacy-choices-footer"><a class="gg-privacy-choices" id="gg-privacy-choices" href="/cookies/#privacy-choices">Privacy choices</a></div>
+<footer class="gg-privacy-choices-footer" aria-label="Legal"><a class="gg-privacy-choices" id="gg-privacy-choices" href="/cookies/#privacy-choices">Privacy choices</a><a class="gg-privacy-choices" href="/privacy/">Privacy</a><a class="gg-privacy-choices" href="/terms/">Terms</a></footer>
 <div class="gg-consent-banner" id="gg-consent-banner" role="dialog" aria-label="Cookie consent" aria-describedby="gg-consent-desc">
   <p class="gg-consent-text" id="gg-consent-desc">We use cookies for analytics to improve this site. No ads, no tracking across sites. <a href="/cookies/">Learn more</a>.</p>
   <button class="gg-consent-btn gg-consent-accept" id="gg-consent-accept">Accept</button>


### PR DESCRIPTION
Adds Privacy and Terms links to the shared consent footer used by generated static pages and to the WordPress mu-plugin footer.

Validation:
- 87 cookie/legal tests passed (2 skipped)
- generated guide, blog index, and roundup contain both legal links
- affected public surfaces deployed and cache purged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Footer markup/CSS and static legal links only; no changes to consent mode, cookies, or geo-gating logic.
> 
> **Overview**
> Extends the shared cookie-consent **privacy footer** on generated static pages (`cookie_consent.py`) and WordPress (`gg-cookie-consent.php`) so it exposes **Privacy** (`/privacy/`) and **Terms** (`/terms/`) alongside the existing **Privacy choices** control.
> 
> The footer markup moves from a single-link `div` to a semantic `<footer aria-label="Legal">`, and footer CSS switches from centered text to a **flex** row with gap/wrap so multiple links lay out cleanly. Consent banner behavior and JS are unchanged.
> 
> Tests in `test_cookie_consent.py` and `test_cookie_consent_mu_plugin.py` assert the new footer structure and legal URLs in both Python and PHP outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03dae274b8336684b9bb5ea51725a1362b23019d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->