### PR TITLE
Record Gravel Weekly outcome receipts

### DIFF
--- a/.github/workflows/gravel-weekly-learning.yml
+++ b/.github/workflows/gravel-weekly-learning.yml
@@ -1,0 +1,57 @@
+name: "Gravel Weekly Learning Receipt"
+
+on:
+  workflow_dispatch:
+    inputs:
+      learning_path:
+        description: "Committed learning source under data/gravel-weekly/learning/"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gravel-weekly-learning
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install -r requirements.txt
+
+      - name: Resolve and validate the committed learning source
+        env:
+          LEARNING_PATH: ${{ inputs.learning_path }}
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          root = Path("data/gravel-weekly/learning").resolve()
+          target = Path(os.environ["LEARNING_PATH"]).resolve()
+          try:
+              target.relative_to(root)
+          except ValueError as exc:
+              raise SystemExit("learning_path must stay under data/gravel-weekly/learning/") from exc
+          if target.suffix != ".json" or not target.is_file():
+              raise SystemExit("learning_path must name one committed JSON file")
+          PY
+          python scripts/validate_gravel_weekly_learning.py
+          python -m pytest tests/test_gravel_weekly.py -q
+
+      - name: Mirror the immutable learning receipt
+        env:
+          LEARNING_PATH: ${{ inputs.learning_path }}
+          CONTROL_PLANE_INGEST_SECRET: ${{ secrets.CONTROL_PLANE_INGEST_SECRET }}
+        run: |
+          python scripts/record_gravel_weekly_learning.py \
+            --learning-source "$LEARNING_PATH" \
+            --source-commit "${{ github.sha }}"

--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -111,6 +111,20 @@ must resolve to a receipt on that story. The publish workflow uploads the
 immutable artifact and opens one idempotent GitHub review issue when actionable
 impacts exist. It never edits a race profile.
 
+After an impact is handled through the owning repository's normal tested pull
+request—or explicitly rejected—commit one
+`gravel-weekly-learning-source/v1` record under `learning/`. The record binds
+the exact issue content hash and impact hash. Accepted outcomes also require
+the merged implementation URL and regression-test selector. Dispatch the
+manual `Gravel Weekly Learning Receipt` workflow with that path; it mirrors an
+idempotent result into usefulness metrics without changing any race data.
+
+A materially important story discovered after its useful issue window uses the
+same source schema with `kind=missed_story`. This is a human-confirmed failure,
+not a model complaint or an engagement signal. It preserves publication,
+discovery, and recording time so the collector can improve against an actual
+miss instead of rewriting history.
+
 Render a local draft for review without making it public:
 
 ```bash

--- a/data/gravel-weekly/learning/README.md
+++ b/data/gravel-weekly/learning/README.md
@@ -1,0 +1,34 @@
+# Gravel Weekly learning sources
+
+This directory stores human-authored, review-only outcomes that cannot be
+inferred from publication or engagement:
+
+- `race_impact_decision` binds one exact impact from a published issue to the
+  owning-repository result. An accepted decision requires a merged
+  implementation URL and the exact regression-test selector. Rejected and
+  superseded decisions preserve the reason and cannot pretend work shipped.
+- `missed_story` records a story a human confirms was materially important and
+  discovered late. Publication and discovery timestamps remain distinct; a
+  model cannot declare its own omission important.
+
+Every JSON file uses `gravel-weekly-learning-source/v1`, is validated against
+its linked immutable issue when one exists, and is mirrored only by the manual
+`Gravel Weekly Learning Receipt` workflow. The workflow binds the source file
+to its Git commit and SHA-256 hash, then submits it to the protected control
+plane. It cannot publish copy, change a race, alter a threshold, or spend model
+budget.
+
+Validate locally:
+
+```bash
+python3 scripts/validate_gravel_weekly_learning.py \
+  data/gravel-weekly/learning/example.json
+```
+
+Preview the exact control-plane payload without sending it:
+
+```bash
+python3 scripts/record_gravel_weekly_learning.py \
+  --learning-source data/gravel-weekly/learning/example.json \
+  --dry-run
+```

--- a/scripts/gravel_weekly_race_impacts.py
+++ b/scripts/gravel_weekly_race_impacts.py
@@ -1,0 +1,19 @@
+"""Stable identities for Gravel Weekly race-impact review records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def canonical_impact_json(impact: dict[str, Any]) -> str:
+    return json.dumps(impact, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def race_impact_hash(impact: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_impact_json(impact).encode("utf-8")).hexdigest()
+
+
+def race_impact_id(impact: dict[str, Any]) -> str:
+    return race_impact_hash(impact)[:12]

--- a/scripts/record_gravel_weekly_learning.py
+++ b/scripts/record_gravel_weekly_learning.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Mirror structured Gravel Weekly corrections into the learning loop."""
+"""Mirror validated Gravel Weekly learning records into the control plane."""
 
 from __future__ import annotations
 
@@ -15,6 +15,11 @@ from pathlib import Path
 from typing import Any
 
 from validate_gravel_weekly import PROJECT_ROOT, validate_issue
+from validate_gravel_weekly_learning import (
+    impact_with_evidence,
+    load_linked_issue,
+    validate_learning_source,
+)
 
 DEFAULT_ENDPOINT = "https://race-intelligence-control-plane.vercel.app/api/editorial-learning-receipt"
 DEFAULT_REPOSITORY = "wattgod/gravel-race-automation"
@@ -74,6 +79,52 @@ def build_correction_receipts(
     return receipts
 
 
+def build_source_receipt(
+    source: dict[str, Any],
+    *,
+    issue: dict[str, Any] | None,
+    source_repository: str,
+    source_path: str,
+    source_commit: str,
+    source_content_hash: str,
+) -> dict[str, Any]:
+    common = {
+        "schemaVersion": "editorial-learning-receipt/v1",
+        "kind": source["kind"],
+        "issueId": issue["issueId"] if issue else None,
+        "candidateId": source["candidateId"],
+        "sourceRepository": source_repository,
+        "sourcePath": source_path,
+        "sourceCommit": source_commit,
+        "sourceContentHash": source_content_hash,
+        "recordedBy": source["recordedBy"],
+        "recordedAt": source["recordedAt"],
+    }
+    if source["kind"] == "missed_story":
+        return {**common, "missedStory": source["missedStory"]}
+
+    decision = source["raceImpactDecision"]
+    if issue is None:
+        raise ValueError("race-impact decisions require a linked issue")
+    impact, evidence_urls = impact_with_evidence(issue, decision["impactId"])
+    if decision["implementationUrl"] is not None:
+        evidence_urls = list(dict.fromkeys([*evidence_urls, decision["implementationUrl"]]))
+    vertical, race_slug = impact["raceId"].split(":", 1)
+    return {
+        **common,
+        "raceImpactDecision": {
+            "impactId": decision["impactId"],
+            "vertical": vertical,
+            "raceSlug": race_slug,
+            "fieldPath": impact["fieldPath"] or "catalog",
+            "outcome": decision["outcome"],
+            "reason": decision["reason"],
+            "decidedAt": decision["decidedAt"],
+            "evidenceUrls": evidence_urls,
+        },
+    }
+
+
 def post_receipts(receipts: list[dict[str, Any]], endpoint: str, secret: str) -> list[dict[str, Any]]:
     responses: list[dict[str, Any]] = []
     for receipt in receipts:
@@ -97,29 +148,49 @@ def post_receipts(receipts: list[dict[str, Any]], endpoint: str, secret: str) ->
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("issue", type=Path)
+    parser.add_argument("issue", nargs="?", type=Path)
+    parser.add_argument("--learning-source", action="append", default=[], type=Path)
     parser.add_argument("--endpoint", default=os.environ.get("CONTROL_PLANE_EDITORIAL_LEARNING_URL", DEFAULT_ENDPOINT))
     parser.add_argument("--source-repository", default=DEFAULT_REPOSITORY)
     parser.add_argument("--source-commit")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
 
-    source_bytes = args.issue.read_bytes()
-    issue = validate_issue(json.loads(source_bytes.decode("utf-8")))
-    if issue["status"] != "published":
-        raise SystemExit("learning receipts require a published issue snapshot")
-    receipts = build_correction_receipts(
-        issue,
-        source_repository=args.source_repository,
-        source_path=_repository_relative(args.issue),
-        source_commit=_source_commit(args.source_commit),
-        source_content_hash=hashlib.sha256(source_bytes).hexdigest(),
-    )
+    if args.issue is None and not args.learning_source:
+        parser.error("provide an issue or at least one --learning-source")
+    commit = _source_commit(args.source_commit)
+    receipts: list[dict[str, Any]] = []
+    if args.issue is not None:
+        source_bytes = args.issue.read_bytes()
+        issue = validate_issue(json.loads(source_bytes.decode("utf-8")))
+        if issue["status"] != "published":
+            raise SystemExit("learning receipts require a published issue snapshot")
+        receipts.extend(build_correction_receipts(
+            issue,
+            source_repository=args.source_repository,
+            source_path=_repository_relative(args.issue),
+            source_commit=commit,
+            source_content_hash=hashlib.sha256(source_bytes).hexdigest(),
+        ))
+    for learning_path in args.learning_source:
+        learning_bytes = learning_path.read_bytes()
+        source = json.loads(learning_bytes.decode("utf-8"))
+        issue_value = load_linked_issue(source)
+        validated = validate_learning_source(source, issue_value)
+        linked_issue = validate_issue(issue_value) if issue_value is not None else None
+        receipts.append(build_source_receipt(
+            validated,
+            issue=linked_issue,
+            source_repository=args.source_repository,
+            source_path=_repository_relative(learning_path),
+            source_commit=commit,
+            source_content_hash=hashlib.sha256(learning_bytes).hexdigest(),
+        ))
     if args.dry_run:
         print(json.dumps(receipts, ensure_ascii=False, indent=2))
         return 0
     if not receipts:
-        print("Recorded 0 correction learning receipt(s)")
+        print("Recorded 0 Gravel Weekly learning receipt(s)")
         return 0
     secret = os.environ.get("CONTROL_PLANE_INGEST_SECRET")
     if not secret:
@@ -127,7 +198,7 @@ def main() -> int:
     responses = post_receipts(receipts, args.endpoint, secret)
     recorded = sum(response.get("recorded") is True for response in responses)
     replayed = len(responses) - recorded
-    print(f"Recorded {recorded} correction learning receipt(s); {replayed} idempotent replay(s)")
+    print(f"Recorded {recorded} Gravel Weekly learning receipt(s); {replayed} idempotent replay(s)")
     return 0
 
 

--- a/scripts/render_gravel_weekly_race_impact_review.py
+++ b/scripts/render_gravel_weekly_race_impact_review.py
@@ -4,12 +4,12 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 from pathlib import Path
 from typing import Any
 
 from validate_gravel_weekly import validate_issue
+from gravel_weekly_race_impacts import race_impact_id
 
 
 def _inline_json(value: Any) -> str:
@@ -43,8 +43,7 @@ def render_review(issue_value: Any) -> tuple[str, int]:
         return "\n".join(lines), 0
 
     for impact in actionable:
-        encoded = json.dumps(impact, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
-        impact_id = hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:12]
+        impact_id = race_impact_id(impact)
         lines.extend([
             f"## {impact['impactKind'].upper()} · {impact['raceId']} · `{impact['fieldPath'] or 'catalog'}`",
             "",

--- a/scripts/validate_gravel_weekly_learning.py
+++ b/scripts/validate_gravel_weekly_learning.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Validate human-authored Gravel Weekly learning source records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from gravel_weekly_race_impacts import race_impact_hash, race_impact_id
+from validate_gravel_weekly import ISSUE_DIR, IssueValidationError, _record, _text, _url, validate_issue
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+LEARNING_DIR = PROJECT_ROOT / "data" / "gravel-weekly" / "learning"
+SCHEMA_VERSION = "gravel-weekly-learning-source/v1"
+OUTER_KEYS = {
+    "schemaVersion", "kind", "issueDate", "issueContentHash", "candidateId",
+    "recordedBy", "recordedAt", "raceImpactDecision", "missedStory",
+}
+RACE_DECISION_KEYS = {
+    "impactId", "reviewedImpactHash", "outcome", "reason", "decidedAt",
+    "implementationUrl", "regressionTest",
+}
+MISSED_STORY_KEYS = {
+    "failureKey", "headline", "whyImportant", "sourceUrl", "publishedAt",
+    "discoveredAt",
+}
+
+
+def _exact_keys(value: dict[str, Any], expected: set[str], name: str) -> None:
+    unknown = set(value) - expected
+    missing = expected - set(value)
+    if unknown or missing:
+        raise IssueValidationError(
+            f"{name} fields are invalid; missing={sorted(missing)}, extra={sorted(unknown)}"
+        )
+
+
+def _timestamp(value: Any, name: str) -> str:
+    raw = _text(value, name, 100)
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise IssueValidationError(f"{name} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        raise IssueValidationError(f"{name} must include a timezone")
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _nullable_text(value: Any, name: str, maximum: int) -> str | None:
+    return None if value is None else _text(value, name, maximum)
+
+
+def _linked_issue(source: dict[str, Any], issue_value: Any | None) -> dict[str, Any] | None:
+    issue_date = source.get("issueDate")
+    issue_hash = source.get("issueContentHash")
+    if (issue_date is None) != (issue_hash is None):
+        raise IssueValidationError("issueDate and issueContentHash must be paired")
+    if issue_date is None:
+        if issue_value is not None:
+            raise IssueValidationError("an unlinked learning source cannot receive an issue")
+        return None
+    if not isinstance(issue_date, str) or not re.fullmatch(r"\d{4}-\d{2}-\d{2}", issue_date):
+        raise IssueValidationError("issueDate must be YYYY-MM-DD")
+    issue = validate_issue(issue_value)
+    if issue["status"] != "published":
+        raise IssueValidationError("learning sources may link only to a published issue")
+    if issue["publicationDate"] != issue_date:
+        raise IssueValidationError("issueDate does not match the linked issue")
+    if issue["contentHash"] != issue_hash:
+        raise IssueValidationError("issueContentHash does not match the linked issue")
+    return issue
+
+
+def impact_with_evidence(issue: dict[str, Any], impact_id_value: str) -> tuple[dict[str, Any], list[str]]:
+    matches = [impact for impact in issue["raceImpacts"] if race_impact_id(impact) == impact_id_value]
+    if len(matches) != 1:
+        raise IssueValidationError("raceImpactDecision.impactId must identify exactly one issue impact")
+    impact = matches[0]
+    if impact["impactKind"] == "no_change":
+        raise IssueValidationError("no_change context cannot receive a race-impact disposition")
+    receipts = {
+        receipt["claimId"]: receipt["canonicalUrl"]
+        for story in issue["stories"] for receipt in story["receipts"]
+    }
+    return impact, list(dict.fromkeys(receipts[claim_id] for claim_id in impact["claimIds"]))
+
+
+def validate_learning_source(value: Any, issue_value: Any | None = None) -> dict[str, Any]:
+    source = _record(value, "learning source")
+    _exact_keys(source, OUTER_KEYS, "learning source")
+    if source.get("schemaVersion") != SCHEMA_VERSION:
+        raise IssueValidationError("unsupported Gravel Weekly learning source schema")
+    kind = source.get("kind")
+    if kind not in {"race_impact_decision", "missed_story"}:
+        raise IssueValidationError("learning source kind is invalid")
+    issue = _linked_issue(source, issue_value)
+    candidate_id = _nullable_text(source.get("candidateId"), "candidateId", 500)
+    _text(source.get("recordedBy"), "recordedBy", 300)
+    recorded_at = _timestamp(source.get("recordedAt"), "recordedAt")
+
+    if kind == "race_impact_decision":
+        if issue is None or candidate_id is None:
+            raise IssueValidationError("race-impact decisions require a linked issue and candidateId")
+        if source.get("missedStory") is not None:
+            raise IssueValidationError("race-impact decisions cannot carry missedStory")
+        decision = _record(source.get("raceImpactDecision"), "raceImpactDecision")
+        _exact_keys(decision, RACE_DECISION_KEYS, "raceImpactDecision")
+        impact_id_value = _text(decision.get("impactId"), "raceImpactDecision.impactId", 12)
+        if not re.fullmatch(r"[a-f0-9]{12}", impact_id_value):
+            raise IssueValidationError("raceImpactDecision.impactId must be 12 lowercase hexadecimal characters")
+        impact, _ = impact_with_evidence(issue, impact_id_value)
+        full_hash = _text(decision.get("reviewedImpactHash"), "raceImpactDecision.reviewedImpactHash", 64)
+        if full_hash != race_impact_hash(impact):
+            raise IssueValidationError("raceImpactDecision.reviewedImpactHash does not match the issue impact")
+        story = next((item for item in issue["stories"] if item["candidateId"] == candidate_id), None)
+        if story is None or not any(race_impact_id(item) == impact_id_value for item in story["raceImpacts"]):
+            raise IssueValidationError("candidateId does not own the reviewed impact")
+        outcome = decision.get("outcome")
+        if outcome not in {"accepted", "rejected", "superseded"}:
+            raise IssueValidationError("raceImpactDecision.outcome is invalid")
+        _text(decision.get("reason"), "raceImpactDecision.reason", 2_000)
+        if _timestamp(decision.get("decidedAt"), "raceImpactDecision.decidedAt") != recorded_at:
+            raise IssueValidationError("raceImpactDecision.decidedAt must equal recordedAt")
+        implementation_url = decision.get("implementationUrl")
+        regression_test = decision.get("regressionTest")
+        if outcome == "accepted":
+            _url(implementation_url, "raceImpactDecision.implementationUrl")
+            _text(regression_test, "raceImpactDecision.regressionTest", 500)
+        elif implementation_url is not None or regression_test is not None:
+            raise IssueValidationError("only accepted race impacts may carry implementation proof")
+    else:
+        if source.get("raceImpactDecision") is not None:
+            raise IssueValidationError("missed stories cannot carry raceImpactDecision")
+        if issue is not None and candidate_id is not None and not any(
+            story["candidateId"] == candidate_id for story in issue["stories"]
+        ):
+            raise IssueValidationError("candidateId does not resolve in the linked issue")
+        missed = _record(source.get("missedStory"), "missedStory")
+        _exact_keys(missed, MISSED_STORY_KEYS, "missedStory")
+        failure_key = _text(missed.get("failureKey"), "missedStory.failureKey", 100)
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]{2,99}", failure_key):
+            raise IssueValidationError("missedStory.failureKey must be a lowercase slug")
+        _text(missed.get("headline"), "missedStory.headline", 500)
+        _text(missed.get("whyImportant"), "missedStory.whyImportant", 2_000)
+        _url(missed.get("sourceUrl"), "missedStory.sourceUrl")
+        published_at = _timestamp(missed.get("publishedAt"), "missedStory.publishedAt")
+        discovered_at = _timestamp(missed.get("discoveredAt"), "missedStory.discoveredAt")
+        if datetime.fromisoformat(discovered_at.replace("Z", "+00:00")) <= datetime.fromisoformat(published_at.replace("Z", "+00:00")):
+            raise IssueValidationError("missedStory.discoveredAt must be after publishedAt")
+        if datetime.fromisoformat(recorded_at.replace("Z", "+00:00")) < datetime.fromisoformat(discovered_at.replace("Z", "+00:00")):
+            raise IssueValidationError("recordedAt cannot predate missedStory.discoveredAt")
+    return source
+
+
+def load_linked_issue(source: dict[str, Any]) -> dict[str, Any] | None:
+    issue_date = source.get("issueDate")
+    if issue_date is None:
+        return None
+    path = ISSUE_DIR / f"{issue_date}.json"
+    if not path.exists():
+        raise IssueValidationError(f"linked issue not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_learning_sources(learning_dir: Path = LEARNING_DIR) -> list[dict[str, Any]]:
+    sources: list[dict[str, Any]] = []
+    identities: set[tuple[str, ...]] = set()
+    for path in sorted(learning_dir.glob("*.json")):
+        try:
+            source = json.loads(path.read_text(encoding="utf-8"))
+            validated = validate_learning_source(source, load_linked_issue(source))
+        except (json.JSONDecodeError, IssueValidationError) as exc:
+            raise IssueValidationError(f"{path}: {exc}") from exc
+        if validated["kind"] == "race_impact_decision":
+            identity = (
+                "race_impact_decision", validated["issueDate"],
+                validated["raceImpactDecision"]["impactId"],
+            )
+        else:
+            identity = (
+                "missed_story", validated["missedStory"]["failureKey"],
+                validated["missedStory"]["sourceUrl"],
+                validated["missedStory"]["publishedAt"],
+            )
+        if identity in identities:
+            raise IssueValidationError(f"duplicate Gravel Weekly learning source identity: {identity}")
+        identities.add(identity)
+        sources.append(validated)
+    return sources
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*", type=Path)
+    args = parser.parse_args()
+    if not args.paths:
+        sources = load_learning_sources()
+        print(f"Validated {len(sources)} Gravel Weekly learning source(s)")
+        return 0
+    paths = args.paths
+    for path in paths:
+        source = json.loads(path.read_text(encoding="utf-8"))
+        validate_learning_source(source, load_linked_issue(source))
+        print(f"OK {path}")
+    print(f"Validated {len(paths)} Gravel Weekly learning source(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -68,6 +68,9 @@ from seal_gravel_weekly_issue import main as seal_issue_main, seal_issue  # noqa
 from render_gravel_weekly_race_impact_review import render_review  # noqa: E402
 from validate_gravel_weekly_decisions import validate_decision_receipt  # noqa: E402
 from record_gravel_weekly_learning import build_correction_receipts  # noqa: E402
+from record_gravel_weekly_learning import build_source_receipt  # noqa: E402
+from gravel_weekly_race_impacts import race_impact_hash, race_impact_id  # noqa: E402
+from validate_gravel_weekly_learning import load_learning_sources, validate_learning_source  # noqa: E402
 
 
 def sample_issue():
@@ -1111,6 +1114,110 @@ def test_structured_corrections_become_hash_bound_learning_receipts():
     missing_source["corrections"][0]["learning"]["evidenceUrls"] = ["https://example.com/new-correction-source"]
     with pytest.raises(IssueValidationError, match="omits correction evidence"):
         validate_issue(missing_source, verify_hash=False)
+
+
+def test_race_impact_outcomes_require_exact_issue_and_implementation_proof():
+    issue = sample_issue()
+    impact = issue["raceImpacts"][0]
+    source = {
+        "schemaVersion": "gravel-weekly-learning-source/v1",
+        "kind": "race_impact_decision",
+        "issueDate": issue["publicationDate"],
+        "issueContentHash": issue["contentHash"],
+        "candidateId": "story_1",
+        "recordedBy": "Matti Rowe",
+        "recordedAt": "2026-08-30T12:00:00Z",
+        "raceImpactDecision": {
+            "impactId": race_impact_id(impact),
+            "reviewedImpactHash": race_impact_hash(impact),
+            "outcome": "accepted",
+            "reason": "The current profile was stale; the owning repository merged the evidence-backed correction.",
+            "decidedAt": "2026-08-30T12:00:00Z",
+            "implementationUrl": "https://github.com/wattgod/gravel-race-automation/pull/999",
+            "regressionTest": "tests/test_gravel_weekly.py::test_race_impact_outcomes_require_exact_issue_and_implementation_proof",
+        },
+        "missedStory": None,
+    }
+    assert validate_learning_source(source, issue) == source
+    receipt = build_source_receipt(
+        source,
+        issue=issue,
+        source_repository="wattgod/gravel-race-automation",
+        source_path="data/gravel-weekly/learning/impact.json",
+        source_commit="a" * 40,
+        source_content_hash="b" * 64,
+    )
+    assert receipt["kind"] == "race_impact_decision"
+    assert receipt["raceImpactDecision"] == {
+        "impactId": race_impact_id(impact),
+        "vertical": "gravel",
+        "raceSlug": "unbound-gravel",
+        "fieldPath": "race.vitals.distance",
+        "outcome": "accepted",
+        "reason": source["raceImpactDecision"]["reason"],
+        "decidedAt": "2026-08-30T12:00:00Z",
+        "evidenceUrls": [
+            "https://www.cyclingnews.com/example/",
+            "https://github.com/wattgod/gravel-race-automation/pull/999",
+        ],
+    }
+
+    stale = copy.deepcopy(source)
+    stale["issueContentHash"] = "0" * 64
+    with pytest.raises(IssueValidationError, match="issueContentHash"):
+        validate_learning_source(stale, issue)
+
+    unimplemented = copy.deepcopy(source)
+    unimplemented["raceImpactDecision"]["implementationUrl"] = None
+    with pytest.raises(IssueValidationError, match="implementationUrl"):
+        validate_learning_source(unimplemented, issue)
+
+    fake_rejection = copy.deepcopy(source)
+    fake_rejection["raceImpactDecision"]["outcome"] = "rejected"
+    with pytest.raises(IssueValidationError, match="implementation proof"):
+        validate_learning_source(fake_rejection, issue)
+
+
+def test_only_a_human_authored_late_discovery_can_become_a_missed_story_receipt():
+    source = {
+        "schemaVersion": "gravel-weekly-learning-source/v1",
+        "kind": "missed_story",
+        "issueDate": None,
+        "issueContentHash": None,
+        "candidateId": None,
+        "recordedBy": "Matti Rowe",
+        "recordedAt": "2026-09-05T18:00:00Z",
+        "raceImpactDecision": None,
+        "missedStory": {
+            "failureKey": "results-feed-late-discovery",
+            "headline": "A wildcard rider won the whole series.",
+            "whyImportant": "The result changed the judgment on whether the admissions process selected the strongest field.",
+            "sourceUrl": "https://example.com/official-results",
+            "publishedAt": "2026-09-04T15:00:00Z",
+            "discoveredAt": "2026-09-05T17:00:00Z",
+        },
+    }
+    assert validate_learning_source(source) == source
+    receipt = build_source_receipt(
+        source,
+        issue=None,
+        source_repository="wattgod/gravel-race-automation",
+        source_path="data/gravel-weekly/learning/missed.json",
+        source_commit="a" * 40,
+        source_content_hash="b" * 64,
+    )
+    assert receipt["kind"] == "missed_story"
+    assert receipt["issueId"] is None
+    assert receipt["missedStory"] == source["missedStory"]
+
+    not_late = copy.deepcopy(source)
+    not_late["missedStory"]["discoveredAt"] = not_late["missedStory"]["publishedAt"]
+    with pytest.raises(IssueValidationError, match="must be after"):
+        validate_learning_source(not_late)
+
+
+def test_every_committed_gravel_weekly_learning_source_is_valid_and_unique():
+    assert isinstance(load_learning_sources(), list)
 
 
 def test_published_issue_renders_immutable_race_impact_review():


### PR DESCRIPTION
## What changed
- add fail-closed human-authored source records for race-impact outcomes and important missed stories
- bind race decisions to the exact published issue and full impact hash
- require merged implementation URL plus regression selector before an impact can count as accepted
- add a manual, read-only-to-repositories workflow that mirrors one immutable receipt into the protected control plane
- share stable impact IDs between the review desk and decision validator

## Verification
- python3 -m pytest tests/test_gravel_weekly.py -q (112 passed)
- python3 -m pytest tests/ -q (7,395 passed, 331 skipped)
- python3 scripts/validate_gravel_weekly_learning.py
- Python YAML parse for every workflow
- python3 scripts/preflight_quality.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Posts authenticated payloads to the external control-plane ingest endpoint and defines strict contracts for editorial outcomes, but workflows are manual, repo permissions are read-only, and nothing in this PR auto-edits race profiles or publishes issues.
> 
> **Overview**
> Adds a **fail-closed learning loop** after race-impact review: humans commit `gravel-weekly-learning-source/v1` JSON under `data/gravel-weekly/learning/` for **`race_impact_decision`** (binds a published issue + exact impact hash; **accepted** requires merged PR URL and regression test selector) or **`missed_story`** (late human-confirmed omissions with distinct publish/discover times).
> 
> **`validate_gravel_weekly_learning.py`** enforces schema, issue hash pairing, impact ownership, duplicate identities, and outcome rules. **`record_gravel_weekly_learning.py`** gains `--learning-source` and **`build_source_receipt`** alongside existing issue correction receipts. **`gravel_weekly_race_impacts.py`** centralizes impact hashing so the review desk and validator share the same 12-char impact IDs.
> 
> A new manual workflow **Gravel Weekly Learning Receipt** validates the path stays under `learning/`, runs validation + tests, then posts an idempotent receipt to the control plane (commit + content hash bound). Docs describe the operator flow; tests cover validation, receipt shape, and committed source uniqueness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eba474c2ddf679c728c39f1e1e452bde1d76427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->