### PR TITLE
Clarify Gravel Weekly history publication state

### DIFF
--- a/scripts/render_gravel_weekly_history_review.py
+++ b/scripts/render_gravel_weekly_history_review.py
@@ -229,6 +229,8 @@ def render_history_review(entries: list[dict[str, Any]], year: int) -> str:
         entry for entry in entries
         if entry["activeFrom"] <= f"{year}-12-31" and entry["activeThrough"] >= f"{year}-01-01"
     ]
+    approved = sum(entry["status"] == "approved" for entry in selected)
+    published = sum(entry["status"] == "published" for entry in selected)
     drafts = sorted(
         (entry for entry in selected if entry["status"] == "draft"),
         key=review_priority,
@@ -313,7 +315,8 @@ code {{ overflow-wrap: anywhere; }} footer {{ background: var(--gg-color-near-bl
   <a class="desk-back" href="index.html">← ALL YEARS</a>
   <header class="desk-head"><div class="eyebrow">PRIVATE EDITORIAL DESK · NOT PUBLIC</div><h1>{year}<br>THE SEASON<br>AS A STORY</h1>
   <p>This queue contains narrative change-points, not one required story per week. Review the point first, then the Take. Receipts from the active period are separated from evidence learned later.</p>
-  <div class="summary"><b>{len(drafts)} DRAFTS</b><b>{ready} READY FOR HUMAN DECISION</b><b>{held} HELD BY EVIDENCE, EDITORIAL, OR PROSE GATES</b></div>
+  <p><b>PUBLICATION BOUNDARY:</b> A complete source review does not make a historical entry public. Only sealed entries count as published; this desk cannot approve or seal anything.</p>
+  <div class="summary"><b>{len(drafts)} DRAFTS</b><b>{ready} READY FOR HUMAN DECISION</b><b>{held} HELD BY EVIDENCE, EDITORIAL, OR PROSE GATES</b><b>{approved} APPROVED BUT UNSEALED</b><b>{published} PUBLISHED</b></div>
   {bulk_instruction}
   <nav class="decision-queue" aria-label="Historical story decision queue"><h2>DECISION QUEUE</h2><ol>{queue}</ol></nav></header>
   {cards or '<section class="story"><header><h2>No draft historical entries for this year.</h2></header></section>'}
@@ -325,6 +328,7 @@ def render_history_review_index(entries: list[dict[str, Any]]) -> str:
     rows = []
     total_ready = 0
     total_held = 0
+    total_published = sum(entry["status"] == "published" for entry in entries)
     years = review_years(entries)
     for year in years:
         drafts = sorted(
@@ -338,6 +342,12 @@ def render_history_review_index(entries: list[dict[str, Any]]) -> str:
         )
         ready = [entry for entry in drafts if not approval_holds(entry)]
         held = [entry for entry in drafts if approval_holds(entry)]
+        published = sum(
+            entry["status"] == "published"
+            for entry in entries
+            if entry["activeFrom"] <= f"{year}-12-31"
+            and entry["activeThrough"] >= f"{year}-01-01"
+        )
         total_ready += len(ready)
         total_held += len(held)
         highlights = "".join(
@@ -350,7 +360,7 @@ def render_history_review_index(entries: list[dict[str, Any]]) -> str:
         rows.append(f'''<article class="year-card">
           <a href="{year}.html" aria-label="Review Gravel Weekly historical drafts for {year}">
             <header><span>REVIEW YEAR</span><h2>{year}</h2></header>
-            <div class="counts"><b>{len(ready)} READY</b><b>{len(held)} HOLD</b></div>
+            <div class="counts"><b>{len(ready)} READY</b><b>{len(held)} HOLD</b><b>{published} PUBLIC</b></div>
             <ol>{highlights}</ol>
             <footer>OPEN {year} DESK →</footer>
           </a>
@@ -376,9 +386,10 @@ main {{ width: min(1120px, calc(100% - 32px)); margin: 32px auto 80px; }}
 .year-card header {{ padding: var(--gg-spacing-md); border-bottom: var(--gg-border-standard); }}
 .year-card header span {{ font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-bold); letter-spacing: var(--gg-letter-spacing-wide); }}
 .year-card h2 {{ margin: 0; font-size: clamp(3.2rem, 8vw, 5rem); line-height: .9; }}
-.counts {{ display: grid; grid-template-columns: 1fr 1fr; border-bottom: var(--gg-border-standard); }}
+.counts {{ display: grid; grid-template-columns: repeat(3, 1fr); border-bottom: var(--gg-border-standard); }}
 .counts b {{ padding: var(--gg-spacing-xs); text-align: center; }}
 .counts b + b {{ border-left: var(--gg-border-standard); background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }}
+.counts b:last-child {{ background: var(--gg-color-teal); }}
 .year-card ol {{ flex: 1; margin: 0; padding: var(--gg-spacing-md) var(--gg-spacing-md) var(--gg-spacing-md) calc(var(--gg-spacing-xl) + var(--gg-spacing-xs)); }}
 .year-card li {{ margin-bottom: var(--gg-spacing-sm); font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-normal); }}
 .year-card li span {{ display: inline-block; margin-right: var(--gg-spacing-xs); font-family: var(--gg-font-data); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); }}
@@ -389,7 +400,7 @@ main {{ width: min(1120px, calc(100% - 32px)); margin: 32px auto 80px; }}
 </style></head><body><main>
   <header class="desk-head"><div>PRIVATE EDITORIAL DESK · NOT PUBLIC</div><h1>THE WHOLE<br>GRAVEL STORY</h1>
   <p>Start with 2026, then work backward. Inside each year, entries that clear every evidence, editorial, hostile-editor, and prose gate come first. HOLD entries remain visible research debt; this index cannot approve, seal, publish, or edit anything.</p>
-  <div class="summary"><b>{len(years)} YEARS</b><b>{total_ready} READY FOR HUMAN DECISION</b><b>{total_held} HELD</b></div></header>
+  <div class="summary"><b>{len(years)} YEARS</b><b>{total_ready} READY FOR HUMAN DECISION</b><b>{total_held} HELD</b><b>{total_published} PUBLISHED</b></div></header>
   <section class="years" aria-label="Historical review years">{"".join(rows)}</section>
 </main></body></html>'''
 

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -1534,6 +1534,9 @@ def test_historical_seal_refuses_a_canonical_draft_changed_after_review(tmp_path
 
 def test_private_historical_review_desk_separates_evidence_and_approval_state():
     draft = sample_history_draft()
+    published = sample_history_entry()
+    published["entryId"] = "history-published-2026"
+    published["contentHash"] = compute_history_content_hash(published)
     held = copy.deepcopy(draft)
     held["entryId"] = "history-held-2026"
     held["headline"] = "A held premise"
@@ -1547,12 +1550,15 @@ def test_private_historical_review_desk_separates_evidence_and_approval_state():
     slopped["headline"] = "A prose-held premise"
     slopped["take"] = "The future isn't coming. It's already here."
     slopped["contentHash"] = compute_history_content_hash(slopped)
-    page = render_history_review([draft, held, slopped], 2026)
+    page = render_history_review([draft, held, slopped, published], 2026)
 
     assert "PRIVATE EDITORIAL DESK · NOT PUBLIC" in page
     assert "3 DRAFTS" in page
     assert "1 READY FOR HUMAN DECISION" in page
     assert "2 HELD BY EVIDENCE, EDITORIAL, OR PROSE GATES" in page
+    assert "0 APPROVED BUT UNSEALED" in page
+    assert "1 PUBLISHED" in page
+    assert "A complete source review does not make a historical entry public" in page
     assert "DECISION QUEUE" in page
     assert f'href="#{draft["entryId"]}"' in page
     assert f'href="#{held["entryId"]}"' in page
@@ -1614,12 +1620,17 @@ def test_historical_review_index_prioritizes_recent_ready_decisions():
 
     assert review_years([ready_2025, held_2026, ready_2026]) == [2026, 2025]
     assert sorted([held_2026, ready_2026], key=review_priority)[0]["entryId"] == ready_2026["entryId"]
-    page = render_history_review_index([ready_2025, held_2026, ready_2026])
+    published = sample_history_entry()
+    published["entryId"] = "history-published-2026"
+    published["contentHash"] = compute_history_content_hash(published)
+    page = render_history_review_index([ready_2025, held_2026, ready_2026, published])
 
     assert "THE WHOLE<br>GRAVEL STORY" in page
     assert "2 YEARS" in page
     assert "2 READY FOR HUMAN DECISION" in page
     assert "1 HELD" in page
+    assert "1 PUBLISHED" in page
+    assert "1 PUBLIC" in page
     assert page.index('href="2026.html"') < page.index('href="2025.html"')
     assert "@font-face" in page
     assert "noindex,nofollow" in page


### PR DESCRIPTION
## Summary
- make the private historical desk distinguish drafts, approved-but-unsealed entries, and published entries
- state explicitly that complete source review is not publication
- expose per-year and whole-desk public counts
- extend regression coverage for the publication boundary

## Verification
- `python3 -m pytest -q tests/test_gravel_weekly.py` (113 passed)
- `python3 -m pytest -q tests/` (7,396 passed, 331 skipped)
- `python3 scripts/preflight_quality.py` (passed with 7 existing environment/data warnings)
- rendered and visually inspected the 2026 private desk at desktop width

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only private HTML rendering and test updates only; no changes to approval, sealing, or public loaders.
> 
> **Overview**
> The private Gravel Weekly **historical review desk** HTML now surfaces **publication state** alongside draft queue metrics, so reviewers can see what is still backstage versus actually public.
> 
> On each **year desk**, the header adds an explicit **publication boundary** note (source review ≠ public; only **sealed** entries count as published) and expands the summary strip with **approved-but-unsealed** and **published** counts for entries overlapping that year. The **all-years index** adds a total **published** badge and a per-year **PUBLIC** count; year-card layout/CSS shifts from two to three count columns with styling for the public column.
> 
> **Tests** extend the historical review desk fixtures with a published entry and assert the new copy and counts on both the year page and index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e44f2ed60cb48b211796fbd13d07cda70d6ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->