### PR TITLE
Add controlled culture artifacts to Gravel Weekly history

### DIFF
--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -129,6 +129,37 @@ A story is marked ready only when all five editorial gates and the prose gate
 pass and at least two contemporary publishers corroborate it. Historical drafts
 that fail the prose gate cannot enter the repository validator at all.
 
+Historical entries may also carry up to six `cultureArtifacts`. These are
+date-bound, rights-bounded links to X, Instagram, YouTube, forums, blogs,
+newsletters, or podcasts that help reconstruct the jokes, arguments,
+personalities, and artifacts circulating during the active period. They are
+part of the entry content hash and therefore part of Matti's exact approval.
+The private desk shows why each artifact was selected; the public timeline
+shows the artifact and original link but not the internal ranking rationale.
+No third-party embed, copied social image, engagement total, or tracking script
+is stored or rendered. Every artifact is permanently marked
+`purpose=culture_sensor`, `canProveClaim=false`, and
+`canEstablishConsensus=false`.
+
+Turn a control-plane `historical-culture-sweep/v1` artifact into a topical,
+date-correct private proposal:
+
+```bash
+python3 scripts/prepare_gravel_weekly_history_culture.py \
+  data/gravel-weekly/history/2026-example.json \
+  artifacts/historical-culture-2026.json
+```
+
+The bridge defaults to at most four artifacts, at most two from one source
+type, and X attention scores of 70 or higher. Generic gravel virality does not
+match a story; a distinctive configured topic must occur in the entry, and the
+artifact date must fall inside its active period. Cross-source recurrence can
+raise research priority but cannot establish consensus. By default the command
+writes to the ignored `history-culture-proposals/` directory and leaves the
+canonical draft unchanged. `--in-place` updates only a status=draft canonical
+entry, changing its content hash and invalidating any stale approval; it still
+cannot approve, seal, publish, deploy, or edit race data.
+
 Apply one explicit decision using `gravel-weekly-history-approval/v1`:
 
 ```bash

--- a/docs/gravel-weekly-visual-system.md
+++ b/docs/gravel-weekly-visual-system.md
@@ -9,6 +9,64 @@ Gravel Weekly must never wait for Matti to choose, license, crop, or approve an 
 
 The SVG is abstract editorial art, visibly labeled as such. It is never presented as a photograph or as evidence of an event.
 
+## Two jobs, clearly separated
+
+The existing procedural visual is the publication signature: fast, deterministic,
+brand-true, and always available. It may set tone without claiming to explain the
+story.
+
+A story graphic has a higher burden. With the headline hidden, a reader should be
+able to infer the story's central turn from the graphic. If they cannot, it remains
+useful brand art, but it must not be described as explanatory.
+
+When evidence supports it, the generator should promote the signature into one of
+five small story grammars instead of inventing a new visual language every week:
+
+- **Before → after:** the prior judgment and changed judgment are the two states.
+- **Tension:** two credible forces pull against one another; neither is a straw man.
+- **Timeline:** only the few events needed to reveal an inflection point.
+- **Network:** access, hierarchy, teams, organizers, and privateers as relationships.
+- **Route / pressure map:** only when verified course geography or race mechanics
+  actually carry the point.
+- **Culture constellation:** several approved culture artifacts orbit the claimed
+  Current Thing; recurrence may show attention, never truth or consensus.
+
+Animation must perform editorial work: reveal the transition, trace the route, or
+show the pressure moving. It gets one restrained loop, remains intelligible as a
+still, and stops under reduced-motion preferences. Decorative perpetual motion is
+not a substitute for a point.
+
+## Story-graphic gate
+
+Before labeling a visual explanatory, the review desk must answer yes to all of the
+following:
+
+1. Does it express the story's point rather than merely its topic?
+2. Is every encoded relationship supported by an approved field or receipt?
+3. Would removing an element make the central turn harder to understand?
+4. Is the most important editorial fact the most visually prominent element?
+5. Is it understandable without animation, color alone, or unexplained symbols?
+6. Does its accessible title describe the meaning, not just the shapes?
+
+Any failure demotes the visual to the permanent brand-art fallback. Missing data
+never licenses fake precision or delays publication.
+
+## Reference systems
+
+- The Pudding's question-first, storyboard-before-code method and willingness to
+  kill weak ideas.
+- ProPublica's insistence that the editorial nut be the most visible element and
+  that unnecessary elements come out.
+- The Markup's conceptual illustration test: communicate the headline or theme,
+  set the mood, avoid cliché, and design accessibility from the start.
+- The Economist's constrained palette, repeatable grammar, and use of color to
+  highlight the main message rather than decorate it.
+
+The Gravel Weekly synthesis is Economist restraint, Markup conceptual wit,
+ProPublica hierarchy, Pudding point-first rigor, and Gravel God type, texture, and
+motion. Those are operating principles, not a license to imitate any publisher's
+trade dress.
+
 ## Non-negotiable gates
 
 - Do not scrape or hotlink publisher, Instagram, race-organizer, photographer, or athlete images.
@@ -20,3 +78,14 @@ The SVG is abstract editorial art, visibly labeled as such. It is never presente
 - Preserve reduced-motion behavior, keyboard focus, accessible titles, and mobile legibility.
 
 This makes visuals a build product, not a new editorial approval queue.
+
+## Culture artifacts
+
+Approved historical stories may include durable culture cards for an X or
+Instagram post, timestamped YouTube moment, forum thread, blog, newsletter, or
+podcast. The card is generated locally from a short excerpt, source identity,
+publication time, and canonical link. It never copies the source image/video,
+loads a third-party embed, or displays engagement as editorial authority. Its
+selection rationale is visible only in the private desk. Because the normalized
+artifact is part of the historical entry content hash, Matti's story approval
+covers the exact culture context that can later appear publicly.

--- a/scripts/prepare_gravel_weekly_history_culture.py
+++ b/scripts/prepare_gravel_weekly_history_culture.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Attach bounded culture-sweep candidates to a private historical draft proposal."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, time, timezone
+from pathlib import Path
+from typing import Any
+
+from validate_gravel_weekly import IssueValidationError, _iso, _list, _record, _text, _url
+from validate_gravel_weekly_history import (
+    compute_history_content_hash,
+    validate_history_entry,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PROPOSAL_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "history-culture-proposals"
+GENERIC_TOPIC_WORDS = {
+    "argument", "arguments", "bike", "culture", "cycling", "drama", "gravel",
+    "joke", "jokes", "meme", "memes", "race", "racing", "scene",
+}
+
+
+def _tokens(value: str) -> set[str]:
+    words = re.findall(r"[a-z0-9]+", value.casefold())
+    return {word[:-1] if len(word) > 4 and word.endswith("s") else word for word in words}
+
+
+def _entry_tokens(entry: dict[str, Any]) -> set[str]:
+    return _tokens(" ".join(str(entry[field]) for field in (
+        "entryId", "headline", "point", "priorJudgment", "changedJudgment", "stakes",
+        "credibleOpposition", "whatHappened", "take",
+    )))
+
+
+def _topic_matches(values: list[str], entry_tokens: set[str]) -> bool:
+    for value in values:
+        raw = _tokens(value.replace("lifetime", "life time"))
+        distinctive = raw - GENERIC_TOPIC_WORDS
+        if distinctive and distinctive <= entry_tokens:
+            return True
+    return False
+
+
+def _in_active_period(entry: dict[str, Any], published_at: str) -> bool:
+    published = datetime.fromisoformat(_iso(published_at, "culture publishedAt").replace("Z", "+00:00")).astimezone(timezone.utc)
+    start = datetime.combine(datetime.strptime(entry["activeFrom"], "%Y-%m-%d").date(), time.min, tzinfo=timezone.utc)
+    end = datetime.combine(datetime.strptime(entry["activeThrough"], "%Y-%m-%d").date(), time.max, tzinfo=timezone.utc)
+    return start <= published <= end
+
+
+def _x_artifact(candidate_value: Any, entry: dict[str, Any], recurring_topics: set[str], min_attention: float) -> tuple[float, dict[str, Any]] | None:
+    candidate = _record(candidate_value, "historical X candidate")
+    if candidate.get("platform") != "x" or candidate.get("purpose") != "culture_sensor" or candidate.get("canProveClaim") is not False:
+        raise IssueValidationError("historical X candidate violates its culture-only boundary")
+    attention = candidate.get("attentionScore")
+    if not isinstance(attention, (int, float)) or isinstance(attention, bool) or not 0 <= attention <= 100:
+        raise IssueValidationError("historical X candidate attentionScore is invalid")
+    if attention < min_attention or not _in_active_period(entry, candidate.get("publishedAt")):
+        return None
+    query_ids = [_text(value, "historical X candidate queryId", 64) for value in _list(candidate.get("queryIds"), "historical X candidate queryIds", 20)]
+    query_labels = [_text(value, "historical X candidate queryLabel", 100) for value in _list(candidate.get("queryLabels"), "historical X candidate queryLabels", 20)]
+    if not query_ids or not _topic_matches([*query_ids, *query_labels], _entry_tokens(entry)):
+        return None
+    handle = _text(candidate.get("authorHandle"), "historical X candidate authorHandle", 100)
+    excerpt = _text(candidate.get("excerpt"), "historical X candidate excerpt", 280)
+    source_url = _url(candidate.get("canonicalUrl"), "historical X candidate canonicalUrl")
+    publisher = candidate.get("authorName") or f"@{handle}"
+    matched_labels = ", ".join(query_labels or query_ids)
+    recurring = sorted(set(query_ids) & recurring_topics)
+    recurrence = f" It also recurred across {', '.join(recurring)} source tags." if recurring else ""
+    artifact = {
+        "artifactId": _text(candidate.get("id"), "historical X candidate id", 500),
+        "sourceKind": "x",
+        "publisher": _text(publisher, "historical X candidate publisher", 300),
+        "author": f"@{handle}",
+        "canonicalUrl": source_url,
+        "publishedAt": _iso(candidate.get("publishedAt"), "historical X candidate publishedAt"),
+        "title": f"@{handle} during {entry['activeFrom']} → {entry['activeThrough']}",
+        "excerpt": excerpt,
+        "timestampSeconds": None,
+        "topicTags": sorted(set(query_ids)),
+        "reviewReason": f"Matched this story through {matched_labels}; attention {attention:g}/100 within the bounded annual sample.{recurrence} Engagement located the artifact but did not judge its truth or publication value.",
+        "collectionMethod": "official_api",
+        "rightsPolicy": "short_excerpt_and_canonical_link",
+        "purpose": "culture_sensor",
+        "canProveClaim": False,
+        "canEstablishConsensus": False,
+    }
+    score = float(attention) + (15 if recurring else 0)
+    return score, artifact
+
+
+def _supplement_artifact(value: Any, entry: dict[str, Any], recurring_topics: set[str]) -> tuple[float, dict[str, Any]] | None:
+    source = _record(value, "historical culture supplement")
+    if source.get("purpose") != "culture_sensor" or source.get("canProveClaim") is not False:
+        raise IssueValidationError("historical supplement violates its culture-only boundary")
+    if not _in_active_period(entry, source.get("publishedAt")):
+        return None
+    topics = [_text(item, "historical supplement topic", 64) for item in _list(source.get("topicTags"), "historical supplement topicTags", 10)]
+    if not topics or not _topic_matches(topics, _entry_tokens(entry)):
+        return None
+    method = _text(source.get("collectionMethod"), "historical supplement collectionMethod", 100)
+    excerpt = source.get("excerpt")
+    if excerpt is not None:
+        excerpt = _text(excerpt, "historical supplement excerpt", 280)
+    timestamp = source.get("timestampSeconds")
+    if timestamp is not None and (not isinstance(timestamp, int) or isinstance(timestamp, bool) or timestamp < 0):
+        raise IssueValidationError("historical supplement timestampSeconds is invalid")
+    recurring = sorted(set(topics) & recurring_topics)
+    recurrence = f" It also recurred across {', '.join(recurring)} source tags." if recurring else ""
+    rights = "timestamped_short_excerpt" if method == "authorized_caption" else (
+        "short_excerpt_and_canonical_link" if excerpt else "metadata_only"
+    )
+    artifact = {
+        "artifactId": _text(source.get("id"), "historical supplement id", 500),
+        "sourceKind": _text(source.get("sourceKind"), "historical supplement sourceKind", 100),
+        "publisher": _text(source.get("publisher"), "historical supplement publisher", 300),
+        "author": source.get("author"),
+        "canonicalUrl": _url(source.get("canonicalUrl"), "historical supplement canonicalUrl"),
+        "publishedAt": _iso(source.get("publishedAt"), "historical supplement publishedAt"),
+        "title": _text(source.get("title"), "historical supplement title", 500),
+        "excerpt": excerpt,
+        "timestampSeconds": timestamp,
+        "topicTags": sorted(set(topics)),
+        "reviewReason": _text(source.get("reviewReason"), "historical supplement reviewReason", 1_000) + recurrence,
+        "collectionMethod": method,
+        "rightsPolicy": rights,
+        "purpose": "culture_sensor",
+        "canProveClaim": False,
+        "canEstablishConsensus": False,
+    }
+    score = 85.0 + (15 if recurring else 0)
+    return score, artifact
+
+
+def prepare_history_culture_proposal(
+    entry_value: Any,
+    sweep_value: Any,
+    *,
+    max_artifacts: int = 4,
+    per_source_cap: int = 2,
+    min_attention: float = 70,
+) -> dict[str, Any]:
+    entry = validate_history_entry(entry_value)
+    if entry["status"] != "draft":
+        raise ValueError("historical culture proposals require a status=draft entry")
+    if not 1 <= max_artifacts <= 6:
+        raise ValueError("max_artifacts must be between 1 and 6")
+    if not 1 <= per_source_cap <= max_artifacts:
+        raise ValueError("per_source_cap must be between 1 and max_artifacts")
+    if not 0 <= min_attention <= 100:
+        raise ValueError("min_attention must be between 0 and 100")
+    sweep = _record(sweep_value, "historical culture sweep")
+    if sweep.get("schemaVersion") != "historical-culture-sweep/v1":
+        raise IssueValidationError("unsupported historical culture sweep schema")
+    if sweep.get("canProveClaim") is not False or sweep.get("canEstablishConsensus") is not False or sweep.get("humanApprovalRequired") is not True or sweep.get("autoPublishAllowed") is not False:
+        raise IssueValidationError("historical culture sweep safety boundary is invalid")
+    entry_years = set(range(int(entry["activeFrom"][:4]), int(entry["activeThrough"][:4]) + 1))
+    if sweep.get("year") not in entry_years:
+        raise IssueValidationError("historical culture sweep year does not overlap the entry")
+    recurring_topics = {
+        _text(pattern.get("topicTag"), "cross-source topicTag", 64)
+        for pattern in (_record(value, "cross-source pattern") for value in _list(sweep.get("crossSourcePatterns", []), "crossSourcePatterns", 100))
+    }
+    ranked: list[tuple[float, dict[str, Any]]] = []
+    for candidate in _list(sweep.get("candidates"), "historical culture candidates", 100):
+        converted = _x_artifact(candidate, entry, recurring_topics, min_attention)
+        if converted:
+            ranked.append(converted)
+    for artifact in _list(sweep.get("supplementalArtifacts", []), "historical culture supplements", 100):
+        converted = _supplement_artifact(artifact, entry, recurring_topics)
+        if converted:
+            ranked.append(converted)
+    ranked.sort(key=lambda item: (-item[0], item[1]["publishedAt"], item[1]["artifactId"]))
+    selected: list[dict[str, Any]] = []
+    source_counts: dict[str, int] = {}
+    urls: set[str] = set()
+    for _, artifact in ranked:
+        source = artifact["sourceKind"]
+        if source_counts.get(source, 0) >= per_source_cap or artifact["canonicalUrl"] in urls:
+            continue
+        selected.append(artifact)
+        source_counts[source] = source_counts.get(source, 0) + 1
+        urls.add(artifact["canonicalUrl"])
+        if len(selected) >= max_artifacts:
+            break
+    proposal = {
+        **entry,
+        "cultureArtifacts": selected,
+        "contentHash": "pending",
+    }
+    proposal["contentHash"] = compute_history_content_hash(proposal)
+    return validate_history_entry(proposal)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("entry", type=Path)
+    parser.add_argument("sweep", type=Path)
+    parser.add_argument("--max-artifacts", type=int, default=4)
+    parser.add_argument("--per-source-cap", type=int, default=2)
+    parser.add_argument("--min-attention", type=float, default=70)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--in-place", action="store_true")
+    args = parser.parse_args()
+    if args.in_place and args.output is not None:
+        parser.error("--in-place cannot be combined with --output")
+    entry = json.loads(args.entry.read_text(encoding="utf-8"))
+    sweep = json.loads(args.sweep.read_text(encoding="utf-8"))
+    proposal = prepare_history_culture_proposal(
+        entry, sweep,
+        max_artifacts=args.max_artifacts,
+        per_source_cap=args.per_source_cap,
+        min_attention=args.min_attention,
+    )
+    output = args.entry if args.in_place else (
+        args.output or PROPOSAL_DIR / f"{proposal['entryId']}.json"
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(f"{json.dumps(proposal, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
+    print(f"Prepared {len(proposal['cultureArtifacts'])} hash-bound culture artifacts: {output}")
+    if not args.in_place:
+        print("Proposal only; the canonical draft and publication state were not changed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_gravel_weekly_history_review.py
+++ b/scripts/render_gravel_weekly_history_review.py
@@ -159,6 +159,9 @@ def _card(entry: dict[str, Any]) -> str:
         receipts=entry["contemporaryReceipts"],
         date_label=f"{entry['activeFrom']} → {entry['activeThrough']}",
         stable_hash=entry["contentHash"],
+        prior_judgment=entry["priorJudgment"],
+        changed_judgment=entry["changedJudgment"],
+        point=entry["point"],
     )
     return f'''<article class="story" id="{esc(entry['entryId'])}">
       <header>

--- a/scripts/render_gravel_weekly_history_review.py
+++ b/scripts/render_gravel_weekly_history_review.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "wordpress"))
 
 from brand_tokens import get_font_face_css, get_tokens_css  # noqa: E402
 from gravel_weekly_visuals import render_story_visual, visual_css  # noqa: E402
+from gravel_weekly_culture import culture_css, render_culture_artifacts  # noqa: E402
 from no_ai_slop import audit_no_ai_slop  # noqa: E402
 from approve_gravel_weekly_history import (  # noqa: E402
     reviewed_headline_copy,
@@ -179,6 +180,7 @@ def _card(entry: dict[str, Any]) -> str:
       </div>
       <section><h3>UNCERTAINTY</h3>{paragraphs(entry['uncertainty'])}</section>
       <details open><summary>CONTEMPORARY RECEIPTS ({len(entry['contemporaryReceipts'])})</summary>{_receipt_list(entry['contemporaryReceipts'])}</details>
+      {render_culture_artifacts(entry.get('cultureArtifacts', []), private_review=True)}
       <details><summary>LATER EVIDENCE ({len(entry['laterEvidence'])})</summary>{_receipt_list(entry['laterEvidence'])}</details>
       <details open><summary>{prose_summary}</summary><p>Checked against <a href="{esc(gate['sourceUrl'])}" rel="noopener" target="_blank">petergyang/no-ai-slop</a> at <code>{esc(str(gate['sourceRevision'])[:8])}</code>. This is a prose-pattern gate, not an AI-authorship detector.</p><ul class="prose-findings">{prose_finding_rows}</ul></details>
       <details><summary>GATES &amp; RACE INTELLIGENCE</summary><ul class="gates">{gate_rows}</ul>{_impact_list(entry['raceImpacts'])}</details>
@@ -229,6 +231,7 @@ def render_history_review(entries: list[dict[str, Any]], year: int) -> str:
 {get_tokens_css()}
 {get_font_face_css()}
 {visual_css()}
+{culture_css()}
 * {{ box-sizing: border-box; }}
 body {{ margin: 0; background: var(--gg-color-sand); color: var(--gg-color-near-black); font-family: var(--gg-font-data); }}
 main {{ width: min(1120px, calc(100% - 32px)); margin: 32px auto 80px; }}

--- a/scripts/validate_gravel_weekly_history.py
+++ b/scripts/validate_gravel_weekly_history.py
@@ -11,12 +11,27 @@ from datetime import datetime, time, timezone
 from pathlib import Path
 from typing import Any
 
-from validate_gravel_weekly import IssueValidationError, _impact, _iso, _list, _receipt, _record, _text
+from validate_gravel_weekly import IssueValidationError, _impact, _iso, _list, _receipt, _record, _text, _url
 from no_ai_slop import audit_no_ai_slop
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 HISTORY_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "history"
 PASSING_GATES = {"party", "point", "friend", "craft", "hostileEditor"}
+CULTURE_SOURCE_KINDS = {"x", "instagram", "youtube", "forum", "blog", "newsletter", "podcast"}
+CULTURE_COLLECTION_METHODS = {
+    "official_api", "authorized_caption", "rss", "sitemap",
+    "public_metadata", "user_authorized",
+}
+CULTURE_RIGHTS_POLICIES = {
+    "metadata_only", "short_excerpt_and_canonical_link",
+    "timestamped_short_excerpt",
+}
+CULTURE_ARTIFACT_KEYS = {
+    "artifactId", "sourceKind", "publisher", "author", "canonicalUrl",
+    "publishedAt", "title", "excerpt", "timestampSeconds", "topicTags",
+    "reviewReason", "collectionMethod", "rightsPolicy", "purpose",
+    "canProveClaim", "canEstablishConsensus",
+}
 DEPRECATED_HISTORICAL_RACE_IDS = {
     "gravel:big-sugar-gravel": "gravel:big-sugar",
     "gravel:gravel-locos-150": "gravel:gravel-locos",
@@ -58,6 +73,53 @@ def _published_timestamp(receipt: dict[str, Any], name: str) -> datetime:
     if result.tzinfo is None:
         raise IssueValidationError(f"{name}.publishedAt must include a timezone")
     return result.astimezone(timezone.utc)
+
+
+def _culture_artifact(value: Any, name: str) -> dict[str, Any]:
+    artifact = _record(value, name)
+    unknown = set(artifact) - CULTURE_ARTIFACT_KEYS
+    if unknown:
+        raise IssueValidationError(f"{name} has unsupported fields: {sorted(unknown)}")
+    _text(artifact.get("artifactId"), f"{name}.artifactId", 500)
+    if artifact.get("sourceKind") not in CULTURE_SOURCE_KINDS:
+        raise IssueValidationError(f"{name}.sourceKind is invalid")
+    _text(artifact.get("publisher"), f"{name}.publisher", 300)
+    if artifact.get("author") is not None:
+        _text(artifact["author"], f"{name}.author", 300)
+    _url(artifact.get("canonicalUrl"), f"{name}.canonicalUrl")
+    _iso(artifact.get("publishedAt"), f"{name}.publishedAt")
+    _text(artifact.get("title"), f"{name}.title", 500)
+    if artifact.get("excerpt") is not None:
+        _text(artifact["excerpt"], f"{name}.excerpt", 280)
+    timestamp = artifact.get("timestampSeconds")
+    if timestamp is not None and (
+        not isinstance(timestamp, int) or isinstance(timestamp, bool)
+        or timestamp < 0 or timestamp > 86_400
+    ):
+        raise IssueValidationError(f"{name}.timestampSeconds is invalid")
+    if artifact.get("collectionMethod") == "authorized_caption" and timestamp is None:
+        raise IssueValidationError(f"{name}.timestampSeconds is required for an authorized caption")
+    topics = _list(artifact.get("topicTags"), f"{name}.topicTags", 10)
+    if not topics:
+        raise IssueValidationError(f"{name}.topicTags must not be empty")
+    for index, topic in enumerate(topics):
+        raw = _text(topic, f"{name}.topicTags[{index}]", 64)
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]+", raw):
+            raise IssueValidationError(f"{name}.topicTags[{index}] is invalid")
+    if len(topics) != len(set(topics)):
+        raise IssueValidationError(f"{name}.topicTags must be unique")
+    _text(artifact.get("reviewReason"), f"{name}.reviewReason", 1_000)
+    if artifact.get("collectionMethod") not in CULTURE_COLLECTION_METHODS:
+        raise IssueValidationError(f"{name}.collectionMethod is invalid")
+    if artifact.get("rightsPolicy") not in CULTURE_RIGHTS_POLICIES:
+        raise IssueValidationError(f"{name}.rightsPolicy is invalid")
+    if artifact.get("purpose") != "culture_sensor":
+        raise IssueValidationError(f"{name}.purpose must be culture_sensor")
+    if artifact.get("canProveClaim") is not False:
+        raise IssueValidationError(f"{name}.canProveClaim must be false")
+    if artifact.get("canEstablishConsensus") is not False:
+        raise IssueValidationError(f"{name}.canEstablishConsensus must be false")
+    return artifact
 
 
 def validate_history_entry(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
@@ -139,6 +201,22 @@ def validate_history_entry(value: Any, *, verify_hash: bool = True) -> dict[str,
             raise IssueValidationError("laterEvidence must not duplicate a contemporary receipt")
         receipt_keys.add(key)
         claim_ids.add(receipt["claimId"])
+
+    culture_artifacts = _list(entry.get("cultureArtifacts", []), "cultureArtifacts", 6)
+    culture_ids: set[str] = set()
+    culture_urls: set[str] = set()
+    for index, artifact_value in enumerate(culture_artifacts):
+        name = f"cultureArtifacts[{index}]"
+        artifact = _culture_artifact(artifact_value, name)
+        published_at = datetime.fromisoformat(
+            _iso(artifact["publishedAt"], f"{name}.publishedAt").replace("Z", "+00:00")
+        ).astimezone(timezone.utc)
+        if not active_from_at <= published_at <= active_through_at:
+            raise IssueValidationError(f"{name} must be dated inside the historical active period")
+        if artifact["artifactId"] in culture_ids or artifact["canonicalUrl"] in culture_urls:
+            raise IssueValidationError("cultureArtifacts must have unique IDs and canonical URLs")
+        culture_ids.add(artifact["artifactId"])
+        culture_urls.add(artifact["canonicalUrl"])
 
     for index, impact_value in enumerate(_list(entry.get("raceImpacts"), "raceImpacts", 100)):
         impact = _impact(impact_value, f"raceImpacts[{index}]")

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -273,6 +273,29 @@ def test_procedural_visual_is_stable_labeled_and_not_documentary():
     assert "<img" not in first
 
 
+def test_historical_story_turn_visual_uses_only_supplied_before_after_copy():
+    visual = render_story_visual(
+        item_id="history-teamification-2026",
+        headline="The privateer became gravel's unpaid control group",
+        body_text="Teams changed access to race-deciding support.",
+        receipts=[],
+        date_label="2026-02-10 → 2026-05-26",
+        stable_hash="abc123",
+        prior_judgment="Top-level gravel remained unusually accessible to independent riders.",
+        changed_judgment="The start stayed open while competitive infrastructure became gated.",
+        point="Open registration survived while race-deciding support became less open.",
+    )
+    assert 'data-visual-role="story-turn"' in visual
+    assert 'data-story-grammar="before-after"' in visual
+    assert "BEFORE" in visual and "AFTER" in visual
+    assert "Top-level gravel remained" in visual
+    assert "competitive infrastructure" in visual
+    assert "Open registration survived" in visual
+    assert "Hash-bound before → after" in visual
+    assert "not a news photo" in visual
+    assert "<img" not in visual and "<iframe" not in visual
+
+
 def test_timestamped_video_visual_links_exact_claim_without_autoplay_or_embed():
     visual = render_story_visual(
         item_id="story_video",
@@ -297,6 +320,8 @@ def test_visual_css_uses_brand_tokens_and_respects_reduced_motion():
     assert "var(--gg-color-" in css
     assert "@media (prefers-reduced-motion: no-preference)" in css
     assert "@media (max-width: 620px)" in css
+    assert "linear 1 both" in css
+    assert "infinite" not in css
     assert "#" not in css
 
 
@@ -993,6 +1018,9 @@ def test_private_historical_review_desk_separates_evidence_and_approval_state():
     assert "no-AI-slop prose gate" in page
     assert "fake_profound_kicker" in page
     assert "not an AI-authorship detector" in page
+    assert 'data-visual-role="story-turn"' in page
+    assert draft["priorJudgment"] in page
+    assert draft["changedJudgment"] in page
     assert "CONTEMPORARY RECEIPTS (2)" in page
     assert "LATER EVIDENCE (1)" in page
     assert "any decision binds to this exact draft hash" in page.lower()
@@ -1693,6 +1721,9 @@ def test_historical_timeline_visually_separates_later_evidence_from_contemporary
     assert "WHY IT MATTERED" in html
     assert "THE FAIR OBJECTION" in html
     assert "The privateer became gravel" in html
+    assert 'data-visual-role="story-turn"' in html
+    assert entry["priorJudgment"] in html
+    assert entry["changedJudgment"] in html
     assert "innerHTML" not in html
     page = build_page(sample_issue(), [sample_issue()], latest=True, history_entries=[entry])
     assert 'id="season-story"' in page

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -59,6 +59,7 @@ from validate_gravel_weekly_history_decisions import validate_history_decision  
 from validate_gravel_weekly_backfill import validate_backfill_ledger  # noqa: E402
 from no_ai_slop import audit_no_ai_slop  # noqa: E402
 from prepare_gravel_weekly_backfill_ledger import build_initial_backfill_ledger  # noqa: E402
+from prepare_gravel_weekly_history_culture import prepare_history_culture_proposal  # noqa: E402
 from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
 from prepare_gravel_weekly_issue import prepare_issue  # noqa: E402
 from approve_gravel_weekly_issue import approve_issue, build_decision_receipt  # noqa: E402
@@ -150,6 +151,7 @@ def sample_history_entry():
         "laterEvidence": [
             {"claimId": "claim_team_later", "canonicalUrl": "https://example.com/later-analysis/", "publisher": "Official series", "publishedAt": "2026-06-10T12:00:00Z", "quoteExcerpt": "A later update.", "transcriptStartSeconds": None, "transcriptEndSeconds": None},
         ],
+        "cultureArtifacts": [],
         "raceImpacts": [],
         "humanApprovalRequired": True,
         "autoPublishAllowed": False,
@@ -175,6 +177,27 @@ def sample_history_draft():
     })
     entry["contentHash"] = compute_history_content_hash(entry)
     return entry
+
+
+def sample_culture_artifact():
+    return {
+        "artifactId": "historical-culture_0123456789abcdef",
+        "sourceKind": "x",
+        "publisher": "Gravel Person",
+        "author": "@gravelperson",
+        "canonicalUrl": "https://x.com/gravelperson/status/123456789",
+        "publishedAt": "2026-03-01T18:30:00Z",
+        "title": "The team bus became the meme",
+        "excerpt": "Gravel has entered its team-bus era.",
+        "timestampSeconds": None,
+        "topicTags": ["privateers", "teamification"],
+        "reviewReason": "A contemporaneous joke compressed the same access argument into one line.",
+        "collectionMethod": "official_api",
+        "rightsPolicy": "short_excerpt_and_canonical_link",
+        "purpose": "culture_sensor",
+        "canProveClaim": False,
+        "canEstablishConsensus": False,
+    }
 
 
 def sample_history_approval(draft=None):
@@ -838,7 +861,7 @@ def test_historical_approval_is_hash_bound_copy_limited_and_non_public(tmp_path)
     for field in (
         "point", "priorJudgment", "changedJudgment", "stakes", "credibleOpposition",
         "whatHappened", "uncertainty", "editorialScore", "editorialGates",
-        "contemporaryReceipts", "laterEvidence", "raceImpacts",
+        "contemporaryReceipts", "laterEvidence", "cultureArtifacts", "raceImpacts",
     ):
         assert approved[field] == draft[field]
     assert decision["reviewedDraftContentHash"] == draft["contentHash"]
@@ -1674,6 +1697,109 @@ def test_historical_timeline_visually_separates_later_evidence_from_contemporary
     page = build_page(sample_issue(), [sample_issue()], latest=True, history_entries=[entry])
     assert 'id="season-story"' in page
     assert page.index("THE CURRENT THING") < page.index("THE SEASON AS A STORY") < page.index("PAST ISSUES")
+
+
+def test_historical_culture_artifacts_are_hash_bound_context_not_evidence():
+    entry = sample_history_entry()
+    original_hash = entry["contentHash"]
+    entry["cultureArtifacts"] = [sample_culture_artifact()]
+    entry["contentHash"] = compute_history_content_hash(entry)
+    validated = validate_history_entry(entry)
+    assert validated["contentHash"] != original_hash
+    assert validated["cultureArtifacts"][0]["canProveClaim"] is False
+    assert validated["cultureArtifacts"][0]["canEstablishConsensus"] is False
+
+    unsafe = copy.deepcopy(entry)
+    unsafe["cultureArtifacts"][0]["canProveClaim"] = True
+    with pytest.raises(IssueValidationError, match="canProveClaim must be false"):
+        validate_history_entry(unsafe, verify_hash=False)
+
+    off_period = copy.deepcopy(entry)
+    off_period["cultureArtifacts"][0]["publishedAt"] = "2025-03-01T18:30:00Z"
+    with pytest.raises(IssueValidationError, match="inside the historical active period"):
+        validate_history_entry(off_period, verify_hash=False)
+
+    copied_media = copy.deepcopy(entry)
+    copied_media["cultureArtifacts"][0]["mediaUrl"] = "https://cdn.example/copied.jpg"
+    with pytest.raises(IssueValidationError, match="unsupported fields"):
+        validate_history_entry(copied_media, verify_hash=False)
+
+
+def test_historical_culture_cards_render_in_review_and_only_after_publication():
+    entry = sample_history_entry()
+    entry["cultureArtifacts"] = [sample_culture_artifact()]
+    entry["contentHash"] = compute_history_content_hash(entry)
+    public = render_history_timeline([entry])
+    assert "CULTURE RECEIPTS" in public
+    assert "WHAT THE GROUP CHAT WAS PASSING AROUND" in public
+    assert 'data-culture-artifact="historical-culture_0123456789abcdef"' in public
+    assert "Gravel has entered its team-bus era." in public
+    assert "https://x.com/gravelperson/status/123456789" in public
+    assert "A contemporaneous joke compressed" not in public
+    assert "iframe" not in public
+    assert "platform.twitter.com" not in public
+
+    draft = sample_history_draft()
+    draft["cultureArtifacts"] = [sample_culture_artifact()]
+    draft["contentHash"] = compute_history_content_hash(draft)
+    private = render_history_review([draft], 2026)
+    assert "PRIVATE CULTURE CHECK" in private
+    assert "A contemporaneous joke compressed" in private
+    approved, _ = apply_history_decision(draft, sample_history_approval(draft))
+    assert approved is not None
+    assert approved["cultureArtifacts"] == draft["cultureArtifacts"]
+
+
+def test_historical_culture_sweep_becomes_diverse_topical_private_proposal():
+    draft = sample_history_draft()
+    sweep = {
+        "schemaVersion": "historical-culture-sweep/v1",
+        "year": 2026,
+        "candidates": [
+            {
+                "id": "x_team_bus", "platform": "x", "canonicalUrl": "https://x.com/gravelperson/status/1",
+                "authorHandle": "gravelperson", "authorName": "Gravel Person", "publishedAt": "2026-03-01T18:30:00Z",
+                "excerpt": "Gravel has entered its team-bus era.", "queryIds": ["teamification"], "queryLabels": ["Teamification"],
+                "attentionScore": 94, "purpose": "culture_sensor", "canProveClaim": False,
+            },
+            {
+                "id": "x_generic", "platform": "x", "canonicalUrl": "https://x.com/other/status/2",
+                "authorHandle": "other", "authorName": None, "publishedAt": "2026-03-02T18:30:00Z",
+                "excerpt": "A viral but generic gravel post.", "queryIds": ["gravel-scene"], "queryLabels": ["Gravel scene"],
+                "attentionScore": 100, "purpose": "culture_sensor", "canProveClaim": False,
+            },
+            {
+                "id": "x_late", "platform": "x", "canonicalUrl": "https://x.com/late/status/3",
+                "authorHandle": "late", "authorName": None, "publishedAt": "2026-07-02T18:30:00Z",
+                "excerpt": "Right topic, wrong moment.", "queryIds": ["teamification"], "queryLabels": ["Teamification"],
+                "attentionScore": 99, "purpose": "culture_sensor", "canProveClaim": False,
+            },
+        ],
+        "supplementalArtifacts": [{
+            "id": "yt_privateer", "sourceKind": "youtube", "publisher": "Bonk Bros", "author": "Bonk Bros",
+            "canonicalUrl": "https://www.youtube.com/watch?v=abcdefghijk", "publishedAt": "2026-03-03T12:00:00Z",
+            "title": "Privateers and the team-bus era", "excerpt": "The paddock suddenly has hierarchy.",
+            "timestampSeconds": 812, "topicTags": ["privateers"], "reviewReason": "A contemporaneous discussion of the same access fight.",
+            "collectionMethod": "authorized_caption", "purpose": "culture_sensor", "canProveClaim": False,
+        }],
+        "crossSourcePatterns": [{"topicTag": "teamification", "sourceKinds": ["x", "youtube"], "artifactIds": ["x_team_bus", "yt_privateer"], "boundary": "research only"}],
+        "canEstablishConsensus": False,
+        "canProveClaim": False,
+        "humanApprovalRequired": True,
+        "autoPublishAllowed": False,
+    }
+    proposal = prepare_history_culture_proposal(draft, sweep, max_artifacts=4)
+    assert [artifact["artifactId"] for artifact in proposal["cultureArtifacts"]] == ["x_team_bus", "yt_privateer"]
+    assert {artifact["sourceKind"] for artifact in proposal["cultureArtifacts"]} == {"x", "youtube"}
+    assert all(artifact["canProveClaim"] is False for artifact in proposal["cultureArtifacts"])
+    assert proposal["contentHash"] != draft["contentHash"]
+    assert proposal["status"] == "draft"
+    assert proposal["editorialApproval"] is None
+
+    unsafe = copy.deepcopy(sweep)
+    unsafe["canEstablishConsensus"] = True
+    with pytest.raises(IssueValidationError, match="safety boundary"):
+        prepare_history_culture_proposal(draft, unsafe)
 
 
 def test_published_history_creates_a_controlled_hash_bound_race_impact_queue():

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -227,6 +227,9 @@ def render_history_timeline(entries: list[dict[str, Any]]) -> str:
             receipts=entry["contemporaryReceipts"],
             date_label=active_label,
             stable_hash=entry["contentHash"],
+            prior_judgment=entry["priorJudgment"],
+            changed_judgment=entry["changedJudgment"],
+            point=entry["point"],
         )
         cards.append(f'''<!-- gravel-weekly-history-hash: {esc(entry['contentHash'])} -->
         <article class="gw-history-entry" id="{esc(entry['entryId'])}">

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 from brand_tokens import get_font_face_css, get_ga4_head_snippet, get_tokens_css  # noqa: E402
 from cookie_consent import get_consent_banner_html  # noqa: E402
 from gravel_weekly_visuals import render_story_visual, visual_css  # noqa: E402
+from gravel_weekly_culture import culture_css, render_culture_artifacts  # noqa: E402
 from shared_header import get_site_header_css, get_site_header_html, get_site_header_js  # noqa: E402
 from validate_gravel_weekly import load_public_issues, validate_issue  # noqa: E402
 from validate_gravel_weekly_history import HISTORY_DIR, load_public_history_entries  # noqa: E402
@@ -237,6 +238,7 @@ def render_history_timeline(entries: list[dict[str, Any]]) -> str:
           </div>
           <div class="gw-history-judgment"><b>WHAT CHANGED:</b> {esc(entry['priorJudgment'])} → {esc(entry['changedJudgment'])}</div>
           <details class="gw-details"><summary>WHAT WAS KNOWABLE THEN · {len(entry['contemporaryReceipts'])}</summary>{render_receipts(entry['contemporaryReceipts'])}</details>
+          {render_culture_artifacts(entry.get('cultureArtifacts', []))}
           {later}
           <p class="gw-history-uncertainty"><b>UNCERTAINTY:</b> {esc(entry['uncertainty'])}</p>
         </article>''')
@@ -420,7 +422,7 @@ def page_css() -> str:
     .gw-history-take { border-left: 0; border-top: var(--gg-border-standard); }
     .gw-story-head, .gw-story-grid section, .gw-utility, .gw-sub { padding: var(--gg-spacing-md); }
   }
-'''
+''' + culture_css()
 
 
 def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, latest: bool, history_entries: list[dict[str, Any]] | None = None) -> str:

--- a/wordpress/gravel_weekly_culture.py
+++ b/wordpress/gravel_weekly_culture.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Durable, rights-bounded Gravel Weekly culture cards."""
+
+from __future__ import annotations
+
+import html
+from datetime import datetime
+from typing import Any
+
+
+def esc(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _timestamp_label(seconds: int | None) -> str:
+    if seconds is None:
+        return ""
+    return f" · {seconds // 60}:{seconds % 60:02d}"
+
+
+def render_culture_artifacts(
+    artifacts: list[dict[str, Any]], *, private_review: bool = False
+) -> str:
+    if not artifacts:
+        return ""
+    cards: list[str] = []
+    for artifact in artifacts:
+        published = datetime.fromisoformat(
+            artifact["publishedAt"].replace("Z", "+00:00")
+        ).strftime("%b %-d, %Y")
+        author = artifact.get("author") or artifact["publisher"]
+        excerpt = (
+            f'<blockquote>{esc(artifact["excerpt"])}</blockquote>'
+            if artifact.get("excerpt") else ""
+        )
+        review_reason = (
+            f'<p class="gw-culture-reason"><b>WHY IT IS HERE:</b> '
+            f'{esc(artifact["reviewReason"])}</p>'
+            if private_review else ""
+        )
+        timestamp = _timestamp_label(artifact.get("timestampSeconds"))
+        cards.append(f'''<article class="gw-culture-card" data-culture-artifact="{esc(artifact['artifactId'])}">
+          <header><span>{esc(artifact['sourceKind'].upper())}</span><time datetime="{esc(artifact['publishedAt'])}">{esc(published)}</time></header>
+          <h5>{esc(artifact['title'])}</h5>
+          <p class="gw-culture-by">{esc(author)}</p>
+          {excerpt}
+          {review_reason}
+          <a href="{esc(artifact['canonicalUrl'])}" rel="noopener noreferrer" target="_blank">OPEN ORIGINAL{esc(timestamp)} →</a>
+        </article>''')
+    mode = "PRIVATE CULTURE CHECK" if private_review else "CULTURE RECEIPTS"
+    explanation = (
+        "These are the jokes, arguments, personalities, and artifacts the desk thinks help reconstruct the moment. "
+        "They are context—not proof, consensus, or a substitute for the point."
+    )
+    return f'''<section class="gw-culture" aria-label="Culture artifacts">
+      <header><span>{mode}</span><h4>WHAT THE GROUP CHAT WAS PASSING AROUND</h4><p>{explanation}</p></header>
+      <div class="gw-culture-grid">{"".join(cards)}</div>
+    </section>'''
+
+
+def culture_css() -> str:
+    return '''
+  .gw-culture { border-top: var(--gg-border-heavy); background: var(--gg-color-teal); color: var(--gg-color-white); }
+  .gw-culture > header { padding: var(--gg-spacing-md); border-bottom: var(--gg-border-standard); }
+  .gw-culture > header > span { display: inline-block; padding: var(--gg-spacing-2xs) var(--gg-spacing-xs); border: var(--gg-border-subtle); background: var(--gg-color-gold); color: var(--gg-color-near-black); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-culture > header h4 { margin: var(--gg-spacing-xs) 0; font-size: clamp(1.4rem, 4vw, 2.4rem); line-height: 1; }
+  .gw-culture > header p { max-width: 760px; margin: 0; font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-normal); }
+  .gw-culture-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--gg-border-width-standard); background: var(--gg-color-near-black); }
+  .gw-culture-card { display: flex; min-width: 0; flex-direction: column; padding: var(--gg-spacing-md); background: var(--gg-color-warm-paper); color: var(--gg-color-near-black); }
+  .gw-culture-card > header { display: flex; justify-content: space-between; gap: var(--gg-spacing-sm); border: 0; padding: 0; font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-culture-card h5 { margin: var(--gg-spacing-md) 0 var(--gg-spacing-xs); font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-xl); line-height: 1.05; }
+  .gw-culture-by { margin: 0 0 var(--gg-spacing-sm); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-bold); text-transform: uppercase; }
+  .gw-culture-card blockquote { flex: 1; margin: 0 0 var(--gg-spacing-md); padding-left: var(--gg-spacing-sm); border-left: var(--gg-border-gold); font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-md); line-height: var(--gg-line-height-normal); }
+  .gw-culture-card a { align-self: flex-start; color: var(--gg-color-primary-brown); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-culture-reason { margin: 0 0 var(--gg-spacing-md); font-size: var(--gg-font-size-sm); line-height: var(--gg-line-height-normal); }
+  @media (max-width: 700px) { .gw-culture-grid { grid-template-columns: 1fr; } }
+'''

--- a/wordpress/gravel_weekly_visuals.py
+++ b/wordpress/gravel_weekly_visuals.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import html
 import re
+import textwrap
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -78,6 +79,34 @@ def _compact_context_label(value: str) -> str:
         return years[0] if len(set(years)) == 1 else f"{years[0]}–{years[-1]}"
     compact = " ".join(value.split()).upper()
     return compact[:28].rstrip()
+
+
+def _svg_text_block(
+    value: str,
+    *,
+    x: int,
+    y: int,
+    class_name: str,
+    max_chars: int = 25,
+    max_lines: int = 5,
+    line_height: int = 18,
+) -> str:
+    """Wrap trusted editorial copy into a compact, escaped native-SVG block."""
+    normalized = " ".join(value.split())
+    lines = textwrap.wrap(
+        normalized,
+        width=max_chars,
+        break_long_words=False,
+        break_on_hyphens=False,
+    ) or [""]
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        lines[-1] = f"{lines[-1][:max_chars - 1].rstrip()}…"
+    spans = "".join(
+        f'<tspan x="{x}" dy="{0 if index == 0 else line_height}">{esc(line)}</tspan>'
+        for index, line in enumerate(lines)
+    )
+    return f'<text class="{esc(class_name)}" x="{x}" y="{y}">{spans}</text>'
 
 
 def classify_theme(*values: str) -> tuple[str, str]:
@@ -197,6 +226,9 @@ def render_story_visual(
     receipts: list[dict[str, Any]],
     date_label: str,
     stable_hash: str | None = None,
+    prior_judgment: str | None = None,
+    changed_judgment: str | None = None,
+    point: str | None = None,
 ) -> str:
     """Render one automatic visual; factual source video wins over abstract art."""
     safe_id = _safe_id(item_id)
@@ -222,6 +254,39 @@ def render_story_visual(
             </svg>
           </a>
           <figcaption><b>VERIFIED SOURCE VIDEO</b><span>The cited passage starts at {esc(timestamp)}. Opens on YouTube.</span></figcaption>
+        </figure>'''
+
+    if prior_judgment and changed_judgment and point:
+        before = _svg_text_block(
+            prior_judgment,
+            x=42,
+            y=91,
+            class_name="gw-turn-copy",
+        )
+        after = _svg_text_block(
+            changed_judgment,
+            x=390,
+            y=91,
+            class_name="gw-turn-copy",
+        )
+        return f'''<figure class="gw-visual gw-visual--turn gw-visual--{esc(theme)}" data-visual-system="{VISUAL_SYSTEM_VERSION}" data-visual-role="story-turn" data-story-grammar="before-after">
+          <svg viewBox="0 0 660 238" role="img" aria-labelledby="gw-visual-title-{safe_id}" focusable="false">
+            <title id="gw-visual-title-{safe_id}">{esc(point)} Before: {esc(prior_judgment)} After: {esc(changed_judgment)}</title>
+            <rect class="gw-visual-paper" x="0" y="0" width="660" height="238" />
+            <path class="gw-visual-route gw-visual-route--background" d="{_route_path(seed)}" pathLength="100" />
+            <text class="gw-visual-kicker" x="24" y="34">GRAVEL WEEKLY · {esc(context_label)}</text>
+            <rect class="gw-turn-panel gw-turn-panel--before" x="24" y="54" width="276" height="132" />
+            <rect class="gw-turn-panel gw-turn-panel--after" x="360" y="54" width="276" height="132" />
+            <text class="gw-turn-label" x="42" y="74">BEFORE</text>
+            <g class="gw-turn-after">
+              <text class="gw-turn-label" x="390" y="74">AFTER</text>
+              {after}
+            </g>
+            {before}
+            <path class="gw-turn-arrow" d="M306 120h42 M334 104l16 16-16 16" pathLength="100" />
+            <text class="gw-visual-meta" x="24" y="217">THE POINT · {esc(theme_label)}</text>
+          </svg>
+          <figcaption><b>STORY TURN // AUTO</b><span>Hash-bound before → after; abstract editorial graphic, not a news photo.</span></figcaption>
         </figure>'''
 
     particles = "".join(
@@ -251,6 +316,7 @@ def visual_css() -> str:
   .gw-visual svg { display: block; width: 100%; height: auto; max-height: 310px; }
   .gw-visual-paper { fill: var(--gg-color-sand); }
   .gw-visual-route { fill: none; stroke: var(--gg-color-teal); stroke-width: 18; stroke-linecap: square; opacity: .9; stroke-dasharray: 10 4; }
+  .gw-visual-route--background { opacity: .23; }
   .gw-visual-gravel circle { fill: var(--gg-color-primary-brown); opacity: .55; }
   .gw-visual-motif { fill: none; stroke: var(--gg-color-near-black); stroke-width: 9; }
   .gw-visual-motif .gw-visual-accent { fill: none; stroke: var(--gg-color-gold); stroke-width: 13; }
@@ -264,11 +330,22 @@ def visual_css() -> str:
   .gw-video-screen { fill: var(--gg-color-near-black); stroke: var(--gg-color-gold); stroke-width: 8; }
   .gw-video-play { fill: var(--gg-color-gold); stroke: var(--gg-color-warm-paper); stroke-width: 4; }
   .gw-visual--video .gw-visual-route { stroke: var(--gg-color-primary-brown); opacity: .35; }
+  .gw-turn-panel { stroke: var(--gg-color-near-black); stroke-width: var(--gg-border-width-standard); }
+  .gw-turn-panel--before { fill: var(--gg-color-warm-paper); }
+  .gw-turn-panel--after { fill: var(--gg-color-gold); }
+  .gw-turn-label, .gw-turn-copy { fill: var(--gg-color-near-black); font-family: var(--gg-font-data); }
+  .gw-turn-label { font-size: 13px; font-weight: var(--gg-font-weight-black); letter-spacing: 2px; }
+  .gw-turn-copy { font-size: 15px; font-weight: var(--gg-font-weight-bold); }
+  .gw-turn-arrow { fill: none; stroke: var(--gg-color-teal); stroke-width: 9; stroke-linecap: square; stroke-linejoin: miter; }
   @media (prefers-reduced-motion: no-preference) {
-    .gw-visual-route { animation: gw-route-pulse 16s linear infinite; }
+    .gw-visual-route { animation: gw-route-pulse 1600ms linear 1 both; }
+    .gw-turn-arrow { animation: gw-turn-reveal 1100ms var(--gg-animation-easing-sharp) 1 both; }
+    .gw-turn-after { animation: gw-turn-land 520ms var(--gg-animation-easing-sharp) 850ms 1 both; }
     .gw-video-facade:hover .gw-video-play { transform: translateX(5px); transform-origin: center; transition: transform 140ms linear; }
   }
   @keyframes gw-route-pulse { to { stroke-dashoffset: -100; } }
+  @keyframes gw-turn-reveal { from { stroke-dasharray: 100; stroke-dashoffset: 100; } to { stroke-dasharray: 100; stroke-dashoffset: 0; } }
+  @keyframes gw-turn-land { from { transform: translateX(-8px); } to { transform: translateX(0); } }
   @media (max-width: 620px) {
     .gw-visual-word { font-size: 30px; }
     .gw-visual-kicker, .gw-visual-meta { display: none; }


### PR DESCRIPTION
## What changed
- add bounded, hash-bound culture artifacts to historical entries
- render durable local culture cards without third-party embeds or copied media
- bridge X and source-diverse historical sweeps into private proposals only
- document the point-first story-graphic grammar and editorial gate

## Safety
- culture artifacts cannot prove claims or establish consensus
- public cards load no third-party scripts or assets
- proposals cannot approve or publish stories

## Verification
- `/opt/homebrew/bin/pytest -q tests/test_gravel_weekly.py` — 97 passed
- `/opt/homebrew/bin/python3 scripts/preflight_quality.py` — passed with pre-existing/environment warnings
- browser QA at `http://127.0.0.1:8769/2026.html`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect published historical timeline HTML, content hashes (invalidating stale approvals), and editorial safety boundaries for third-party culture links; mitigated by fail-closed validation and proposal-only defaults.
> 
> **Overview**
> Adds **bounded `cultureArtifacts`** (up to six per historical entry) as hash-bound editorial context—links and short excerpts only, explicitly not evidence—with strict validator rules (active-period dates, `culture_sensor`, `canProveClaim` / `canEstablishConsensus` false).
> 
> A new **`prepare_gravel_weekly_history_culture.py`** bridge turns `historical-culture-sweep/v1` into private draft proposals (topic match, attention floor, per-source caps) without approving or publishing. **`gravel_weekly_culture.py`** renders local culture cards on the public timeline and private desk (internal `reviewReason` only in review).
> 
> Historical and public pages now pass **prior/changed judgment** into **`render_story_visual`**, which can emit a **before→after “story turn”** SVG instead of generic brand art when those fields are present; visual CSS drops infinite decorative motion in favor of one-shot editorial animation.
> 
> Docs in the history README and visual-system guide describe culture workflow, story-graphic grammars, and the explanatory-art gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db30deb734ff7efb82349dbb418e3659d14502ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->