### PR TITLE
Publish Gravel Weekly history independently

### DIFF
--- a/.github/workflows/gravel-weekly-history-publish.yml
+++ b/.github/workflows/gravel-weekly-history-publish.yml
@@ -1,0 +1,173 @@
+name: "Gravel Weekly History Publish"
+
+# Historical narrative entries have their own approval and sealing boundary.
+# This manual workflow deploys already-published snapshots without inventing or
+# requiring a weekly issue. It cannot approve or seal history.
+on:
+  workflow_dispatch:
+    inputs:
+      year:
+        description: "Published historical year to verify and deploy"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: gravel-weekly-publish
+  cancel-in-progress: false
+
+jobs:
+  publish-history:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Require the canonical main branch
+        env:
+          DEPLOY_REF: ${{ github.ref }}
+        run: |
+          if [[ "$DEPLOY_REF" != "refs/heads/main" ]]; then
+            echo "::error::Historical publication must run from main, not $DEPLOY_REF"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Verify every public history snapshot has an immutable decision
+        id: history
+        env:
+          HISTORY_YEAR: ${{ inputs.year }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+          from scripts.validate_gravel_weekly_history import load_public_history_entries
+          from scripts.validate_gravel_weekly_history_decisions import validate_history_decision
+
+          year = int(os.environ["HISTORY_YEAR"])
+          entries = load_public_history_entries()
+          selected = [
+              entry for entry in entries
+              if entry["activeFrom"] <= f"{year}-12-31"
+              and entry["activeThrough"] >= f"{year}-01-01"
+          ]
+          if not selected:
+              raise SystemExit(f"No status=published historical entries overlap {year}")
+          decision_dir = Path("data/gravel-weekly/history-decisions")
+          for entry in entries:
+              decision_path = decision_dir / f"{entry['entryId']}.json"
+              if not decision_path.exists():
+                  raise SystemExit(f"Immutable historical decision not found: {decision_path}")
+              validate_history_decision(json.loads(decision_path.read_text()), entry)
+          selected = sorted(selected, key=lambda entry: entry["entryId"])
+          payload = "\n".join(f"{entry['entryId']}:{entry['contentHash']}" for entry in selected)
+          set_hash = hashlib.sha256(payload.encode()).hexdigest()
+          Path("artifacts").mkdir(exist_ok=True)
+          Path("artifacts/history-hashes.txt").write_text(
+              "\n".join(entry["contentHash"] for entry in selected) + "\n"
+          )
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"set_hash={set_hash}\n")
+              output.write(f"entry_count={len(selected)}\n")
+          print(f"Verified {len(selected)} published {year} entries; set hash {set_hash}")
+          PY
+
+      - name: Generate the historical timeline and homepage
+        run: |
+          python wordpress/generate_gravel_weekly.py
+          python wordpress/generate_homepage.py
+
+      - name: Verify publication infrastructure
+        run: |
+          python -m pytest tests/test_gravel_weekly.py -q
+          grep -q "G-EJJZ9T6M52" wordpress/output/gravel-weekly.html
+          while IFS= read -r history_hash; do
+            grep -q "gravel-weekly-history-hash: $history_hash" wordpress/output/gravel-weekly.html
+          done < artifacts/history-hashes.txt
+          python scripts/preflight_quality.py
+
+      - name: Build controlled historical race-impact review
+        env:
+          HISTORY_YEAR: ${{ inputs.year }}
+        run: |
+          python scripts/render_gravel_weekly_history_race_impact_review.py \
+            --year "$HISTORY_YEAR" \
+            --output artifacts/gravel-weekly-history-race-impact-review.md
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: gravel-weekly-history-${{ inputs.year }}-${{ steps.history.outputs.set_hash }}
+          path: artifacts/gravel-weekly-history-race-impact-review.md
+          retention-days: 90
+
+      - name: Open immutable historical race-impact review queue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HISTORY_YEAR: ${{ inputs.year }}
+          HISTORY_SET_HASH: ${{ steps.history.outputs.set_hash }}
+        run: |
+          if grep -q '<!-- meaningful-history-race-impact-count: 0 -->' artifacts/gravel-weekly-history-race-impact-review.md; then
+            echo "No historical race impact; no review issue needed."
+            exit 0
+          fi
+          short_hash="${HISTORY_SET_HASH:0:12}"
+          title="Gravel Weekly $HISTORY_YEAR historical race-impact review · $short_hash"
+          gh label create gravel-weekly-history-impact --color 5319e7 --description "Published historical evidence awaiting controlled race-profile review" --force
+          existing="$(gh issue list --label gravel-weekly-history-impact --state all --limit 200 --json number,title --jq ".[] | select(.title == \"$title\") | .number" | head -1)"
+          if [[ -n "$existing" ]]; then
+            echo "Review issue #$existing already exists; preserving its history."
+          else
+            gh issue create --title "$title" --label gravel-weekly-history-impact --body-file artifacts/gravel-weekly-history-race-impact-review.md
+          fi
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/siteground_key
+          chmod 600 ~/.ssh/siteground_key
+          ssh-keyscan -p "${{ secrets.SSH_PORT }}" "${{ secrets.SSH_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy timeline, homepage, redirect, and purge cache
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ secrets.SSH_PORT }}
+        run: python scripts/push_wordpress.py --sync-gravel-weekly --sync-homepage --sync-redirects --purge-cache
+
+      - name: Verify the exact historical set is live
+        env:
+          HISTORY_SET_HASH: ${{ steps.history.outputs.set_hash }}
+        run: |
+          found=false
+          for attempt in 1 2 3 4 5; do
+            if page="$(curl -fsSL "https://gravelgodcycling.com/gravel-weekly/?v=$HISTORY_SET_HASH")"; then
+              missing=false
+              while IFS= read -r history_hash; do
+                if ! grep -q "gravel-weekly-history-hash: $history_hash" <<< "$page"; then
+                  missing=true
+                fi
+              done < artifacts/history-hashes.txt
+              if [[ "$missing" == false ]]; then
+                found=true
+                break
+              fi
+            fi
+            sleep 10
+          done
+          if [[ "$found" != true ]]; then
+            echo "::error::Expected historical set is not live at /gravel-weekly/"
+            exit 1
+          fi
+          test "$(curl -sIL -o /dev/null -w '%{url_effective}' https://gravelgodcycling.com/gravel-tv/)" = "https://gravelgodcycling.com/gravel-weekly/"

--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -155,3 +155,12 @@ Sealing verifies the decision against the unchanged canonical draft, replaces
 that draft with the published immutable snapshot, and writes its durable
 decision under `history-decisions/`. It does not deploy the site, and race
 impacts remain editorial-review proposals with `autoFixAllowed: false`.
+
+After the sealed snapshots and decisions merge to `main`, dispatch
+`Gravel Weekly History Publish` with the reviewed year. This route is separate
+from weekly issue publication: it requires no Issue #001, validates every
+public snapshot against its immutable decision, generates entry-level hash
+markers, opens an idempotent controlled race-impact review when needed, deploys
+the timeline and homepage, purges SiteGround cache, and verifies every selected
+hash plus the legacy Gravel TV redirect on the live site. Approved-but-unsealed
+entries remain private and are excluded from the public loader.

--- a/scripts/render_gravel_weekly_history_race_impact_review.py
+++ b/scripts/render_gravel_weekly_history_race_impact_review.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Render a controlled race-impact queue from published historical entries."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from validate_gravel_weekly_history import HISTORY_DIR, load_history_entries
+from validate_gravel_weekly_history_decisions import validate_history_decision
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DECISION_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "history-decisions"
+
+
+def history_set_hash(entries: list[dict[str, Any]]) -> str:
+    payload = "\n".join(
+        f"{entry['entryId']}:{entry['contentHash']}"
+        for entry in sorted(entries, key=lambda item: item["entryId"])
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def render_history_race_impact_review(
+    entries: list[dict[str, Any]],
+    decisions: dict[str, dict[str, Any]],
+    *,
+    year: int,
+) -> tuple[str, int, str]:
+    selected = [
+        entry
+        for entry in entries
+        if entry["status"] == "published"
+        and entry["activeFrom"] <= f"{year}-12-31"
+        and entry["activeThrough"] >= f"{year}-01-01"
+    ]
+    if not selected:
+        raise ValueError(f"no published {year} historical entries are available")
+    for entry in selected:
+        decision = decisions.get(entry["entryId"])
+        if decision is None:
+            raise ValueError(f"historical decision missing for {entry['entryId']}")
+        validate_history_decision(decision, entry)
+
+    set_hash = history_set_hash(selected)
+    impacts = [
+        (entry, impact)
+        for entry in selected
+        for impact in entry["raceImpacts"]
+    ]
+    lines = [
+        f"<!-- meaningful-history-race-impact-count: {len(impacts)} -->",
+        f"<!-- gravel-weekly-history-set-hash: {set_hash} -->",
+        f"# Gravel Weekly {year} historical race-impact review",
+        "",
+        f"Published timeline: https://gravelgodcycling.com/gravel-weekly/#season-story",
+        f"History set hash: `{set_hash}` · entries: {len(selected)}",
+        "",
+        "> Controlled review only. Publishing a historical narrative does not authorize or perform a race-profile edit.",
+        "> Confirm each claim against the current canonical profile, then use a normal branch, regression test, and pull request.",
+        "",
+    ]
+    if not impacts:
+        lines.extend(["No historical race-profile implication was proposed.", ""])
+        return "\n".join(lines), 0, set_hash
+
+    for entry, impact in impacts:
+        receipts = {
+            receipt["claimId"]: receipt
+            for receipt in entry["contemporaryReceipts"] + entry["laterEvidence"]
+        }
+        encoded = json.dumps(impact, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        impact_id = hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:12]
+        lines.extend([
+            f"## {impact['raceId']} · `{impact['fieldPath'] or 'catalog'}`",
+            "",
+            f"Story: [{entry['headline']}](https://gravelgodcycling.com/gravel-weekly/#{entry['entryId']})",
+            f"Entry: `{entry['entryId']}` · history hash: `{entry['contentHash']}`",
+            f"Impact ID: `{impact_id}` · evidence confidence: {round(float(impact['confidence']) * 100)}% · owner: `{impact['owner']}`",
+            "",
+            "### Evidence",
+            "",
+        ])
+        for claim_id in impact["claimIds"]:
+            receipt = receipts[claim_id]
+            published = f" · {receipt['publishedAt'][:10]}" if receipt.get("publishedAt") else ""
+            timestamp = ""
+            if receipt.get("transcriptStartSeconds") is not None:
+                seconds = int(receipt["transcriptStartSeconds"])
+                timestamp = f" · {seconds // 60}:{seconds % 60:02d}"
+            lines.append(
+                f"- `{claim_id}` · [{receipt['publisher']}]({receipt['canonicalUrl']}){published}{timestamp}"
+            )
+        lines.extend([
+            "",
+            "### Human disposition",
+            "",
+            "- [ ] Confirm the current canonical profile and source freshness",
+            "- [ ] Decide whether the narrative belongs in `race.history`; reject or revise with a reason if not",
+            "- [ ] Add a failing regression fixture before any accepted change",
+            "- [ ] Apply only through the owning repository's normal pull-request path",
+            "",
+        ])
+    return "\n".join(lines), len(impacts), set_hash
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--year", required=True, type=int)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--history-dir", type=Path, default=HISTORY_DIR)
+    parser.add_argument("--decision-dir", type=Path, default=DECISION_DIR)
+    args = parser.parse_args()
+
+    entries = load_history_entries(args.history_dir)
+    decisions: dict[str, dict[str, Any]] = {}
+    if args.decision_dir.exists():
+        for path in sorted(args.decision_dir.glob("*.json")):
+            decision = json.loads(path.read_text(encoding="utf-8"))
+            entry_id = decision.get("entryId")
+            if isinstance(entry_id, str):
+                decisions[entry_id] = decision
+    try:
+        review, count, set_hash = render_history_race_impact_review(
+            entries, decisions, year=args.year
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(f"{review.rstrip()}\n", encoding="utf-8")
+    print(f"Rendered {count} controlled historical race impact(s); set hash {set_hash}: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_gravel_weekly_history.py
+++ b/scripts/validate_gravel_weekly_history.py
@@ -188,7 +188,7 @@ def load_history_entries(history_dir: Path = HISTORY_DIR) -> list[dict[str, Any]
 
 def load_public_history_entries(history_dir: Path = HISTORY_DIR) -> list[dict[str, Any]]:
     """Load only history entries that have cleared the editorial publication boundary."""
-    return [entry for entry in load_history_entries(history_dir) if entry["status"] in {"approved", "published"}]
+    return [entry for entry in load_history_entries(history_dir) if entry["status"] == "published"]
 
 
 def main() -> int:

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -39,6 +39,9 @@ from seal_gravel_weekly_history import (  # noqa: E402
     main as seal_history_main,
     seal_history_entry,
 )
+from render_gravel_weekly_history_race_impact_review import (  # noqa: E402
+    render_history_race_impact_review,
+)
 from validate_gravel_weekly_history_decisions import validate_history_decision  # noqa: E402
 from validate_gravel_weekly_backfill import validate_backfill_ledger  # noqa: E402
 from no_ai_slop import audit_no_ai_slop  # noqa: E402
@@ -953,9 +956,15 @@ def test_historical_race_impacts_are_review_only_and_use_canonical_race_ids():
         validate_history_entry(entry, verify_hash=False)
 
 
-def test_historical_drafts_never_cross_the_public_loader(tmp_path):
-    approved = sample_history_entry()
-    draft = copy.deepcopy(approved)
+def test_only_sealed_historical_snapshots_cross_the_public_loader(tmp_path):
+    published = sample_history_entry()
+    approved = copy.deepcopy(published)
+    approved.update({
+        "entryId": "history-approved-but-unpublished-2026",
+        "status": "approved",
+        "publishedAt": None,
+    })
+    draft = copy.deepcopy(published)
     draft.update({
         "entryId": "history-held-model-draft-2026",
         "status": "draft",
@@ -964,16 +973,19 @@ def test_historical_drafts_never_cross_the_public_loader(tmp_path):
         "editorialApproval": None,
     })
     draft["editorialGates"]["hostileEditor"] = "hold"
+    published["contentHash"] = compute_history_content_hash(published)
     approved["contentHash"] = compute_history_content_hash(approved)
     draft["contentHash"] = compute_history_content_hash(draft)
+    (tmp_path / "published.json").write_text(json.dumps(published))
     (tmp_path / "approved.json").write_text(json.dumps(approved))
     (tmp_path / "draft.json").write_text(json.dumps(draft))
 
     assert {entry["entryId"] for entry in load_history_entries(tmp_path)} == {
+        published["entryId"],
         approved["entryId"],
         draft["entryId"],
     }
-    assert [entry["entryId"] for entry in load_public_history_entries(tmp_path)] == [approved["entryId"]]
+    assert [entry["entryId"] for entry in load_public_history_entries(tmp_path)] == [published["entryId"]]
 
 
 def test_2025_backfill_ledger_preserves_the_complete_assigning_desk_review():
@@ -1518,6 +1530,7 @@ def test_2026_backfill_ledger_accounts_for_every_window_and_closes_research_revi
 def test_historical_timeline_visually_separates_later_evidence_from_contemporary_receipts():
     entry = sample_history_entry()
     html = render_history_timeline([entry])
+    assert f"gravel-weekly-history-hash: {entry['contentHash']}" in html
     assert "THE SEASON AS A STORY" in html
     assert "WHAT WAS KNOWABLE THEN" in html
     assert "LATER EVIDENCE — NOT AVAILABLE THEN" in html
@@ -1528,6 +1541,39 @@ def test_historical_timeline_visually_separates_later_evidence_from_contemporary
     page = build_page(sample_issue(), [sample_issue()], latest=True, history_entries=[entry])
     assert 'id="season-story"' in page
     assert page.index("THE CURRENT THING") < page.index("THE SEASON AS A STORY") < page.index("PAST ISSUES")
+
+
+def test_published_history_creates_a_controlled_hash_bound_race_impact_queue():
+    draft = sample_history_draft()
+    draft["raceImpacts"] = [{
+        "impactKind": "editorial_review",
+        "raceId": "gravel:unbound-200",
+        "fieldPath": "race.history",
+        "claimIds": ["claim_team_1"],
+        "confidence": 0.91,
+        "owner": "Gravel God historical editorial review",
+        "autoFixAllowed": False,
+    }]
+    draft["contentHash"] = compute_history_content_hash(draft)
+    approval = sample_history_approval(draft)
+    approved, decision = apply_history_decision(draft, approval)
+    assert approved is not None
+    published = seal_history_entry(approved, "2026-08-28T16:05:00Z")
+
+    review, count, set_hash = render_history_race_impact_review(
+        [published], {published["entryId"]: decision}, year=2026
+    )
+
+    assert count == 1
+    assert len(set_hash) == 64
+    assert f"gravel-weekly-history-set-hash: {set_hash}" in review
+    assert published["contentHash"] in review
+    assert "Controlled review only" in review
+    assert "does not authorize or perform a race-profile edit" in review
+    assert "claim_team_1" in review
+    assert "https://www.cyclingnews.com/team-story/" in review
+    with pytest.raises(ValueError, match="historical decision missing"):
+        render_history_race_impact_review([published], {}, year=2026)
 
 
 def test_historical_chronology_rejects_hindsight_in_contemporary_receipts_and_preexisting_later_evidence():
@@ -1566,6 +1612,17 @@ def test_deploy_path_and_legacy_redirect_are_wired():
     assert "validate_decision_receipt" in workflow
     assert "record_gravel_weekly_decisions.py" in workflow
     assert "CONTROL_PLANE_INGEST_SECRET" in workflow
+    history_workflow = (ROOT / ".github" / "workflows" / "gravel-weekly-history-publish.yml").read_text()
+    assert "workflow_dispatch:" in history_workflow
+    assert 'group: gravel-weekly-publish' in history_workflow
+    assert 'refs/heads/main' in history_workflow
+    assert "load_public_history_entries" in history_workflow
+    assert "validate_history_decision" in history_workflow
+    assert "render_gravel_weekly_history_race_impact_review.py" in history_workflow
+    assert "meaningful-history-race-impact-count: 0" in history_workflow
+    assert "gravel-weekly-history-hash:" in history_workflow
+    assert "--sync-gravel-weekly --sync-homepage --sync-redirects --purge-cache" in history_workflow
+    assert "send_gravel_weekly.py" not in history_workflow
 
 
 def test_homepage_surfaces_gravel_weekly_without_a_gravel_tv_content_path():

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -205,7 +205,8 @@ def render_history_timeline(entries: list[dict[str, Any]]) -> str:
               <summary>LATER EVIDENCE — NOT AVAILABLE THEN · {len(entry['laterEvidence'])}</summary>
               {render_receipts(entry['laterEvidence'])}
             </details>'''
-        cards.append(f'''<article class="gw-history-entry" id="{esc(entry['entryId'])}">
+        cards.append(f'''<!-- gravel-weekly-history-hash: {esc(entry['contentHash'])} -->
+        <article class="gw-history-entry" id="{esc(entry['entryId'])}">
           <header><span class="gw-history-date">{esc(active_label.upper())}</span><span class="gw-score">EDITORIAL SCORE {entry['editorialScore']}/100</span><h3>{esc(entry['headline'])}</h3></header>
           <div class="gw-history-grid">
             <section><h4>THE POINT</h4>{prose(entry['point'])}<h4>WHAT HAPPENED</h4>{prose(entry['whatHappened'])}<h4>WHY IT MATTERED</h4>{prose(entry['stakes'])}<h4>THE FAIR OBJECTION</h4>{prose(entry['credibleOpposition'])}</section>


### PR DESCRIPTION
## Summary
- add a manual, main-only historical publication workflow that does not require a weekly issue
- expose only sealed `status=published` history; approved-but-unsealed copy remains private
- emit entry-level content-hash markers and verify the exact selected set after SiteGround deployment and cache purge
- produce an immutable, review-only historical race-impact artifact and idempotent GitHub queue without editing race data
- preserve the existing shared publication lock and Gravel TV redirect verification

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` — 82 passed
- `python3 scripts/preflight_quality.py` — passed (7 pre-existing/environment warnings)
- `python3 wordpress/generate_gravel_weekly.py` — generated shell with no unsealed history
- parsed `.github/workflows/gravel-weekly-history-publish.yml` successfully
- `git diff --check`

No historical entry was approved, sealed, published, deployed, emailed, or applied to race data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deploy (SSH, cache purge) and tightens what history is public, but changes are gated on main, decision validation, and post-deploy hash checks rather than auto-editing race data.
> 
> **Overview**
> Adds a **manual, main-only** GitHub Actions workflow (`Gravel Weekly History Publish`) that deploys already **sealed** historical narrative snapshots for a chosen year—**without** approving, sealing, or requiring a weekly issue.
> 
> **Publication boundary:** `load_public_history_entries` now exposes only `status=published` entries; approved-but-unsealed history stays off the public timeline. The generator embeds **entry-level** `gravel-weekly-history-hash` markers in the timeline HTML.
> 
> **Deploy path:** The workflow validates every public snapshot against its immutable `history-decisions` receipt, computes a year set hash, runs tests/preflight, syncs gravel-weekly/homepage/redirects, purges cache, and **retries live verification** that each hash appears on `/gravel-weekly/` plus the Gravel TV → Gravel Weekly redirect. It shares the existing `gravel-weekly-publish` concurrency group with weekly publication.
> 
> **Race impacts:** New `render_gravel_weekly_history_race_impact_review.py` builds a hash-bound, review-only markdown queue; the workflow uploads it and opens an **idempotent** GitHub issue when meaningful impacts exist—**no** automatic race-profile edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25c3f589c81012afa12b3c5aab7446a1db4d5464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->