### PR TITLE
Require the full no-ai-slop editorial pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@
 Before drafting, rewriting, or approving copy presented as Matti Rowe or one of
 his brands, read `docs/AI_WRITING_POLICY.md`. Its source-retrieval,
 provenance, privacy, and anti-slop requirements are binding.
+This includes the complete pinned `petergyang/no-ai-slop` skill and eval;
+passing a phrase linter alone is not approval.
 
 ## Baseline editorial and citation rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,8 @@
 Before drafting, rewriting, or approving copy presented as Matti Rowe or one of
 his brands, read `docs/AI_WRITING_POLICY.md`. Its source-retrieval,
 provenance, privacy, and anti-slop requirements are binding.
+This includes the complete pinned `petergyang/no-ai-slop` skill and eval;
+passing a phrase linter alone is not approval.
 
 ## Baseline editorial and citation rules
 

--- a/docs/AI_WRITING_POLICY.md
+++ b/docs/AI_WRITING_POLICY.md
@@ -29,6 +29,28 @@ Matti outranks both.
    a quota.
 7. Run the target repo's slop/voice gate. If none exists, run the writing graph's
    `scripts/check_ai_writing.py --strict` against the draft.
+8. Apply the complete pinned `petergyang/no-ai-slop` edit workflow and every
+   check in its `eval.md`. The deterministic gate is not a substitute for this
+   editorial pass.
+
+## Required no-ai-slop pass
+
+The canonical copy is vendored in `wattgod/writing-graph/vendor/no-ai-slop/`
+from https://github.com/petergyang/no-ai-slop at commit
+`d30eddb9e04562234f2070b5ee63ca4649d9a05e`. Read both `SKILL.md` and
+`eval.md`. Preserve the point, facts, vocabulary, useful edge, and natural
+cadence while removing portable filler, fake drama, inflated claims, structural
+tics, and formatting decoration.
+
+Use detect mode for raw Matti-authored sources and derived analytical notes.
+Name findings without scoring authorship or silently rewriting the evidence.
+Historical use of a flagged pattern does not authorize an AI to imitate it.
+
+Use edit mode for AI-assisted copy presented as Matti or one of his brands.
+Make the minimum effective edit, run the strict mechanical gate, complete the
+full human eval, and fix every failed check before approval. Portability,
+meaning preservation, synonym cycling, robotic rhythm, and voice flattening
+always require editorial judgment.
 
 ## Valid voice evidence
 
@@ -80,4 +102,3 @@ Before approval, identify:
 
 Voice is the consequence of judgment, evidence, and relationship. It is not a
 bag of tricks.
-


### PR DESCRIPTION
## What changed\n\n- makes the complete pinned petergyang/no-ai-slop skill and eval binding\n- states that a mechanical phrase checker alone is not approval\n- separates detect-only treatment of historical voice evidence from strict editing of AI copy\n- requires the minimum-effective-edit workflow and full human eval\n\nCanonical implementation and corpus audit: https://github.com/wattgod/writing-graph/pull/2\n\nPolicy-only change. No public copy, plans, or deployment state changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-instruction updates only; no application code, auth, or data paths change.
> 
> **Overview**
> **Agent and writing policy now treat the pinned `petergyang/no-ai-slop` skill and `eval.md` as mandatory**, not optional on top of repo phrase linters. `AGENTS.md` and `CLAUDE.md` both state that passing a mechanical slop gate alone is **not** approval.
> 
> `docs/AI_WRITING_POLICY.md` adds workflow step **8** and a **Required no-ai-slop pass** section: canonical vendored copy at a pinned commit in `wattgod/writing-graph`, **detect mode** for historical Matti sources (flag patterns without rewriting evidence), and **edit mode** for AI-assisted brand copy (minimum effective edit, strict gate, full human eval, fix all failures). Editorial judgment stays required for portability, meaning, rhythm, and voice.
> 
> Policy-only; no runtime, deploy, or public site copy changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fac14a9b0ec076f6b5baf8792af5d6dd8356a49a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->