### PR TITLE
Speed historical editorial decisions

### DIFF
--- a/scripts/render_gravel_weekly_history_review.py
+++ b/scripts/render_gravel_weekly_history_review.py
@@ -155,8 +155,29 @@ def render_history_review(entries: list[dict[str, Any]], year: int) -> str:
         if entry["activeFrom"] <= f"{year}-12-31" and entry["activeThrough"] >= f"{year}-01-01"
     ]
     drafts = [entry for entry in selected if entry["status"] == "draft"]
-    ready = sum(not approval_holds(entry) for entry in drafts)
-    held = len(drafts) - ready
+    ready_entries = [entry for entry in drafts if not approval_holds(entry)]
+    held_entries = [entry for entry in drafts if approval_holds(entry)]
+    ready_entry_ids = {entry["entryId"] for entry in ready_entries}
+    ready = len(ready_entries)
+    held = len(held_entries)
+    queue = "".join(
+        '<li><a href="#{entry_id}"><span>{status}</span><b>{headline}</b>'
+        '<code>{content_hash}</code></a></li>'.format(
+            entry_id=esc(entry["entryId"]),
+            status="READY" if entry["entryId"] in ready_entry_ids else "HOLD",
+            headline=esc(entry["headline"]),
+            content_hash=esc(entry["contentHash"][:12]),
+        )
+        for entry in drafts
+    )
+    ready_ids = ", ".join(entry["entryId"] for entry in ready_entries)
+    bulk_instruction = (
+        f'<p class="bulk"><b>ONE-LINE APPROVAL:</b> If—and only if—you agree with every READY headline and Take, reply '
+        f'<q>approve all READY {year} entries as written</q>. That instruction is limited to: <code>{esc(ready_ids)}</code>. '
+        "HOLD entries remain excluded and cannot be rescued by bulk approval.</p>"
+        if ready_entries
+        else '<p class="bulk"><b>NO BULK APPROVAL AVAILABLE.</b> Every draft is held.</p>'
+    )
     cards = "".join(_card(entry) for entry in drafts)
     return f'''<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
@@ -172,6 +193,15 @@ main {{ width: min(1120px, calc(100% - 32px)); margin: 32px auto 80px; }}
 .summary {{ display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }}
 .summary b, .ready, .hold {{ border: var(--gg-border-standard); padding: 6px 10px; background: var(--gg-color-warm-paper); }}
 .hold {{ background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }}
+.bulk {{ max-width: none !important; margin: 20px 0 0; border: var(--gg-border-standard); background: var(--gg-color-warm-paper); padding: var(--gg-spacing-md); }}
+.bulk q {{ font-weight: var(--gg-font-weight-black); }}
+.decision-queue {{ margin-top: 20px; border: var(--gg-border-standard); background: var(--gg-color-white); }}
+.decision-queue h2 {{ margin: 0; padding: 10px 12px; border-bottom: var(--gg-border-standard); }}
+.decision-queue ol {{ margin: 0; padding: 0; list-style: none; }}
+.decision-queue li + li {{ border-top: var(--gg-border-subtle); }}
+.decision-queue a {{ display: grid; grid-template-columns: 64px minmax(0, 1fr) auto; gap: 12px; align-items: center; padding: 10px 12px; color: inherit; text-decoration: none; }}
+.decision-queue a:hover, .decision-queue a:focus-visible {{ background: var(--gg-color-sand); }}
+.decision-queue span {{ font-weight: var(--gg-font-weight-black); }}
 .story {{ margin-top: 32px; border: var(--gg-border-heavy); background: var(--gg-color-warm-paper); }}
 .story > header, .story > section, .story > div, .story > details, .story > footer {{ padding: var(--gg-spacing-lg); border-top: var(--gg-border-standard); }}
 .story > header {{ border-top: 0; background: var(--gg-color-white); }}
@@ -186,11 +216,13 @@ summary {{ cursor: pointer; font-weight: var(--gg-font-weight-black); }}
 .receipts li {{ margin: 16px 0; }} blockquote {{ margin: 8px 0; font-family: var(--gg-font-editorial); }}
 .gates {{ max-width: 520px; padding: 0; list-style: none; }} .gates li {{ display: flex; justify-content: space-between; border-bottom: var(--gg-border-subtle); padding: 8px 0; }}
 code {{ overflow-wrap: anywhere; }} footer {{ background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }} footer code {{ color: var(--gg-color-light-gold); }}
-@media (max-width: 700px) {{ .judgment {{ grid-template-columns: 1fr; }} .judgment section + section {{ border-left: 0; border-top: var(--gg-border-standard); }} main {{ width: min(100% - 16px, 1120px); margin-top: 8px; }} }}
+@media (max-width: 700px) {{ .judgment {{ grid-template-columns: 1fr; }} .judgment section + section {{ border-left: 0; border-top: var(--gg-border-standard); }} .decision-queue a {{ grid-template-columns: 56px minmax(0, 1fr); }} .decision-queue code {{ grid-column: 2; }} main {{ width: min(100% - 16px, 1120px); margin-top: 8px; }} }}
 </style></head><body><main>
   <header class="desk-head"><div class="eyebrow">PRIVATE EDITORIAL DESK · NOT PUBLIC</div><h1>{year}<br>THE SEASON<br>AS A STORY</h1>
   <p>This queue contains narrative change-points, not one required story per week. Review the point first, then the Take. Receipts from the active period are separated from evidence learned later.</p>
-  <div class="summary"><b>{len(drafts)} DRAFTS</b><b>{ready} READY FOR HUMAN DECISION</b><b>{held} HELD BY EVIDENCE, EDITORIAL, OR PROSE GATES</b></div></header>
+  <div class="summary"><b>{len(drafts)} DRAFTS</b><b>{ready} READY FOR HUMAN DECISION</b><b>{held} HELD BY EVIDENCE, EDITORIAL, OR PROSE GATES</b></div>
+  {bulk_instruction}
+  <nav class="decision-queue" aria-label="Historical story decision queue"><h2>DECISION QUEUE</h2><ol>{queue}</ol></nav></header>
   {cards or '<section class="story"><header><h2>No draft historical entries for this year.</h2></header></section>'}
 </main></body></html>'''
 

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -842,6 +842,15 @@ def test_private_historical_review_desk_separates_evidence_and_approval_state():
     assert "3 DRAFTS" in page
     assert "1 READY FOR HUMAN DECISION" in page
     assert "2 HELD BY EVIDENCE, EDITORIAL, OR PROSE GATES" in page
+    assert "DECISION QUEUE" in page
+    assert f'href="#{draft["entryId"]}"' in page
+    assert f'href="#{held["entryId"]}"' in page
+    assert "approve all READY 2026 entries as written" in page
+    assert draft["entryId"] in page.split("HOLD entries remain excluded", 1)[0]
+    bulk_scope = page.split("That instruction is limited to:", 1)[1].split(
+        "HOLD entries remain excluded", 1
+    )[0]
+    assert held["entryId"] not in bulk_scope
     assert "THE TAKE · MODEL DRAFT" in page
     assert "NO-AI-SLOP PROSE GATE · PASS" in page
     assert "NO-AI-SLOP PROSE GATE · FAIL" in page


### PR DESCRIPTION
## Summary
- add a linked READY/HOLD decision queue to the private yearly historical desk
- expose one exact bulk-approval phrase whose scope is limited to the READY entry IDs
- keep held stories explicitly outside bulk approval
- preserve individual, hash-bound decision instructions on every story

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` — 80 passed
- `git diff --check`
- rendered the real 2026 desk and visually inspected the top/decision queue in the Codex in-app browser

No story was approved, sealed, published, deployed, emailed, or applied to race data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to private HTML rendering and test expectations; approval gates and apply/seal logic are untouched in this diff.
> 
> **Overview**
> The private yearly **historical review** HTML desk now surfaces editorial decisions at the top, not only per-story cards.
> 
> **render_history_review** builds explicit **READY** vs **HOLD** draft lists (same `approval_holds` rules as before) and adds a **DECISION QUEUE** nav: each draft links to its story card with status, headline, and a short content-hash prefix. A **ONE-LINE APPROVAL** block shows the exact phrase `approve all READY {year} entries as written`, lists only READY entry IDs in scope, and states that HOLD entries cannot be bulk-approved; if every draft is held, it shows **NO BULK APPROVAL AVAILABLE**.
> 
> Styling covers the bulk callout and queue (including mobile layout). Tests assert the queue, anchor links, bulk phrase, and that held IDs stay outside the bulk scope string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50feb491e82c394d026700df2040897b7078137e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->