### PR TITLE
Add automatic Gravel Weekly culture posters

### DIFF
--- a/docs/gravel-weekly-visual-system.md
+++ b/docs/gravel-weekly-visual-system.md
@@ -6,6 +6,10 @@ Gravel Weekly must never wait for Matti to choose, license, crop, or approve an 
 
 1. A contemporary receipt that is both a valid YouTube URL and a timestamped transcript claim becomes a branded source-video facade. The link opens the exact cited moment. It never autoplays or embeds tracking code.
 2. Every other story receives deterministic inline SVG generated from the story ID, content hash, and approved copy. Identical content produces an identical visual; a substantive edit produces a new one.
+3. Every approved culture artifact receives its own local poster. A timestamped
+   YouTube artifact gets an unmistakable source-video facade linked to the
+   reviewed moment; every other source gets abstract, hash-stable context art.
+   Neither path downloads, hotlinks, screenshots, or imitates the source media.
 
 The SVG is abstract editorial art, visibly labeled as such. It is never presented as a photograph or as evidence of an event.
 
@@ -95,3 +99,10 @@ editorial authority. Its selection rationale is visible only in draft/private
 review. Because the normalized artifact is part of the weekly issue or
 historical-entry content hash, Matti's story approval covers the exact culture
 context that can later appear publicly.
+
+Culture cards are visual artifacts rather than a text-only evidence ledger. The
+poster makes the selected object visible in the issue's rhythm while its caption
+states the rights boundary: local facade or abstract context art, never the
+publisher's image. The visible title, source, date, tags, excerpt, and canonical
+link remain normal HTML beneath the poster, so retrieval and accessibility do
+not depend on SVG text or JavaScript.

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -521,8 +521,39 @@ def test_timestamped_youtube_culture_card_opens_the_reviewed_moment():
     card = render_culture_artifacts([artifact])
     assert "OPEN ORIGINAL · 52:10" in card
     assert "https://www.youtube.com/watch?v=abcdefghijk&amp;list=example&amp;t=3130s" in card
+    assert 'data-culture-visual="gravel-weekly-culture-visual/v1"' in card
+    assert "SOURCE VIDEO // LOCAL FACADE" in card
+    assert "WATCH @ 52:10" in card
+    assert "no embed or thumbnail" in card
+    assert "<img" not in card
     assert "iframe" not in card
     assert ".gw-culture-card:only-child { grid-column: 1 / -1; }" in culture_css()
+
+
+def test_non_video_culture_artifact_gets_stable_local_poster_not_fake_source_media():
+    artifact = sample_weekly_culture_artifact()
+    artifact["title"] = "Privateers, team buses & <script>alert(1)</script>"
+    first = render_culture_artifacts([artifact])
+    second = render_culture_artifacts([artifact])
+
+    assert first == second
+    assert 'data-culture-visual="gravel-weekly-culture-visual/v1"' in first
+    assert "GW CULTURE DESK // AUTO" in first
+    assert "Abstract context poster; not the source image." in first
+    assert "FROM THE GROUP CHAT · BLUESKY" in first
+    assert "CALENDAR / WORLDS" in first
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in first
+    assert "<script>" not in first
+    assert "<img" not in first and "<iframe" not in first
+
+
+def test_culture_poster_css_is_brand_token_only_and_accessible_without_motion():
+    css = culture_css()
+    assert ".gw-culture-poster" in css
+    assert "var(--gg-color-" in css
+    assert ":focus-visible" in css
+    assert "#" not in css
+    assert "infinite" not in css
 
 
 def test_claim_bound_cast_and_field_notes_survive_approval_and_render_as_optional_departments():

--- a/wordpress/gravel_weekly_culture.py
+++ b/wordpress/gravel_weekly_culture.py
@@ -4,9 +4,15 @@
 from __future__ import annotations
 
 import html
+import hashlib
+import re
+import textwrap
 from datetime import datetime
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+CULTURE_VISUAL_VERSION = "gravel-weekly-culture-visual/v1"
 
 
 def esc(value: Any) -> str:
@@ -33,6 +39,113 @@ def _source_url(artifact: dict[str, Any]) -> str:
     )
 
 
+def _safe_id(value: str) -> str:
+    safe = re.sub(r"[^a-zA-Z0-9_-]+", "-", value).strip("-").lower()
+    return safe or "culture-artifact"
+
+
+def _seed(artifact: dict[str, Any]) -> str:
+    stable = "\n".join([
+        str(artifact.get("artifactId", "")),
+        str(artifact.get("canonicalUrl", "")),
+        str(artifact.get("publishedAt", "")),
+        str(artifact.get("title", "")),
+    ])
+    return hashlib.sha256(stable.encode("utf-8")).hexdigest()
+
+
+def _svg_text_block(
+    value: str, *, x: int, y: int, class_name: str,
+    max_chars: int, max_lines: int, line_height: int,
+) -> str:
+    lines = textwrap.wrap(
+        " ".join(value.split()),
+        width=max_chars,
+        break_long_words=False,
+        break_on_hyphens=False,
+    ) or [""]
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        lines[-1] = f"{lines[-1][:max_chars - 1].rstrip()}…"
+    spans = "".join(
+        f'<tspan x="{x}" dy="{0 if index == 0 else line_height}">{esc(line)}</tspan>'
+        for index, line in enumerate(lines)
+    )
+    return f'<text class="{esc(class_name)}" x="{x}" y="{y}">{spans}</text>'
+
+
+def _poster_marks(seed: str) -> str:
+    marks: list[str] = []
+    for index in range(0, 30, 6):
+        x = 34 + (int(seed[index:index + 2], 16) % 568)
+        y = 26 + (int(seed[index + 2:index + 4], 16) % 226)
+        size = 8 + (int(seed[index + 4:index + 6], 16) % 24)
+        marks.append(
+            f'<rect x="{x}" y="{y}" width="{size}" height="{size}" '
+            'transform="rotate(45 ' + f'{x + size // 2} {y + size // 2}' + ')" />'
+        )
+    return "".join(marks)
+
+
+def _culture_poster(artifact: dict[str, Any], source_url: str) -> str:
+    """Render local editorial artwork without copying or hotlinking source media."""
+    safe_id = _safe_id(str(artifact["artifactId"]))
+    seed = _seed(artifact)
+    source_kind = str(artifact["sourceKind"]).upper()
+    publisher = str(artifact.get("author") or artifact["publisher"])
+    timestamp_seconds = artifact.get("timestampSeconds")
+    is_timestamped_video = (
+        artifact.get("sourceKind") == "youtube"
+        and isinstance(timestamp_seconds, int)
+        and not isinstance(timestamp_seconds, bool)
+        and timestamp_seconds >= 0
+    )
+    if is_timestamped_video:
+        timestamp = f"{timestamp_seconds // 60}:{timestamp_seconds % 60:02d}"
+        title = (
+            f"Timestamped source-video facade for {artifact['title']} at {timestamp}. "
+            "No source image or video is embedded."
+        )
+        artwork = f'''
+          <rect class="gw-culture-poster-screen" x="32" y="34" width="238" height="174" />
+          <path class="gw-culture-poster-play" d="M118 78l74 43-74 43z" />
+          <text class="gw-culture-poster-time" x="151" y="238" text-anchor="middle">WATCH @ {esc(timestamp)}</text>
+          <text class="gw-culture-poster-kicker" x="304" y="62">TIMESTAMPED SOURCE VIDEO</text>
+          {_svg_text_block(str(artifact['title']), x=304, y=103, class_name='gw-culture-poster-title', max_chars=20, max_lines=4, line_height=30)}
+          <text class="gw-culture-poster-meta" x="304" y="238">{esc(publisher.upper())}</text>'''
+        visual_kind = "video"
+        caption_label = "SOURCE VIDEO // LOCAL FACADE"
+        caption_text = f"Opens the reviewed moment at {timestamp}; no embed or thumbnail."
+    else:
+        topic_label = " / ".join(
+            str(tag).upper() for tag in artifact.get("topicTags", [])[:3]
+        ) or "CULTURE"
+        title = (
+            f"Abstract Gravel Weekly culture poster for {artifact['title']}. "
+            "Context artwork, not a source image or documentary depiction."
+        )
+        artwork = f'''
+          <g class="gw-culture-poster-marks" aria-hidden="true">{_poster_marks(seed)}</g>
+          <rect class="gw-culture-poster-frame" x="28" y="28" width="584" height="224" />
+          <text class="gw-culture-poster-kicker" x="52" y="62">FROM THE GROUP CHAT · {esc(source_kind)}</text>
+          {_svg_text_block(str(artifact['title']), x=52, y=110, class_name='gw-culture-poster-title', max_chars=34, max_lines=3, line_height=34)}
+          <text class="gw-culture-poster-meta" x="52" y="230">{esc(topic_label)}</text>
+          <text class="gw-culture-poster-stamp" x="588" y="230" text-anchor="end">{esc(seed[:8].upper())}</text>'''
+        visual_kind = "artifact"
+        caption_label = "GW CULTURE DESK // AUTO"
+        caption_text = "Abstract context poster; not the source image."
+    return f'''<figure class="gw-culture-poster gw-culture-poster--{visual_kind}" data-culture-visual="{CULTURE_VISUAL_VERSION}">
+      <a href="{esc(source_url)}" target="_blank" rel="noopener noreferrer" aria-label="Open the original {esc(source_kind)} culture source: {esc(artifact['title'])}">
+        <svg viewBox="0 0 640 280" role="img" aria-labelledby="gw-culture-poster-title-{safe_id}" focusable="false">
+          <title id="gw-culture-poster-title-{safe_id}">{esc(title)}</title>
+          <rect class="gw-culture-poster-paper" x="0" y="0" width="640" height="280" />
+          {artwork}
+        </svg>
+      </a>
+      <figcaption><b>{caption_label}</b><span>{esc(caption_text)}</span></figcaption>
+    </figure>'''
+
+
 def render_culture_artifacts(
     artifacts: list[dict[str, Any]], *, private_review: bool = False,
     section_id: str | None = None,
@@ -55,13 +168,17 @@ def render_culture_artifacts(
             if private_review else ""
         )
         timestamp = _timestamp_label(artifact.get("timestampSeconds"))
+        source_url = _source_url(artifact)
         cards.append(f'''<article class="gw-culture-card" data-culture-artifact="{esc(artifact['artifactId'])}">
+          {_culture_poster(artifact, source_url)}
+          <div class="gw-culture-card-copy">
           <header><span>{esc(artifact['sourceKind'].upper())}</span><time datetime="{esc(artifact['publishedAt'])}">{esc(published)}</time></header>
           <h5>{esc(artifact['title'])}</h5>
           <p class="gw-culture-by">{esc(author)}</p>
           {excerpt}
           {review_reason}
-          <a href="{esc(_source_url(artifact))}" rel="noopener noreferrer" target="_blank">OPEN ORIGINAL{esc(timestamp)} →</a>
+          <a href="{esc(source_url)}" rel="noopener noreferrer" target="_blank">OPEN ORIGINAL{esc(timestamp)} →</a>
+          </div>
         </article>''')
     mode = "PRIVATE CULTURE CHECK" if private_review else "THE SCENE REPORT"
     explanation = (
@@ -83,13 +200,33 @@ def culture_css() -> str:
   .gw-culture > header h4 { margin: var(--gg-spacing-xs) 0; font-size: clamp(1.4rem, 4vw, 2.4rem); line-height: 1; }
   .gw-culture > header p { max-width: 760px; margin: 0; font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-normal); }
   .gw-culture-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--gg-border-width-standard); background: var(--gg-color-near-black); }
-  .gw-culture-card { display: flex; min-width: 0; flex-direction: column; padding: var(--gg-spacing-md); background: var(--gg-color-warm-paper); color: var(--gg-color-near-black); }
+  .gw-culture-card { display: flex; min-width: 0; flex-direction: column; background: var(--gg-color-warm-paper); color: var(--gg-color-near-black); }
   .gw-culture-card:only-child { grid-column: 1 / -1; }
-  .gw-culture-card > header { display: flex; justify-content: space-between; gap: var(--gg-spacing-sm); border: 0; padding: 0; font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-culture-card-copy { display: flex; flex: 1; min-width: 0; flex-direction: column; padding: var(--gg-spacing-md); }
+  .gw-culture-card-copy > header { display: flex; justify-content: space-between; gap: var(--gg-spacing-sm); border: 0; padding: 0; font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
   .gw-culture-card h5 { margin: var(--gg-spacing-md) 0 var(--gg-spacing-xs); font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-xl); line-height: 1.05; }
   .gw-culture-by { margin: 0 0 var(--gg-spacing-sm); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-bold); text-transform: uppercase; }
   .gw-culture-card blockquote { flex: 1; margin: 0 0 var(--gg-spacing-md); padding-left: var(--gg-spacing-sm); border-left: var(--gg-border-gold); font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-md); line-height: var(--gg-line-height-normal); }
   .gw-culture-card a { align-self: flex-start; color: var(--gg-color-primary-brown); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
   .gw-culture-reason { margin: 0 0 var(--gg-spacing-md); font-size: var(--gg-font-size-sm); line-height: var(--gg-line-height-normal); }
+  .gw-culture-poster { margin: 0; border-bottom: var(--gg-border-standard); background: var(--gg-color-near-black); }
+  .gw-culture-poster > a { display: block; width: 100%; color: inherit; }
+  .gw-culture-poster > a:focus-visible { outline: var(--gg-border-gold); outline-offset: calc(var(--gg-border-width-standard) * -2); }
+  .gw-culture-poster svg { display: block; width: 100%; height: auto; }
+  .gw-culture-poster-paper { fill: var(--gg-color-sand); }
+  .gw-culture-poster-frame { fill: var(--gg-color-warm-paper); stroke: var(--gg-color-near-black); stroke-width: 5; }
+  .gw-culture-poster-marks { fill: var(--gg-color-teal); opacity: .72; }
+  .gw-culture-poster-kicker, .gw-culture-poster-title, .gw-culture-poster-meta, .gw-culture-poster-stamp, .gw-culture-poster-time { fill: var(--gg-color-near-black); font-family: var(--gg-font-data); }
+  .gw-culture-poster-kicker { font-size: 14px; font-weight: var(--gg-font-weight-black); letter-spacing: 2px; }
+  .gw-culture-poster-title { font-size: 27px; font-weight: var(--gg-font-weight-black); }
+  .gw-culture-poster-meta, .gw-culture-poster-stamp { font-size: 12px; font-weight: var(--gg-font-weight-black); letter-spacing: 1px; }
+  .gw-culture-poster-screen { fill: var(--gg-color-near-black); stroke: var(--gg-color-teal); stroke-width: 8; }
+  .gw-culture-poster-play { fill: var(--gg-color-gold); stroke: var(--gg-color-warm-paper); stroke-width: 5; }
+  .gw-culture-poster-time { font-size: 17px; font-weight: var(--gg-font-weight-black); letter-spacing: 1px; }
+  .gw-culture-poster figcaption { display: flex; justify-content: space-between; gap: var(--gg-spacing-sm); padding: var(--gg-spacing-xs) var(--gg-spacing-sm); color: var(--gg-color-warm-paper); font-size: var(--gg-font-size-xs); letter-spacing: var(--gg-letter-spacing-wide); text-transform: uppercase; }
   @media (max-width: 700px) { .gw-culture-grid { grid-template-columns: 1fr; } }
+  @media (max-width: 620px) {
+    .gw-culture-poster-title { font-size: 23px; }
+    .gw-culture-poster figcaption { display: grid; }
+  }
 '''


### PR DESCRIPTION
## Summary
- turn every approved culture artifact into deterministic local poster art
- give timestamped YouTube moments a branded source-video facade linked to the reviewed second
- preserve the rights boundary: no embeds, thumbnails, screenshots, hotlinks, or synthetic documentary imagery
- retain full source metadata and copy as accessible HTML beneath each visual

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` (108 passed)
- `python3 -m pytest tests/ -q` (7,391 passed, 331 skipped)
- `python3 scripts/validate_gravel_weekly_history.py` (82 entries)
- `python3 scripts/preflight_quality.py` (passed; 7 existing environment/backlog warnings)
- in-app browser visual and semantic QA of the 2026 Scene Report
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer change in culture card HTML/CSS with strong test coverage; no auth, data, or approval workflow changes.
> 
> **Overview**
> **Culture cards now lead with a local SVG poster** for every approved artifact, while title, excerpt, metadata, and the canonical link stay in HTML below the visual.
> 
> **Timestamped YouTube** artifacts get a branded **source-video facade** (play motif, `WATCH @` time) that links to the reviewed moment via `t=` on the canonical URL—still **no** embeds, thumbnails, or `<img>`.
> 
> **All other sources** get **hash-stable abstract context art** from artifact id, URL, date, and title (`gravel-weekly-culture-visual/v1`), with explicit captions (`GW CULTURE DESK // AUTO` / `SOURCE VIDEO // LOCAL FACADE`) stating the rights boundary.
> 
> Card markup splits into poster + `gw-culture-card-copy`; **poster CSS** uses brand tokens, `:focus-visible`, and no perpetual motion. **Docs** extend the visual-system hierarchy and culture-artifact section to match.
> 
> **Tests** lock determinism, XSS escaping, YouTube timestamp links, and the no-embed/no-hotlink contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 589571238dae068479b1178c456b3df020d05033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->