### PR TITLE
Add automatic Gravel Weekly story visuals

### DIFF
--- a/docs/gravel-weekly-visual-system.md
+++ b/docs/gravel-weekly-visual-system.md
@@ -1,0 +1,22 @@
+# Gravel Weekly visual system
+
+Gravel Weekly must never wait for Matti to choose, license, crop, or approve an image.
+
+## Selection hierarchy
+
+1. A contemporary receipt that is both a valid YouTube URL and a timestamped transcript claim becomes a branded source-video facade. The link opens the exact cited moment. It never autoplays or embeds tracking code.
+2. Every other story receives deterministic inline SVG generated from the story ID, content hash, and approved copy. Identical content produces an identical visual; a substantive edit produces a new one.
+
+The SVG is abstract editorial art, visibly labeled as such. It is never presented as a photograph or as evidence of an event.
+
+## Non-negotiable gates
+
+- Do not scrape or hotlink publisher, Instagram, race-organizer, photographer, or athlete images.
+- Do not manufacture documentary-looking depictions of riders, crashes, results, or named events.
+- Do not convert an unverified video into a visual. Video requires a valid YouTube host and a timestamped claim already attached to the story.
+- Do not autoplay video, load an iframe, or make the publication depend on a third-party media request.
+- Do not hold publication because media is missing or broken. The procedural visual is the permanent fallback.
+- Label procedural art `GW ART DEPT. // AUTO` with an explicit not-a-news-photo disclosure, and source video `VERIFIED SOURCE VIDEO`.
+- Preserve reduced-motion behavior, keyboard focus, accessible titles, and mobile legibility.
+
+This makes visuals a build product, not a new editorial approval queue.

--- a/scripts/render_gravel_weekly_history_review.py
+++ b/scripts/render_gravel_weekly_history_review.py
@@ -14,6 +14,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "wordpress"))
 
 from brand_tokens import get_tokens_css  # noqa: E402
+from gravel_weekly_visuals import render_story_visual, visual_css  # noqa: E402
 from no_ai_slop import audit_no_ai_slop  # noqa: E402
 from approve_gravel_weekly_history import (  # noqa: E402
     reviewed_headline_copy,
@@ -124,12 +125,26 @@ def _card(entry: dict[str, Any]) -> str:
         if not holds
         else "Resolve the named hold or reject this premise. Approval fails closed while any hold remains."
     )
+    visual = render_story_visual(
+        item_id=entry["entryId"],
+        headline=reviewed_headline_copy(entry),
+        body_text=" ".join([
+            entry["point"],
+            entry["whatHappened"],
+            entry["stakes"],
+            reviewed_take_copy(entry),
+        ]),
+        receipts=entry["contemporaryReceipts"],
+        date_label=f"{entry['activeFrom']} → {entry['activeThrough']}",
+        stable_hash=entry["contentHash"],
+    )
     return f'''<article class="story" id="{esc(entry['entryId'])}">
       <header>
         <div class="eyebrow">{esc(entry['activeFrom'])} → {esc(entry['activeThrough'])} · SCORE {entry['editorialScore']}</div>
         <h2>{esc(reviewed_headline_copy(entry))}</h2>
         <div class="status">{readiness}<code>{esc(entry['entryId'])}</code></div>
       </header>
+      {visual}
       <section class="point"><h3>THE POINT</h3>{paragraphs(entry['point'])}</section>
       <div class="judgment">
         <section><h3>BEFORE</h3>{paragraphs(entry['priorJudgment'])}</section>
@@ -188,6 +203,7 @@ def render_history_review(entries: list[dict[str, Any]], year: int) -> str:
 <meta name="robots" content="noindex,nofollow"><title>Gravel Weekly {year} Historical Review</title>
 <style>
 {get_tokens_css()}
+{visual_css()}
 * {{ box-sizing: border-box; }}
 body {{ margin: 0; background: var(--gg-color-sand); color: var(--gg-color-near-black); font-family: var(--gg-font-data); }}
 main {{ width: min(1120px, calc(100% - 32px)); margin: 32px auto 80px; }}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -12,6 +12,13 @@ sys.path.insert(0, str(ROOT / "scripts"))
 sys.path.insert(0, str(ROOT / "wordpress"))
 
 from generate_gravel_weekly import build_page, render_history_timeline  # noqa: E402
+from gravel_weekly_visuals import (  # noqa: E402
+    classify_theme,
+    render_story_visual,
+    timestamped_youtube_receipt,
+    visual_css,
+    youtube_video_id,
+)
 from generate_homepage import build_gravel_weekly_band  # noqa: E402
 from validate_gravel_weekly import (  # noqa: E402
     IssueValidationError,
@@ -178,6 +185,90 @@ def sample_history_approval(draft=None):
         "editSummary": "Removed the model label and tightened the judgment.",
         "reason": None,
     }
+
+
+def test_visual_theme_classification_is_deterministic_and_story_aware():
+    assert classify_theme("A flat tire made gravel admit teams exist") == ("teams", "TEAMWORK")
+    assert classify_theme("Leadville banned the bike its course wanted") == ("category", "CATEGORY")
+    assert classify_theme("The host community paid for the wildfire") == ("community", "HOST COMMUNITY")
+    assert classify_theme(
+        "Gravel built a governing body by accident",
+        "A team roster and a series selection policy changed.",
+    ) == ("governance", "GOVERNANCE")
+    assert classify_theme(
+        "The women had to race everybody else",
+        "Many categories and bikes shared the course.",
+    ) == ("equity", "COST TRANSFER")
+    assert classify_theme("A story with no matching vocabulary") == ("pulse", "THE CURRENT THING")
+
+
+@pytest.mark.parametrize(("url", "expected"), [
+    ("https://www.youtube.com/watch?v=abcdefghijk", "abcdefghijk"),
+    ("https://youtu.be/abcdefghijk", "abcdefghijk"),
+    ("https://www.youtube.com/shorts/abcdefghijk", "abcdefghijk"),
+    ("https://example.com/watch?v=abcdefghijk", None),
+    ("https://www.youtube.com/watch?v=too-short", None),
+])
+def test_youtube_video_id_fails_closed(url, expected):
+    assert youtube_video_id(url) == expected
+
+
+def test_only_timestamped_youtube_receipts_can_become_video_visuals():
+    untimestamped = [{"canonicalUrl": "https://youtu.be/abcdefghijk", "transcriptStartSeconds": None}]
+    wrong_host = [{"canonicalUrl": "https://example.com/abcdefghijk", "transcriptStartSeconds": 42}]
+    invalid_timestamp = [{"canonicalUrl": "https://youtu.be/abcdefghijk", "transcriptStartSeconds": -1}]
+    valid = [{"canonicalUrl": "https://youtu.be/abcdefghijk", "transcriptStartSeconds": 42, "publisher": "Race channel"}]
+    assert timestamped_youtube_receipt(untimestamped) is None
+    assert timestamped_youtube_receipt(wrong_host) is None
+    assert timestamped_youtube_receipt(invalid_timestamp) is None
+    assert timestamped_youtube_receipt(valid)["videoId"] == "abcdefghijk"
+
+
+def test_procedural_visual_is_stable_labeled_and_not_documentary():
+    kwargs = {
+        "item_id": "story_1",
+        "headline": "A flat tire made gravel admit teams exist",
+        "body_text": "The team worked together.",
+        "receipts": [],
+        "date_label": "May 2026",
+        "stable_hash": "abc123",
+    }
+    first = render_story_visual(**kwargs)
+    second = render_story_visual(**kwargs)
+    assert first == second
+    assert 'data-visual-system="gravel-weekly-visual/v1"' in first
+    assert "GW ART DEPT. // AUTO" in first
+    assert "not a news photo" in first.casefold()
+    assert "TEAMWORK" in first
+    assert "<iframe" not in first
+    assert "<img" not in first
+
+
+def test_timestamped_video_visual_links_exact_claim_without_autoplay_or_embed():
+    visual = render_story_visual(
+        item_id="story_video",
+        headline="A race changed",
+        body_text="A timestamped rider account.",
+        receipts=[{
+            "canonicalUrl": "https://www.youtube.com/watch?v=abcdefghijk",
+            "transcriptStartSeconds": 125,
+            "publisher": "Rider channel",
+        }],
+        date_label="August 2026",
+    )
+    assert "VERIFIED SOURCE VIDEO" in visual
+    assert "WATCH @ 2:05" in visual
+    assert "https://www.youtube.com/watch?v=abcdefghijk&amp;t=125s" in visual
+    assert "autoplay" not in visual.casefold()
+    assert "<iframe" not in visual
+
+
+def test_visual_css_uses_brand_tokens_and_respects_reduced_motion():
+    css = visual_css()
+    assert "var(--gg-color-" in css
+    assert "@media (prefers-reduced-motion: no-preference)" in css
+    assert "@media (max-width: 620px)" in css
+    assert "#" not in css
 
 
 def passing_editorial_gate():

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
 from brand_tokens import get_font_face_css, get_ga4_head_snippet, get_tokens_css  # noqa: E402
 from cookie_consent import get_consent_banner_html  # noqa: E402
+from gravel_weekly_visuals import render_story_visual, visual_css  # noqa: E402
 from shared_header import get_site_header_css, get_site_header_html, get_site_header_js  # noqa: E402
 from validate_gravel_weekly import load_issues, validate_issue  # noqa: E402
 from validate_gravel_weekly_history import HISTORY_DIR, load_public_history_entries  # noqa: E402
@@ -136,6 +137,13 @@ def render_retrospectives(retrospectives: list[dict[str, Any]], issues: list[dic
 def render_story(story: dict[str, Any], *, current: bool = False, draft: bool = False) -> str:
     label = "THE CURRENT THING" if current else story["storyKind"].replace("_", " ").upper()
     take_label = "THE TAKE — MODEL DRAFT" if draft else "THE TAKE"
+    visual = render_story_visual(
+        item_id=story["candidateId"],
+        headline=story["headline"],
+        body_text=" ".join([story["dek"], story["whatHappened"], story["take"]]),
+        receipts=story["receipts"],
+        date_label=story["storyKind"].replace("_", " "),
+    )
     return f'''<article class="gw-story{' gw-story--cover' if current else ''}" id="{esc(story['candidateId'])}">
       <header class="gw-story-head">
         <span class="gw-cover-line">{esc(label)}</span>
@@ -143,6 +151,7 @@ def render_story(story: dict[str, Any], *, current: bool = False, draft: bool = 
         <h2>{esc(story['headline'])}</h2>
         <p class="gw-dek">{esc(story['dek'])}</p>
       </header>
+      {visual}
       <div class="gw-story-grid">
         <section class="gw-facts" aria-labelledby="facts-{esc(story['candidateId'])}">
           <h3 id="facts-{esc(story['candidateId'])}">WHAT HAPPENED</h3>
@@ -205,9 +214,23 @@ def render_history_timeline(entries: list[dict[str, Any]]) -> str:
               <summary>LATER EVIDENCE — NOT AVAILABLE THEN · {len(entry['laterEvidence'])}</summary>
               {render_receipts(entry['laterEvidence'])}
             </details>'''
+        visual = render_story_visual(
+            item_id=entry["entryId"],
+            headline=entry["headline"],
+            body_text=" ".join([
+                entry["point"],
+                entry["whatHappened"],
+                entry["stakes"],
+                entry["take"],
+            ]),
+            receipts=entry["contemporaryReceipts"],
+            date_label=active_label,
+            stable_hash=entry["contentHash"],
+        )
         cards.append(f'''<!-- gravel-weekly-history-hash: {esc(entry['contentHash'])} -->
         <article class="gw-history-entry" id="{esc(entry['entryId'])}">
           <header><span class="gw-history-date">{esc(active_label.upper())}</span><span class="gw-score">EDITORIAL SCORE {entry['editorialScore']}/100</span><h3>{esc(entry['headline'])}</h3></header>
+          {visual}
           <div class="gw-history-grid">
             <section><h4>THE POINT</h4>{prose(entry['point'])}<h4>WHAT HAPPENED</h4>{prose(entry['whatHappened'])}<h4>WHY IT MATTERED</h4>{prose(entry['stakes'])}<h4>THE FAIR OBJECTION</h4>{prose(entry['credibleOpposition'])}</section>
             <section class="gw-history-take"><h4>THE TAKE</h4>{prose(entry['take'])}</section>
@@ -453,6 +476,7 @@ def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, la
 {get_font_face_css()}
 {get_site_header_css()}
 {page_css()}
+{visual_css()}
   </style>
 </head>
 <body>

--- a/wordpress/gravel_weekly_visuals.py
+++ b/wordpress/gravel_weekly_visuals.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Deterministic, rights-safe visual system for Gravel Weekly stories."""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import re
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+
+VISUAL_SYSTEM_VERSION = "gravel-weekly-visual/v1"
+YOUTUBE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+
+THEMES = (
+    (
+        "category",
+        "CATEGORY",
+        (
+            "handlebar",
+            "drop bar",
+            "flat bar",
+            "category",
+            "equipment rule",
+            "banned the bike",
+        ),
+    ),
+    (
+        "community",
+        "HOST COMMUNITY",
+        ("community", "wildfire", "fire", "town", "business", "hotel", "recovery"),
+    ),
+    (
+        "equity",
+        "COST TRANSFER",
+        ("women", "woman", "gender", "female", "traffic tax", "equal"),
+    ),
+    (
+        "safety",
+        "SAFETY SYSTEM",
+        ("safety", "vehicle", "crash", "traffic", "feed zone", "intersection"),
+    ),
+    (
+        "teams",
+        "TEAMWORK",
+        ("team", "privateer", "teammate", "roster", "squad", "organization"),
+    ),
+    (
+        "governance",
+        "GOVERNANCE",
+        ("governing", "admission", "selection", "qualifier", "policy", "series"),
+    ),
+    (
+        "course",
+        "COURSE",
+        ("route", "course", "distance", "terrain", "climb", "reroute"),
+    ),
+)
+
+
+def esc(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _safe_id(value: str) -> str:
+    safe = re.sub(r"[^a-zA-Z0-9_-]+", "-", value).strip("-").lower()
+    return safe or "story"
+
+
+def _seed(*values: str) -> str:
+    return hashlib.sha256("\n".join(values).encode("utf-8")).hexdigest()
+
+
+def _compact_context_label(value: str) -> str:
+    years = re.findall(r"\b20\d{2}\b", value)
+    if years:
+        return years[0] if len(set(years)) == 1 else f"{years[0]}–{years[-1]}"
+    compact = " ".join(value.split()).upper()
+    return compact[:28].rstrip()
+
+
+def classify_theme(*values: str) -> tuple[str, str]:
+    scores: dict[str, int] = {}
+    labels: dict[str, str] = {}
+    for theme, label, keywords in THEMES:
+        labels[theme] = label
+        score = 0
+        for index, value in enumerate(values):
+            weight = 8 if index == 0 else 1
+            text = value.casefold()
+            score += weight * sum(min(text.count(keyword), 3) for keyword in keywords)
+        scores[theme] = score
+    winner = max(scores, key=scores.get)
+    if scores[winner] > 0:
+        return winner, labels[winner]
+    return "pulse", "THE CURRENT THING"
+
+
+def youtube_video_id(url: str) -> str | None:
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    host = (parsed.hostname or "").casefold()
+    candidate = ""
+    if host in {"youtu.be", "www.youtu.be"}:
+        candidate = parsed.path.strip("/").split("/", 1)[0]
+    elif host in {"youtube.com", "www.youtube.com", "m.youtube.com"}:
+        if parsed.path == "/watch":
+            candidate = parse_qs(parsed.query).get("v", [""])[0]
+        elif parsed.path.startswith(("/shorts/", "/embed/")):
+            parts = parsed.path.strip("/").split("/")
+            candidate = parts[1] if len(parts) > 1 else ""
+    return candidate if YOUTUBE_ID_RE.fullmatch(candidate) else None
+
+
+def timestamped_youtube_receipt(receipts: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for receipt in receipts:
+        seconds = receipt.get("transcriptStartSeconds")
+        if (
+            not isinstance(seconds, (int, float))
+            or isinstance(seconds, bool)
+            or seconds < 0
+        ):
+            continue
+        video_id = youtube_video_id(str(receipt.get("canonicalUrl", "")))
+        if video_id:
+            return {**receipt, "videoId": video_id}
+    return None
+
+
+def _route_path(seed: str) -> str:
+    values = [int(seed[index:index + 2], 16) for index in range(0, 12, 2)]
+    y_values = [38 + (value % 104) for value in values]
+    points = [
+        (0, y_values[0]),
+        (132, y_values[1]),
+        (264, y_values[2]),
+        (396, y_values[3]),
+        (528, y_values[4]),
+        (660, y_values[5]),
+    ]
+    commands = [f"M {points[0][0]} {points[0][1]}"]
+    for index in range(1, len(points)):
+        x0, y0 = points[index - 1]
+        x1, y1 = points[index]
+        midpoint = (x0 + x1) // 2
+        commands.append(f"C {midpoint} {y0}, {midpoint} {y1}, {x1} {y1}")
+    return " ".join(commands)
+
+
+def _motif(theme: str) -> str:
+    motifs = {
+        "category": '''<g class="gw-visual-motif" aria-hidden="true">
+          <path d="M62 64h102v72H62z M84 88h58 M113 64v72" />
+          <path class="gw-visual-accent" d="M164 52v96 M180 64v72" />
+        </g>''',
+        "community": '''<g class="gw-visual-motif" aria-hidden="true">
+          <path d="M52 128V82l38-30 38 30v46 M66 128V92h48v36" />
+          <path class="gw-visual-accent" d="M142 128V70l28-22 28 22v58 M152 128V82h36v46" />
+        </g>''',
+        "equity": '''<g class="gw-visual-motif" aria-hidden="true">
+          <path d="M50 58c44 0 44 80 88 80 M50 138c44 0 44-80 88-80" />
+          <path class="gw-visual-accent" d="M154 48v100 M138 66l16-18 16 18 M138 130l16 18 16-18" />
+        </g>''',
+        "safety": '''<g class="gw-visual-motif" aria-hidden="true">
+          <path d="M52 52h116v86H52z M68 70h84v50H68z" />
+          <path class="gw-visual-accent" d="M110 76v38 M91 95h38" />
+        </g>''',
+        "teams": '''<g class="gw-visual-motif" aria-hidden="true">
+          <path d="M52 54l58 42-58 42 M110 54v84 M168 54l-58 42 58 42" />
+          <circle class="gw-visual-accent" cx="110" cy="96" r="20" />
+        </g>''',
+        "governance": '''<g class="gw-visual-motif" aria-hidden="true">
+          <path d="M58 54h108v84H58z M76 72h72v48H76z M94 54v84 M130 54v84" />
+          <path class="gw-visual-accent" d="M46 42h132v108H46z" />
+        </g>''',
+        "course": '''<g class="gw-visual-motif" aria-hidden="true">
+          <circle cx="104" cy="96" r="50" />
+          <circle class="gw-visual-accent" cx="104" cy="96" r="17" />
+          <path d="M104 46v100 M54 96h100 M69 61l70 70 M139 61l-70 70" />
+        </g>''',
+        "pulse": '''<g class="gw-visual-motif" aria-hidden="true">
+          <path d="M44 98h36l14-40 26 80 18-56 14 16h38" />
+          <circle class="gw-visual-accent" cx="120" cy="98" r="52" />
+        </g>''',
+    }
+    return motifs[theme]
+
+
+def render_story_visual(
+    *,
+    item_id: str,
+    headline: str,
+    body_text: str,
+    receipts: list[dict[str, Any]],
+    date_label: str,
+    stable_hash: str | None = None,
+) -> str:
+    """Render one automatic visual; factual source video wins over abstract art."""
+    safe_id = _safe_id(item_id)
+    theme, theme_label = classify_theme(headline, body_text)
+    seed = _seed(stable_hash or "", item_id, headline, body_text)
+    context_label = _compact_context_label(date_label)
+    video = timestamped_youtube_receipt(receipts)
+    if video:
+        seconds = int(video["transcriptStartSeconds"])
+        source_url = f'https://www.youtube.com/watch?v={video["videoId"]}&t={seconds}s'
+        timestamp = f"{seconds // 60}:{seconds % 60:02d}"
+        return f'''<figure class="gw-visual gw-visual--video" data-visual-system="{VISUAL_SYSTEM_VERSION}">
+          <a class="gw-video-facade" href="{esc(source_url)}" target="_blank" rel="noopener noreferrer" aria-label="Watch the timestamped source video for {esc(headline)} on YouTube at {esc(timestamp)}">
+            <svg viewBox="0 0 660 190" role="img" aria-labelledby="gw-video-title-{safe_id}" focusable="false">
+              <title id="gw-video-title-{safe_id}">Timestamped source video for {esc(headline)}</title>
+              <rect class="gw-visual-paper" x="0" y="0" width="660" height="190" />
+              <path class="gw-visual-route" d="{_route_path(seed)}" pathLength="100" />
+              <rect class="gw-video-screen" x="42" y="34" width="184" height="122" />
+              <path class="gw-video-play" d="M112 68l55 27-55 27z" />
+              <text class="gw-visual-kicker" x="260" y="61">TIMESTAMPED SOURCE VIDEO</text>
+              <text class="gw-visual-word" x="260" y="113">WATCH @ {esc(timestamp)}</text>
+              <text class="gw-visual-meta" x="260" y="145">{esc(str(video['publisher']).upper())} · {esc(context_label)}</text>
+            </svg>
+          </a>
+          <figcaption><b>VERIFIED SOURCE VIDEO</b><span>The cited passage starts at {esc(timestamp)}. Opens on YouTube.</span></figcaption>
+        </figure>'''
+
+    particles = "".join(
+        f'<circle cx="{238 + (int(seed[index:index + 2], 16) % 390)}" '
+        f'cy="{24 + (int(seed[index + 2:index + 4], 16) % 142)}" '
+        f'r="{2 + (int(seed[index + 4:index + 6], 16) % 5)}" />'
+        for index in range(0, 30, 6)
+    )
+    return f'''<figure class="gw-visual gw-visual--{esc(theme)}" data-visual-system="{VISUAL_SYSTEM_VERSION}">
+      <svg viewBox="0 0 660 190" role="img" aria-labelledby="gw-visual-title-{safe_id}" focusable="false">
+        <title id="gw-visual-title-{safe_id}">Abstract Gravel Weekly editorial graphic for {esc(headline)}. Theme: {esc(theme_label)}. Not documentary imagery.</title>
+        <rect class="gw-visual-paper" x="0" y="0" width="660" height="190" />
+        <path class="gw-visual-route" d="{_route_path(seed)}" pathLength="100" />
+        <g class="gw-visual-gravel" aria-hidden="true">{particles}</g>
+        {_motif(theme)}
+        <text class="gw-visual-kicker" x="238" y="61">GRAVEL WEEKLY · {esc(context_label)}</text>
+        <text class="gw-visual-word" x="238" y="120">{esc(theme_label)}</text>
+        <text class="gw-visual-meta" x="238" y="151">BUILT AUTOMATICALLY · {esc(seed[:8].upper())}</text>
+      </svg>
+      <figcaption><b>GW ART DEPT. // AUTO</b><span>Abstract story graphic, not a news photo.</span></figcaption>
+    </figure>'''
+
+
+def visual_css() -> str:
+    return '''
+  .gw-visual { margin: 0; border-bottom: var(--gg-border-standard); background: var(--gg-color-near-black); }
+  .gw-visual svg { display: block; width: 100%; height: auto; max-height: 310px; }
+  .gw-visual-paper { fill: var(--gg-color-sand); }
+  .gw-visual-route { fill: none; stroke: var(--gg-color-teal); stroke-width: 18; stroke-linecap: square; opacity: .9; stroke-dasharray: 10 4; }
+  .gw-visual-gravel circle { fill: var(--gg-color-primary-brown); opacity: .55; }
+  .gw-visual-motif { fill: none; stroke: var(--gg-color-near-black); stroke-width: 9; }
+  .gw-visual-motif .gw-visual-accent { fill: none; stroke: var(--gg-color-gold); stroke-width: 13; }
+  .gw-visual-kicker, .gw-visual-meta, .gw-visual-word { fill: var(--gg-color-near-black); font-family: var(--gg-font-data); font-weight: var(--gg-font-weight-black); }
+  .gw-visual-kicker { font-size: 16px; letter-spacing: 2px; }
+  .gw-visual-word { font-size: 40px; letter-spacing: -2px; }
+  .gw-visual-meta { font-size: 12px; letter-spacing: 1px; }
+  .gw-visual figcaption { display: flex; justify-content: space-between; gap: var(--gg-spacing-sm); padding: var(--gg-spacing-xs) var(--gg-spacing-sm); color: var(--gg-color-warm-paper); font-size: var(--gg-font-size-xs); letter-spacing: var(--gg-letter-spacing-wide); text-transform: uppercase; }
+  .gw-video-facade { display: block; color: inherit; }
+  .gw-video-facade:focus-visible { outline: var(--gg-border-gold); outline-offset: calc(var(--gg-border-width-standard) * -2); }
+  .gw-video-screen { fill: var(--gg-color-near-black); stroke: var(--gg-color-gold); stroke-width: 8; }
+  .gw-video-play { fill: var(--gg-color-gold); stroke: var(--gg-color-warm-paper); stroke-width: 4; }
+  .gw-visual--video .gw-visual-route { stroke: var(--gg-color-primary-brown); opacity: .35; }
+  @media (prefers-reduced-motion: no-preference) {
+    .gw-visual-route { animation: gw-route-pulse 16s linear infinite; }
+    .gw-video-facade:hover .gw-video-play { transform: translateX(5px); transform-origin: center; transition: transform 140ms linear; }
+  }
+  @keyframes gw-route-pulse { to { stroke-dashoffset: -100; } }
+  @media (max-width: 620px) {
+    .gw-visual-word { font-size: 30px; }
+    .gw-visual-kicker, .gw-visual-meta { display: none; }
+    .gw-visual figcaption { display: grid; }
+  }
+'''


### PR DESCRIPTION
Adds deterministic, brand-token Gravel Weekly story art plus a timestamp-gated YouTube source-video lane. Missing media always falls back to labeled abstract art, so Matti never becomes an asset-selection blocker. No publisher or social images are scraped or hotlinked. Voice provenance reviewed: writing-graph/self/voice-and-beliefs-profile.md, inbox/gravel-god/your-eating-habits-are-killing-your-performance.md, and inbox/gravel-god/since-no-one-asked-why-did-dumoulin-retire-he-just-wants-to-eat-some-cheese-2.md. Gates: 92 Gravel Weekly tests pass; 7,373 repository tests pass; preflight_quality passes; desktop and 390px mobile visual checks show no horizontal overflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static HTML/CSS generation only; no auth or data-path changes. Main risk is editorial misrepresentation if receipt/video gates are bypassed—mitigated by tests and documented non-negotiable gates.
> 
> **Overview**
> Introduces a **build-time visual system** so Gravel Weekly stories always ship with media—without manual image pick, license, or approval.
> 
> Stories with a **timestamped YouTube receipt** get a branded **source-video facade** (external link to the cited moment; no embed, autoplay, or third-party load on publish). Everything else gets **deterministic inline SVG** from story ID, optional content hash, and copy, with theme labels derived from headline/body keywords. Procedural art is explicitly labeled **GW ART DEPT. // AUTO**; video lanes use **VERIFIED SOURCE VIDEO**.
> 
> Wiring adds `render_story_visual` and `visual_css()` to **issue story cards**, the **public history timeline**, and the **private historical review desk**, plus a short policy doc (`docs/gravel-weekly-visual-system.md`). Tests lock stability, fail-closed YouTube parsing, no `<img>`/`<iframe>`, brand-token CSS, and reduced-motion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8b06cc6d237d441da783937f16d7b17d4dbd184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->