### PR TITLE
Mirror Gravel Weekly corrections into learning loop

### DIFF
--- a/.github/workflows/weekly-broadcast.yml
+++ b/.github/workflows/weekly-broadcast.yml
@@ -79,6 +79,16 @@ jobs:
             "data/gravel-weekly/decisions/$ISSUE_DATE.json" \
             "data/gravel-weekly/issues/$ISSUE_DATE.json"
 
+      - name: Record immutable correction learning receipts
+        env:
+          ISSUE_DATE: ${{ inputs.issue_date }}
+          CONTROL_PLANE_INGEST_SECRET: ${{ secrets.CONTROL_PLANE_INGEST_SECRET }}
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: |
+          python scripts/record_gravel_weekly_learning.py \
+            "data/gravel-weekly/issues/$ISSUE_DATE.json" \
+            --source-commit "$SOURCE_COMMIT"
+
       - name: Generate publication and homepage
         run: |
           python wordpress/generate_gravel_weekly.py

--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -11,7 +11,13 @@ stores its exact quiet-issue approval in that receipt.
 The intelligence service may prepare candidates and reaction packets, but it
 does not write to `issues/`. An issue enters that directory only after Matti
 approves The Take. Published files are historical snapshots: corrections are appended
-to `corrections`; old copy is not silently rewritten.
+to `corrections`; old copy is not silently rewritten. Every correction is
+structured as both a reader-facing note and a learning receipt: it preserves
+the original and corrected claim, a bounded failure key, severity, evidence
+URLs, and the human recorder. The publish workflow mirrors that hash- and
+commit-bound event into the control plane. Replays are idempotent. Two matching
+failure keys can rank work for reproduction, but they cannot alter a model,
+threshold, issue, or race profile.
 
 Later issues can revisit an earlier story through `retrospectives`. Each entry
 must name the prior issue and story, classify the take as `aged_well`,

--- a/scripts/record_gravel_weekly_learning.py
+++ b/scripts/record_gravel_weekly_learning.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Mirror structured Gravel Weekly corrections into the learning loop."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from validate_gravel_weekly import PROJECT_ROOT, validate_issue
+
+DEFAULT_ENDPOINT = "https://race-intelligence-control-plane.vercel.app/api/editorial-learning-receipt"
+DEFAULT_REPOSITORY = "wattgod/gravel-race-automation"
+
+
+def _source_commit(value: str | None) -> str:
+    commit = value or os.environ.get("GITHUB_SHA")
+    if not commit:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=PROJECT_ROOT, text=True
+        ).strip()
+    commit = commit.lower()
+    if not re.fullmatch(r"[a-f0-9]{40,64}", commit):
+        raise ValueError("source commit must be a full hexadecimal Git commit")
+    return commit
+
+
+def _repository_relative(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(PROJECT_ROOT.resolve()).as_posix()
+    except ValueError as exc:
+        raise ValueError("issue path must be inside the source repository") from exc
+
+
+def build_correction_receipts(
+    issue: dict[str, Any],
+    *,
+    source_repository: str,
+    source_path: str,
+    source_commit: str,
+    source_content_hash: str,
+) -> list[dict[str, Any]]:
+    receipts: list[dict[str, Any]] = []
+    for correction in issue["corrections"]:
+        learning = correction["learning"]
+        receipts.append({
+            "schemaVersion": "editorial-learning-receipt/v1",
+            "kind": "correction",
+            "issueId": issue["issueId"],
+            "candidateId": correction["storyId"],
+            "sourceRepository": source_repository,
+            "sourcePath": source_path,
+            "sourceCommit": source_commit,
+            "sourceContentHash": source_content_hash,
+            "recordedBy": learning["recordedBy"],
+            "recordedAt": correction["publishedAt"],
+            "correction": {
+                "failureKey": learning["failureKey"],
+                "publishedAt": correction["publishedAt"],
+                "originalClaim": learning["originalClaim"],
+                "correctedClaim": learning["correctedClaim"],
+                "severity": learning["severity"],
+                "evidenceUrls": learning["evidenceUrls"],
+            },
+        })
+    return receipts
+
+
+def post_receipts(receipts: list[dict[str, Any]], endpoint: str, secret: str) -> list[dict[str, Any]]:
+    responses: list[dict[str, Any]] = []
+    for receipt in receipts:
+        request = urllib.request.Request(
+            endpoint,
+            data=json.dumps(receipt, ensure_ascii=False).encode("utf-8"),
+            headers={"Authorization": f"Bearer {secret}", "Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:1_000]
+            raise RuntimeError(f"control-plane learning receipt rejected with HTTP {exc.code}: {detail}") from exc
+        if not isinstance(payload, dict) or payload.get("accepted") is not True:
+            raise RuntimeError("control plane did not acknowledge the learning receipt")
+        responses.append(payload)
+    return responses
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("issue", type=Path)
+    parser.add_argument("--endpoint", default=os.environ.get("CONTROL_PLANE_EDITORIAL_LEARNING_URL", DEFAULT_ENDPOINT))
+    parser.add_argument("--source-repository", default=DEFAULT_REPOSITORY)
+    parser.add_argument("--source-commit")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    source_bytes = args.issue.read_bytes()
+    issue = validate_issue(json.loads(source_bytes.decode("utf-8")))
+    if issue["status"] != "published":
+        raise SystemExit("learning receipts require a published issue snapshot")
+    receipts = build_correction_receipts(
+        issue,
+        source_repository=args.source_repository,
+        source_path=_repository_relative(args.issue),
+        source_commit=_source_commit(args.source_commit),
+        source_content_hash=hashlib.sha256(source_bytes).hexdigest(),
+    )
+    if args.dry_run:
+        print(json.dumps(receipts, ensure_ascii=False, indent=2))
+        return 0
+    if not receipts:
+        print("Recorded 0 correction learning receipt(s)")
+        return 0
+    secret = os.environ.get("CONTROL_PLANE_INGEST_SECRET")
+    if not secret:
+        raise SystemExit("CONTROL_PLANE_INGEST_SECRET is required")
+    responses = post_receipts(receipts, args.endpoint, secret)
+    recorded = sum(response.get("recorded") is True for response in responses)
+    replayed = len(responses) - recorded
+    print(f"Recorded {recorded} correction learning receipt(s); {replayed} idempotent replay(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_gravel_weekly.py
+++ b/scripts/validate_gravel_weekly.py
@@ -47,6 +47,11 @@ QUIET_ISSUE_KEYS = {"headline", "note", "provenance"}
 EDITORIAL_APPROVAL_KEYS = {
     "approver", "approvedAt", "reviewedDraftContentHash",
 }
+CORRECTION_KEYS = {"publishedAt", "text", "storyId", "learning"}
+CORRECTION_LEARNING_KEYS = {
+    "failureKey", "originalClaim", "correctedClaim", "severity",
+    "evidenceUrls", "recordedBy",
+}
 
 
 class IssueValidationError(ValueError):
@@ -139,6 +144,48 @@ def _impact(value: Any, name: str) -> dict[str, Any]:
     _text(item.get("owner"), f"{name}.owner", 300)
     if item.get("autoFixAllowed") is not False:
         raise IssueValidationError(f"{name}.autoFixAllowed must be false")
+    return item
+
+
+def _correction(value: Any, name: str, story_ids: set[str]) -> dict[str, Any]:
+    item = _record(value, name)
+    unknown = set(item) - CORRECTION_KEYS
+    missing = CORRECTION_KEYS - set(item)
+    if unknown or missing:
+        raise IssueValidationError(
+            f"{name} fields are invalid; missing={sorted(missing)}, extra={sorted(unknown)}"
+        )
+    _iso(item.get("publishedAt"), f"{name}.publishedAt")
+    _text(item.get("text"), f"{name}.text", 2_000)
+    story_id = item.get("storyId")
+    if story_id is not None and story_id not in story_ids:
+        raise IssueValidationError(f"{name}.storyId must reference an issue story")
+    learning = _record(item.get("learning"), f"{name}.learning")
+    unknown = set(learning) - CORRECTION_LEARNING_KEYS
+    missing = CORRECTION_LEARNING_KEYS - set(learning)
+    if unknown or missing:
+        raise IssueValidationError(
+            f"{name}.learning fields are invalid; missing={sorted(missing)}, extra={sorted(unknown)}"
+        )
+    failure_key = _text(learning.get("failureKey"), f"{name}.learning.failureKey", 100)
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]{2,99}", failure_key):
+        raise IssueValidationError(f"{name}.learning.failureKey must be a lowercase slug")
+    original = _text(learning.get("originalClaim"), f"{name}.learning.originalClaim", 2_000)
+    corrected = _text(learning.get("correctedClaim"), f"{name}.learning.correctedClaim", 2_000)
+    if original == corrected:
+        raise IssueValidationError(f"{name}.learning must change the original claim")
+    if learning.get("severity") not in {"minor", "material"}:
+        raise IssueValidationError(f"{name}.learning.severity must be minor or material")
+    evidence_urls = _list(learning.get("evidenceUrls"), f"{name}.learning.evidenceUrls", 20)
+    if not evidence_urls:
+        raise IssueValidationError(f"{name}.learning.evidenceUrls must not be empty")
+    normalized_urls = [
+        _url(url, f"{name}.learning.evidenceUrls[{index}]")
+        for index, url in enumerate(evidence_urls)
+    ]
+    if len(normalized_urls) != len(set(normalized_urls)):
+        raise IssueValidationError(f"{name}.learning.evidenceUrls must be unique")
+    _text(learning.get("recordedBy"), f"{name}.learning.recordedBy", 300)
     return item
 
 
@@ -449,18 +496,23 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
         retrospective_refs.append((item["priorIssueId"], item["priorStoryId"]))
     if len(retrospective_refs) != len(set(retrospective_refs)):
         raise IssueValidationError("retrospectives must not revisit the same prior story twice")
+    correction_sources: set[str] = set()
+    correction_times: list[datetime] = []
     for index, correction_value in enumerate(_list(issue.get("corrections"), "corrections", 100)):
-        correction = _record(correction_value, f"corrections[{index}]")
-        _iso(correction.get("publishedAt"), f"corrections[{index}].publishedAt")
-        _text(correction.get("text"), f"corrections[{index}].text", 2_000)
-        if correction.get("storyId") is not None and correction.get("storyId") not in story_ids:
-            raise IssueValidationError(f"corrections[{index}].storyId must reference an issue story")
+        correction = _correction(correction_value, f"corrections[{index}]", set(story_ids))
+        correction_sources.update(correction["learning"]["evidenceUrls"])
+        correction_times.append(
+            datetime.fromisoformat(correction["publishedAt"].replace("Z", "+00:00")).astimezone(timezone.utc)
+        )
     source_index = [_url(item, f"sourceIndex[{index}]") for index, item in enumerate(_list(issue.get("sourceIndex"), "sourceIndex", 200))]
     if len(source_index) != len(set(source_index)):
         raise IssueValidationError("sourceIndex must not contain duplicates")
     missing_culture_sources = story_culture_urls - set(source_index)
     if missing_culture_sources:
         raise IssueValidationError(f"sourceIndex omits culture artifact URLs: {sorted(missing_culture_sources)}")
+    missing_correction_sources = correction_sources - set(source_index)
+    if missing_correction_sources:
+        raise IssueValidationError(f"sourceIndex omits correction evidence URLs: {sorted(missing_correction_sources)}")
 
     approval = issue.get("editorialApproval")
     if status != "draft" and not isinstance(approval, dict):
@@ -489,9 +541,19 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
             )
     if status == "published" and issue.get("publishedAt") is None:
         raise IssueValidationError("published issues require publishedAt")
+    issue_published_at = None
     if issue.get("publishedAt") is not None:
         _iso(issue["publishedAt"], "publishedAt")
-    _iso(issue.get("updatedAt"), "updatedAt")
+        issue_published_at = datetime.fromisoformat(
+            issue["publishedAt"].replace("Z", "+00:00")
+        ).astimezone(timezone.utc)
+    updated_at_raw = _iso(issue.get("updatedAt"), "updatedAt")
+    updated_at = datetime.fromisoformat(updated_at_raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+    for correction_time in correction_times:
+        if issue_published_at is None or correction_time < issue_published_at:
+            raise IssueValidationError("corrections cannot predate the issue publication")
+        if correction_time > updated_at:
+            raise IssueValidationError("updatedAt must include every published correction")
     content_hash = _text(issue.get("contentHash"), "contentHash", 64)
     expected = compute_content_hash(issue)
     if verify_hash and content_hash != expected:

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -67,6 +67,7 @@ from approve_gravel_weekly_issue import approve_issue, build_decision_receipt  #
 from seal_gravel_weekly_issue import main as seal_issue_main, seal_issue  # noqa: E402
 from render_gravel_weekly_race_impact_review import render_review  # noqa: E402
 from validate_gravel_weekly_decisions import validate_decision_receipt  # noqa: E402
+from record_gravel_weekly_learning import build_correction_receipts  # noqa: E402
 
 
 def sample_issue():
@@ -1053,6 +1054,63 @@ def test_issue_race_impacts_exactly_preserve_story_impacts_and_receipts():
     missing_receipt["raceImpacts"][0]["claimIds"] = ["claim_missing"]
     with pytest.raises(IssueValidationError, match="without story receipts"):
         validate_issue(missing_receipt, verify_hash=False)
+
+
+def test_structured_corrections_become_hash_bound_learning_receipts():
+    issue = sample_issue()
+    issue["corrections"] = [{
+        "publishedAt": "2026-08-29T12:00:00Z",
+        "text": "Correction: the wet-course route was 148 miles; 150 remains the canonical distance.",
+        "storyId": "story_1",
+        "learning": {
+            "failureKey": "official-distance-not-rechecked",
+            "originalClaim": "The canonical race distance changed to 148 miles.",
+            "correctedClaim": "The 2026 wet-course route was 148 miles; 150 remains the canonical distance.",
+            "severity": "material",
+            "evidenceUrls": ["https://www.cyclingnews.com/example/"],
+            "recordedBy": "Matti Rowe",
+        },
+    }]
+    issue["updatedAt"] = "2026-08-29T12:00:00Z"
+    issue["contentHash"] = compute_content_hash(issue)
+    validated = validate_issue(issue)
+    receipts = build_correction_receipts(
+        validated,
+        source_repository="wattgod/gravel-race-automation",
+        source_path="data/gravel-weekly/issues/2026-08-28.json",
+        source_commit="a" * 40,
+        source_content_hash="b" * 64,
+    )
+    assert receipts == [{
+        "schemaVersion": "editorial-learning-receipt/v1",
+        "kind": "correction",
+        "issueId": "gravel-weekly-001",
+        "candidateId": "story_1",
+        "sourceRepository": "wattgod/gravel-race-automation",
+        "sourcePath": "data/gravel-weekly/issues/2026-08-28.json",
+        "sourceCommit": "a" * 40,
+        "sourceContentHash": "b" * 64,
+        "recordedBy": "Matti Rowe",
+        "recordedAt": "2026-08-29T12:00:00Z",
+        "correction": {
+            "failureKey": "official-distance-not-rechecked",
+            "publishedAt": "2026-08-29T12:00:00Z",
+            "originalClaim": "The canonical race distance changed to 148 miles.",
+            "correctedClaim": "The 2026 wet-course route was 148 miles; 150 remains the canonical distance.",
+            "severity": "material",
+            "evidenceUrls": ["https://www.cyclingnews.com/example/"],
+        },
+    }]
+
+    malformed = copy.deepcopy(issue)
+    malformed["corrections"][0]["learning"]["correctedClaim"] = malformed["corrections"][0]["learning"]["originalClaim"]
+    with pytest.raises(IssueValidationError, match="must change"):
+        validate_issue(malformed, verify_hash=False)
+
+    missing_source = copy.deepcopy(issue)
+    missing_source["corrections"][0]["learning"]["evidenceUrls"] = ["https://example.com/new-correction-source"]
+    with pytest.raises(IssueValidationError, match="omits correction evidence"):
+        validate_issue(missing_source, verify_hash=False)
 
 
 def test_published_issue_renders_immutable_race_impact_review():


### PR DESCRIPTION
## What changed
- require structured, evidence-backed correction metadata in immutable Gravel Weekly issues
- bind correction chronology and evidence URLs into the canonical issue hash
- convert published corrections into idempotent control-plane learning receipts
- mirror receipts during the approval-gated publish workflow without adding publication or race-data authority

## Verification
- python3 -m pytest tests/test_gravel_weekly.py -q (109 passed)
- python3 -m pytest tests/ -q (7,392 passed, 331 skipped)
- python3 scripts/validate_gravel_weekly.py
- python3 scripts/preflight_quality.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the published-issue schema and adds a secret-authenticated control-plane ingest on the deploy path; failures block publish but do not change live editorial copy by themselves.
> 
> **Overview**
> Published Gravel Weekly **corrections** are no longer plain reader notes: each entry must carry a nested **`learning`** block (failure key, original vs corrected claim, severity, evidence URLs, recorder) that participates in the issue **content hash**, must appear in **`sourceIndex`**, and must sit between **`publishedAt`** and **`updatedAt`**.
> 
> A new **`record_gravel_weekly_learning.py`** step validates the sealed issue, builds **`editorial-learning-receipt/v1`** payloads bound to repo path, commit, and file SHA-256, and POSTs them to the race-intelligence control plane (idempotent replays). The manual **Gravel Weekly Publish** workflow runs this after editorial decision ingest and before site generation. Docs and tests cover the contract and receipt shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf7fc7dbc8840d725f20da5f3525e3312e29e4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->