### PR TITLE
Add 2026 Gravel Weekly culture context

### DIFF
--- a/data/gravel-weekly/history/2026-traka-womens-traffic-tax.json
+++ b/data/gravel-weekly/history/2026-traka-womens-traffic-tax.json
@@ -22,6 +22,29 @@
     "craft": "pass",
     "hostileEditor": "pass"
   },
+  "cultureArtifacts": [
+    {
+      "artifactId": "historical-culture-artifact_f04f5c9039124f402d5a18a7",
+      "sourceKind": "youtube",
+      "publisher": "Drew Dillman",
+      "author": "Drew Dillman",
+      "canonicalUrl": "https://www.youtube.com/watch?v=Ni80UfChRNE",
+      "publishedAt": "2026-05-06T19:00:32.000Z",
+      "title": "The Unbound of Europe? TRAKA 360 Pro Men's Race Analysis",
+      "excerpt": null,
+      "timestampSeconds": 38,
+      "topicTags": [
+        "amateurs",
+        "traka"
+      ],
+      "reviewReason": "At 0:38, a first-person race analysis describes a stopped start after some amateurs launched with the pro men. It records the event's wave-control chaos; it does not prove the separate claims about the elite women's race.",
+      "collectionMethod": "public_metadata",
+      "rightsPolicy": "metadata_only",
+      "purpose": "culture_sensor",
+      "canProveClaim": false,
+      "canEstablishConsensus": false
+    }
+  ],
   "contemporaryReceipts": [
     {
       "claimId": "claim_traka_rules_open_may_catch_elite_women",
@@ -110,5 +133,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T19:42:33Z",
-  "contentHash": "4d62869a2376b68941f313dbf5a6454c5dfe19ed2fbf08bccb44173f638cd4d9"
+  "contentHash": "6a73a381e4e10907e70f089e5475bf76c6ad2cc21e413d3a269d473fb7ed609e"
 }

--- a/data/gravel-weekly/history/2026-unbound-teamification.json
+++ b/data/gravel-weekly/history/2026-unbound-teamification.json
@@ -22,6 +22,29 @@
     "craft": "pass",
     "hostileEditor": "pass"
   },
+  "cultureArtifacts": [
+    {
+      "artifactId": "historical-culture-artifact_7380ad7052cb228788c1a4b4",
+      "sourceKind": "youtube",
+      "publisher": "Bonk Bros",
+      "author": "Bonk Bros",
+      "canonicalUrl": "https://www.youtube.com/watch?v=WCO5caKfLd0",
+      "publishedAt": "2026-05-28T16:00:38.000Z",
+      "title": "Big Wheels & Bigger Unbound Predictions",
+      "excerpt": null,
+      "timestampSeconds": 3130,
+      "topicTags": [
+        "teams",
+        "unbound"
+      ],
+      "reviewReason": "At 52:10, the pre-race show imagines Mads Würtz Schmidt, Matt Beers, and Keegan Swenson swapping pulls on a ride. That puts cooperation inside the culture before the race; it does not prove coordination at Unbound.",
+      "collectionMethod": "public_metadata",
+      "rightsPolicy": "metadata_only",
+      "purpose": "culture_sensor",
+      "canProveClaim": false,
+      "canEstablishConsensus": false
+    }
+  ],
   "contemporaryReceipts": [
     {
       "claimId": "claim_specialized_offroad_superteam_2026",
@@ -145,5 +168,5 @@
   "editorialApproval": null,
   "publishedAt": null,
   "updatedAt": "2026-08-28T03:25:00Z",
-  "contentHash": "6b42baedb9568ba738b17aca8475d1e95debc9b62159dae17d5a85e03113c511"
+  "contentHash": "718334814a7b3d63d7f738884e8c3f810e07b356be202382fb8b080de1893cd2"
 }

--- a/docs/gravel-weekly-manual-for-speed-reference.md
+++ b/docs/gravel-weekly-manual-for-speed-reference.md
@@ -6,12 +6,13 @@ illustration, gradients, page composition, recurring names, or trade dress.
 
 ## Archive sample
 
-The review used nine representative Internet Archive captures:
+The review used ten representative Internet Archive captures:
 
 - [February 2012 homepage](https://web.archive.org/web/20120228222408if_/http://www.manualforspeed.com/)
 - [December 2012 homepage](https://web.archive.org/web/20121218044342/http://manualforspeed.com/)
 - [2012 photo essay: Nice Work. Disappointment.](https://web.archive.org/web/20121101234132/http://manualforspeed.com/2012/09/nice-work-disappointment/)
 - [December 2014 homepage](https://web.archive.org/web/20141204191607if_/http://www.manualforspeed.com/)
+- [2014 field guide: At the Races, Chapter 1](https://web.archive.org/web/20140607065638/http://www.manualforspeed.com/pro-tour/at-the-races-chapter-1)
 - [2014 brief: Hair Care](https://web.archive.org/web/20141205153449if_/http://www.manualforspeed.com/briefs/mfsm-003-bonus-tip-hair-care/)
 - [March 2016 homepage](https://web.archive.org/web/20160306025636/http://manualforspeed.com/)
 - [2015 Tour de France: Stage 01](https://web.archive.org/web/20160323053644/http://manualforspeed.com/road-racing/2015-tour-de-france-stage-01/)
@@ -105,6 +106,33 @@ feed. A Tour report can contain a conventional `RACE BIBLE` and a parallel
 meal report, corrections, quote of the day, playlist, and chronological diary.
 Those departments create continuity without forcing every item into a generic
 article template.
+
+### The killer pattern: report the scene as if it deserves a field guide
+
+`At the Races: Chapter 1` turns spectators into a comic but remarkably precise
+taxonomy. It names a recurring character type, supplies subtypes, associates,
+habitat, diet, proclivities, and dangers, then serializes the idea across ten
+weekly installments. The straight-faced structure is what makes the joke work:
+the observation is specific enough to be recognizable, the invented bureaucracy
+creates comic escalation, and the recurring format turns an otherwise disposable
+detail into shared lore.
+
+This is a better model for Gravel Weekly's cultural layer than a generic social
+post roundup. The system should look for a repeated, recognizable gravel-world
+behavior or character and prepare a possible field-guide treatment only when the
+sample supports it. Candidate fields may include `TYPE`, `HABITAT`, `NATURAL
+PREDATOR`, `STANDARD DEFENSE`, `EQUIPMENT TELLS`, and `WHERE SIGHTED`, but the
+visible labels must be written for the particular joke rather than emitted as
+mandatory furniture. One observation is a field note. Multiple independent,
+reviewed observations may earn a named type. Neither engagement nor model
+confidence can manufacture recurrence.
+
+The visual lesson is equally specific. A bold, deliberately simple illustration
+functions as the chapter's front door; the prose and taxonomy carry the factual
+and comic precision. Gravel Weekly can translate that division of labor with its
+deterministic story graphics: one oversized visual premise, followed by the
+evidence-bound labels and Matti's approved take. It should not copy MFS's drawing
+style, character names, heavy black frame, typography, or page composition.
 
 ## Layout and UI patterns worth translating
 

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 sys.path.insert(0, str(ROOT / "wordpress"))
 
 from generate_gravel_weekly import build_page, render_history_timeline  # noqa: E402
+from gravel_weekly_culture import culture_css, render_culture_artifacts  # noqa: E402
 from gravel_weekly_visuals import (  # noqa: E402
     classify_theme,
     render_story_visual,
@@ -507,6 +508,21 @@ def test_weekly_culture_artifacts_are_direct_hash_bound_context_and_survive_appr
     missing_index["sourceIndex"].remove(artifact["canonicalUrl"])
     with pytest.raises(IssueValidationError, match="sourceIndex omits culture artifact URLs"):
         validate_issue(missing_index, verify_hash=False)
+
+
+def test_timestamped_youtube_culture_card_opens_the_reviewed_moment():
+    artifact = sample_culture_artifact()
+    artifact.update({
+        "sourceKind": "youtube",
+        "canonicalUrl": "https://www.youtube.com/watch?v=abcdefghijk&list=example",
+        "timestampSeconds": 3130,
+        "collectionMethod": "public_metadata",
+    })
+    card = render_culture_artifacts([artifact])
+    assert "OPEN ORIGINAL · 52:10" in card
+    assert "https://www.youtube.com/watch?v=abcdefghijk&amp;list=example&amp;t=3130s" in card
+    assert "iframe" not in card
+    assert ".gw-culture-card:only-child { grid-column: 1 / -1; }" in culture_css()
 
 
 def test_claim_bound_cast_and_field_notes_survive_approval_and_render_as_optional_departments():

--- a/wordpress/gravel_weekly_culture.py
+++ b/wordpress/gravel_weekly_culture.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import html
 from datetime import datetime
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 
 def esc(value: Any) -> str:
@@ -16,6 +17,20 @@ def _timestamp_label(seconds: int | None) -> str:
     if seconds is None:
         return ""
     return f" · {seconds // 60}:{seconds % 60:02d}"
+
+
+def _source_url(artifact: dict[str, Any]) -> str:
+    """Make timestamped YouTube culture links land on the reviewed moment."""
+    url = artifact["canonicalUrl"]
+    seconds = artifact.get("timestampSeconds")
+    if artifact.get("sourceKind") != "youtube" or seconds is None:
+        return url
+    parsed = urlsplit(url)
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query["t"] = f"{int(seconds)}s"
+    return urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urlencode(query), parsed.fragment)
+    )
 
 
 def render_culture_artifacts(
@@ -46,7 +61,7 @@ def render_culture_artifacts(
           <p class="gw-culture-by">{esc(author)}</p>
           {excerpt}
           {review_reason}
-          <a href="{esc(artifact['canonicalUrl'])}" rel="noopener noreferrer" target="_blank">OPEN ORIGINAL{esc(timestamp)} →</a>
+          <a href="{esc(_source_url(artifact))}" rel="noopener noreferrer" target="_blank">OPEN ORIGINAL{esc(timestamp)} →</a>
         </article>''')
     mode = "PRIVATE CULTURE CHECK" if private_review else "THE SCENE REPORT"
     explanation = (
@@ -69,6 +84,7 @@ def culture_css() -> str:
   .gw-culture > header p { max-width: 760px; margin: 0; font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-normal); }
   .gw-culture-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--gg-border-width-standard); background: var(--gg-color-near-black); }
   .gw-culture-card { display: flex; min-width: 0; flex-direction: column; padding: var(--gg-spacing-md); background: var(--gg-color-warm-paper); color: var(--gg-color-near-black); }
+  .gw-culture-card:only-child { grid-column: 1 / -1; }
   .gw-culture-card > header { display: flex; justify-content: space-between; gap: var(--gg-spacing-sm); border: 0; padding: 0; font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
   .gw-culture-card h5 { margin: var(--gg-spacing-md) 0 var(--gg-spacing-xs); font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-xl); line-height: 1.05; }
   .gw-culture-by { margin: 0 0 var(--gg-spacing-sm); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-bold); text-transform: uppercase; }


### PR DESCRIPTION
## Summary
- add two dated, rights-safe YouTube culture moments to private 2026 historical drafts
- send source links to the exact reviewed timestamp and make a single Scene Report card full-width
- extend the Manual for Speed archive study with its field-guide taxonomy pattern and explicit no-copy guardrail

## Verification
- `python3 -m pytest tests/ -q` (7,389 passed, 331 skipped)
- `python3 scripts/preflight_quality.py` (passed; 7 known environment/backlog warnings)
- `python3 scripts/validate_gravel_weekly_history.py` (82 entries)
- visual browser check of 2026 private review desk
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial data and presentation tweaks to culture cards; no auth, publishing, or evidence-validation logic changes beyond hash updates on touched history JSON.
> 
> **Overview**
> Adds **rights-safe YouTube culture moments** to two private 2026 historical drafts (Traka wave chaos, Unbound teamification pre-race talk), each with `timestampSeconds`, review reasons, and updated `contentHash`es.
> 
> **Scene Report rendering** now builds YouTube **OPEN ORIGINAL** links with a `t=` query from `timestampSeconds` (preserving other query params), still without embeds. A lone culture card spans the full grid via `.gw-culture-card:only-child`.
> 
> The **Manual for Speed** reference doc gains a tenth archive capture and a **field-guide taxonomy** section (recurring scene types, evidence gates, no-copy guardrails) as editorial direction for the cultural layer.
> 
> A pytest contract asserts the labeled timestamp, deep link, no iframe, and full-width CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c4ebb50ba9888270d3f444e9e8549f0f828b823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->