### PR TITLE
Harden Gravel Weekly historical hold reasons

### DIFF
--- a/data/gravel-weekly/history/2026-life-time-admissions-office.json
+++ b/data/gravel-weekly/history/2026-life-time-admissions-office.json
@@ -22,6 +22,9 @@
     "craft": "pass",
     "hostileEditor": "hold"
   },
+  "editorialGateNotes": {
+    "hostileEditor": "The evidence proves that Life Time controls eligibility and terms inside its own Grand Prix, but not that it governs gravel careers broadly enough to earn the governing-body frame. Hold until athlete contracts, selection discretion, or consequences outside the series establish that reach."
+  },
   "contemporaryReceipts": [
     {
       "claimId": "claim_ltgp_wildcard_audition_pool_2026",
@@ -118,5 +121,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T03:25:00Z",
-  "contentHash": "500befbc6801a56d2c3ce995dc3f0f6519a29d72cef4c03a41ced64fab834669"
+  "contentHash": "53fae123aa00288bdd1225eb5876e43ecf145672afd4650eb49aa0d0d0fc0f17"
 }

--- a/scripts/preflight_quality.py
+++ b/scripts/preflight_quality.py
@@ -1214,6 +1214,21 @@ def check_questionnaire_parity():
     )
 
 
+ROBOTS_NOINDEX_NOFOLLOW_RE = re.compile(
+    r'''<meta\b
+        (?=[^>]*\bname=["']robots["'])
+        (?=[^>]*\bcontent=["'][^"']*\bnoindex\b[^"']*["'])
+        (?=[^>]*\bcontent=["'][^"']*\bnofollow\b[^"']*["'])
+        [^>]*>''',
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _is_internal_noindex_nofollow(content: str) -> bool:
+    """Recognize private/internal robots directives without formatting assumptions."""
+    return ROBOTS_NOINDEX_NOFOLLOW_RE.search(content) is not None
+
+
 def check_ga4_in_output_html():
     """Verify every HTML file in wordpress/output/ contains the GA4 measurement ID.
 
@@ -1240,7 +1255,7 @@ def check_ga4_in_output_html():
             continue
         # Internal tools (noindex, nofollow) are exempt — GA4 there would
         # pollute analytics with the coach's own visits.
-        if 'content="noindex, nofollow"' in content:
+        if _is_internal_noindex_nofollow(content):
             continue
         # PWA offline fallbacks render without network — GA4 can't load
         if html_file.name == 'offline.html':

--- a/scripts/render_gravel_weekly_history_review.py
+++ b/scripts/render_gravel_weekly_history_review.py
@@ -141,8 +141,17 @@ def _card(entry: dict[str, Any]) -> str:
         if not holds
         else f'<span class="hold">HOLD · {esc(", ".join(holds))}</span>'
     )
+    gate_notes = entry.get("editorialGateNotes") or {}
     gate_rows = "".join(
-        f"<li><b>{esc(name)}</b><span>{esc(verdict.upper())}</span></li>"
+        '<li class="gate-{verdict}"><div><b>{name}</b><span>{verdict_label}</span></div>{note}</li>'.format(
+            verdict=esc(verdict),
+            name=esc(name),
+            verdict_label=esc(verdict.upper()),
+            note=(
+                f'<p><b>WHY {esc(verdict.upper())}:</b> {esc(gate_notes[name])}</p>'
+                if name in gate_notes else ""
+            ),
+        )
         for name, verdict in entry["editorialGates"].items()
     )
     prose_findings = gate["findings"]
@@ -293,7 +302,11 @@ main {{ width: min(1120px, calc(100% - 32px)); margin: 32px auto 80px; }}
 .point {{ background: var(--gg-color-gold); }} .take {{ background: var(--gg-color-sand); }}
 summary {{ cursor: pointer; font-weight: var(--gg-font-weight-black); }}
 .receipts li {{ margin: 16px 0; }} blockquote {{ margin: 8px 0; font-family: var(--gg-font-editorial); }}
-.gates {{ max-width: 520px; padding: 0; list-style: none; }} .gates li {{ display: flex; justify-content: space-between; border-bottom: var(--gg-border-subtle); padding: 8px 0; }}
+.gates {{ max-width: 760px; padding: 0; list-style: none; }}
+.gates li {{ border-bottom: var(--gg-border-subtle); padding: 8px 0; }}
+.gates li > div {{ display: flex; justify-content: space-between; gap: var(--gg-spacing-md); }}
+.gates li > p {{ margin: var(--gg-spacing-xs) 0 0; padding: var(--gg-spacing-sm); border-left: var(--gg-border-gold); background: var(--gg-color-sand); font-size: var(--gg-font-size-sm); }}
+.gates .gate-hold > div span, .gates .gate-fail > div span {{ font-weight: var(--gg-font-weight-black); }}
 code {{ overflow-wrap: anywhere; }} footer {{ background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }} footer code {{ color: var(--gg-color-light-gold); }}
 @media (max-width: 700px) {{ .judgment {{ grid-template-columns: 1fr; }} .judgment section + section {{ border-left: 0; border-top: var(--gg-border-standard); }} .decision-queue a {{ grid-template-columns: 56px minmax(0, 1fr); }} .decision-queue code {{ grid-column: 2; }} main {{ width: min(100% - 16px, 1120px); margin-top: 8px; }} }}
 </style></head><body><main>

--- a/scripts/validate_gravel_weekly_history.py
+++ b/scripts/validate_gravel_weekly_history.py
@@ -171,6 +171,28 @@ def validate_history_entry(value: Any, *, verify_hash: bool = True) -> dict[str,
             raise IssueValidationError(f"editorialGates.{gate_name} is invalid")
         if status != "draft" and verdict != "pass":
             raise IssueValidationError("approved historical entries require every editorial gate to pass")
+    non_passing_gates = {
+        gate_name for gate_name, verdict in gates.items() if verdict != "pass"
+    }
+    gate_notes_value = entry.get("editorialGateNotes")
+    if non_passing_gates:
+        if not isinstance(gate_notes_value, dict):
+            raise IssueValidationError(
+                "editorialGateNotes must contain exactly the non-passing editorial gates"
+            )
+        gate_notes = _record(gate_notes_value, "editorialGateNotes")
+        if set(gate_notes) != non_passing_gates:
+            raise IssueValidationError(
+                "editorialGateNotes must contain exactly the non-passing editorial gates"
+            )
+        for gate_name, note in gate_notes.items():
+            _text(note, f"editorialGateNotes.{gate_name}", 1_000)
+    elif gate_notes_value is not None:
+        gate_notes = _record(gate_notes_value, "editorialGateNotes")
+        if gate_notes:
+            raise IssueValidationError(
+                "editorialGateNotes must be empty when every editorial gate passes"
+            )
 
     contemporary = _list(entry.get("contemporaryReceipts"), "contemporaryReceipts", 100)
     if not contemporary:

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -1129,8 +1129,23 @@ def test_historical_current_thing_requires_contemporary_corroboration_and_human_
 
     held_gate = copy.deepcopy(entry)
     held_gate["editorialGates"]["friend"] = "hold"
+    held_gate["editorialGateNotes"] = {
+        "friend": "The story still fails the friend-at-a-party attention test."
+    }
     with pytest.raises(IssueValidationError, match="every editorial gate"):
         validate_history_entry(held_gate, verify_hash=False)
+
+    undocumented_hold = sample_history_draft()
+    undocumented_hold["editorialGates"]["hostileEditor"] = "hold"
+    with pytest.raises(IssueValidationError, match="exactly the non-passing"):
+        validate_history_entry(undocumented_hold, verify_hash=False)
+
+    stale_gate_note = sample_history_draft()
+    stale_gate_note["editorialGateNotes"] = {
+        "hostileEditor": "This note must not survive after the gate passes."
+    }
+    with pytest.raises(IssueValidationError, match="must be empty"):
+        validate_history_entry(stale_gate_note, verify_hash=False)
 
     model_take = copy.deepcopy(entry)
     model_take["takeProvenance"] = "model_draft"
@@ -1207,6 +1222,9 @@ def test_historical_rejection_records_the_reason_without_approved_copy():
 def test_historical_approval_cannot_rescue_a_held_editorial_gate():
     draft = sample_history_draft()
     draft["editorialGates"]["hostileEditor"] = "hold"
+    draft["editorialGateNotes"] = {
+        "hostileEditor": "The governing claim outruns the evidence currently attached."
+    }
     draft["contentHash"] = compute_history_content_hash(draft)
     with pytest.raises(IssueValidationError, match="every editorial gate"):
         apply_history_decision(draft, sample_history_approval(draft))
@@ -1264,6 +1282,9 @@ def test_private_historical_review_desk_separates_evidence_and_approval_state():
     held["entryId"] = "history-held-2026"
     held["headline"] = "A held premise"
     held["editorialGates"]["friend"] = "hold"
+    held["editorialGateNotes"] = {
+        "friend": "The premise is accurate but would lose the room before reaching a point."
+    }
     held["contentHash"] = compute_history_content_hash(held)
     slopped = copy.deepcopy(draft)
     slopped["entryId"] = "history-slopped-2026"
@@ -1303,6 +1324,8 @@ def test_private_historical_review_desk_separates_evidence_and_approval_state():
     assert "LATER EVIDENCE (1)" in page
     assert "any decision binds to this exact draft hash" in page.lower()
     assert "approval fails closed while any hold remains" in page.lower()
+    assert "WHY HOLD:" in page
+    assert held["editorialGateNotes"]["friend"] in page
     assert draft["contentHash"] in page
     assert "noindex,nofollow" in page
     assert "@font-face" in page
@@ -1328,6 +1351,9 @@ def test_historical_review_index_prioritizes_recent_ready_decisions():
         "editorialScore": 100,
     })
     held_2026["editorialGates"]["hostileEditor"] = "hold"
+    held_2026["editorialGateNotes"] = {
+        "hostileEditor": "The headline claims more institutional control than the record proves."
+    }
     held_2026["contentHash"] = compute_history_content_hash(held_2026)
 
     assert review_years([ready_2025, held_2026, ready_2026]) == [2026, 2025]
@@ -1348,6 +1374,9 @@ def test_bulk_history_approval_is_exact_ready_only_and_non_publishing(tmp_path):
     held = copy.deepcopy(ready)
     held["entryId"] = "history-held-2026"
     held["editorialGates"]["hostileEditor"] = "hold"
+    held["editorialGateNotes"] = {
+        "hostileEditor": "The conclusion outruns the evidence currently attached."
+    }
     held["contentHash"] = compute_history_content_hash(held)
 
     prepared = prepare_ready_approvals(
@@ -1435,6 +1464,9 @@ def test_only_sealed_historical_snapshots_cross_the_public_loader(tmp_path):
         "editorialApproval": None,
     })
     draft["editorialGates"]["hostileEditor"] = "hold"
+    draft["editorialGateNotes"] = {
+        "hostileEditor": "The conclusion outruns the evidence currently attached."
+    }
     published["contentHash"] = compute_history_content_hash(published)
     approved["contentHash"] = compute_history_content_hash(approved)
     draft["contentHash"] = compute_history_content_hash(draft)

--- a/tests/test_preflight_ga4.py
+++ b/tests/test_preflight_ga4.py
@@ -1,0 +1,46 @@
+"""Regression tests for GA4 output classification."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_preflight_quality():
+    path = PROJECT_ROOT / "scripts" / "preflight_quality.py"
+    spec = importlib.util.spec_from_file_location("preflight_quality_ga4_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_private_noindex_nofollow_pages_are_exempt_regardless_of_spacing_or_order():
+    preflight = _load_preflight_quality()
+
+    assert preflight._is_internal_noindex_nofollow(
+        '<meta name="robots" content="noindex,nofollow">'
+    )
+    assert preflight._is_internal_noindex_nofollow(
+        "<meta content='nofollow, noindex' name='robots'>"
+    )
+    assert preflight._is_internal_noindex_nofollow(
+        '<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">'
+    )
+
+
+def test_public_or_indexable_pages_are_not_exempt_from_ga4_coverage():
+    preflight = _load_preflight_quality()
+
+    assert not preflight._is_internal_noindex_nofollow(
+        '<meta name="robots" content="index,follow">'
+    )
+    assert not preflight._is_internal_noindex_nofollow(
+        '<meta name="robots" content="noindex,follow">'
+    )
+    assert not preflight._is_internal_noindex_nofollow(
+        '<p>Internal note: noindex,nofollow</p>'
+    )


### PR DESCRIPTION
## Summary
- require exact, hash-bound notes for every non-passing historical editorial gate
- show the hold reason directly in the private historical review desk
- recognize private noindex/nofollow pages regardless robots-meta formatting so the GA4 preflight remains accurate

## Verification
- `python3 -m pytest tests/ -q` — 7,386 passed, 331 skipped
- `python3 scripts/validate_gravel_weekly_history.py` — all 82 entries valid
- `python3 scripts/preflight_quality.py` — all checks passed
- rendered and visually inspected the 2026 private review desk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unable to generate summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8476398be6ab074cd7a0ef47d184be37621c6d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->