### PR TITLE
Translate Manual for Speed patterns into Gravel Weekly

### DIFF
--- a/docs/gravel-weekly-manual-for-speed-reference.md
+++ b/docs/gravel-weekly-manual-for-speed-reference.md
@@ -148,6 +148,20 @@ On mobile, contents is a horizontally scrollable chapter rail. On desktop it may
 be sticky only while the issue is in view. Every chapter remains a normal anchor
 target; the page works without JavaScript.
 
+### Implemented first pass
+
+The public issue renderer and private historical review desk now generate the
+chapter rail from available data. `THE SCENE REPORT` appears only when culture
+artifacts survived review; `WHAT THIS CHANGES` enters the public contents only
+for a non-`no_change` race impact; draft Takes are labeled as model drafts rather
+than approved judgments. The public and historical surfaces now distinguish
+`THE RECORD`, `THE SCENE REPORT`, `THE TAKE`, and `WHAT THIS CHANGES` with stable
+anchor targets and keyboard-visible focus states.
+
+`THE CAST` and `FIELD NOTES` remain deliberately unimplemented. They require
+sourced role and observation fields in the issue contract; the renderer must not
+infer them from a headline, a social post, or a publisher byline.
+
 ## What not to import
 
 - No copied masthead, wordmark, gradients, iconography, or condensed-type lockup.

--- a/docs/gravel-weekly-manual-for-speed-reference.md
+++ b/docs/gravel-weekly-manual-for-speed-reference.md
@@ -1,0 +1,174 @@
+# Manual for Speed reference study
+
+This is an interface and editorial-mechanics study for Gravel Weekly. It is not
+permission to copy Manual for Speed's logo, type treatment, photography,
+illustration, gradients, page composition, recurring names, or trade dress.
+
+## Archive sample
+
+The review used five representative Internet Archive captures:
+
+- [December 2012 homepage](https://web.archive.org/web/20121218044342/http://manualforspeed.com/)
+- [2012 photo essay: Nice Work. Disappointment.](https://web.archive.org/web/20121101234132/http://manualforspeed.com/2012/09/nice-work-disappointment/)
+- [March 2016 homepage](https://web.archive.org/web/20160306025636/http://manualforspeed.com/)
+- [2015 Tour de France: Stage 01](https://web.archive.org/web/20160323053644/http://manualforspeed.com/road-racing/2015-tour-de-france-stage-01/)
+- [Clown Dreams Lookbook](https://web.archive.org/web/20160323030820/http://manualforspeed.com/bonus-treasures/clown-dreams-lookbook/)
+
+The 2012 and 2016 systems are materially different. The early site is a quiet,
+photo-led index of essays with short, pointed headlines. By 2016 it has become a
+maximal magazine: full-bleed story cards, huge condensed display type, issue-like
+tables of contents, recurring departments, character credits, and deliberately
+over-specific field notes. The durable lesson is the editorial structure, not
+either skin.
+
+## What made it cultural coverage
+
+Manual for Speed ran two records at the same time:
+
+1. The official race record: route, result, distance, course, date, and place.
+2. The lived record: who was there, what went wrong, what people ate, what the
+   access hierarchy felt like, overheard lines, visual oddities, travel details,
+   jokes, embarrassment, and the author's changing judgment.
+
+The second record is why the work still feels like culture instead of a results
+feed. A Tour report can contain a conventional `RACE BIBLE` and a parallel
+`MANUAL FOR SPEED BIBLE`, plus a cast, objectives, highs and lows, observations,
+meal report, corrections, quote of the day, playlist, and chronological diary.
+Those departments create continuity without forcing every item into a generic
+article template.
+
+## Layout and UI patterns worth translating
+
+### 1. Photograph or graphic as the front door
+
+The early homepage lets one documentary image carry a story card. The later
+homepage turns each story into a full-bleed visual poster with only the minimum
+metadata needed to enter it.
+
+**Gravel Weekly translation:** keep the automatic story graphic as the issue's
+front door. Follow it with compact, rights-safe culture artifacts and verified
+source-video facades. Never use synthetic documentary imagery or hotlinked
+publisher media.
+
+### 2. Extreme hierarchy, quiet metadata
+
+The headline is enormous; date, place, category, and production notes are tiny.
+This makes the editorial judgment unmistakable without losing the archival
+record.
+
+**Gravel Weekly translation:** make the point or headline the largest element.
+Keep receipt count, dates, confidence, and source mechanics in the data face.
+Do not let review controls or evidence plumbing compete with the story.
+
+### 3. An issue has departments, not a pile of cards
+
+The Tour report's Roman-numeral contents turn a long scroll into an issue with a
+rhythm. Repeated departments reward return readers and allow strange material to
+belong without pretending it is hard news.
+
+**Gravel Weekly translation:** use a compact contents rail and a fixed family of
+departments. The data may leave a department empty; the renderer must never pad
+an issue with weak material.
+
+Recommended public departments:
+
+- `THE CURRENT THING` — the one change-point that explains the week.
+- `THE RECORD` — verified facts, results, dates, and race intelligence.
+- `THE SCENE REPORT` — approved culture artifacts and the lived texture around
+  the story.
+- `THE CAST` — only people materially involved in the story, with sourced roles.
+- `WHAT EVERYONE IS SLAGGING` — recurring jokes or criticism, labeled as sampled
+  attention rather than consensus.
+- `FIELD NOTES` — specific details that make the scene legible.
+- `THE TAKE` — Matti's approved judgment.
+- `WHAT THIS CHANGES` — controlled implications for race profiles and earlier
+  Gravel Weekly judgments.
+- `CORRECTIONS / THINGS WE GOT WRONG` — a permanent memory mechanism.
+
+### 4. Cast creates a scene
+
+Manual for Speed credits photographers, producers, logistics people, and odd
+roles as a cast rather than treating the author as a disembodied narrator.
+
+**Gravel Weekly translation:** generate a cast strip from approved entities in
+the evidence graph. Each entry needs a sourced role and relationship to the
+story. No inferred motives, personality labels, or synthetic portraits.
+
+### 5. Structured chaos
+
+The pages permit abrupt shifts between facts, jokes, photographs, logistics,
+quoted speech, and self-correction. The structure is strict enough that the
+content can be loose.
+
+**Gravel Weekly translation:** the schema remains rigid while the issue cadence
+can vary. A short oddity can be one field note; it does not need a fake thesis.
+A strong story can expand into multiple chapters. A dead week can remain short.
+
+### 6. A visual sequence can be the argument
+
+The photo essays do not treat imagery as decoration between paragraphs. The
+sequence itself supplies pacing, character, and evidence of atmosphere.
+
+**Gravel Weekly translation:** use a sequence of locally rendered culture cards,
+timestamped source-video facades, and deterministic story graphics. Each item
+must have an editorial job: establish the cast, reveal the turn, show recurrence,
+or provide comic release. Remove any item that only makes the page longer.
+
+### 7. Specific language beats category language
+
+The archive's strongest headlines and departments are concrete and sometimes
+strange. The taxonomy sounds like a publication made by people inside a scene,
+not a CMS navigation menu.
+
+**Gravel Weekly translation:** retain stable machine-readable story kinds, but
+let the visible department label be specific. `Culture artifact` is a schema
+term, not a reader-facing headline.
+
+## Proposed issue anatomy
+
+```text
+MASTHEAD / ISSUE DATE / ONE-SENTENCE POINT
+STORY GRAPHIC OR VERIFIED SOURCE VIDEO
+
+CONTENTS
+I.   THE CURRENT THING
+II.  THE RECORD
+III. THE SCENE REPORT
+IV.  THE CAST
+V.   WHAT EVERYONE IS SLAGGING
+VI.  THE TAKE
+VII. WHAT THIS CHANGES
+VIII.CORRECTIONS / MEMORY
+
+SEASON TIMELINE
+Each change-point opens the same record/culture/take structure.
+```
+
+On mobile, contents is a horizontally scrollable chapter rail. On desktop it may
+be sticky only while the issue is in view. Every chapter remains a normal anchor
+target; the page works without JavaScript.
+
+## What not to import
+
+- No copied masthead, wordmark, gradients, iconography, or condensed-type lockup.
+- No copied department names such as `MFS Bible` or `Bonus Treasures`.
+- No unlicensed photography, screenshots of social posts, or third-party embeds.
+- No small body copy simply because the headline is large.
+- No endless undifferentiated scroll; long issues require navigation and a clear
+  return to the Current Thing.
+- No sponsor placement that can be mistaken for editorial judgment.
+- No maximalism without a point. Novelty must carry character, evidence, pacing,
+  or an actual joke.
+
+## Acceptance gate for the Gravel Weekly translation
+
+The translated design passes only if:
+
+1. The reader can state the issue's point after the hero and first screen.
+2. The official record and cultural record are visibly distinct.
+3. Every visual has an editorial job and rights-safe provenance.
+4. Repeated departments improve navigation without creating filler quotas.
+5. The Scene Report communicates a culture, not an engagement leaderboard.
+6. The Take is visibly Matti-approved and cannot be mistaken for model output.
+7. The season timeline preserves what was knowable then and what changed later.
+8. The result still looks unmistakably like Gravel God.

--- a/docs/gravel-weekly-visual-system.md
+++ b/docs/gravel-weekly-visual-system.md
@@ -53,6 +53,11 @@ never licenses fake precision or delays publication.
 
 ## Reference systems
 
+- Manual for Speed's separation of the official race record from the lived
+  cultural record, plus its cast, recurring departments, issue contents, visual
+  sequencing, and specific field notes. See
+  [`gravel-weekly-manual-for-speed-reference.md`](gravel-weekly-manual-for-speed-reference.md)
+  for the archive study and the explicit no-copy boundary.
 - The Pudding's question-first, storyboard-before-code method and willingness to
   kill weak ideas.
 - ProPublica's insistence that the editorial nut be the most visible element and
@@ -62,10 +67,10 @@ never licenses fake precision or delays publication.
 - The Economist's constrained palette, repeatable grammar, and use of color to
   highlight the main message rather than decorate it.
 
-The Gravel Weekly synthesis is Economist restraint, Markup conceptual wit,
-ProPublica hierarchy, Pudding point-first rigor, and Gravel God type, texture, and
-motion. Those are operating principles, not a license to imitate any publisher's
-trade dress.
+The Gravel Weekly synthesis is Manual for Speed's inhabited scene record,
+Economist restraint, Markup conceptual wit, ProPublica hierarchy, Pudding
+point-first rigor, and Gravel God type, texture, and motion. Those are operating
+principles, not a license to imitate any publisher's trade dress.
 
 ## Non-negotiable gates
 

--- a/scripts/render_gravel_weekly_history_review.py
+++ b/scripts/render_gravel_weekly_history_review.py
@@ -113,6 +113,26 @@ def _impact_list(impacts: list[dict[str, Any]]) -> str:
     )
 
 
+def _story_contents(entry: dict[str, Any]) -> str:
+    """Map a long review card without manufacturing unavailable departments."""
+    entry_id = entry["entryId"]
+    chapters = [
+        (f"#{entry_id}-point", "THE POINT"),
+        (f"#{entry_id}-record", "THE RECORD"),
+        (f"#{entry_id}-take", "THE TAKE"),
+        (f"#{entry_id}-opposition", "THE OTHER SIDE"),
+        (f"#{entry_id}-receipts", "THE RECEIPTS"),
+    ]
+    if entry.get("cultureArtifacts"):
+        chapters.append((f"#{entry_id}-scene", "THE SCENE REPORT"))
+    chapters.append((f"#{entry_id}-changes", "WHAT THIS CHANGES"))
+    items = "".join(
+        f'<li><a href="{esc(target)}"><span>{index:02d}</span>{esc(label)}</a></li>'
+        for index, (target, label) in enumerate(chapters, start=1)
+    )
+    return f'<nav class="story-contents" aria-label="Sections in {esc(reviewed_headline_copy(entry))}"><ol>{items}</ol></nav>'
+
+
 def _card(entry: dict[str, Any]) -> str:
     gate = prose_gate(entry)
     holds = approval_holds(entry, gate)
@@ -170,23 +190,24 @@ def _card(entry: dict[str, Any]) -> str:
         <div class="status">{readiness}<code>{esc(entry['entryId'])}</code></div>
       </header>
       {visual}
-      <section class="point"><h3>THE POINT</h3>{paragraphs(entry['point'])}</section>
+      {_story_contents(entry)}
+      <section class="point" id="{esc(entry['entryId'])}-point"><h3>THE POINT</h3>{paragraphs(entry['point'])}</section>
       <div class="judgment">
         <section><h3>BEFORE</h3>{paragraphs(entry['priorJudgment'])}</section>
         <section><h3>AFTER</h3>{paragraphs(entry['changedJudgment'])}</section>
       </div>
-      <section><h3>WHAT HAPPENED</h3>{paragraphs(entry['whatHappened'])}</section>
-      <section class="take"><h3>THE TAKE · MODEL DRAFT</h3>{paragraphs(reviewed_take_copy(entry))}</section>
+      <section id="{esc(entry['entryId'])}-record"><h3>THE RECORD</h3>{paragraphs(entry['whatHappened'])}</section>
+      <section class="take" id="{esc(entry['entryId'])}-take"><h3>THE TAKE · MODEL DRAFT</h3>{paragraphs(reviewed_take_copy(entry))}</section>
       <div class="judgment">
         <section><h3>STAKES</h3>{paragraphs(entry['stakes'])}</section>
-        <section><h3>CREDIBLE OPPOSITION</h3>{paragraphs(entry['credibleOpposition'])}</section>
+        <section id="{esc(entry['entryId'])}-opposition"><h3>THE OTHER SIDE</h3>{paragraphs(entry['credibleOpposition'])}</section>
       </div>
       <section><h3>UNCERTAINTY</h3>{paragraphs(entry['uncertainty'])}</section>
-      <details open><summary>CONTEMPORARY RECEIPTS ({len(entry['contemporaryReceipts'])})</summary>{_receipt_list(entry['contemporaryReceipts'])}</details>
-      {render_culture_artifacts(entry.get('cultureArtifacts', []), private_review=True)}
+      <details open id="{esc(entry['entryId'])}-receipts"><summary>CONTEMPORARY RECEIPTS ({len(entry['contemporaryReceipts'])})</summary>{_receipt_list(entry['contemporaryReceipts'])}</details>
+      {render_culture_artifacts(entry.get('cultureArtifacts', []), private_review=True, section_id=f"{entry['entryId']}-scene")}
       <details><summary>LATER EVIDENCE ({len(entry['laterEvidence'])})</summary>{_receipt_list(entry['laterEvidence'])}</details>
       <details open><summary>{prose_summary}</summary><p>Checked against <a href="{esc(gate['sourceUrl'])}" rel="noopener" target="_blank">petergyang/no-ai-slop</a> at <code>{esc(str(gate['sourceRevision'])[:8])}</code>. This is a prose-pattern gate, not an AI-authorship detector.</p><ul class="prose-findings">{prose_finding_rows}</ul></details>
-      <details><summary>GATES &amp; RACE INTELLIGENCE</summary><ul class="gates">{gate_rows}</ul>{_impact_list(entry['raceImpacts'])}</details>
+      <details id="{esc(entry['entryId'])}-changes"><summary>WHAT THIS CHANGES · GATES &amp; RACE INTELLIGENCE</summary><ul class="gates">{gate_rows}</ul>{_impact_list(entry['raceImpacts'])}</details>
       <footer>
         <p><b>DECIDE:</b> {decision_instruction} Any decision binds to this exact draft hash and still does not publish.</p>
         <code>{esc(entry['contentHash'])}</code>
@@ -258,6 +279,12 @@ main {{ width: min(1120px, calc(100% - 32px)); margin: 32px auto 80px; }}
 .story > header, .story > section, .story > div, .story > details, .story > footer {{ padding: var(--gg-spacing-lg); border-top: var(--gg-border-standard); }}
 .story > header {{ border-top: 0; background: var(--gg-color-white); }}
 .story h2 {{ margin: 8px 0 16px; max-width: 900px; font-family: var(--gg-font-editorial); font-size: clamp(2rem, 6vw, 4rem); line-height: .95; }}
+.story-contents {{ padding: 0 !important; background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }}
+.story-contents ol {{ display: flex; margin: 0; padding: 0; overflow-x: auto; list-style: none; scroll-snap-type: x proximity; }}
+.story-contents li {{ flex: 1 0 150px; border-right: var(--gg-border-subtle); scroll-snap-align: start; }}
+.story-contents a {{ display: grid; grid-template-columns: auto 1fr; gap: var(--gg-spacing-xs); align-items: center; min-height: 100%; padding: var(--gg-spacing-sm); color: inherit; font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); text-decoration: none; }}
+.story-contents a:hover, .story-contents a:focus-visible {{ background: var(--gg-color-teal); outline: var(--gg-border-gold); outline-offset: calc(var(--gg-border-width-standard) * -1); }}
+.story-contents span {{ color: var(--gg-color-gold); font-size: var(--gg-font-size-xl); line-height: .9; }}
 .story h3 {{ margin: 0 0 8px; letter-spacing: var(--gg-letter-spacing-wide); }}
 .story p {{ max-width: 900px; font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-md); line-height: var(--gg-line-height-relaxed); }}
 .status {{ display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }}

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -470,7 +470,9 @@ def test_weekly_culture_artifacts_are_direct_hash_bound_context_and_survive_appr
     assert validated["stories"][0]["cultureArtifacts"][0]["canProveClaim"] is False
     assert validated["stories"][0]["cultureArtifacts"][0]["canEstablishConsensus"] is False
     public = build_page(published, [published], latest=True)
-    assert "CULTURE RECEIPTS" in public
+    assert "THE SCENE REPORT" in public
+    assert 'href="#scene-story_1"' in public
+    assert 'id="scene-story_1"' in public
     assert artifact["title"] in public
     assert artifact["reviewReason"] not in public
     assert "iframe" not in public
@@ -559,6 +561,8 @@ def test_review_prepares_a_draft_but_cannot_imply_approval():
     preview = build_page(issue, [issue], latest=True)
     assert "DRAFT — NOT PUBLISHED" in preview
     assert "THE TAKE — MODEL DRAFT" in preview
+    assert "The model draft awaiting approval" in preview
+    assert "The approved judgment" not in preview
     assert "PRIVATE CULTURE CHECK" in preview
     assert culture_artifact["reviewReason"] in preview
     assert "application/ld+json" not in preview
@@ -826,6 +830,13 @@ def test_rendered_issue_preserves_site_infrastructure_and_honest_form():
     page = build_page(issue, [issue], latest=True)
     assert "GRAVEL <span>WEEKLY</span>" in page
     assert "THE CURRENT THING" in page
+    assert 'class="gw-contents"' in page
+    assert 'href="#record-story_1"' in page
+    assert 'id="record-story_1"' in page
+    assert 'href="#take-story_1"' in page
+    assert 'id="take-story_1"' in page
+    assert "THE RECORD" in page
+    assert "WHAT THIS CHANGES" in page
     assert "G-EJJZ9T6M52" in page
     assert "gravel_weekly_subscribe" in page
     assert "if (!response.ok)" in page
@@ -1826,7 +1837,7 @@ def test_historical_culture_cards_render_in_review_and_only_after_publication():
     entry["cultureArtifacts"] = [sample_culture_artifact()]
     entry["contentHash"] = compute_history_content_hash(entry)
     public = render_history_timeline([entry])
-    assert "CULTURE RECEIPTS" in public
+    assert "THE SCENE REPORT" in public
     assert "WHAT THE GROUP CHAT WAS PASSING AROUND" in public
     assert 'data-culture-artifact="historical-culture_0123456789abcdef"' in public
     assert "Gravel has entered its team-bus era." in public
@@ -1840,6 +1851,12 @@ def test_historical_culture_cards_render_in_review_and_only_after_publication():
     draft["contentHash"] = compute_history_content_hash(draft)
     private = render_history_review([draft], 2026)
     assert "PRIVATE CULTURE CHECK" in private
+    assert 'class="story-contents"' in private
+    assert f'href="#{draft["entryId"]}-scene"' in private
+    assert f'id="{draft["entryId"]}-scene"' in private
+    assert "THE RECORD" in private
+    assert "THE OTHER SIDE" in private
+    assert "WHAT THIS CHANGES" in private
     assert "A contemporaneous joke compressed" in private
     approved, _ = apply_history_decision(draft, sample_history_approval(draft))
     assert approved is not None

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -60,6 +60,55 @@ def story_by_id(issue: dict[str, Any], story_id: str | None) -> dict[str, Any] |
     return next((story for story in issue["stories"] if story["candidateId"] == story_id), None)
 
 
+def meaningful_impacts(impacts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [impact for impact in impacts if impact["impactKind"] != "no_change"]
+
+
+def render_issue_contents(issue: dict[str, Any]) -> str:
+    """Render an evidence-aware issue map without inventing empty departments."""
+    current = story_by_id(issue, issue.get("currentThingStoryId"))
+    if current is None:
+        return ""
+    story_id = current["candidateId"]
+    chapters: list[tuple[str, str, str]] = [
+        (f"#{story_id}", "THE CURRENT THING", current["headline"]),
+        (f"#record-{story_id}", "THE RECORD", "The verified account"),
+    ]
+    if current.get("cultureArtifacts"):
+        chapters.append((f"#scene-{story_id}", "THE SCENE REPORT", "What the culture sample adds"))
+    take_description = (
+        "The model draft awaiting approval"
+        if issue["status"] == "draft"
+        else "The approved judgment"
+    )
+    chapters.append((f"#take-{story_id}", "THE TAKE", take_description))
+    if meaningful_impacts(current["raceImpacts"]):
+        chapters.append((f"#changes-{story_id}", "WHAT THIS CHANGES", "Controlled race intelligence"))
+    other_stories = [
+        story for story in issue["stories"]
+        if story["candidateId"] != issue.get("currentThingStoryId")
+    ]
+    if other_stories:
+        noun = "story" if len(other_stories) == 1 else "stories"
+        chapters.append((
+            f"#{other_stories[0]['candidateId']}",
+            "ALSO THIS WEEK",
+            f"{len(other_stories)} more {noun} that cleared the gate",
+        ))
+    if issue["retrospectives"]:
+        chapters.append(("#memory", "MEMORY", "Earlier takes meet later evidence"))
+    if issue["corrections"]:
+        chapters.append(("#corrections", "CORRECTIONS", "The permanent record"))
+    items = "".join(
+        f'''<li><a href="{esc(target)}"><span>{index}</span><b>{esc(label)}</b><small>{esc(description)}</small></a></li>'''
+        for index, (target, label, description) in enumerate(chapters, start=1)
+    )
+    return f'''<nav class="gw-contents" aria-label="In this issue">
+      <header><span>IN THIS ISSUE</span><p>The record, the scene, the Take, and the receipts.</p></header>
+      <ol>{items}</ol>
+    </nav>'''
+
+
 def render_receipts(receipts: list[dict[str, Any]]) -> str:
     items = []
     for receipt in receipts:
@@ -83,7 +132,7 @@ def render_receipts(receipts: list[dict[str, Any]]) -> str:
 
 
 def render_impacts(impacts: list[dict[str, Any]]) -> str:
-    meaningful = [impact for impact in impacts if impact["impactKind"] != "no_change"]
+    meaningful = meaningful_impacts(impacts)
     if not meaningful:
         return '<p class="gw-empty">No race-profile change proposed.</p>'
     labels = {
@@ -132,7 +181,7 @@ def render_retrospectives(retrospectives: list[dict[str, Any]], issues: list[dic
           </div>
           <details class="gw-details"><summary>RECEIPTS · {len(item['receipts'])}</summary>{render_receipts(item['receipts'])}</details>
         </article>''')
-    return f'<section class="gw-retrospectives"><h2>THE RECEIPTS ON US</h2><p class="gw-retro-dek">Old takes do not disappear when the timeline moves on.</p>{"".join(cards)}</section>'
+    return f'<section class="gw-retrospectives" id="memory"><h2>THE RECEIPTS ON US</h2><p class="gw-retro-dek">Old takes do not disappear when the timeline moves on.</p>{"".join(cards)}</section>'
 
 
 def render_story(story: dict[str, Any], *, current: bool = False, draft: bool = False) -> str:
@@ -154,22 +203,22 @@ def render_story(story: dict[str, Any], *, current: bool = False, draft: bool = 
       </header>
       {visual}
       <div class="gw-story-grid">
-        <section class="gw-facts" aria-labelledby="facts-{esc(story['candidateId'])}">
-          <h3 id="facts-{esc(story['candidateId'])}">WHAT HAPPENED</h3>
+        <section class="gw-facts" id="record-{esc(story['candidateId'])}" aria-labelledby="record-label-{esc(story['candidateId'])}">
+          <h3 id="record-label-{esc(story['candidateId'])}">THE RECORD</h3>
           {prose(story['whatHappened'])}
         </section>
-        <section class="gw-take" aria-labelledby="take-{esc(story['candidateId'])}">
-          <h3 id="take-{esc(story['candidateId'])}">{take_label}</h3>
+        <section class="gw-take" id="take-{esc(story['candidateId'])}" aria-labelledby="take-label-{esc(story['candidateId'])}">
+          <h3 id="take-label-{esc(story['candidateId'])}">{take_label}</h3>
           {prose(story['take'])}
         </section>
       </div>
-      {render_culture_artifacts(story.get('cultureArtifacts', []), private_review=draft)}
+      {render_culture_artifacts(story.get('cultureArtifacts', []), private_review=draft, section_id=f"scene-{story['candidateId']}")}
       <details class="gw-details">
         <summary>RECEIPTS · {len(story['receipts'])}</summary>
         {render_receipts(story['receipts'])}
       </details>
-      <details class="gw-details">
-        <summary>RACE INTELLIGENCE</summary>
+      <details class="gw-details" id="changes-{esc(story['candidateId'])}">
+        <summary>WHAT THIS CHANGES</summary>
         {render_impacts(story['raceImpacts'])}
       </details>
     </article>'''
@@ -237,7 +286,7 @@ def render_history_timeline(entries: list[dict[str, Any]]) -> str:
           <header><span class="gw-history-date">{esc(active_label.upper())}</span><span class="gw-score">EDITORIAL SCORE {entry['editorialScore']}/100</span><h3>{esc(entry['headline'])}</h3></header>
           {visual}
           <div class="gw-history-grid">
-            <section><h4>THE POINT</h4>{prose(entry['point'])}<h4>WHAT HAPPENED</h4>{prose(entry['whatHappened'])}<h4>WHY IT MATTERED</h4>{prose(entry['stakes'])}<h4>THE FAIR OBJECTION</h4>{prose(entry['credibleOpposition'])}</section>
+            <section><h4>THE POINT</h4>{prose(entry['point'])}<h4>THE RECORD</h4>{prose(entry['whatHappened'])}<h4>WHY IT MATTERED</h4>{prose(entry['stakes'])}<h4>THE FAIR OBJECTION</h4>{prose(entry['credibleOpposition'])}</section>
             <section class="gw-history-take"><h4>THE TAKE</h4>{prose(entry['take'])}</section>
           </div>
           <div class="gw-history-judgment"><b>WHAT CHANGED:</b> {esc(entry['priorJudgment'])} → {esc(entry['changedJudgment'])}</div>
@@ -334,6 +383,17 @@ def page_css() -> str:
   .gw-cover-lines span { padding: var(--gg-spacing-sm); border-right: var(--gg-border-subtle); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-bold); text-align: center; text-transform: uppercase; }
   .gw-cover-lines span:last-child { border-right: 0; }
   .gw-back { display: inline-block; margin: var(--gg-spacing-lg) 0 0; color: var(--gg-color-primary-brown); font-weight: var(--gg-font-weight-bold); }
+  .gw-contents { margin-top: var(--gg-spacing-xl); border: var(--gg-border-heavy); background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }
+  .gw-contents > header { display: flex; justify-content: space-between; gap: var(--gg-spacing-md); align-items: baseline; padding: var(--gg-spacing-sm) var(--gg-spacing-md); border-bottom: var(--gg-border-standard); }
+  .gw-contents > header span { font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wider); }
+  .gw-contents > header p { margin: 0; font-family: var(--gg-font-editorial); }
+  .gw-contents ol { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); margin: 0; padding: 0; list-style: none; }
+  .gw-contents li { min-width: 0; border-right: var(--gg-border-subtle); border-bottom: var(--gg-border-subtle); }
+  .gw-contents a { display: grid; grid-template-columns: auto 1fr; gap: 0 var(--gg-spacing-xs); min-height: 100%; padding: var(--gg-spacing-sm); color: inherit; text-decoration: none; }
+  .gw-contents a:hover, .gw-contents a:focus-visible { background: var(--gg-color-teal); outline: var(--gg-border-gold); outline-offset: calc(var(--gg-border-width-standard) * -1); }
+  .gw-contents a > span { grid-row: 1 / span 2; color: var(--gg-color-gold); font-size: var(--gg-font-size-xl); font-weight: var(--gg-font-weight-black); line-height: .9; }
+  .gw-contents b { font-size: var(--gg-font-size-xs); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-contents small { margin-top: var(--gg-spacing-2xs); color: var(--gg-color-tan); font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-tight); }
   .gw-story { margin-top: var(--gg-spacing-xl); border: var(--gg-border-heavy); background: var(--gg-color-white); }
   .gw-story--cover { border-width: calc(var(--gg-border-width-heavy) * 2); }
   .gw-story-head { padding: var(--gg-spacing-lg); border-bottom: var(--gg-border-standard); }
@@ -418,6 +478,9 @@ def page_css() -> str:
   .gw-empty { font-family: var(--gg-font-editorial); font-style: italic; color: var(--gg-color-secondary-brown); }
   code { font-family: var(--gg-font-data); overflow-wrap: anywhere; }
   @media (max-width: 720px) {
+    .gw-contents > header { display: grid; }
+    .gw-contents ol { display: flex; overflow-x: auto; scroll-snap-type: x proximity; }
+    .gw-contents li { flex: 0 0 min(78vw, 260px); scroll-snap-align: start; }
     .gw-cover-lines, .gw-story-grid, .gw-utility-grid, .gw-memory-grid, .gw-history-grid { grid-template-columns: 1fr; }
     .gw-cover-lines span { border-right: 0; border-bottom: var(--gg-border-subtle); }
     .gw-cover-lines span:last-child { border-bottom: 0; }
@@ -444,11 +507,12 @@ def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, la
         corrections = ""
         if issue["corrections"]:
             items = "".join(f'<li><strong>{esc(item["publishedAt"][:10])}</strong> — {esc(item["text"])}</li>' for item in issue["corrections"])
-            corrections = f'<section class="gw-corrections"><h2>CORRECTIONS</h2><ul>{items}</ul></section>'
-        issue_body = f'''{content}
+            corrections = f'<section class="gw-corrections" id="corrections"><h2>CORRECTIONS</h2><ul>{items}</ul></section>'
+        issue_body = f'''{render_issue_contents(issue)}
+        {content}
         <div class="gw-utility-grid">
           <section class="gw-utility"><h2>CALENDAR WATCH</h2><ul class="gw-watch">{watch}</ul></section>
-          <section class="gw-utility"><h2>RACE INTELLIGENCE</h2>{render_impacts(issue['raceImpacts'])}</section>
+          <section class="gw-utility"><h2>WHAT THIS CHANGES</h2>{render_impacts(issue['raceImpacts'])}</section>
         </div>
         {render_retrospectives(issue['retrospectives'], issues, draft=is_draft)}
         {corrections}'''
@@ -494,7 +558,7 @@ def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, la
     <div class="gw-masthead-top"><span>ISSUE #{issue_number:03d}</span><span>{esc(date_label)}</span><span>{esc(publication_label)}</span></div>
     <h1 class="gw-name">GRAVEL <span>WEEKLY</span></h1>
     <p class="gw-deck">THE PEOPLE, RACES, MONEY &amp; BAD IDEAS MOVING GRAVEL</p>
-    <div class="gw-cover-lines"><span>WHAT HAPPENED</span><span>WHAT IT MEANS</span><span>WHAT CHANGES</span></div>
+    <div class="gw-cover-lines"><span>THE RECORD</span><span>THE SCENE</span><span>THE TAKE</span></div>
   </header>
   {issue_body}
   {render_history_timeline(history_entries or []) if latest else ''}

--- a/wordpress/gravel_weekly_culture.py
+++ b/wordpress/gravel_weekly_culture.py
@@ -19,7 +19,8 @@ def _timestamp_label(seconds: int | None) -> str:
 
 
 def render_culture_artifacts(
-    artifacts: list[dict[str, Any]], *, private_review: bool = False
+    artifacts: list[dict[str, Any]], *, private_review: bool = False,
+    section_id: str | None = None,
 ) -> str:
     if not artifacts:
         return ""
@@ -47,12 +48,13 @@ def render_culture_artifacts(
           {review_reason}
           <a href="{esc(artifact['canonicalUrl'])}" rel="noopener noreferrer" target="_blank">OPEN ORIGINAL{esc(timestamp)} →</a>
         </article>''')
-    mode = "PRIVATE CULTURE CHECK" if private_review else "CULTURE RECEIPTS"
+    mode = "PRIVATE CULTURE CHECK" if private_review else "THE SCENE REPORT"
     explanation = (
         "These are the jokes, arguments, personalities, and artifacts the desk thinks help reconstruct the moment. "
         "They are context—not proof, consensus, or a substitute for the point."
     )
-    return f'''<section class="gw-culture" aria-label="Culture artifacts">
+    id_attribute = f' id="{esc(section_id)}"' if section_id else ""
+    return f'''<section class="gw-culture"{id_attribute} aria-label="Culture artifacts">
       <header><span>{mode}</span><h4>WHAT THE GROUP CHAT WAS PASSING AROUND</h4><p>{explanation}</p></header>
       <div class="gw-culture-grid">{"".join(cards)}</div>
     </section>'''


### PR DESCRIPTION
## Summary
- document representative 2012 and 2016 Manual for Speed layouts and separate durable mechanics from protected trade dress
- add a data-aware issue contents system to the public issue renderer and private historical desk
- distinguish The Record, The Scene Report, The Take, The Other Side, and What This Changes
- omit empty departments: Scene Report requires approved culture artifacts and public What This Changes requires a meaningful race impact
- preserve draft truthfulness by describing an unapproved Take as a model draft awaiting approval
- defer Cast and Field Notes until the issue contract carries sourced roles and observations

## Verification
- python3 -m pytest tests/test_gravel_weekly.py (99 passed)
- python3 scripts/preflight_quality.py (passed; existing environment/data warnings only)
- python3 -m py_compile wordpress/generate_gravel_weekly.py wordpress/gravel_weekly_culture.py scripts/render_gravel_weekly_history_review.py
- git diff --check
- regenerated and visually inspected data/gravel-weekly/history-review/2026.html in the in-app browser

## Sources
- Internet Archive captures linked directly in the reference study

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and documentation only; editorial contracts and approval gates are unchanged aside from renamed section labels and conditional nav.
> 
> **Overview**
> Adds a **Manual for Speed** editorial reference study (with explicit no-copy boundaries) and wires that framing into the visual-system docs. The product change is a first-pass **magazine-style issue anatomy** on public pages and the private historical review desk.
> 
> Public issues now get an evidence-aware **IN THIS ISSUE** contents nav (`gw-contents`) that only lists chapters when data exists—e.g. **THE SCENE REPORT** when culture artifacts are present, **WHAT THIS CHANGES** only for meaningful race impacts, and draft-specific Take copy in the rail. Story sections are renamed and anchored for keyboard-friendly jump links: **WHAT HAPPENED** → **THE RECORD**, culture blocks → **THE SCENE REPORT** (with `scene-{storyId}` ids), race intelligence → **WHAT THIS CHANGES**. Masthead cover lines and utility headings follow the same vocabulary.
> 
> The historical review renderer mirrors this with a horizontal **story-contents** chapter rail, stable section ids, and **THE OTHER SIDE** instead of **CREDIBLE OPPOSITION**. Tests assert the new labels, anchors, and draft vs approved Take signaling in rendered HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7917652e3e0df6e9c764e3781a38232d10ca79bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->