### PR TITLE
Block unresolved reviews from issue preparation

### DIFF
--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -37,7 +37,11 @@ python3 scripts/prepare_gravel_weekly_issue.py REVIEW.json \
 The bridge refuses any review carrying model errors or deterministic-fallback
 packets. An incomplete evaluation remains a usable evidence record, but it is
 not proof of a quiet week and cannot generate quiet-issue copy. Replay the same
-locked Friday window after restoring model evaluation.
+locked Friday window after restoring model evaluation. The bridge also refuses
+an unresolved editorial `hold`: complete the named evidence work and replay the
+locked window before preparing either a story issue or a quiet issue. A passing
+premise with an incomplete gate or failed/stale prose audit is likewise a
+blocker requiring repair, not evidence that the week was quiet.
 
 The bridge independently recomputes the pinned `petergyang/no-ai-slop` audit
 over the exact headline, deck, `whatHappened`, and Take. A missing, failed, or

--- a/scripts/prepare_gravel_weekly_issue.py
+++ b/scripts/prepare_gravel_weekly_issue.py
@@ -170,6 +170,50 @@ def prepare_issue(review_value: Any, publication_date: str, issue_number: int, *
             + "; ".join(details)
             + ". Replay the same locked window after restoring model evaluation."
         )
+    held_candidates = []
+    invalid_gate_candidates = []
+    rewrite_candidates = []
+    for packet in review.get("packets", []):
+        if not isinstance(packet, dict):
+            invalid_gate_candidates.append("unknown")
+            continue
+        candidate_id = packet.get("candidateId", "unknown")
+        gate = packet.get("editorialGate")
+        if not isinstance(gate, dict):
+            invalid_gate_candidates.append(candidate_id)
+            continue
+        verdicts = []
+        for key in ("partyTest", "pointTest", "friendTest"):
+            test = gate.get(key)
+            verdicts.append(test.get("verdict") if isinstance(test, dict) else None)
+        decision = gate.get("decision")
+        if decision == "hold" or "hold" in verdicts:
+            held_candidates.append(candidate_id)
+            continue
+        if decision == "pass":
+            if not _passes_editorial_gate(packet):
+                invalid_gate_candidates.append(candidate_id)
+            elif not _passes_prose_gate(packet):
+                rewrite_candidates.append(candidate_id)
+        elif decision != "reject":
+            invalid_gate_candidates.append(candidate_id)
+    if held_candidates:
+        raise ValueError(
+            "cannot prepare a Gravel Weekly issue while editorial research remains HOLD: "
+            + ", ".join(map(str, held_candidates))
+            + ". Complete the named evidence work and replay the same locked window."
+        )
+    if invalid_gate_candidates:
+        raise ValueError(
+            "cannot prepare a Gravel Weekly issue from malformed or incomplete editorial gates: "
+            + ", ".join(map(str, invalid_gate_candidates))
+        )
+    if rewrite_candidates:
+        raise ValueError(
+            "cannot prepare a Gravel Weekly issue while passing premises require a prose rewrite: "
+            + ", ".join(map(str, rewrite_candidates))
+            + ". Rerun the no-AI-slop gate on the exact replacement copy."
+        )
     if issue_number < 1:
         raise ValueError("issue_number must be positive")
     datetime.strptime(publication_date, "%Y-%m-%d")

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -856,7 +856,7 @@ def test_sealing_writes_the_issue_and_its_canonical_decision_receipt_together(tm
 
 
 @pytest.mark.parametrize("gate_mutation", ["missing", "hold", "party_hold", "no_point", "friend_fail", "friend_kill", "no_mechanics"])
-def test_review_excludes_stories_that_do_not_clear_every_editorial_gate(gate_mutation):
+def test_issue_bridge_refuses_unresolved_or_malformed_editorial_gates(gate_mutation):
     gate = passing_editorial_gate()
     if gate_mutation == "hold":
         gate["decision"] = "hold"
@@ -887,10 +887,9 @@ def test_review_excludes_stories_that_do_not_clear_every_editorial_gate(gate_mut
         "candidates": [{"id": "story_1", "score": 93, "headline": "Unbound changed the course", "storyKind": "route"}],
         "packets": [packet],
     }
-    issue = prepare_issue(review, "2026-08-28", 1, now="2026-08-27T17:00:00Z")
-    assert issue["stories"] == []
-    assert issue["currentThingStoryId"] is None
-    assert issue["quietIssue"]["provenance"] == "model_draft"
+    expected = "editorial research remains HOLD" if gate_mutation in {"hold", "party_hold"} else "malformed or incomplete editorial gates"
+    with pytest.raises(ValueError, match=expected):
+        prepare_issue(review, "2026-08-28", 1, now="2026-08-27T17:00:00Z")
 
 
 @pytest.mark.parametrize("prose_mutation", ["missing", "failed", "stale"])
@@ -926,10 +925,8 @@ def test_review_excludes_missing_failed_or_stale_prose_gates(prose_mutation):
         }],
         "packets": [packet],
     }
-    issue = prepare_issue(review, "2026-08-28", 1, now="2026-08-27T17:00:00Z")
-    assert issue["stories"] == []
-    assert issue["currentThingStoryId"] is None
-    assert issue["quietIssue"]["provenance"] == "model_draft"
+    with pytest.raises(ValueError, match="passing premises require a prose rewrite"):
+        prepare_issue(review, "2026-08-28", 1, now="2026-08-27T17:00:00Z")
 
 
 def test_quiet_issue_requires_explicit_human_copy_approval_and_has_a_durable_receipt():
@@ -1004,6 +1001,25 @@ def test_issue_bridge_refuses_to_call_an_incomplete_editorial_review_quiet(failu
         }]
 
     with pytest.raises(ValueError, match="incomplete editorial review"):
+        prepare_issue(review, "2026-09-04", 2, now="2026-09-03T17:00:00Z")
+
+
+def test_issue_bridge_refuses_to_call_an_unresolved_editorial_hold_quiet():
+    review = {
+        "schemaVersion": "gravel-weekly-review/v1",
+        "modelErrors": [],
+        "candidates": [{
+            "id": "story_1", "score": 75, "headline": "Research is incomplete",
+            "storyKind": "business",
+        }],
+        "packets": [{
+            "candidateId": "story_1",
+            "generatorModel": "openai/gpt-5.6-sol",
+            "editorialGate": {"decision": "hold"},
+        }],
+    }
+
+    with pytest.raises(ValueError, match="editorial research remains HOLD"):
         prepare_issue(review, "2026-09-04", 2, now="2026-09-03T17:00:00Z")
 
 


### PR DESCRIPTION
## Outcome
The publication bridge now refuses unresolved HOLD packets, malformed or incomplete passing gates, and passing premises whose no-AI-slop audit is missing, failed, or stale.

Those states require research or rewrite. They can no longer fall through to a model-drafted quiet issue.

## Verification
- Gravel Weekly tests: 116 passed
- Existing fully evaluated quiet review still prepares when every packet is rejected
- git diff --check: pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when issue drafts can be created in the editorial pipeline; mis-timed runs will error instead of silently emitting quiet-issue copy, but legitimate fully rejected or empty reviews still prepare.
> 
> **Overview**
> **`prepare_issue` now aborts draft preparation** when the review still has editorial debt, instead of producing an empty story list and a model-drafted quiet week.
> 
> The bridge raises distinct `ValueError`s for: unresolved **`hold`** (gate decision or party/point/friend verdict), **malformed or incomplete** passing gates, and **passing premises** whose no-AI-slop prose gate is missing, failed, or stale (rewrite + re-audit required). Model errors and deterministic-fallback packets were already blocked; this extends the same fail-closed posture to gate and prose states that are not evidence of a quiet week.
> 
> The Gravel Weekly README documents the new rules. Tests that previously expected a quiet-issue draft now expect the matching error; a dedicated test asserts HOLD cannot be treated as quiet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b6aea59217a32ff6020c2e81c7875e7367d87b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->