### PR TITLE
Require sealed Gravel Weekly snapshots for publication

### DIFF
--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -75,6 +75,11 @@ Generate the latest page and dated archive:
 python3 wordpress/generate_gravel_weekly.py
 ```
 
+The public generator and sender both use the same fail-closed loader: only a
+sealed `status=published` snapshot can cross the publication boundary.
+`status=approved` remains private staging even if a file is placed in the
+canonical issue directory by mistake.
+
 Render the controlled race-profile review for a published issue:
 
 ```bash

--- a/scripts/send_gravel_weekly.py
+++ b/scripts/send_gravel_weekly.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "wordpress"))
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
 from brand_tokens import COLORS  # noqa: E402
-from validate_gravel_weekly import load_issues  # noqa: E402
+from validate_gravel_weekly import load_public_issues  # noqa: E402
 
 RESEND_API = "https://api.resend.com"
 AUDIENCE_NAMES = ("Gravel Weekly", "Gravel TV")
@@ -110,9 +110,9 @@ def main() -> int:
     if missing:
         print(f"Missing {missing} — skipping Gravel Weekly send")
         return 0
-    issues = [issue for issue in load_issues() if issue["status"] in {"approved", "published"}]
+    issues = load_public_issues()
     if not issues:
-        print("No approved Gravel Weekly issue — refusing to send")
+        print("No sealed Gravel Weekly issue — refusing to send")
         return 0
     issue = issues[0]
     try:

--- a/scripts/validate_gravel_weekly.py
+++ b/scripts/validate_gravel_weekly.py
@@ -312,6 +312,16 @@ def load_issues(issue_dir: Path = ISSUE_DIR) -> list[dict[str, Any]]:
     return sorted(issues, key=lambda issue: issue["publicationDate"], reverse=True)
 
 
+def load_public_issues(issue_dir: Path = ISSUE_DIR) -> list[dict[str, Any]]:
+    """Return only sealed issue snapshots that are eligible for publication.
+
+    ``status=approved`` is an intentionally private staging state.  Keeping the
+    filter here gives the page generator and sender the same fail-closed
+    boundary instead of relying on every caller to remember it.
+    """
+    return [issue for issue in load_issues(issue_dir) if issue["status"] == "published"]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("paths", nargs="*", type=Path)

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -24,6 +24,7 @@ from validate_gravel_weekly import (  # noqa: E402
     IssueValidationError,
     compute_content_hash,
     load_issues,
+    load_public_issues,
     validate_issue,
 )
 from validate_gravel_weekly_history import (  # noqa: E402
@@ -1724,7 +1725,7 @@ def test_homepage_surfaces_gravel_weekly_without_a_gravel_tv_content_path():
     assert "Gravel TV" not in band
 
 
-def test_email_preserves_legacy_subscribers_and_uses_approved_issue():
+def test_email_preserves_legacy_subscribers_and_renders_a_sealed_issue():
     issue = sample_issue()
     email = build_email_html(issue)
     assert SUBSCRIBER_SOURCES == ("gravel_weekly_subscribe", "gravel_tv_subscribe")
@@ -1732,3 +1733,28 @@ def test_email_preserves_legacy_subscribers_and_uses_approved_issue():
     assert "Unbound changed the course" in email
     assert "/gravel-weekly/2026-08-28/" in email
     assert "RESEND_UNSUBSCRIBE_URL" in email
+
+
+def test_only_sealed_issue_snapshots_cross_the_public_loader(tmp_path):
+    published = sample_issue()
+    approved = copy.deepcopy(published)
+    approved.update({
+        "issueId": "gravel-weekly-002",
+        "issueNumber": 2,
+        "publicationDate": "2026-09-04",
+        "slug": "2026-09-04",
+        "status": "approved",
+        "publishedAt": None,
+        "updatedAt": "2026-09-04T16:00:00Z",
+    })
+    approved["contentHash"] = compute_content_hash(approved)
+    (tmp_path / "2026-08-28.json").write_text(json.dumps(published))
+    (tmp_path / "2026-09-04.json").write_text(json.dumps(approved))
+
+    assert [issue["issueId"] for issue in load_issues(tmp_path)] == [
+        approved["issueId"],
+        published["issueId"],
+    ]
+    assert [issue["issueId"] for issue in load_public_issues(tmp_path)] == [
+        published["issueId"],
+    ]

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -19,7 +19,7 @@ from brand_tokens import get_font_face_css, get_ga4_head_snippet, get_tokens_css
 from cookie_consent import get_consent_banner_html  # noqa: E402
 from gravel_weekly_visuals import render_story_visual, visual_css  # noqa: E402
 from shared_header import get_site_header_css, get_site_header_html, get_site_header_js  # noqa: E402
-from validate_gravel_weekly import load_issues, validate_issue  # noqa: E402
+from validate_gravel_weekly import load_public_issues, validate_issue  # noqa: E402
 from validate_gravel_weekly_history import HISTORY_DIR, load_public_history_entries  # noqa: E402
 
 ISSUE_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "issues"
@@ -512,9 +512,8 @@ def main() -> int:
         args.preview_output.write_text(build_page(issue, [issue], latest=True), encoding="utf-8")
         print(f"Generated draft-only preview: {args.preview_output}")
         return 0
-    all_issues = load_issues(ISSUE_DIR)
     public_history_entries = load_public_history_entries(HISTORY_DIR)
-    public_issues = [issue for issue in all_issues if issue["status"] in {"approved", "published"}]
+    public_issues = load_public_issues(ISSUE_DIR)
     latest_issue = public_issues[0] if public_issues else None
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
     OUTPUT.write_text(build_page(latest_issue, public_issues, latest=True, history_entries=public_history_entries), encoding="utf-8")


### PR DESCRIPTION
## Summary
- centralize the public issue loader on `status=published`
- keep approved-but-unsealed issues out of web generation and broadcast selection
- add a regression test and document the boundary

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` (93 passed)
- `python3 scripts/preflight_quality.py` (passed with existing environment warnings)
- `python3 wordpress/generate_gravel_weekly.py`
- Python 3.11 `py_compile` on changed Python modules
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which issues appear on the public site and in the Resend broadcast; misconfiguration could block sends or hide the latest issue until sealing, but the change intentionally narrows exposure rather than widening it.
> 
> **Overview**
> **Tightens the publication boundary** so only **`status=published`** (sealed) issue snapshots are used for public output. Previously, the site generator and weekly sender treated **`approved`** and **`published`** as eligible, which could expose staging copy if an approved file landed in the canonical `issues/` directory.
> 
> Adds **`load_public_issues()`** in `validate_gravel_weekly.py` as the shared fail-closed loader and switches **`generate_gravel_weekly.py`** and **`send_gravel_weekly.py`** to use it instead of ad hoc filters. The sender’s empty-state message now refers to a **sealed** issue rather than an approved one.
> 
> Documents the rule in **`data/gravel-weekly/README.md`** and adds **`test_only_sealed_issue_snapshots_cross_the_public_loader`** to assert `load_issues` still returns approved files while `load_public_issues` excludes them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a17453df2dfe4d458953346d840ec65cc4ed0cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->