### PR TITLE
Preserve race-impact implementation proof

### DIFF
--- a/scripts/record_gravel_weekly_learning.py
+++ b/scripts/record_gravel_weekly_learning.py
@@ -121,6 +121,8 @@ def build_source_receipt(
             "reason": decision["reason"],
             "decidedAt": decision["decidedAt"],
             "evidenceUrls": evidence_urls,
+            "implementationUrl": decision["implementationUrl"],
+            "regressionTest": decision["regressionTest"],
         },
     }
 

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -1160,6 +1160,8 @@ def test_race_impact_outcomes_require_exact_issue_and_implementation_proof():
             "https://www.cyclingnews.com/example/",
             "https://github.com/wattgod/gravel-race-automation/pull/999",
         ],
+        "implementationUrl": "https://github.com/wattgod/gravel-race-automation/pull/999",
+        "regressionTest": "tests/test_gravel_weekly.py::test_race_impact_outcomes_require_exact_issue_and_implementation_proof",
     }
 
     stale = copy.deepcopy(source)


### PR DESCRIPTION
## What changed
- carry the merged implementation URL and exact regression selector from the human source record into the protected control-plane receipt
- assert the complete outbound payload in the Gravel Weekly contract test

## Verification
- python3 -m pytest tests/test_gravel_weekly.py -q (112 passed)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small schema extension on editorial learning receipts and test expectations; no auth or deploy-path changes.
> 
> **Overview**
> Race-impact **accepted** learning receipts sent to the control plane now include **`implementationUrl`** and **`regressionTest`** from the validated human learning source, alongside existing decision metadata and evidence URLs.
> 
> The Gravel Weekly contract test asserts the full `raceImpactDecision` payload from `build_source_receipt`, including those proof fields, so outbound receipts stay aligned with source validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fac5e2418e896d8453ac7b03d3376a8fb1809ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->