### PR TITLE
fix(seo): treat NBSP headings as empty

### DIFF
--- a/tests/test_heading_normalizer.py
+++ b/tests/test_heading_normalizer.py
@@ -19,6 +19,7 @@ def test_plugin_repairs_empty_and_placeholder_titles():
     source = PLUGIN.read_text()
     assert "heading_text === ''" in source
     assert "POST_TITLE" in source
+    assert "00A0" in source
     assert "esc_html( $title )" in source
 
 

--- a/wordpress/mu-plugins/gg-heading-normalizer.php
+++ b/wordpress/mu-plugins/gg-heading-normalizer.php
@@ -41,11 +41,12 @@ function gg_h1_normalize_markup( $html, $title ) {
             $h1_pattern,
             function ( $match ) use ( &$seen, $title ) {
                 $seen++;
-                $heading_text = trim(
-                    wp_strip_all_tags(
-                        html_entity_decode( $match[2], ENT_QUOTES | ENT_HTML5, 'UTF-8' )
-                    )
+                $heading_text = wp_strip_all_tags(
+                    html_entity_decode( $match[2], ENT_QUOTES | ENT_HTML5, 'UTF-8' )
                 );
+                // PHP trim() does not remove non-breaking spaces, which appear
+                // in one legacy Elementor title as &nbsp;.
+                $heading_text = trim( preg_replace( '/[\s\x{00A0}]+/u', ' ', $heading_text ) );
 
                 if ( $seen === 1 ) {
                     if ( $heading_text === '' || preg_match( '/^\[POST_TITLE\]$/i', $heading_text ) ) {


### PR DESCRIPTION
Handles a legacy Elementor H1 containing only `&nbsp;`, which PHP `trim()` does not consider empty. Unicode whitespace is normalized before title validation.

Validation:
- focused tests passed
- production PHP lint passed
- five server-side normalization fixtures passed, including the live NBSP shape

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to first-H1 text normalization on singular public pages; behavior only broadens empty detection for NBSP-only headings.
> 
> **Overview**
> Fixes **first H1 repair** when legacy Elementor markup uses only a non-breaking space (`&nbsp;` / U+00A0). PHP `trim()` leaves NBSP in place, so those headings were not treated as empty and did not get replaced with the post title.
> 
> Heading text is now **normalized** by collapsing Unicode whitespace (including `\x{00A0}`) to a single space before the empty/`[POST_TITLE]` checks. A regression test asserts the plugin source includes that NBSP handling (`00A0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1ccd1f382220e94f63659998e89efaa76301793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->