### PR TITLE
Keep incomplete reviews from becoming quiet issues

### DIFF
--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -34,6 +34,11 @@ python3 scripts/prepare_gravel_weekly_issue.py REVIEW.json \
   --publication-date 2026-08-28 --issue-number 1
 ```
 
+The bridge refuses any review carrying model errors or deterministic-fallback
+packets. An incomplete evaluation remains a usable evidence record, but it is
+not proof of a quiet week and cannot generate quiet-issue copy. Replay the same
+locked Friday window after restoring model evaluation.
+
 The bridge independently recomputes the pinned `petergyang/no-ai-slop` audit
 over the exact headline, deck, `whatHappened`, and Take. A missing, failed, or
 stale content-hashed prose verdict excludes the packet even when every story

--- a/scripts/prepare_gravel_weekly_issue.py
+++ b/scripts/prepare_gravel_weekly_issue.py
@@ -146,6 +146,30 @@ def prepare_issue(review_value: Any, publication_date: str, issue_number: int, *
     review = _record(review_value, "review")
     if review.get("schemaVersion") != "gravel-weekly-review/v1":
         raise ValueError("unsupported Gravel Weekly review schema")
+    model_errors = review.get("modelErrors", [])
+    if not isinstance(model_errors, list) or any(
+        not isinstance(error, str) or not error.strip() for error in model_errors
+    ):
+        raise ValueError("review.modelErrors must be an array of non-empty strings")
+    fallback_candidates = [
+        packet.get("candidateId", "unknown")
+        for packet in review.get("packets", [])
+        if isinstance(packet, dict)
+        and packet.get("generatorModel") == "deterministic-fallback"
+    ]
+    if model_errors or fallback_candidates:
+        details = []
+        if model_errors:
+            details.append(f"{len(model_errors)} model error(s)")
+        if fallback_candidates:
+            details.append(
+                "deterministic fallback for " + ", ".join(map(str, fallback_candidates))
+            )
+        raise ValueError(
+            "cannot prepare a Gravel Weekly issue from an incomplete editorial review: "
+            + "; ".join(details)
+            + ". Replay the same locked window after restoring model evaluation."
+        )
     if issue_number < 1:
         raise ValueError("issue_number must be positive")
     datetime.strptime(publication_date, "%Y-%m-%d")

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -987,6 +987,26 @@ def test_quiet_issue_requires_explicit_human_copy_approval_and_has_a_durable_rec
     assert approved["quietIssue"]["note"] in email
 
 
+@pytest.mark.parametrize("failure_mode", ["model_error", "deterministic_fallback"])
+def test_issue_bridge_refuses_to_call_an_incomplete_editorial_review_quiet(failure_mode):
+    review = {
+        "schemaVersion": "gravel-weekly-review/v1",
+        "modelErrors": [],
+        "candidates": [],
+        "packets": [],
+    }
+    if failure_mode == "model_error":
+        review["modelErrors"] = ["story_1: rejected Gateway credential"]
+    else:
+        review["packets"] = [{
+            "candidateId": "story_1",
+            "generatorModel": "deterministic-fallback",
+        }]
+
+    with pytest.raises(ValueError, match="incomplete editorial review"):
+        prepare_issue(review, "2026-09-04", 2, now="2026-09-03T17:00:00Z")
+
+
 def test_rejecting_every_story_can_become_a_human_approved_quiet_issue():
     draft = sample_draft()
     approval = sample_approval(draft)


### PR DESCRIPTION
## Outcome
Makes the issue-preparation bridge reject review artifacts carrying model errors or deterministic-fallback packets.

An evidence sweep can remain usable after an editorial model failure, but that failure can no longer be translated into Nothing cleared the gate. The same locked Friday window must be replayed with completed model evaluation first.

The fully evaluated August 28 production artifact still prepares the existing private quiet-issue draft successfully.

## Verification
- Gravel Weekly tests: 115 passed
- Production artifact bridge check: pass
- git diff --check: pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes editorial draft generation for weekly issues; misclassification of review artifacts could block legitimate quiet weeks or still allow bad drafts if upstream omits errors.
> 
> **Overview**
> **Fail-closed issue bridge:** `prepare_issue` now aborts before ranking stories or emitting quiet-issue copy when a `gravel-weekly-review/v1` artifact is editorially incomplete.
> 
> The script validates `modelErrors` as a list of non-empty strings, scans packets for `generatorModel: deterministic-fallback`, and raises with a message to replay the locked Friday window after model evaluation is restored. That closes the hole where zero passing stories could still produce *Nothing cleared the gate* after a model outage or fallback packets.
> 
> **Docs and tests:** `data/gravel-weekly/README.md` states the same rule, and a parametrized test covers both `modelErrors` and deterministic-fallback refusal paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ebf9977873a21470c218e9eefbed03a7512f49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->