### PR TITLE
Render approved culture cards in weekly issues

### DIFF
--- a/docs/gravel-weekly-visual-system.md
+++ b/docs/gravel-weekly-visual-system.md
@@ -81,11 +81,12 @@ This makes visuals a build product, not a new editorial approval queue.
 
 ## Culture artifacts
 
-Approved historical stories may include durable culture cards for an X or
-Instagram post, timestamped YouTube moment, forum thread, blog, newsletter, or
-podcast. The card is generated locally from a short excerpt, source identity,
-publication time, and canonical link. It never copies the source image/video,
-loads a third-party embed, or displays engagement as editorial authority. Its
-selection rationale is visible only in the private desk. Because the normalized
-artifact is part of the historical entry content hash, Matti's story approval
-covers the exact culture context that can later appear publicly.
+Approved weekly and historical stories may include durable culture cards for a
+Bluesky, X, or Instagram post, timestamped YouTube moment, forum thread, blog,
+newsletter, or podcast. The card is generated locally from a short excerpt,
+source identity, publication time, and canonical link. It never copies the
+source image/video, loads a third-party embed, or displays engagement as
+editorial authority. Its selection rationale is visible only in draft/private
+review. Because the normalized artifact is part of the weekly issue or
+historical-entry content hash, Matti's story approval covers the exact culture
+context that can later appear publicly.

--- a/scripts/approve_gravel_weekly_issue.py
+++ b/scripts/approve_gravel_weekly_issue.py
@@ -107,7 +107,8 @@ def approve_issue(draft_value: Any, approval_value: Any) -> dict[str, Any]:
         if decision["decision"] == "reject":
             continue
         # Only these three fields come from the human approval. Every factual,
-        # evidentiary, scoring, and race-impact field remains the reviewed draft.
+        # evidentiary, scoring, race-impact, and culture-context field remains
+        # the reviewed draft.
         approved_stories.append({
             **draft_story,
             "headline": decision["headline"],
@@ -132,6 +133,8 @@ def approve_issue(draft_value: Any, approval_value: Any) -> dict[str, Any]:
     ])
     source_index = sorted({
         receipt["canonicalUrl"] for story in approved_stories for receipt in story["receipts"]
+    } | {
+        artifact["canonicalUrl"] for story in approved_stories for artifact in story.get("cultureArtifacts", [])
     })
     approved = {
         **draft,

--- a/scripts/prepare_gravel_weekly_issue.py
+++ b/scripts/prepare_gravel_weekly_issue.py
@@ -106,6 +106,28 @@ def _passes_prose_gate(packet: dict[str, Any]) -> bool:
     )
 
 
+def _culture_artifacts(packet: dict[str, Any], candidate_id: str) -> list[dict[str, Any]]:
+    culture_read = packet.get("cultureRead")
+    if culture_read is None:
+        return []
+    culture_read = _record(culture_read, f"packet {candidate_id} cultureRead")
+    artifacts = culture_read.get("artifacts", [])
+    if not isinstance(artifacts, list) or len(artifacts) > 6:
+        raise ValueError(f"packet {candidate_id} cultureRead.artifacts must contain at most 6 items")
+    if artifacts and culture_read.get("relevance") != "direct":
+        raise ValueError(f"packet {candidate_id} culture artifacts require direct relevance")
+    source_urls = culture_read.get("sourceUrls", [])
+    if not isinstance(source_urls, list) or any(not isinstance(url, str) for url in source_urls):
+        raise ValueError(f"packet {candidate_id} cultureRead.sourceUrls is invalid")
+    copied: list[dict[str, Any]] = []
+    for index, artifact in enumerate(artifacts):
+        item = _record(artifact, f"packet {candidate_id} cultureRead.artifacts[{index}]")
+        if item.get("canonicalUrl") not in source_urls:
+            raise ValueError(f"packet {candidate_id} culture artifact is outside the bounded panel")
+        copied.append(dict(item))
+    return copied
+
+
 def prepare_issue(review_value: Any, publication_date: str, issue_number: int, *, now: str | None = None) -> dict[str, Any]:
     review = _record(review_value, "review")
     if review.get("schemaVersion") != "gravel-weekly-review/v1":
@@ -148,6 +170,7 @@ def prepare_issue(review_value: Any, publication_date: str, issue_number: int, *
         receipts = packet.get("receipts", [])
         if not isinstance(impacts, list) or not isinstance(receipts, list):
             raise ValueError(f"packet {candidate['id']} has invalid impacts or receipts")
+        culture_artifacts = _culture_artifacts(packet, candidate["id"])
         stories.append({
             "candidateId": candidate["id"],
             "headline": packet.get("suggestedHeadline") or candidate["headline"],
@@ -159,9 +182,11 @@ def prepare_issue(review_value: Any, publication_date: str, issue_number: int, *
             "takeProvenance": "model_draft",
             "receipts": receipts,
             "raceImpacts": impacts,
+            "cultureArtifacts": culture_artifacts,
         })
         all_impacts.extend(impacts)
         source_urls.extend(receipt["canonicalUrl"] for receipt in receipts)
+        source_urls.extend(artifact["canonicalUrl"] for artifact in culture_artifacts)
 
     current = next((story["candidateId"] for story in stories if story["score"] >= 85), None)
     issue = {

--- a/scripts/validate_gravel_weekly.py
+++ b/scripts/validate_gravel_weekly.py
@@ -7,7 +7,7 @@ import argparse
 import hashlib
 import json
 import re
-from datetime import datetime
+from datetime import datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -26,6 +26,21 @@ IMPACT_KINDS = {
     "new_race_candidate",
 }
 RETROSPECTIVE_VERDICTS = {"aged_well", "aged_poorly", "still_developing"}
+CULTURE_SOURCE_KINDS = {"bluesky", "x", "instagram", "youtube", "forum", "blog", "newsletter", "podcast"}
+CULTURE_COLLECTION_METHODS = {
+    "official_api", "authorized_caption", "rss", "sitemap",
+    "public_metadata", "user_authorized",
+}
+CULTURE_RIGHTS_POLICIES = {
+    "metadata_only", "short_excerpt_and_canonical_link",
+    "timestamped_short_excerpt",
+}
+CULTURE_ARTIFACT_KEYS = {
+    "artifactId", "sourceKind", "publisher", "author", "canonicalUrl",
+    "publishedAt", "title", "excerpt", "timestampSeconds", "topicTags",
+    "reviewReason", "collectionMethod", "rightsPolicy", "purpose",
+    "canProveClaim", "canEstablishConsensus",
+}
 
 
 class IssueValidationError(ValueError):
@@ -121,6 +136,53 @@ def _impact(value: Any, name: str) -> dict[str, Any]:
     return item
 
 
+def _culture_artifact(value: Any, name: str) -> dict[str, Any]:
+    artifact = _record(value, name)
+    unknown = set(artifact) - CULTURE_ARTIFACT_KEYS
+    if unknown:
+        raise IssueValidationError(f"{name} has unsupported fields: {sorted(unknown)}")
+    _text(artifact.get("artifactId"), f"{name}.artifactId", 500)
+    if artifact.get("sourceKind") not in CULTURE_SOURCE_KINDS:
+        raise IssueValidationError(f"{name}.sourceKind is invalid")
+    _text(artifact.get("publisher"), f"{name}.publisher", 300)
+    if artifact.get("author") is not None:
+        _text(artifact["author"], f"{name}.author", 300)
+    _url(artifact.get("canonicalUrl"), f"{name}.canonicalUrl")
+    _iso(artifact.get("publishedAt"), f"{name}.publishedAt")
+    _text(artifact.get("title"), f"{name}.title", 500)
+    if artifact.get("excerpt") is not None:
+        _text(artifact["excerpt"], f"{name}.excerpt", 280)
+    timestamp = artifact.get("timestampSeconds")
+    if timestamp is not None and (
+        not isinstance(timestamp, int) or isinstance(timestamp, bool)
+        or timestamp < 0 or timestamp > 86_400
+    ):
+        raise IssueValidationError(f"{name}.timestampSeconds is invalid")
+    if artifact.get("collectionMethod") == "authorized_caption" and timestamp is None:
+        raise IssueValidationError(f"{name}.timestampSeconds is required for an authorized caption")
+    topics = _list(artifact.get("topicTags"), f"{name}.topicTags", 10)
+    if not topics:
+        raise IssueValidationError(f"{name}.topicTags must not be empty")
+    for index, topic in enumerate(topics):
+        raw = _text(topic, f"{name}.topicTags[{index}]", 64)
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]+", raw):
+            raise IssueValidationError(f"{name}.topicTags[{index}] is invalid")
+    if len(topics) != len(set(topics)):
+        raise IssueValidationError(f"{name}.topicTags must be unique")
+    _text(artifact.get("reviewReason"), f"{name}.reviewReason", 1_000)
+    if artifact.get("collectionMethod") not in CULTURE_COLLECTION_METHODS:
+        raise IssueValidationError(f"{name}.collectionMethod is invalid")
+    if artifact.get("rightsPolicy") not in CULTURE_RIGHTS_POLICIES:
+        raise IssueValidationError(f"{name}.rightsPolicy is invalid")
+    if artifact.get("purpose") != "culture_sensor":
+        raise IssueValidationError(f"{name}.purpose must be culture_sensor")
+    if artifact.get("canProveClaim") is not False:
+        raise IssueValidationError(f"{name}.canProveClaim must be false")
+    if artifact.get("canEstablishConsensus") is not False:
+        raise IssueValidationError(f"{name}.canEstablishConsensus must be false")
+    return artifact
+
+
 def _retrospective(value: Any, name: str, *, status: str) -> dict[str, Any]:
     item = _record(value, name)
     if item.get("verdict") not in RETROSPECTIVE_VERDICTS:
@@ -185,6 +247,10 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
     stories = _list(issue.get("stories"), "stories", 30)
     story_ids: list[str] = []
     story_impacts: list[dict[str, Any]] = []
+    story_culture_urls: set[str] = set()
+    publication_day = datetime.strptime(publication_date, "%Y-%m-%d").date()
+    culture_window_start = datetime.combine(publication_day - timedelta(days=14), time.min, tzinfo=timezone.utc)
+    culture_window_end = datetime.combine(publication_day + timedelta(days=1), time.min, tzinfo=timezone.utc)
     for index, raw_story in enumerate(stories):
         story = _record(raw_story, f"stories[{index}]")
         story_id = _text(story.get("candidateId"), f"stories[{index}].candidateId", 500)
@@ -224,6 +290,21 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
                     f"stories[{index}].raceImpacts[{impact_index}] references claims without story receipts: {sorted(missing_claims)}"
                 )
             story_impacts.append(validated_impact)
+        culture_ids: set[str] = set()
+        culture_urls: set[str] = set()
+        for artifact_index, artifact_value in enumerate(_list(story.get("cultureArtifacts", []), f"stories[{index}].cultureArtifacts", 6)):
+            artifact_name = f"stories[{index}].cultureArtifacts[{artifact_index}]"
+            artifact = _culture_artifact(artifact_value, artifact_name)
+            published_at = datetime.fromisoformat(
+                _iso(artifact["publishedAt"], f"{artifact_name}.publishedAt").replace("Z", "+00:00")
+            ).astimezone(timezone.utc)
+            if not culture_window_start <= published_at < culture_window_end:
+                raise IssueValidationError(f"{artifact_name} must be dated inside the 14-day weekly culture window")
+            if artifact["artifactId"] in culture_ids or artifact["canonicalUrl"] in culture_urls:
+                raise IssueValidationError(f"stories[{index}].cultureArtifacts must have unique IDs and canonical URLs")
+            culture_ids.add(artifact["artifactId"])
+            culture_urls.add(artifact["canonicalUrl"])
+            story_culture_urls.add(artifact["canonicalUrl"])
     if len(story_ids) != len(set(story_ids)):
         raise IssueValidationError("story candidate IDs must be unique")
 
@@ -263,6 +344,9 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
     source_index = [_url(item, f"sourceIndex[{index}]") for index, item in enumerate(_list(issue.get("sourceIndex"), "sourceIndex", 200))]
     if len(source_index) != len(set(source_index)):
         raise IssueValidationError("sourceIndex must not contain duplicates")
+    missing_culture_sources = story_culture_urls - set(source_index)
+    if missing_culture_sources:
+        raise IssueValidationError(f"sourceIndex omits culture artifact URLs: {sorted(missing_culture_sources)}")
 
     approval = issue.get("editorialApproval")
     if status != "draft" and not isinstance(approval, dict):

--- a/scripts/validate_gravel_weekly_history.py
+++ b/scripts/validate_gravel_weekly_history.py
@@ -17,7 +17,7 @@ from no_ai_slop import audit_no_ai_slop
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 HISTORY_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "history"
 PASSING_GATES = {"party", "point", "friend", "craft", "hostileEditor"}
-CULTURE_SOURCE_KINDS = {"x", "instagram", "youtube", "forum", "blog", "newsletter", "podcast"}
+CULTURE_SOURCE_KINDS = {"bluesky", "x", "instagram", "youtube", "forum", "blog", "newsletter", "podcast"}
 CULTURE_COLLECTION_METHODS = {
     "official_api", "authorized_caption", "rss", "sitemap",
     "public_metadata", "user_authorized",

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -200,6 +200,23 @@ def sample_culture_artifact():
     }
 
 
+def sample_weekly_culture_artifact():
+    artifact = sample_culture_artifact()
+    artifact.update({
+        "artifactId": "culture-artifact_0123456789abcdef",
+        "sourceKind": "bluesky",
+        "publisher": "Cycling Reno",
+        "author": "cyclingreno.bsky.social",
+        "canonicalUrl": "https://bsky.app/profile/cyclingreno.bsky.social/post/3example",
+        "publishedAt": "2026-08-27T18:30:00Z",
+        "title": "The Worlds field has become calendar discourse in a rainbow jersey",
+        "excerpt": "Apparently the real qualification standard is having the correct flight itinerary.",
+        "topicTags": ["calendar", "worlds"],
+        "reviewReason": "Directly names the race in the evidence-backed story; context only.",
+    })
+    return artifact
+
+
 def sample_history_approval(draft=None):
     draft = draft or sample_history_draft()
     return {
@@ -443,6 +460,44 @@ def test_issue_contract_requires_receipts_approval_and_hash():
         validate_issue(slopped_draft, verify_hash=False)
 
 
+def test_weekly_culture_artifacts_are_direct_hash_bound_context_and_survive_approval():
+    artifact = sample_weekly_culture_artifact()
+    published = sample_issue()
+    published["stories"][0]["cultureArtifacts"] = [artifact]
+    published["sourceIndex"].append(artifact["canonicalUrl"])
+    published["contentHash"] = compute_content_hash(published)
+    validated = validate_issue(published)
+    assert validated["stories"][0]["cultureArtifacts"][0]["canProveClaim"] is False
+    assert validated["stories"][0]["cultureArtifacts"][0]["canEstablishConsensus"] is False
+    public = build_page(published, [published], latest=True)
+    assert "CULTURE RECEIPTS" in public
+    assert artifact["title"] in public
+    assert artifact["reviewReason"] not in public
+    assert "iframe" not in public
+
+    draft = sample_draft()
+    draft["stories"][0]["cultureArtifacts"] = [artifact]
+    draft["sourceIndex"].append(artifact["canonicalUrl"])
+    draft["contentHash"] = compute_content_hash(draft)
+    approved = approve_issue(draft, sample_approval())
+    assert approved["stories"][0]["cultureArtifacts"] == [artifact]
+
+    unsafe = copy.deepcopy(published)
+    unsafe["stories"][0]["cultureArtifacts"][0]["canEstablishConsensus"] = True
+    with pytest.raises(IssueValidationError, match="canEstablishConsensus must be false"):
+        validate_issue(unsafe, verify_hash=False)
+
+    stale = copy.deepcopy(published)
+    stale["stories"][0]["cultureArtifacts"][0]["publishedAt"] = "2026-07-01T18:30:00Z"
+    with pytest.raises(IssueValidationError, match="14-day weekly culture window"):
+        validate_issue(stale, verify_hash=False)
+
+    missing_index = copy.deepcopy(published)
+    missing_index["sourceIndex"].remove(artifact["canonicalUrl"])
+    with pytest.raises(IssueValidationError, match="sourceIndex omits culture artifact URLs"):
+        validate_issue(missing_index, verify_hash=False)
+
+
 def test_no_ai_slop_audit_names_patterns_without_guessing_authorship():
     clean = audit_no_ai_slop({
         "headline": "Gravel Worlds Moved Lunch Forty Miles",
@@ -468,6 +523,7 @@ def test_no_ai_slop_audit_names_patterns_without_guessing_authorship():
 
 
 def test_review_prepares_a_draft_but_cannot_imply_approval():
+    culture_artifact = sample_weekly_culture_artifact()
     packet = with_passing_prose_gate({
         "candidateId": "story_1",
         "editorialGate": passing_editorial_gate(),
@@ -477,6 +533,11 @@ def test_review_prepares_a_draft_but_cannot_imply_approval():
         "whatHappened": "The organizer published a revised distance. It affects preparation.",
         "receipts": [sample_issue()["stories"][0]["receipts"][0]],
         "raceImpacts": sample_issue()["stories"][0]["raceImpacts"],
+        "cultureRead": {
+            "relevance": "direct",
+            "sourceUrls": [culture_artifact["canonicalUrl"]],
+            "artifacts": [culture_artifact],
+        },
     })
     review = {
         "schemaVersion": "gravel-weekly-review/v1",
@@ -492,10 +553,14 @@ def test_review_prepares_a_draft_but_cannot_imply_approval():
     assert issue["currentThingStoryId"] == "story_1"
     assert issue["stories"][0]["headline"] == "The course moved"
     assert issue["stories"][0]["takeProvenance"] == "model_draft"
+    assert issue["stories"][0]["cultureArtifacts"] == [culture_artifact]
+    assert culture_artifact["canonicalUrl"] in issue["sourceIndex"]
     assert validate_issue(issue)["contentHash"] == issue["contentHash"]
     preview = build_page(issue, [issue], latest=True)
     assert "DRAFT — NOT PUBLISHED" in preview
     assert "THE TAKE — MODEL DRAFT" in preview
+    assert "PRIVATE CULTURE CHECK" in preview
+    assert culture_artifact["reviewReason"] in preview
     assert "application/ld+json" not in preview
 
 

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -163,6 +163,7 @@ def render_story(story: dict[str, Any], *, current: bool = False, draft: bool = 
           {prose(story['take'])}
         </section>
       </div>
+      {render_culture_artifacts(story.get('cultureArtifacts', []), private_review=draft)}
       <details class="gw-details">
         <summary>RECEIPTS · {len(story['receipts'])}</summary>
         {render_receipts(story['receipts'])}


### PR DESCRIPTION
## Summary\n- carry direct packet culture artifacts into Gravel Weekly drafts and source indexes\n- preserve exact artifacts through human approval and content hashing\n- render durable weekly culture cards with private-only selection rationale\n- accept Bluesky alongside existing historical culture sources\n\n## Safety\n- no embeds, copied media, or engagement counts\n- artifacts cannot prove claims or establish consensus\n- six-card and 14-day windows fail closed\n\n## Verification\n- pytest -q tests/test_gravel_weekly.py (99 passed)\n- pytest -q (7,920 passed, 331 skipped)\n- python3 scripts/preflight_quality.py (passed; 7 known environment/backlog warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes editorial publication contracts and public rendering of third-party excerpts/links; safeguards (no consensus/proof flags, windows, source index) are explicit but mistakes could surface wrong context on approved issues.
> 
> **Overview**
> **Gravel Weekly weekly issues now carry the same bounded culture-card pipeline as historical entries**—social/context artifacts flow from review packets into drafts, survive human approval unchanged, and render on issue pages without embeds.
> 
> `prepare_gravel_weekly_issue` copies **direct** `cultureRead` artifacts (≤6, URLs inside the packet panel) onto each story and folds their canonical URLs into `sourceIndex`. Approval still only edits headline/dek/take; culture context stays hash-bound with receipts and race impacts. `validate_gravel_weekly` adds fail-closed artifact schema checks, a **14-day window** around publication date, and requires every culture URL in `sourceIndex`. **Bluesky** is added as a source kind for weekly and history validation.
> 
> The page generator calls `render_culture_artifacts` on each story: published issues show **CULTURE RECEIPTS** cards; draft previews show **PRIVATE CULTURE CHECK** with `reviewReason`. Docs describe weekly + historical culture rules and Bluesky.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6251ac476a9002b1db17feabc96a4c443a3b7bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->