### PR TITLE
Bind Gravel Weekly approval to the exact reviewed draft

### DIFF
--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -40,12 +40,15 @@ python3 scripts/approve_gravel_weekly_issue.py \
   data/gravel-weekly/drafts/2026-08-28.json APPROVAL.json
 ```
 
-The approval packet must use `gravel-weekly-approval/v1`, decide every reviewed
-story exactly once, and supply the final headline, deck, Take, and edit summary
-for every approved story. The bridge preserves the reviewed facts, scores,
-receipts, and race impacts verbatim. It emits both a `status=approved` issue and
-a decision receipt under the ignored `data/gravel-weekly/approved/` directory,
-which the deploy workflow refuses.
+The approval packet must use `gravel-weekly-approval/v2`, name the exact
+`reviewedDraftContentHash`, decide every reviewed story exactly once, and supply
+the final headline, deck, Take, and edit summary for every approved story. A
+stale approval cannot be replayed against a regenerated draft with the same
+issue ID. The reviewed hash remains in the approved snapshot and must match its
+decision receipt again at sealing and deploy time. The bridge preserves the
+reviewed facts, scores, receipts, and race impacts verbatim. It emits both a
+`status=approved` issue and a decision receipt under the ignored
+`data/gravel-weekly/approved/` directory, which the deploy workflow refuses.
 
 After a separate explicit publication instruction, seal the approved file:
 

--- a/scripts/approve_gravel_weekly_issue.py
+++ b/scripts/approve_gravel_weekly_issue.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -18,9 +19,10 @@ from validate_gravel_weekly_decisions import DECISION_SCHEMA, RECEIPT_SCHEMA, va
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 APPROVED_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "approved"
-APPROVAL_SCHEMA = "gravel-weekly-approval/v1"
+APPROVAL_SCHEMA = "gravel-weekly-approval/v2"
 ALLOWED_APPROVAL_KEYS = {
-    "schemaVersion", "issueId", "approver", "approvedAt", "currentThingStoryId", "stories",
+    "schemaVersion", "issueId", "reviewedDraftContentHash", "approver",
+    "approvedAt", "currentThingStoryId", "stories",
 }
 ALLOWED_STORY_DECISION_KEYS = {
     "candidateId", "decision", "headline", "dek", "take", "editSummary", "reason",
@@ -86,6 +88,15 @@ def approve_issue(draft_value: Any, approval_value: Any) -> dict[str, Any]:
         raise ValueError("unsupported Gravel Weekly approval schema")
     if approval.get("issueId") != draft["issueId"]:
         raise ValueError("approval.issueId must match the draft issueId")
+    reviewed_hash = _text(
+        approval.get("reviewedDraftContentHash"),
+        "approval.reviewedDraftContentHash",
+        64,
+    )
+    if not re.fullmatch(r"[0-9a-f]{64}", reviewed_hash):
+        raise ValueError("approval.reviewedDraftContentHash must be a lowercase SHA-256 hash")
+    if reviewed_hash != draft["contentHash"]:
+        raise ValueError("approval.reviewedDraftContentHash must match the exact reviewed draft")
 
     decisions_raw = approval.get("stories")
     if not isinstance(decisions_raw, list):
@@ -143,7 +154,11 @@ def approve_issue(draft_value: Any, approval_value: Any) -> dict[str, Any]:
         "currentThingStoryId": current_id,
         "raceImpacts": all_impacts,
         "sourceIndex": source_index,
-        "editorialApproval": {"approver": approver, "approvedAt": approved_at},
+        "editorialApproval": {
+            "approver": approver,
+            "approvedAt": approved_at,
+            "reviewedDraftContentHash": reviewed_hash,
+        },
         "publishedAt": None,
         "updatedAt": approved_at,
         "contentHash": "pending",

--- a/scripts/validate_gravel_weekly.py
+++ b/scripts/validate_gravel_weekly.py
@@ -43,6 +43,9 @@ CULTURE_ARTIFACT_KEYS = {
 }
 STORY_CAST_KEYS = {"name", "role", "claimIds"}
 STORY_FIELD_NOTE_KEYS = {"text", "claimIds"}
+EDITORIAL_APPROVAL_KEYS = {
+    "approver", "approvedAt", "reviewedDraftContentHash",
+}
 
 
 class IssueValidationError(ValueError):
@@ -424,9 +427,28 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
     approval = issue.get("editorialApproval")
     if status != "draft" and not isinstance(approval, dict):
         raise IssueValidationError(f"{status} issues require editorial approval")
+    if status == "draft" and approval is not None:
+        raise IssueValidationError("draft issues cannot carry editorial approval")
     if isinstance(approval, dict):
+        unknown = set(approval) - EDITORIAL_APPROVAL_KEYS
+        missing = EDITORIAL_APPROVAL_KEYS - set(approval)
+        if unknown or missing:
+            raise IssueValidationError(
+                "editorialApproval fields must exactly preserve the approver, "
+                f"approval time, and reviewed draft hash; missing={sorted(missing)}, "
+                f"extra={sorted(unknown)}"
+            )
         _text(approval.get("approver"), "editorialApproval.approver", 300)
         _iso(approval.get("approvedAt"), "editorialApproval.approvedAt")
+        reviewed_hash = _text(
+            approval.get("reviewedDraftContentHash"),
+            "editorialApproval.reviewedDraftContentHash",
+            64,
+        )
+        if not re.fullmatch(r"[0-9a-f]{64}", reviewed_hash):
+            raise IssueValidationError(
+                "editorialApproval.reviewedDraftContentHash must be a lowercase SHA-256 hash"
+            )
     if status == "published" and issue.get("publishedAt") is None:
         raise IssueValidationError("published issues require publishedAt")
     if issue.get("publishedAt") is not None:

--- a/scripts/validate_gravel_weekly_decisions.py
+++ b/scripts/validate_gravel_weekly_decisions.py
@@ -72,6 +72,8 @@ def validate_decision_receipt(value: Any, issue_value: Any) -> dict[str, Any]:
     approval = issue["editorialApproval"]
     if decided_by != approval["approver"] or decided_at != approval["approvedAt"]:
         raise ValueError("decision receipt identity and time must match editorial approval")
+    if draft_hash != approval["reviewedDraftContentHash"]:
+        raise ValueError("decision receipt reviewed draft hash must match editorial approval")
 
     raw_decisions = receipt.get("decisions")
     if not isinstance(raw_decisions, list) or not raw_decisions:

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -119,7 +119,11 @@ def sample_issue():
         "retrospectives": [],
         "corrections": [],
         "sourceIndex": ["https://www.cyclingnews.com/example/"],
-        "editorialApproval": {"approver": "Matti Rowe", "approvedAt": "2026-08-28T16:00:00Z"},
+        "editorialApproval": {
+            "approver": "Matti Rowe",
+            "approvedAt": "2026-08-28T16:00:00Z",
+            "reviewedDraftContentHash": "1" * 64,
+        },
         "publishedAt": "2026-08-28T16:05:00Z",
         "updatedAt": "2026-08-28T16:05:00Z",
         "contentHash": "pending",
@@ -410,10 +414,12 @@ def sample_draft():
     return issue
 
 
-def sample_approval():
+def sample_approval(draft=None):
+    draft = draft or sample_draft()
     return {
-        "schemaVersion": "gravel-weekly-approval/v1",
+        "schemaVersion": "gravel-weekly-approval/v2",
         "issueId": "gravel-weekly-001",
+        "reviewedDraftContentHash": draft["contentHash"],
         "approver": "Matti Rowe",
         "approvedAt": "2026-08-28T16:00:00Z",
         "currentThingStoryId": "story_1",
@@ -484,7 +490,7 @@ def test_weekly_culture_artifacts_are_direct_hash_bound_context_and_survive_appr
     draft["stories"][0]["cultureArtifacts"] = [artifact]
     draft["sourceIndex"].append(artifact["canonicalUrl"])
     draft["contentHash"] = compute_content_hash(draft)
-    approved = approve_issue(draft, sample_approval())
+    approved = approve_issue(draft, sample_approval(draft))
     assert approved["stories"][0]["cultureArtifacts"] == [artifact]
 
     unsafe = copy.deepcopy(published)
@@ -530,7 +536,7 @@ def test_claim_bound_cast_and_field_notes_survive_approval_and_render_as_optiona
     draft["stories"][0]["cast"] = copy.deepcopy(story["cast"])
     draft["stories"][0]["fieldNotes"] = copy.deepcopy(story["fieldNotes"])
     draft["contentHash"] = compute_content_hash(draft)
-    approved = approve_issue(draft, sample_approval())
+    approved = approve_issue(draft, sample_approval(draft))
     assert approved["stories"][0]["cast"] == story["cast"]
     assert approved["stories"][0]["fieldNotes"] == story["fieldNotes"]
 
@@ -631,12 +637,14 @@ def test_review_prepares_a_draft_but_cannot_imply_approval():
 
 def test_human_approval_bridge_changes_only_editorial_copy_and_stays_non_deployable():
     draft = sample_draft()
-    approved = approve_issue(draft, sample_approval())
+    approved = approve_issue(draft, sample_approval(draft))
 
     assert approved["status"] == "approved"
     assert approved["publishedAt"] is None
     assert approved["editorialApproval"] == {
-        "approver": "Matti Rowe", "approvedAt": "2026-08-28T16:00:00Z",
+        "approver": "Matti Rowe",
+        "approvedAt": "2026-08-28T16:00:00Z",
+        "reviewedDraftContentHash": draft["contentHash"],
     }
     assert approved["stories"][0]["headline"] == "The approved headline"
     assert approved["stories"][0]["take"] == "The approved take makes a concrete judgment."
@@ -711,6 +719,27 @@ def test_approval_bridge_requires_an_exact_human_decision_for_every_reviewed_sto
     misleading["whatHappened"] = "Quietly replace the reviewed facts."
     with pytest.raises(ValueError, match="unsupported fields"):
         approve_issue(draft, misleading)
+
+
+def test_weekly_approval_is_bound_to_the_exact_reviewed_draft_hash():
+    draft = sample_draft()
+    stale = sample_approval(draft)
+    stale["reviewedDraftContentHash"] = "0" * 64
+    with pytest.raises(ValueError, match="exact reviewed draft"):
+        approve_issue(draft, stale)
+
+    malformed = sample_approval(draft)
+    malformed["reviewedDraftContentHash"] = "not-a-hash"
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        approve_issue(draft, malformed)
+
+    approved = approve_issue(draft, sample_approval(draft))
+    receipt = build_decision_receipt(draft, sample_approval(draft), approved)
+    forged = copy.deepcopy(approved)
+    forged["editorialApproval"]["reviewedDraftContentHash"] = "f" * 64
+    forged["contentHash"] = compute_content_hash(forged)
+    with pytest.raises(ValueError, match="reviewed draft hash"):
+        validate_decision_receipt(receipt, forged)
 
 
 def test_approval_bridge_rejects_copy_that_still_claims_to_be_a_model_draft():


### PR DESCRIPTION
## Summary
- require a lowercase SHA-256 reviewedDraftContentHash in every weekly approval packet
- preserve the reviewed hash inside editorialApproval and cross-check it against the decision receipt
- reject stale approvals, malformed hashes, and forged receipt/snapshot pairings
- document the v2 approval packet contract

## Verification
- python3 -m pytest tests/test_gravel_weekly.py -q (101 passed)
- python3 -m pytest -q (7922 passed, 331 skipped)
- python3 scripts/preflight_quality.py (all checks passed; 7 existing warnings)
- python3 -m py_compile scripts/approve_gravel_weekly_issue.py scripts/validate_gravel_weekly.py scripts/validate_gravel_weekly_decisions.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the editorial approval contract and validation on the path to sealing/deploy; existing v1 approval packets will be rejected until regenerated with the draft hash.
> 
> **Overview**
> Gravel Weekly human approval moves from **`gravel-weekly-approval/v1`** to **v2**, which must include a lowercase SHA-256 **`reviewedDraftContentHash`** matching the draft’s **`contentHash`**. The approval bridge rejects stale packets (same issue ID, different draft) and malformed hashes, and copies the hash into **`editorialApproval`** on the approved snapshot.
> 
> Publication validation now treats **`editorialApproval`** as a fixed three-field object (approver, time, reviewed hash), forbids approval on drafts, and requires the hash on approved/published issues. Decision receipt validation additionally requires **`reviewedDraftContentHash`** on the receipt to match **`editorialApproval`**, so tampering the snapshot without the receipt fails closed.
> 
> README documents the v2 contract; tests cover mismatch, bad hash format, and forged approval metadata against an unchanged receipt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdafc7e53b5ba966534a4a8347c61d1a6481897c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->