### PR TITLE
fix(seo): normalize Gravel page headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ python3 scripts/push_wordpress.py --sync-pages --sync-widget --sync-index --purg
 | `--sync-photos` | Race photos (curated) |
 | `--sync-redirects` | .htaccess redirect rules (33) |
 | `--sync-noindex` | Noindex mu-plugin |
+| `--sync-headings` | Server-rendered H1 normalizer mu-plugin |
 | `--sync-sitemap` | Sitemap index + race sitemap |
 | `--purge-cache` | SiteGround cache purge |
 | `--deploy-content` | Pages + index + widget + cache |

--- a/scripts/push_wordpress.py
+++ b/scripts/push_wordpress.py
@@ -2175,6 +2175,36 @@ def sync_noindex():
         return False
 
 
+def sync_headings():
+    """Deploy the server-rendered H1 normalizer mu-plugin to WordPress."""
+    ssh = get_ssh_credentials()
+    if not ssh:
+        return False
+    host, user, port = ssh
+
+    project_root = Path(__file__).resolve().parent.parent
+    plugin_file = project_root / "wordpress" / "mu-plugins" / "gg-heading-normalizer.php"
+    if not plugin_file.exists():
+        print(f"✗ mu-plugin not found: {plugin_file}")
+        return False
+
+    remote_path = "~/www/gravelgodcycling.com/public_html/wp-content/mu-plugins"
+    try:
+        subprocess.run(
+            [
+                "scp", "-i", str(SSH_KEY), "-P", port,
+                str(plugin_file),
+                f"{user}@{host}:{remote_path}/gg-heading-normalizer.php",
+            ],
+            capture_output=True, text=True, timeout=15, check=True,
+        )
+        print("✓ Deployed gg-heading-normalizer.php mu-plugin")
+        return True
+    except Exception as e:
+        print(f"✗ Failed to deploy heading normalizer mu-plugin: {e}")
+        return False
+
+
 def sync_meta_descriptions():
     """Deploy meta description mu-plugin + JSON data to WordPress.
 
@@ -4051,6 +4081,10 @@ if __name__ == "__main__":
         help="Deploy noindex mu-plugin to wp-content/mu-plugins/"
     )
     parser.add_argument(
+        "--sync-headings", action="store_true",
+        help="Deploy H1 normalizer mu-plugin to wp-content/mu-plugins/"
+    )
+    parser.add_argument(
         "--sync-ctas", action="store_true",
         help="Deploy race CTA mu-plugin to wp-content/mu-plugins/"
     )
@@ -4222,6 +4256,7 @@ if __name__ == "__main__":
         args.sync_sitemap = True
         args.sync_redirects = True
         args.sync_noindex = True
+        args.sync_headings = True
         args.sync_ctas = True
         args.sync_training_form = True
         args.sync_ga4 = True
@@ -4253,7 +4288,7 @@ if __name__ == "__main__":
                       args.sync_consult_intake,
                       args.sync_training_plans, args.sync_success, args.sync_pages,
                       args.sync_sitemap, args.sync_redirects,
-                      args.sync_noindex, args.sync_ctas, args.sync_training_form, args.sync_ga4, args.sync_header, args.sync_prep_kits, args.sync_plan_pages, args.sync_tire_guides,
+                      args.sync_noindex, args.sync_headings, args.sync_ctas, args.sync_training_form, args.sync_ga4, args.sync_header, args.sync_prep_kits, args.sync_plan_pages, args.sync_tire_guides,
                       args.sync_series, args.sync_blog,
                       args.sync_blog_index, args.sync_photos, args.sync_ab, args.sync_courses,
                       args.sync_meta_descriptions, args.sync_mission_control,
@@ -4323,6 +4358,8 @@ if __name__ == "__main__":
         _run("sync-redirects", sync_redirects)
     if args.sync_noindex:
         _run("sync-noindex", sync_noindex)
+    if args.sync_headings:
+        _run("sync-headings", sync_headings)
     if args.sync_ctas:
         _run("sync-ctas", sync_ctas)
     if args.sync_training_form:

--- a/tests/test_guide_cluster.py
+++ b/tests/test_guide_cluster.py
@@ -110,6 +110,20 @@ def all_htmls(pillar_html, chapter_htmls, configurator_html):
 
 
 class TestOutputStructure:
+    def test_chapter_hero_has_one_page_h1(self):
+        chapter = {
+            "number": 1,
+            "id": "test-chapter",
+            "title": "Test Chapter",
+            "subtitle": "Test subtitle",
+            "gated": False,
+            "sections": [],
+        }
+        html = ggc.build_chapter_hero(chapter)
+        assert html.count("<h1") == 1
+        assert '<h1 class="gg-guide-chapter-title">Test Chapter</h1>' in html
+        assert '<h2 class="gg-guide-chapter-title">' not in html
+
     def test_pillar_page_exists(self, output_dir):
         assert (output_dir / "index.html").exists(), "Pillar page not generated"
 

--- a/tests/test_heading_normalizer.py
+++ b/tests/test_heading_normalizer.py
@@ -1,0 +1,44 @@
+"""Regression coverage for the WordPress heading normalizer."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN = ROOT / "wordpress" / "mu-plugins" / "gg-heading-normalizer.php"
+DEPLOYER = ROOT / "scripts" / "push_wordpress.py"
+
+
+def test_plugin_normalizes_the_final_server_response():
+    source = PLUGIN.read_text()
+    assert "is_singular()" in source
+    assert "ob_start( 'gg_h1_normalize_response' )" in source
+    assert "template_redirect" in source
+
+
+def test_plugin_repairs_empty_and_placeholder_titles():
+    source = PLUGIN.read_text()
+    assert "heading_text === ''" in source
+    assert "POST_TITLE" in source
+    assert "esc_html( $title )" in source
+
+
+def test_plugin_demotes_every_h1_after_the_first():
+    source = PLUGIN.read_text()
+    assert "if ( $seen === 1 )" in source
+    assert "return '<h2' . $match[1]" in source
+
+
+def test_plugin_injects_after_navigation_when_h1_is_missing():
+    source = PLUGIN.read_text()
+    assert "data-elementor-type" in source
+    assert "wp-page" in source
+    assert "gg-auto-title" in source
+    assert "<main" in source
+
+
+def test_deployer_exposes_and_runs_heading_sync():
+    source = DEPLOYER.read_text()
+    assert "def sync_headings():" in source
+    assert '"--sync-headings"' in source
+    assert "args.sync_headings = True" in source
+    assert '_run("sync-headings", sync_headings)' in source

--- a/wordpress/generate_guide_cluster.py
+++ b/wordpress/generate_guide_cluster.py
@@ -332,7 +332,7 @@ def build_chapter_hero(chapter: dict) -> str:
       {plate}
       <div class="gg-guide-chapter-title-block">
         <span class="gg-guide-chapter-num">CHAPTER {num:02d}</span>
-        <h2 class="gg-guide-chapter-title">{title}</h2>
+        <h1 class="gg-guide-chapter-title">{title}</h1>
         {subtitle_html}
       </div>
     </div>'''

--- a/wordpress/mu-plugins/gg-heading-normalizer.php
+++ b/wordpress/mu-plugins/gg-heading-normalizer.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Plugin Name: Gravel God Heading Normalizer
+ * Description: Guarantee one meaningful H1 on WordPress-managed public pages.
+ * Version: 1.0.0
+ *
+ * Deployed via: python3 scripts/push_wordpress.py --sync-headings
+ *
+ * Legacy Elementor templates contain three recurring defects:
+ *   - no H1 at all;
+ *   - a literal [POST_TITLE] or empty first H1;
+ *   - footer and section headings incorrectly marked up as additional H1s.
+ *
+ * This plugin corrects the final server-rendered HTML. Static race and guide
+ * pages bypass WordPress and remain the responsibility of their generators.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Normalize a complete HTML response to one meaningful H1.
+ */
+function gg_h1_normalize_markup( $html, $title ) {
+    if ( ! is_string( $html ) || $html === '' ) {
+        return $html;
+    }
+
+    $title = trim( wp_strip_all_tags( (string) $title ) );
+    if ( $title === '' ) {
+        return $html;
+    }
+
+    $h1_pattern = '~<h1\b([^>]*)>(.*?)</h1\s*>~is';
+    $h1_count = preg_match_all( $h1_pattern, $html );
+
+    if ( $h1_count > 0 ) {
+        $seen = 0;
+        return preg_replace_callback(
+            $h1_pattern,
+            function ( $match ) use ( &$seen, $title ) {
+                $seen++;
+                $heading_text = trim(
+                    wp_strip_all_tags(
+                        html_entity_decode( $match[2], ENT_QUOTES | ENT_HTML5, 'UTF-8' )
+                    )
+                );
+
+                if ( $seen === 1 ) {
+                    if ( $heading_text === '' || preg_match( '/^\[POST_TITLE\]$/i', $heading_text ) ) {
+                        return '<h1' . $match[1] . '>' . esc_html( $title ) . '</h1>';
+                    }
+                    return $match[0];
+                }
+
+                return '<h2' . $match[1] . '>' . $match[2] . '</h2>';
+            },
+            $html
+        );
+    }
+
+    $heading = '<div class="gg-auto-title-wrap"><h1 class="gg-auto-title">'
+        . esc_html( $title )
+        . '</h1></div>';
+    $inserted = 0;
+
+    // Elementor header/footer templates have no <main>. Insert immediately
+    // before their page root so the title appears after site navigation.
+    $html = preg_replace(
+        '~(?=<div\b[^>]*\bdata-elementor-type=(["\'])wp-page\1[^>]*>)~i',
+        $heading,
+        $html,
+        1,
+        $inserted
+    );
+    if ( $inserted ) {
+        return $html;
+    }
+
+    // Astra's default template provides a main landmark.
+    $html = preg_replace( '~(<main\b[^>]*>)~i', '$1' . $heading, $html, 1, $inserted );
+    if ( $inserted ) {
+        return $html;
+    }
+
+    // Defensive fallback for an unusual singular template.
+    return preg_replace( '~(<body\b[^>]*>)~i', '$1' . $heading, $html, 1 );
+}
+
+/**
+ * Resolve the queried title only after WordPress has built the response.
+ */
+function gg_h1_normalize_response( $html ) {
+    $post_id = get_queried_object_id();
+    return gg_h1_normalize_markup( $html, get_the_title( $post_id ) );
+}
+
+/**
+ * Buffer singular public responses so Elementor and theme markup can be fixed
+ * after every component has rendered, while bots still receive corrected HTML.
+ */
+function gg_h1_begin_response_buffer() {
+    if ( is_admin() || ! is_singular() || is_feed() || wp_doing_ajax() ) {
+        return;
+    }
+    ob_start( 'gg_h1_normalize_response' );
+}
+add_action( 'template_redirect', 'gg_h1_begin_response_buffer', 0 );
+
+/**
+ * Styling for titles injected into pages whose legacy template omitted one.
+ */
+function gg_h1_normalizer_styles() {
+    if ( ! is_singular() ) {
+        return;
+    }
+    echo '<style id="gg-heading-normalizer-css">'
+        . '.gg-auto-title-wrap{max-width:1100px;margin:0 auto;padding:32px 24px 16px}'
+        . '.gg-auto-title{margin:0;color:#3a2e25;font-family:"Source Serif 4",Georgia,serif;'
+        . 'font-size:clamp(32px,5vw,64px);font-weight:700;line-height:1.05;letter-spacing:-.025em}'
+        . '@media(max-width:600px){.gg-auto-title-wrap{padding:24px 20px 12px}}'
+        . '</style>' . "\n";
+}
+add_action( 'wp_head', 'gg_h1_normalizer_styles', 20 );


### PR DESCRIPTION
Repairs the 45 live sitemap heading irregularities at their source:

- makes each static handbook chapter title its page H1
- adds a WordPress response normalizer for missing, placeholder, empty, and duplicate H1 markup
- exposes the normalizer through the fail-closed deploy command

Validation:
- 348 focused guide/heading tests passed (130 skipped generated-artifact cases)
- all 10 regenerated guide pages contain exactly one H1
- production PHP lint passed
- four server-side normalization fixtures passed
- full local collection is unavailable in this clean worktree because fastmcp and ddgs are not installed; GitHub CI installs requirements.txt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The mu-plugin rewrites full HTML for every singular public WordPress response via output buffering, which could interact with caching or unusual templates if regex edge cases appear.
> 
> **Overview**
> Addresses sitemap heading issues by fixing **static guide chapters** and **WordPress-rendered pages** in one pass.
> 
> **Guide cluster:** Chapter hero titles in `generate_guide_cluster.py` now render as a single `<h1>` (was `<h2>`), with a regression test on `build_chapter_hero`.
> 
> **WordPress:** New mu-plugin `gg-heading-normalizer.php` buffers singular public HTML on `template_redirect`, then ensures exactly one meaningful H1—repairs empty or `[POST_TITLE]` first headings, demotes extra `<h1>` tags to `<h2>`, and injects a styled auto-title when none exists (Elementor `wp-page` root, `<main>`, or `<body>` fallback). Static race/guide HTML is explicitly out of scope.
> 
> **Deploy:** `push_wordpress.py` adds `sync_headings()` and `--sync-headings`, documented in the README and included in `--deploy-all`. `test_heading_normalizer.py` locks plugin behavior and deploy wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e9e04406eccac34e56587ec940e378013a4a4e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->