### PR TITLE
Add human-approved quiet Gravel Weekly issues

### DIFF
--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -5,7 +5,8 @@ Approved issue snapshots live in `issues/YYYY-MM-DD.json` and use
 `gravel-weekly-issue/v1` from the race-intelligence control plane.
 Each snapshot has a paired `decisions/YYYY-MM-DD.json` receipt containing every
 explicit approve/reject verdict, the exact model Take that Matti reviewed, the
-approved Take, and the human edit summary.
+approved Take, and the human edit summary. A deliberately short issue also
+stores its exact quiet-issue approval in that receipt.
 
 The intelligence service may prepare candidates and reaction packets, but it
 does not write to `issues/`. An issue enters that directory only after Matti
@@ -40,7 +41,7 @@ python3 scripts/approve_gravel_weekly_issue.py \
   data/gravel-weekly/drafts/2026-08-28.json APPROVAL.json
 ```
 
-The approval packet must use `gravel-weekly-approval/v2`, name the exact
+The approval packet must use `gravel-weekly-approval/v3`, name the exact
 `reviewedDraftContentHash`, decide every reviewed story exactly once, and supply
 the final headline, deck, Take, and edit summary for every approved story. A
 stale approval cannot be replayed against a regenerated draft with the same
@@ -49,6 +50,13 @@ decision receipt again at sealing and deploy time. The bridge preserves the
 reviewed facts, scores, receipts, and race impacts verbatim. It emits both a
 `status=approved` issue and a decision receipt under the ignored
 `data/gravel-weekly/approved/` directory, which the deploy workflow refuses.
+
+If no story survives, the approval must instead include an explicit
+`quietIssue` decision with the exact final headline, note, and edit summary.
+This also works when Matti rejects every reviewed candidate. The approved issue
+contains no Current Thing and no manufactured story; its short public note has
+`human_approved` provenance and a dedicated immutable decision record. A quiet
+issue without that decision fails closed.
 
 After a separate explicit publication instruction, seal the approved file:
 

--- a/docs/gravel-weekly-manual-for-speed-reference.md
+++ b/docs/gravel-weekly-manual-for-speed-reference.md
@@ -194,3 +194,12 @@ The translated design passes only if:
 6. The Take is visibly Matti-approved and cannot be mistaken for model output.
 7. The season timeline preserves what was knowable then and what changed later.
 8. The result still looks unmistakably like Gravel God.
+
+## The quiet-week rule
+
+Weekly cadence is a deadline, not a story quota. If nothing clears the party,
+point, friend, story, comedy, and prose gates, Gravel Weekly publishes only
+after Matti approves an exact short quiet-week note. The issue carries no
+Current Thing, story, or empty department furniture. The note and its edit
+summary are hash-bound in the issue and decision receipt, so the system cannot
+silently convert a weak candidate into filler.

--- a/scripts/approve_gravel_weekly_issue.py
+++ b/scripts/approve_gravel_weekly_issue.py
@@ -15,17 +15,25 @@ from pathlib import Path
 from typing import Any
 
 from validate_gravel_weekly import compute_content_hash, validate_issue
-from validate_gravel_weekly_decisions import DECISION_SCHEMA, RECEIPT_SCHEMA, validate_decision_receipt
+from validate_gravel_weekly_decisions import (
+    DECISION_SCHEMA,
+    QUIET_DECISION_SCHEMA,
+    RECEIPT_SCHEMA,
+    validate_decision_receipt,
+)
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 APPROVED_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "approved"
-APPROVAL_SCHEMA = "gravel-weekly-approval/v2"
+APPROVAL_SCHEMA = "gravel-weekly-approval/v3"
 ALLOWED_APPROVAL_KEYS = {
     "schemaVersion", "issueId", "reviewedDraftContentHash", "approver",
-    "approvedAt", "currentThingStoryId", "stories",
+    "approvedAt", "currentThingStoryId", "stories", "quietIssue",
 }
 ALLOWED_STORY_DECISION_KEYS = {
     "candidateId", "decision", "headline", "dek", "take", "editSummary", "reason",
+}
+ALLOWED_QUIET_DECISION_KEYS = {
+    "decision", "headline", "note", "editSummary",
 }
 
 
@@ -62,6 +70,23 @@ def _approval_story(value: Any, index: int) -> dict[str, Any]:
         "dek": _text(item.get("dek"), f"approval.stories[{index}].dek", 600),
         "take": _text(item.get("take"), f"approval.stories[{index}].take", 8_000),
         "editSummary": _text(item.get("editSummary"), f"approval.stories[{index}].editSummary", 2_000),
+    }
+
+
+def _approval_quiet_issue(value: Any) -> dict[str, Any]:
+    item = _record(value, "approval.quietIssue")
+    unknown = set(item) - ALLOWED_QUIET_DECISION_KEYS
+    if unknown:
+        raise ValueError(f"approval.quietIssue has unsupported fields: {sorted(unknown)}")
+    if item.get("decision") != "approve":
+        raise ValueError("approval.quietIssue.decision must be approve")
+    return {
+        "decision": "approve",
+        "headline": _text(item.get("headline"), "approval.quietIssue.headline", 300),
+        "note": _text(item.get("note"), "approval.quietIssue.note", 1_000),
+        "editSummary": _text(
+            item.get("editSummary"), "approval.quietIssue.editSummary", 2_000
+        ),
     }
 
 
@@ -127,8 +152,22 @@ def approve_issue(draft_value: Any, approval_value: Any) -> dict[str, Any]:
             "take": decision["take"],
             "takeProvenance": "human_approved",
         })
-    if not approved_stories:
-        raise ValueError("an approved issue must contain at least one approved story")
+    quiet_decision_raw = approval.get("quietIssue")
+    if approved_stories:
+        if quiet_decision_raw is not None:
+            raise ValueError("approval.quietIssue cannot coexist with approved stories")
+        approved_quiet_issue = None
+    else:
+        if quiet_decision_raw is None:
+            raise ValueError(
+                "an issue without approved stories requires an explicit quiet issue decision"
+            )
+        quiet_decision = _approval_quiet_issue(quiet_decision_raw)
+        approved_quiet_issue = {
+            "headline": quiet_decision["headline"],
+            "note": quiet_decision["note"],
+            "provenance": "human_approved",
+        }
 
     approved_at = _text(approval.get("approvedAt"), "approval.approvedAt", 100)
     approver = _text(approval.get("approver"), "approval.approver", 300)
@@ -138,6 +177,8 @@ def approve_issue(draft_value: Any, approval_value: Any) -> dict[str, Any]:
     approved_ids = {story["candidateId"] for story in approved_stories}
     if current_id is not None and current_id not in approved_ids:
         raise ValueError("approval.currentThingStoryId must reference an approved story")
+    if approved_quiet_issue is not None and current_id is not None:
+        raise ValueError("a quiet issue cannot designate The Current Thing")
 
     all_impacts = _dedupe_records([
         impact for story in approved_stories for impact in story["raceImpacts"]
@@ -151,6 +192,7 @@ def approve_issue(draft_value: Any, approval_value: Any) -> dict[str, Any]:
         **draft,
         "status": "approved",
         "stories": approved_stories,
+        "quietIssue": approved_quiet_issue,
         "currentThingStoryId": current_id,
         "raceImpacts": all_impacts,
         "sourceIndex": source_index,
@@ -204,7 +246,24 @@ def build_decision_receipt(draft_value: Any, approval_value: Any, approved_value
         "decidedBy": approval["approver"],
         "decidedAt": approval["approvedAt"],
         "decisions": records,
+        "quietIssueDecision": None,
     }
+    if approved.get("quietIssue") is not None:
+        quiet_decision = _approval_quiet_issue(approval.get("quietIssue"))
+        suggested = draft.get("quietIssue")
+        receipt["quietIssueDecision"] = {
+            "schemaVersion": QUIET_DECISION_SCHEMA,
+            "issueId": approved["issueId"],
+            "decision": "approve",
+            "reason": f"Approved a quiet Gravel Weekly #{approved['issueNumber']:03d}.",
+            "decidedBy": approval["approver"],
+            "decidedAt": approval["approvedAt"],
+            "suggestedHeadline": suggested["headline"] if suggested else None,
+            "suggestedNote": suggested["note"] if suggested else None,
+            "approvedHeadline": approved["quietIssue"]["headline"],
+            "approvedNote": approved["quietIssue"]["note"],
+            "editSummary": quiet_decision["editSummary"],
+        }
     return validate_decision_receipt(receipt, approved)
 
 

--- a/scripts/prepare_gravel_weekly_issue.py
+++ b/scripts/prepare_gravel_weekly_issue.py
@@ -207,6 +207,14 @@ def prepare_issue(review_value: Any, publication_date: str, issue_number: int, *
         source_urls.extend(artifact["canonicalUrl"] for artifact in culture_artifacts)
 
     current = next((story["candidateId"] for story in stories if story["score"] >= 85), None)
+    quiet_issue = None if stories else {
+        "headline": "Nothing cleared the gate this week.",
+        "note": (
+            "The Friday deadline does not turn an update into a story. "
+            "Gravel Weekly will be back when there is a point worth making."
+        ),
+        "provenance": "model_draft",
+    }
     issue = {
         "schemaVersion": "gravel-weekly-issue/v1",
         "issueId": f"gravel-weekly-{issue_number:03d}",
@@ -218,6 +226,7 @@ def prepare_issue(review_value: Any, publication_date: str, issue_number: int, *
         "mastheadDeck": "The people, races, money and bad ideas moving gravel.",
         "currentThingStoryId": current,
         "stories": stories,
+        "quietIssue": quiet_issue,
         "calendarWatch": [],
         "raceImpacts": _dedupe_records(all_impacts),
         "retrospectives": [],

--- a/scripts/send_gravel_weekly.py
+++ b/scripts/send_gravel_weekly.py
@@ -92,6 +92,13 @@ def build_email_html(issue: dict) -> str:
       <h2 style="font:700 30px Georgia,serif;line-height:1.05;margin:8px 0 12px;">{html.escape(story['headline'])}</h2>
       {_paragraphs(story['take'])}
     </div>'''
+    quiet = issue.get("quietIssue")
+    if quiet:
+        story_html = f'''<div style="border-top:3px solid {COLORS['near_black']};background:{COLORS['gold']};padding:24px 18px;">
+      <div style="font:700 12px monospace;letter-spacing:2px;">THE QUIET WEEK</div>
+      <h2 style="font:700 30px Georgia,serif;line-height:1.05;margin:8px 0 12px;">{html.escape(quiet['headline'])}</h2>
+      {_paragraphs(quiet['note'])}
+    </div>'''
     issue_url = f"{ISSUE_BASE_URL}{issue['slug']}/"
     return f'''<div style="max-width:620px;margin:0 auto;color:{COLORS['near_black']};font-family:monospace;">
   <div style="background:{COLORS['white']};border:4px solid {COLORS['near_black']};padding:20px;">
@@ -133,6 +140,8 @@ def main() -> int:
         subject = f"Gravel Weekly #{issue['issueNumber']:03d}"
         if current:
             subject += f": {current['headline']}"
+        elif issue.get("quietIssue"):
+            subject += f": {issue['quietIssue']['headline']}"
         broadcast = resend("/broadcasts", "POST", {
             "audience_id": audience_id,
             "from": FROM_ADDR,

--- a/scripts/validate_gravel_weekly.py
+++ b/scripts/validate_gravel_weekly.py
@@ -43,6 +43,7 @@ CULTURE_ARTIFACT_KEYS = {
 }
 STORY_CAST_KEYS = {"name", "role", "claimIds"}
 STORY_FIELD_NOTE_KEYS = {"text", "claimIds"}
+QUIET_ISSUE_KEYS = {"headline", "note", "provenance"}
 EDITORIAL_APPROVAL_KEYS = {
     "approver", "approvedAt", "reviewedDraftContentHash",
 }
@@ -277,6 +278,35 @@ def _retrospective(value: Any, name: str, *, status: str) -> dict[str, Any]:
     return item
 
 
+def _quiet_issue(value: Any, name: str, *, status: str) -> dict[str, Any]:
+    item = _record(value, name)
+    unknown = set(item) - QUIET_ISSUE_KEYS
+    missing = QUIET_ISSUE_KEYS - set(item)
+    if unknown or missing:
+        raise IssueValidationError(
+            f"{name} fields are invalid; missing={sorted(missing)}, extra={sorted(unknown)}"
+        )
+    headline = _text(item.get("headline"), f"{name}.headline", 300)
+    note = _text(item.get("note"), f"{name}.note", 1_000)
+    provenance = item.get("provenance")
+    if provenance not in {"model_draft", "human_approved"}:
+        raise IssueValidationError(f"{name}.provenance is invalid")
+    if status != "draft" and provenance != "human_approved":
+        raise IssueValidationError(f"{name} requires human-approved provenance")
+    if status != "draft" and re.search(
+        r"model draft|not matti(?:’|')s approved", note, re.IGNORECASE
+    ):
+        raise IssueValidationError(f"{name} still contains model-draft language")
+    prose_gate = audit_no_ai_slop({"quiet_headline": headline, "quiet_note": note})
+    if prose_gate["verdict"] != "pass":
+        findings = ", ".join(
+            f"{finding['field']}:{finding['pattern']}"
+            for finding in prose_gate["findings"]
+        )
+        raise IssueValidationError(f"{name} fails the no-ai-slop gate: {findings}")
+    return item
+
+
 def canonical_issue_json(issue: dict[str, Any]) -> str:
     payload = dict(issue)
     payload.pop("contentHash", None)
@@ -383,6 +413,14 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
             story_culture_urls.add(artifact["canonicalUrl"])
     if len(story_ids) != len(set(story_ids)):
         raise IssueValidationError("story candidate IDs must be unique")
+
+    quiet_issue = issue.get("quietIssue")
+    if stories and quiet_issue is not None:
+        raise IssueValidationError("quietIssue cannot coexist with issue stories")
+    if not stories:
+        if quiet_issue is None:
+            raise IssueValidationError("an issue without stories requires quietIssue")
+        _quiet_issue(quiet_issue, "quietIssue", status=status)
 
     current_id = issue.get("currentThingStoryId")
     if current_id is not None:

--- a/scripts/validate_gravel_weekly_decisions.py
+++ b/scripts/validate_gravel_weekly_decisions.py
@@ -12,15 +12,21 @@ try:
 except ModuleNotFoundError:  # Imported as scripts.validate_gravel_weekly_decisions.
     from scripts.validate_gravel_weekly import validate_issue
 
-RECEIPT_SCHEMA = "gravel-weekly-decision-receipt/v1"
+RECEIPT_SCHEMA = "gravel-weekly-decision-receipt/v2"
 DECISION_SCHEMA = "editorial-decision/v1"
+QUIET_DECISION_SCHEMA = "editorial-quiet-decision/v1"
 OUTER_KEYS = {
     "schemaVersion", "issueId", "publicationDate", "reviewedDraftContentHash",
-    "decidedBy", "decidedAt", "decisions",
+    "decidedBy", "decidedAt", "decisions", "quietIssueDecision",
 }
 DECISION_KEYS = {
     "schemaVersion", "issueId", "candidateId", "decision", "reason",
     "decidedBy", "decidedAt", "suggestedCopy", "approvedCopy", "editSummary",
+}
+QUIET_DECISION_KEYS = {
+    "schemaVersion", "issueId", "decision", "reason", "decidedBy", "decidedAt",
+    "suggestedHeadline", "suggestedNote", "approvedHeadline", "approvedNote",
+    "editSummary",
 }
 
 
@@ -76,8 +82,8 @@ def validate_decision_receipt(value: Any, issue_value: Any) -> dict[str, Any]:
         raise ValueError("decision receipt reviewed draft hash must match editorial approval")
 
     raw_decisions = receipt.get("decisions")
-    if not isinstance(raw_decisions, list) or not raw_decisions:
-        raise ValueError("decision receipt decisions must be a non-empty list")
+    if not isinstance(raw_decisions, list):
+        raise ValueError("decision receipt decisions must be a list")
     decisions: list[dict[str, Any]] = []
     seen: set[str] = set()
     for index, raw_value in enumerate(raw_decisions):
@@ -132,6 +138,71 @@ def validate_decision_receipt(value: Any, issue_value: Any) -> dict[str, Any]:
         if approved_by_id[candidate_id]["approvedCopy"] != story["take"]:
             raise ValueError(f"approved copy does not match issue story {candidate_id}")
 
+    quiet_issue = issue.get("quietIssue")
+    quiet_raw = receipt.get("quietIssueDecision")
+    quiet_decision = None
+    if quiet_issue is None:
+        if quiet_raw is not None:
+            raise ValueError("quietIssueDecision cannot exist for an issue with stories")
+        if not decisions:
+            raise ValueError("a story issue requires at least one editorial decision")
+    else:
+        quiet = _record(quiet_raw, "quietIssueDecision")
+        extra = set(quiet) - QUIET_DECISION_KEYS
+        missing = QUIET_DECISION_KEYS - set(quiet)
+        if extra or missing:
+            raise ValueError(
+                "quietIssueDecision fields are invalid; "
+                f"missing={sorted(missing)}, extra={sorted(extra)}"
+            )
+        if quiet.get("schemaVersion") != QUIET_DECISION_SCHEMA:
+            raise ValueError("quietIssueDecision has unsupported schema")
+        if quiet.get("issueId") != issue["issueId"]:
+            raise ValueError("quietIssueDecision issueId does not match issue")
+        if quiet.get("decision") != "approve":
+            raise ValueError("quietIssueDecision must approve the quiet issue")
+        if quiet.get("decidedBy") != decided_by or quiet.get("decidedAt") != decided_at:
+            raise ValueError("quietIssueDecision identity and time must match receipt")
+        reason = _text(quiet.get("reason"), "quietIssueDecision.reason", 2_000)
+        suggested_headline = quiet.get("suggestedHeadline")
+        suggested_note = quiet.get("suggestedNote")
+        if (suggested_headline is None) != (suggested_note is None):
+            raise ValueError("quietIssueDecision suggested copy must be paired")
+        if suggested_headline is not None:
+            suggested_headline = _text(
+                suggested_headline, "quietIssueDecision.suggestedHeadline", 300
+            )
+            suggested_note = _text(
+                suggested_note, "quietIssueDecision.suggestedNote", 1_000
+            )
+        approved_headline = _text(
+            quiet.get("approvedHeadline"), "quietIssueDecision.approvedHeadline", 300
+        )
+        approved_note = _text(
+            quiet.get("approvedNote"), "quietIssueDecision.approvedNote", 1_000
+        )
+        edit_summary = _text(
+            quiet.get("editSummary"), "quietIssueDecision.editSummary", 2_000
+        )
+        if (
+            approved_headline != quiet_issue["headline"]
+            or approved_note != quiet_issue["note"]
+        ):
+            raise ValueError("quiet issue approved copy does not match the issue")
+        quiet_decision = {
+            "schemaVersion": QUIET_DECISION_SCHEMA,
+            "issueId": issue["issueId"],
+            "decision": "approve",
+            "reason": reason,
+            "decidedBy": decided_by,
+            "decidedAt": decided_at,
+            "suggestedHeadline": suggested_headline,
+            "suggestedNote": suggested_note,
+            "approvedHeadline": approved_headline,
+            "approvedNote": approved_note,
+            "editSummary": edit_summary,
+        }
+
     return {
         "schemaVersion": RECEIPT_SCHEMA,
         "issueId": issue["issueId"],
@@ -140,4 +211,5 @@ def validate_decision_receipt(value: Any, issue_value: Any) -> dict[str, Any]:
         "decidedBy": decided_by,
         "decidedAt": decided_at,
         "decisions": decisions,
+        "quietIssueDecision": quiet_decision,
     }

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -417,7 +417,7 @@ def sample_draft():
 def sample_approval(draft=None):
     draft = draft or sample_draft()
     return {
-        "schemaVersion": "gravel-weekly-approval/v2",
+        "schemaVersion": "gravel-weekly-approval/v3",
         "issueId": "gravel-weekly-001",
         "reviewedDraftContentHash": draft["contentHash"],
         "approver": "Matti Rowe",
@@ -712,7 +712,7 @@ def test_approval_bridge_requires_an_exact_human_decision_for_every_reviewed_sto
         "candidateId": "story_1", "decision": "reject", "reason": "The premise is still slop.",
     }]
     rejected["currentThingStoryId"] = None
-    with pytest.raises(ValueError, match="at least one approved story"):
+    with pytest.raises(ValueError, match="explicit quiet issue decision"):
         approve_issue(draft, rejected)
 
     misleading = sample_approval()
@@ -839,6 +839,7 @@ def test_review_excludes_stories_that_do_not_clear_every_editorial_gate(gate_mut
     issue = prepare_issue(review, "2026-08-28", 1, now="2026-08-27T17:00:00Z")
     assert issue["stories"] == []
     assert issue["currentThingStoryId"] is None
+    assert issue["quietIssue"]["provenance"] == "model_draft"
 
 
 @pytest.mark.parametrize("prose_mutation", ["missing", "failed", "stale"])
@@ -877,6 +878,114 @@ def test_review_excludes_missing_failed_or_stale_prose_gates(prose_mutation):
     issue = prepare_issue(review, "2026-08-28", 1, now="2026-08-27T17:00:00Z")
     assert issue["stories"] == []
     assert issue["currentThingStoryId"] is None
+    assert issue["quietIssue"]["provenance"] == "model_draft"
+
+
+def test_quiet_issue_requires_explicit_human_copy_approval_and_has_a_durable_receipt():
+    review = {
+        "schemaVersion": "gravel-weekly-review/v1",
+        "candidates": [],
+        "packets": [],
+    }
+    draft = prepare_issue(
+        review, "2026-09-04", 2, now="2026-09-03T17:00:00Z"
+    )
+    approval = {
+        "schemaVersion": "gravel-weekly-approval/v3",
+        "issueId": draft["issueId"],
+        "reviewedDraftContentHash": draft["contentHash"],
+        "approver": "Matti Rowe",
+        "approvedAt": "2026-09-04T16:00:00Z",
+        "currentThingStoryId": None,
+        "stories": [],
+        "quietIssue": {
+            "decision": "approve",
+            "headline": "Nothing cleared the gate this week.",
+            "note": (
+                "The Friday deadline does not turn an update into a story. "
+                "Gravel Weekly will be back when there is a point worth making."
+            ),
+            "editSummary": "Approved the short issue without manufacturing a story.",
+        },
+    }
+
+    approved = approve_issue(draft, approval)
+    assert approved["status"] == "approved"
+    assert approved["stories"] == []
+    assert approved["currentThingStoryId"] is None
+    assert approved["quietIssue"]["provenance"] == "human_approved"
+
+    receipt = build_decision_receipt(draft, approval, approved)
+    assert receipt["schemaVersion"] == "gravel-weekly-decision-receipt/v2"
+    assert receipt["decisions"] == []
+    assert receipt["quietIssueDecision"]["approvedHeadline"] == approved["quietIssue"]["headline"]
+    assert receipt["quietIssueDecision"]["approvedNote"] == approved["quietIssue"]["note"]
+    assert validate_decision_receipt(receipt, approved) == receipt
+
+    sealed = seal_issue(approved, "2026-09-04T16:05:00Z")
+    assert validate_decision_receipt(receipt, sealed) == receipt
+    page = build_page(sealed, [sealed], latest=True)
+    assert 'id="quiet-week"' in page
+    assert "THE QUIET WEEK" in page
+    assert "Nothing cleared the gate this week." in page
+    assert "CALENDAR WATCH" not in page
+    assert "WHAT THIS CHANGES" not in page
+    assert "MODEL DRAFT" not in page
+    email = build_email_html(sealed)
+    assert "THE QUIET WEEK" in email
+    assert approved["quietIssue"]["note"] in email
+
+
+def test_rejecting_every_story_can_become_a_human_approved_quiet_issue():
+    draft = sample_draft()
+    approval = sample_approval(draft)
+    approval["stories"] = [{
+        "candidateId": "story_1",
+        "decision": "reject",
+        "reason": "The premise is still slop.",
+    }]
+    approval["currentThingStoryId"] = None
+    approval["quietIssue"] = {
+        "decision": "approve",
+        "headline": "Nothing cleared the gate this week.",
+        "note": "One candidate arrived. It did not have a point worth publishing.",
+        "editSummary": "Rejected the candidate and approved the exact quiet note.",
+    }
+
+    approved = approve_issue(draft, approval)
+    assert approved["stories"] == []
+    assert approved["quietIssue"]["provenance"] == "human_approved"
+    receipt = build_decision_receipt(draft, approval, approved)
+    assert receipt["decisions"][0]["decision"] == "reject"
+    assert receipt["quietIssueDecision"]["suggestedHeadline"] is None
+
+
+def test_quiet_issue_cannot_coexist_with_stories_or_unapproved_copy():
+    issue = sample_issue()
+    issue["quietIssue"] = {
+        "headline": "Nothing cleared the gate this week.",
+        "note": "There is no issue.",
+        "provenance": "human_approved",
+    }
+    with pytest.raises(IssueValidationError, match="cannot coexist"):
+        validate_issue(issue, verify_hash=False)
+
+    review = {"schemaVersion": "gravel-weekly-review/v1", "candidates": [], "packets": []}
+    draft = prepare_issue(review, "2026-09-04", 2, now="2026-09-03T17:00:00Z")
+    unapproved = copy.deepcopy(draft)
+    unapproved["status"] = "approved"
+    unapproved["editorialApproval"] = {
+        "approver": "Matti Rowe",
+        "approvedAt": "2026-09-04T16:00:00Z",
+        "reviewedDraftContentHash": draft["contentHash"],
+    }
+    with pytest.raises(IssueValidationError, match="human-approved provenance"):
+        validate_issue(unapproved, verify_hash=False)
+
+    slopped = copy.deepcopy(draft)
+    slopped["quietIssue"]["note"] = "The future isn't coming. It's already here."
+    with pytest.raises(IssueValidationError, match="no-ai-slop gate"):
+        validate_issue(slopped, verify_hash=False)
 
 
 def test_current_thing_requires_editorial_score_of_85():

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -68,7 +68,13 @@ def render_issue_contents(issue: dict[str, Any]) -> str:
     """Render an evidence-aware issue map without inventing empty departments."""
     current = story_by_id(issue, issue.get("currentThingStoryId"))
     if current is None:
-        return ""
+        quiet = issue.get("quietIssue")
+        if quiet is None:
+            return ""
+        return f'''<nav class="gw-contents" aria-label="In this issue">
+      <header><span>IN THIS ISSUE</span><p>A deliberate short issue. No filler.</p></header>
+      <ol><li><a href="#quiet-week"><span>1</span><b>THE QUIET WEEK</b><small>{esc(quiet['headline'])}</small></a></li></ol>
+    </nav>'''
     story_id = current["candidateId"]
     chapters: list[tuple[str, str, str]] = [
         (f"#{story_id}", "THE CURRENT THING", current["headline"]),
@@ -133,6 +139,15 @@ def render_receipts(receipts: list[dict[str, Any]]) -> str:
           {excerpt}
         </li>''')
     return f'<ol class="gw-receipts">{"".join(items)}</ol>'
+
+
+def render_quiet_issue(quiet: dict[str, Any], *, draft: bool) -> str:
+    label = "QUIET ISSUE — MODEL DRAFT" if draft else "THE QUIET WEEK"
+    return f'''<section class="gw-quiet" id="quiet-week">
+      <span>{esc(label)}</span>
+      <h2>{esc(quiet['headline'])}</h2>
+      {prose(quiet['note'])}
+    </section>'''
 
 
 def render_claim_markers(
@@ -581,6 +596,10 @@ def page_css() -> str:
   .gw-sub-msg { min-height: 1.5em; font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-bold); }
   .gw-hp, .gw-sr-only { position: absolute; left: -10000px; width: 1px; height: 1px; overflow: hidden; }
   .gw-empty { font-family: var(--gg-font-editorial); font-style: italic; color: var(--gg-color-secondary-brown); }
+  .gw-quiet { scroll-margin-top: 7rem; margin-top: var(--gg-spacing-xl); padding: clamp(1.5rem, 5vw, 4rem); border: var(--gg-border-heavy); background: var(--gg-color-gold); color: var(--gg-color-near-black); }
+  .gw-quiet > span { display: inline-block; font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-quiet h2 { max-width: 15ch; margin: var(--gg-spacing-sm) 0; font-family: var(--gg-font-editorial); font-size: clamp(2.25rem, 8vw, 5.5rem); line-height: .95; }
+  .gw-quiet p { max-width: 48rem; margin: 0; font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-lg); line-height: var(--gg-line-height-relaxed); }
   code { font-family: var(--gg-font-data); overflow-wrap: anywhere; }
   @media (max-width: 720px) {
     .gw-contents > header { display: grid; }
@@ -606,19 +625,26 @@ def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, la
         other_stories = [story for story in issue["stories"] if story["candidateId"] != issue.get("currentThingStoryId")]
         title = f"Gravel Weekly #{issue['issueNumber']:03d} — {display_date(issue['publicationDate'])}"
         description = current["dek"] if current else issue["mastheadDeck"]
-        content = (render_story(current, current=True, draft=is_draft) if current else '<p class="gw-empty">Nothing this week deserved a manufactured Current Thing.</p>')
+        quiet = issue.get("quietIssue")
+        content = (
+            render_story(current, current=True, draft=is_draft)
+            if current else render_quiet_issue(quiet, draft=is_draft)
+        )
         content += "".join(render_story(story, draft=is_draft) for story in other_stories)
         watch = "".join(f"<li>{esc(item)}</li>" for item in issue["calendarWatch"]) or '<li class="gw-empty">No calendar item cleared the gate.</li>'
         corrections = ""
         if issue["corrections"]:
             items = "".join(f'<li><strong>{esc(item["publishedAt"][:10])}</strong> — {esc(item["text"])}</li>' for item in issue["corrections"])
             corrections = f'<section class="gw-corrections" id="corrections"><h2>CORRECTIONS</h2><ul>{items}</ul></section>'
-        issue_body = f'''{render_issue_contents(issue)}
-        {content}
-        <div class="gw-utility-grid">
+        utility = ""
+        if issue["calendarWatch"] or issue["raceImpacts"]:
+            utility = f'''<div class="gw-utility-grid">
           <section class="gw-utility"><h2>CALENDAR WATCH</h2><ul class="gw-watch">{watch}</ul></section>
           <section class="gw-utility"><h2>WHAT THIS CHANGES</h2>{render_impacts(issue['raceImpacts'])}</section>
-        </div>
+        </div>'''
+        issue_body = f'''{render_issue_contents(issue)}
+        {content}
+        {utility}
         {render_retrospectives(issue['retrospectives'], issues, draft=is_draft)}
         {corrections}'''
         schema = "" if is_draft else f'<script type="application/ld+json">{json_ld(issue, canonical_url)}</script>'

--- a/wordpress/generate_homepage.py
+++ b/wordpress/generate_homepage.py
@@ -546,9 +546,14 @@ def build_gravel_weekly_band() -> str:
     if latest and latest.get("currentThingStoryId"):
         current = next((story for story in latest["stories"]
                         if story["candidateId"] == latest["currentThingStoryId"]), None)
-    issue_line = (f"Issue #{latest['issueNumber']:03d}: {current['headline']}"
-                  if latest and current else
-                  "The first issue is being assembled. The evidence is ready; the opinion still requires a person.")
+    quiet = latest.get("quietIssue") if latest else None
+    issue_line = (
+        f"Issue #{latest['issueNumber']:03d}: {current['headline']}"
+        if latest and current else
+        f"Issue #{latest['issueNumber']:03d}: {quiet['headline']}"
+        if latest and quiet else
+        "The first issue is being assembled. The evidence is ready; the opinion still requires a person."
+    )
     return f'''<section class="gg-hp-gw" id="gravel-weekly">
     <a class="gg-hp-gw-inner" href="/gravel-weekly/">
       <span class="gg-hp-gw-logo">GRAVEL <em>WEEKLY</em></span>


### PR DESCRIPTION
## Summary
- add a distinct quiet-issue state when no story clears the editorial gate
- require exact human approval and an immutable quiet-issue decision receipt
- render the short state on the publication, homepage, and email without empty departments
- document the rule that weekly cadence is not a story quota

## Voice provenance
- `wattgod/writing-graph/self/voice-and-beliefs-profile.md`
- `inbox/gravel-god/no-one-cares-if-youre-bored.md`
- `inbox/gravel-god/the-tyranny-of-irony-in-cycling.md`
- direct owner correction: do not publish a story without a point

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` (105 passed)
- `python3 -m pytest -q` (7926 passed, 331 skipped)
- `python3 scripts/preflight_quality.py` (all checks passed; 7 known warnings)
- pinned no-ai-slop deterministic gate passed with zero findings
- in-app browser visual/DOM verification at 1280x720; no overflow or console errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the publication and approval contract (schema versions, sealing/deploy validation) and subscriber-facing email/HTML; behavior is fail-closed and heavily tested but a mistaken quiet approval would still ship to the list.
> 
> **Overview**
> Introduces a **quiet-week** path when no candidate clears editorial gates: drafts can carry a `quietIssue` (default model-drafted headline/note) instead of inventing stories, and publication **requires** explicit human approval of that copy—reject-all weeks use the same mechanism.
> 
> **Approval and receipts** bump to `gravel-weekly-approval/v3` and `gravel-weekly-decision-receipt/v2`. An issue with zero approved stories must include `quietIssue` in the approval packet (mutually exclusive with approved stories and `currentThingStoryId`). Validators enforce `quietIssue` ↔ empty `stories`, human-approved provenance, and no-ai-slop on the note; decision receipts gain an immutable `quietIssueDecision` (`editorial-quiet-decision/v1`).
> 
> **Surfaces** render **THE QUIET WEEK** on the issue page (dedicated section, slim contents nav), homepage teaser, and Resend email (subject + body), and skip empty **CALENDAR WATCH** / **WHAT THIS CHANGES** furniture when there is no story content.
> 
> Docs state that weekly cadence is a deadline, not a story quota.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8411530a93dac4870e70ea84351e10cb4ef67b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->