### PR TITLE
Gate Gravel Weekly drafts on source coverage

### DIFF
--- a/scripts/prepare_gravel_weekly_issue.py
+++ b/scripts/prepare_gravel_weekly_issue.py
@@ -142,10 +142,75 @@ def _scene_items(
     ]
 
 
+def _validate_source_coverage(review: dict[str, Any]) -> dict[str, Any]:
+    coverage_value = review.get("sourceCoverage")
+    if not isinstance(coverage_value, dict):
+        raise ValueError(
+            "cannot prepare a Gravel Weekly issue from incomplete source coverage: "
+            "the source-coverage receipt is missing"
+        )
+    coverage = coverage_value
+    if coverage.get("schemaVersion") != "gravel-weekly-source-coverage/v1":
+        raise ValueError("unsupported Gravel Weekly source-coverage schema")
+    status = coverage.get("status")
+    if status not in {"complete", "partial", "unavailable"}:
+        raise ValueError("review.sourceCoverage.status is invalid")
+    if status == "unavailable":
+        raise ValueError(
+            "cannot prepare a Gravel Weekly issue from incomplete source coverage: "
+            "public discovery was not observed successfully for the locked window"
+        )
+    if not isinstance(coverage.get("runCount"), int) or coverage["runCount"] < 1:
+        raise ValueError("review.sourceCoverage.runCount must be positive")
+    latest = _record(
+        coverage.get("latestSourceHealth"),
+        "review.sourceCoverage.latestSourceHealth",
+    )
+    public = _record(
+        latest.get("publicDiscovery"),
+        "review.sourceCoverage.latestSourceHealth.publicDiscovery",
+    )
+    attempted = public.get("attempted")
+    succeeded = public.get("succeeded")
+    failed = public.get("failed")
+    if not all(isinstance(value, int) and value >= 0 for value in (attempted, succeeded, failed)):
+        raise ValueError("review.sourceCoverage public-discovery health is invalid")
+    if succeeded + failed != attempted or attempted == 0 or succeeded == 0:
+        raise ValueError(
+            "cannot prepare a Gravel Weekly issue from incomplete source coverage: "
+            "the latest public-discovery lane was not usable"
+        )
+    sources = coverage.get("discoverySources")
+    if not isinstance(sources, list) or not sources:
+        raise ValueError(
+            "cannot prepare a Gravel Weekly issue from incomplete source coverage: "
+            "source-by-source receipts are missing"
+        )
+    if not any(
+        isinstance(source, dict)
+        and source.get("connector") in {"rss", "sitemap"}
+        and source.get("latestStatus") == "succeeded"
+        for source in sources
+    ):
+        raise ValueError(
+            "cannot prepare a Gravel Weekly issue from incomplete source coverage: "
+            "no named public news, blog, forum, or feed source succeeded"
+        )
+    errors = coverage.get("sourceErrors")
+    if not isinstance(errors, list) or any(
+        not isinstance(error, str) or not error.strip() for error in errors
+    ):
+        raise ValueError("review.sourceCoverage.sourceErrors must be an array of non-empty strings")
+    if status == "complete" and errors:
+        raise ValueError("complete source coverage cannot contain collection errors")
+    return coverage
+
+
 def prepare_issue(review_value: Any, publication_date: str, issue_number: int, *, now: str | None = None) -> dict[str, Any]:
     review = _record(review_value, "review")
     if review.get("schemaVersion") != "gravel-weekly-review/v1":
         raise ValueError("unsupported Gravel Weekly review schema")
+    _validate_source_coverage(review)
     model_errors = review.get("modelErrors", [])
     if not isinstance(model_errors, list) or any(
         not isinstance(error, str) or not error.strip() for error in model_errors
@@ -300,6 +365,7 @@ def prepare_issue(review_value: Any, publication_date: str, issue_number: int, *
         "retrospectives": [],
         "corrections": [],
         "sourceIndex": sorted(set(source_urls)),
+        "sourceCoverage": dict(review["sourceCoverage"]),
         "editorialApproval": None,
         "publishedAt": None,
         "updatedAt": generated_at,

--- a/scripts/validate_gravel_weekly.py
+++ b/scripts/validate_gravel_weekly.py
@@ -52,6 +52,16 @@ CORRECTION_LEARNING_KEYS = {
     "failureKey", "originalClaim", "correctedClaim", "severity",
     "evidenceUrls", "recordedBy",
 }
+SOURCE_COVERAGE_KEYS = {
+    "schemaVersion", "status", "runCount", "sweepRunIds",
+    "latestSweepCompletedAt", "latestSourceHealth", "aggregateSourceHealth",
+    "discoverySources", "sourceErrors",
+}
+SOURCE_COVERAGE_SOURCE_KEYS = {
+    "sourceId", "publisher", "purpose", "connector", "attempts",
+    "successes", "failures", "parsedItems", "emittedItems", "latestStatus",
+    "lastAttemptedAt", "lastSucceededAt", "lastError",
+}
 
 
 class IssueValidationError(ValueError):
@@ -145,6 +155,121 @@ def _impact(value: Any, name: str) -> dict[str, Any]:
     if item.get("autoFixAllowed") is not False:
         raise IssueValidationError(f"{name}.autoFixAllowed must be false")
     return item
+
+
+def _connector_health(value: Any, name: str) -> dict[str, int]:
+    item = _record(value, name)
+    if set(item) != {"attempted", "succeeded", "failed"}:
+        raise IssueValidationError(f"{name} must contain attempted, succeeded, and failed")
+    if any(
+        not isinstance(item.get(key), int)
+        or isinstance(item.get(key), bool)
+        or item[key] < 0
+        for key in ("attempted", "succeeded", "failed")
+    ):
+        raise IssueValidationError(f"{name} counts must be non-negative integers")
+    if item["succeeded"] + item["failed"] != item["attempted"]:
+        raise IssueValidationError(f"{name} counts do not reconcile")
+    return item
+
+
+def _sweep_source_health(value: Any, name: str) -> dict[str, dict[str, int]]:
+    item = _record(value, name)
+    expected = {"officialObservation", "publicDiscovery", "officialSocial"}
+    if set(item) != expected:
+        raise IssueValidationError(f"{name} must contain all three connector lanes")
+    for lane in sorted(expected):
+        _connector_health(item[lane], f"{name}.{lane}")
+    return item
+
+
+def validate_source_coverage(value: Any, name: str = "sourceCoverage") -> dict[str, Any]:
+    coverage = _record(value, name)
+    unknown = set(coverage) - SOURCE_COVERAGE_KEYS
+    missing = SOURCE_COVERAGE_KEYS - set(coverage)
+    if unknown or missing:
+        raise IssueValidationError(
+            f"{name} fields are invalid; missing={sorted(missing)}, extra={sorted(unknown)}"
+        )
+    if coverage.get("schemaVersion") != "gravel-weekly-source-coverage/v1":
+        raise IssueValidationError(f"{name}.schemaVersion is invalid")
+    if coverage.get("status") not in {"complete", "partial"}:
+        raise IssueValidationError(f"{name}.status must be complete or partial")
+    run_count = coverage.get("runCount")
+    if not isinstance(run_count, int) or isinstance(run_count, bool) or run_count < 1:
+        raise IssueValidationError(f"{name}.runCount must be positive")
+    run_ids = _list(coverage.get("sweepRunIds"), f"{name}.sweepRunIds", 100)
+    if len(run_ids) != run_count:
+        raise IssueValidationError(f"{name}.sweepRunIds must match runCount")
+    normalized_run_ids = [
+        _text(run_id, f"{name}.sweepRunIds[{index}]", 500)
+        for index, run_id in enumerate(run_ids)
+    ]
+    if len(normalized_run_ids) != len(set(normalized_run_ids)):
+        raise IssueValidationError(f"{name}.sweepRunIds must be unique")
+    _iso(coverage.get("latestSweepCompletedAt"), f"{name}.latestSweepCompletedAt")
+    latest_health = _sweep_source_health(
+        coverage.get("latestSourceHealth"), f"{name}.latestSourceHealth"
+    )
+    _sweep_source_health(
+        coverage.get("aggregateSourceHealth"), f"{name}.aggregateSourceHealth"
+    )
+    public = latest_health["publicDiscovery"]
+    if public["attempted"] == 0 or public["succeeded"] == 0:
+        raise IssueValidationError(f"{name} has no usable public-discovery lane")
+    sources = _list(coverage.get("discoverySources"), f"{name}.discoverySources", 200)
+    if not sources:
+        raise IssueValidationError(f"{name}.discoverySources must not be empty")
+    source_keys: list[tuple[str, str]] = []
+    has_public_success = False
+    has_latest_failure = False
+    for index, source_value in enumerate(sources):
+        source_name = f"{name}.discoverySources[{index}]"
+        source = _record(source_value, source_name)
+        unknown = set(source) - SOURCE_COVERAGE_SOURCE_KEYS
+        missing = SOURCE_COVERAGE_SOURCE_KEYS - set(source)
+        if unknown or missing:
+            raise IssueValidationError(
+                f"{source_name} fields are invalid; missing={sorted(missing)}, extra={sorted(unknown)}"
+            )
+        source_id = _text(source.get("sourceId"), f"{source_name}.sourceId", 500)
+        _text(source.get("publisher"), f"{source_name}.publisher", 300)
+        if source.get("purpose") not in {"evidence_source", "culture_sensor"}:
+            raise IssueValidationError(f"{source_name}.purpose is invalid")
+        connector = source.get("connector")
+        if connector not in {"rss", "sitemap", "bluesky", "x", "instagram", "reddit"}:
+            raise IssueValidationError(f"{source_name}.connector is invalid")
+        for key in ("attempts", "successes", "failures", "parsedItems", "emittedItems"):
+            number = source.get(key)
+            if not isinstance(number, int) or isinstance(number, bool) or number < 0:
+                raise IssueValidationError(f"{source_name}.{key} must be a non-negative integer")
+        if source["successes"] + source["failures"] != source["attempts"]:
+            raise IssueValidationError(f"{source_name} attempt counts do not reconcile")
+        latest_status = source.get("latestStatus")
+        if latest_status not in {"succeeded", "failed"}:
+            raise IssueValidationError(f"{source_name}.latestStatus is invalid")
+        _iso(source.get("lastAttemptedAt"), f"{source_name}.lastAttemptedAt")
+        if source.get("lastSucceededAt") is not None:
+            _iso(source["lastSucceededAt"], f"{source_name}.lastSucceededAt")
+        if source.get("lastError") is not None:
+            _text(source["lastError"], f"{source_name}.lastError", 2_000)
+        source_keys.append((connector, source_id))
+        has_public_success |= connector in {"rss", "sitemap"} and latest_status == "succeeded"
+        has_latest_failure |= latest_status == "failed"
+    if len(source_keys) != len(set(source_keys)):
+        raise IssueValidationError(f"{name}.discoverySources must be unique by connector and sourceId")
+    if not has_public_success:
+        raise IssueValidationError(f"{name} has no named successful public source")
+    errors = _list(coverage.get("sourceErrors"), f"{name}.sourceErrors", 500)
+    for index, error in enumerate(errors):
+        _text(error, f"{name}.sourceErrors[{index}]", 2_000)
+    if coverage["status"] == "complete" and (
+        errors
+        or has_latest_failure
+        or any(latest_health[lane]["failed"] for lane in latest_health)
+    ):
+        raise IssueValidationError(f"{name} marked complete despite collection gaps")
+    return coverage
 
 
 def _correction(value: Any, name: str, story_ids: set[str]) -> dict[str, Any]:
@@ -386,6 +511,8 @@ def validate_issue(value: Any, *, verify_hash: bool = True) -> dict[str, Any]:
         raise IssueValidationError("status is invalid")
     _text(issue.get("title"), "title", 300)
     _text(issue.get("mastheadDeck"), "mastheadDeck", 500)
+    if issue.get("sourceCoverage") is not None:
+        validate_source_coverage(issue["sourceCoverage"])
 
     stories = _list(issue.get("stories"), "stories", 30)
     story_ids: list[str] = []

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -137,6 +137,42 @@ def sample_issue():
     return issue
 
 
+def sample_source_coverage(status="complete"):
+    return {
+        "schemaVersion": "gravel-weekly-source-coverage/v1",
+        "status": status,
+        "runCount": 1,
+        "sweepRunIds": ["run_coverage"],
+        "latestSweepCompletedAt": "2026-08-28T14:00:00.000Z",
+        "latestSourceHealth": {
+            "officialObservation": {"attempted": 25, "succeeded": 25, "failed": 0},
+            "publicDiscovery": {"attempted": 2, "succeeded": 2, "failed": 0},
+            "officialSocial": {"attempted": 2, "succeeded": 2, "failed": 0},
+        },
+        "aggregateSourceHealth": {
+            "officialObservation": {"attempted": 25, "succeeded": 25, "failed": 0},
+            "publicDiscovery": {"attempted": 2, "succeeded": 2, "failed": 0},
+            "officialSocial": {"attempted": 2, "succeeded": 2, "failed": 0},
+        },
+        "discoverySources": [{
+            "sourceId": "cyclingnews",
+            "publisher": "Cyclingnews",
+            "purpose": "evidence_source",
+            "connector": "rss",
+            "attempts": 1,
+            "successes": 1,
+            "failures": 0,
+            "parsedItems": 12,
+            "emittedItems": 2,
+            "latestStatus": "succeeded",
+            "lastAttemptedAt": "2026-08-28T14:00:00.000Z",
+            "lastSucceededAt": "2026-08-28T14:00:00.000Z",
+            "lastError": None,
+        }],
+        "sourceErrors": [],
+    }
+
+
 def sample_history_entry():
     entry = {
         "schemaVersion": "gravel-weekly-history-entry/v1",
@@ -659,6 +695,7 @@ def test_review_prepares_a_draft_but_cannot_imply_approval():
     })
     review = {
         "schemaVersion": "gravel-weekly-review/v1",
+        "sourceCoverage": sample_source_coverage(),
         "candidates": [{
             "id": "story_1", "score": 93, "headline": "Unbound changed the course",
             "storyKind": "route",
@@ -674,6 +711,7 @@ def test_review_prepares_a_draft_but_cannot_imply_approval():
     assert issue["stories"][0]["cultureArtifacts"] == [culture_artifact]
     assert issue["stories"][0]["cast"][0]["name"] == "The organizer"
     assert issue["stories"][0]["fieldNotes"][0]["claimIds"] == ["claim_1"]
+    assert issue["sourceCoverage"]["status"] == "complete"
     assert culture_artifact["canonicalUrl"] in issue["sourceIndex"]
     assert validate_issue(issue)["contentHash"] == issue["contentHash"]
     preview = build_page(issue, [issue], latest=True)
@@ -682,6 +720,8 @@ def test_review_prepares_a_draft_but_cannot_imply_approval():
     assert "The model draft awaiting approval" in preview
     assert "The approved judgment" not in preview
     assert "PRIVATE CULTURE CHECK" in preview
+    assert "PRIVATE COLLECTION RECEIPT — NOT PUBLIC COPY" in preview
+    assert "Cyclingnews" in preview
     assert culture_artifact["reviewReason"] in preview
     assert "application/ld+json" not in preview
 
@@ -884,6 +924,7 @@ def test_issue_bridge_refuses_unresolved_or_malformed_editorial_gates(gate_mutat
         packet["editorialGate"] = gate
     review = {
         "schemaVersion": "gravel-weekly-review/v1",
+        "sourceCoverage": sample_source_coverage(),
         "candidates": [{"id": "story_1", "score": 93, "headline": "Unbound changed the course", "storyKind": "route"}],
         "packets": [packet],
     }
@@ -919,6 +960,7 @@ def test_review_excludes_missing_failed_or_stale_prose_gates(prose_mutation):
         packet["suggestedHeadline"] = "The course moved again"
     review = {
         "schemaVersion": "gravel-weekly-review/v1",
+        "sourceCoverage": sample_source_coverage(),
         "candidates": [{
             "id": "story_1", "score": 93,
             "headline": "Unbound changed the course", "storyKind": "route",
@@ -932,11 +974,15 @@ def test_review_excludes_missing_failed_or_stale_prose_gates(prose_mutation):
 def test_quiet_issue_requires_explicit_human_copy_approval_and_has_a_durable_receipt():
     review = {
         "schemaVersion": "gravel-weekly-review/v1",
+        "sourceCoverage": sample_source_coverage(),
         "candidates": [],
         "packets": [],
     }
     draft = prepare_issue(
         review, "2026-09-04", 2, now="2026-09-03T17:00:00Z"
+    )
+    assert "PRIVATE COLLECTION RECEIPT — NOT PUBLIC COPY" in build_page(
+        draft, [draft], latest=True
     )
     approval = {
         "schemaVersion": "gravel-weekly-approval/v3",
@@ -976,6 +1022,7 @@ def test_quiet_issue_requires_explicit_human_copy_approval_and_has_a_durable_rec
     assert 'id="quiet-week"' in page
     assert "THE QUIET WEEK" in page
     assert "Nothing cleared the gate this week." in page
+    assert "PRIVATE COLLECTION RECEIPT — NOT PUBLIC COPY" not in page
     assert "CALENDAR WATCH" not in page
     assert "WHAT THIS CHANGES" not in page
     assert "MODEL DRAFT" not in page
@@ -988,6 +1035,7 @@ def test_quiet_issue_requires_explicit_human_copy_approval_and_has_a_durable_rec
 def test_issue_bridge_refuses_to_call_an_incomplete_editorial_review_quiet(failure_mode):
     review = {
         "schemaVersion": "gravel-weekly-review/v1",
+        "sourceCoverage": sample_source_coverage(),
         "modelErrors": [],
         "candidates": [],
         "packets": [],
@@ -1004,9 +1052,47 @@ def test_issue_bridge_refuses_to_call_an_incomplete_editorial_review_quiet(failu
         prepare_issue(review, "2026-09-04", 2, now="2026-09-03T17:00:00Z")
 
 
+@pytest.mark.parametrize("failure_mode", ["missing", "unavailable", "public_outage"])
+def test_issue_bridge_refuses_to_call_an_unwatched_window_quiet(failure_mode):
+    review = {
+        "schemaVersion": "gravel-weekly-review/v1",
+        "sourceCoverage": sample_source_coverage(),
+        "modelErrors": [],
+        "candidates": [],
+        "packets": [],
+    }
+    if failure_mode == "missing":
+        del review["sourceCoverage"]
+    elif failure_mode == "unavailable":
+        review["sourceCoverage"]["status"] = "unavailable"
+    else:
+        review["sourceCoverage"]["latestSourceHealth"]["publicDiscovery"] = {
+            "attempted": 2, "succeeded": 0, "failed": 2,
+        }
+
+    with pytest.raises(ValueError, match="incomplete source coverage"):
+        prepare_issue(review, "2026-09-04", 2, now="2026-09-03T17:00:00Z")
+
+
+def test_issue_bridge_allows_visible_partial_coverage_for_human_quiet_review():
+    coverage = sample_source_coverage("partial")
+    coverage["sourceErrors"] = ["run_coverage: reddit:r/gravelcycling: credentials unavailable"]
+    review = {
+        "schemaVersion": "gravel-weekly-review/v1",
+        "sourceCoverage": coverage,
+        "modelErrors": [],
+        "candidates": [],
+        "packets": [],
+    }
+    draft = prepare_issue(review, "2026-09-04", 2, now="2026-09-03T17:00:00Z")
+    assert draft["status"] == "draft"
+    assert draft["quietIssue"]["provenance"] == "model_draft"
+
+
 def test_issue_bridge_refuses_to_call_an_unresolved_editorial_hold_quiet():
     review = {
         "schemaVersion": "gravel-weekly-review/v1",
+        "sourceCoverage": sample_source_coverage(),
         "modelErrors": [],
         "candidates": [{
             "id": "story_1", "score": 75, "headline": "Research is incomplete",
@@ -1057,7 +1143,12 @@ def test_quiet_issue_cannot_coexist_with_stories_or_unapproved_copy():
     with pytest.raises(IssueValidationError, match="cannot coexist"):
         validate_issue(issue, verify_hash=False)
 
-    review = {"schemaVersion": "gravel-weekly-review/v1", "candidates": [], "packets": []}
+    review = {
+        "schemaVersion": "gravel-weekly-review/v1",
+        "sourceCoverage": sample_source_coverage(),
+        "candidates": [],
+        "packets": [],
+    }
     draft = prepare_issue(review, "2026-09-04", 2, now="2026-09-03T17:00:00Z")
     unapproved = copy.deepcopy(draft)
     unapproved["status"] = "approved"

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -150,6 +150,36 @@ def render_quiet_issue(quiet: dict[str, Any], *, draft: bool) -> str:
     </section>'''
 
 
+def render_source_coverage_receipt(coverage: dict[str, Any]) -> str:
+    latest = coverage["latestSourceHealth"]
+    lane_labels = (
+        ("OFFICIAL RACE/RESULTS", latest["officialObservation"]),
+        ("PUBLIC NEWS/BLOGS/FORUMS", latest["publicDiscovery"]),
+        ("SOCIAL/CULTURE APIS", latest["officialSocial"]),
+    )
+    lanes = "".join(
+        f'''<li><b>{esc(label)}</b><span>{health['succeeded']}/{health['attempted']} succeeded{f" · {health['failed']} failed" if health['failed'] else ""}</span></li>'''
+        for label, health in lane_labels
+    )
+    sources = "".join(
+        f'''<li><b>{esc(source['publisher'])}</b><span>{esc(source['connector'])} · {esc(source['latestStatus'])} · {source['parsedItems']} parsed · {source['emittedItems']} new</span></li>'''
+        for source in coverage["discoverySources"]
+    )
+    errors = "".join(f"<li>{esc(error)}</li>" for error in coverage["sourceErrors"])
+    error_block = (
+        f'''<details><summary>COLLECTION GAPS ({len(coverage['sourceErrors'])})</summary><ul>{errors}</ul></details>'''
+        if errors else ""
+    )
+    return f'''<aside class="gw-coverage" id="source-coverage">
+      <span>PRIVATE COLLECTION RECEIPT — NOT PUBLIC COPY</span>
+      <h2>{esc(coverage['status'].upper())} COVERAGE</h2>
+      <p>{coverage['runCount']} collection run{'s' if coverage['runCount'] != 1 else ''}; latest completed {esc(coverage['latestSweepCompletedAt'])}. A partial receipt keeps every gap visible for the human quiet-issue decision.</p>
+      <ul class="gw-coverage-lanes">{lanes}</ul>
+      <details><summary>SOURCES ATTEMPTED ({len(coverage['discoverySources'])})</summary><ul>{sources}</ul></details>
+      {error_block}
+    </aside>'''
+
+
 def render_claim_markers(
     claim_ids: list[str], receipts: list[dict[str, Any]]
 ) -> str:
@@ -664,6 +694,15 @@ def page_css() -> str:
   .gw-quiet > span { display: inline-block; font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
   .gw-quiet h2 { max-width: 15ch; margin: var(--gg-spacing-sm) 0; font-family: var(--gg-font-editorial); font-size: clamp(2.25rem, 8vw, 5.5rem); line-height: .95; }
   .gw-quiet p { max-width: 48rem; margin: 0; font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-lg); line-height: var(--gg-line-height-relaxed); }
+  .gw-coverage { margin-top: var(--gg-spacing-lg); padding: var(--gg-spacing-lg); border: var(--gg-border-heavy); background: var(--gg-color-warm-paper); }
+  .gw-coverage > span { font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-coverage h2 { margin: var(--gg-spacing-xs) 0; font-size: clamp(1.5rem, 4vw, 2.5rem); }
+  .gw-coverage p { max-width: 56rem; font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-relaxed); }
+  .gw-coverage ul { margin: var(--gg-spacing-sm) 0; padding: 0; list-style: none; }
+  .gw-coverage li { display: flex; justify-content: space-between; gap: var(--gg-spacing-sm); padding: var(--gg-spacing-xs) 0; border-bottom: var(--gg-border-subtle); }
+  .gw-coverage li span { text-align: right; }
+  .gw-coverage details { margin-top: var(--gg-spacing-md); border-top: var(--gg-border-standard); padding-top: var(--gg-spacing-sm); }
+  .gw-coverage summary { cursor: pointer; font-weight: var(--gg-font-weight-black); }
   code { font-family: var(--gg-font-data); overflow-wrap: anywhere; }
   @media (max-width: 720px) {
     .gw-issue-neighbors { grid-template-columns: 1fr; }
@@ -681,6 +720,8 @@ def page_css() -> str:
     .gw-memory-grid section + section { border-left: 0; border-top: var(--gg-border-standard); }
     .gw-history-take { border-left: 0; border-top: var(--gg-border-standard); }
     .gw-story-head, .gw-story-grid section, .gw-utility, .gw-sub { padding: var(--gg-spacing-md); }
+    .gw-coverage li { display: block; }
+    .gw-coverage li span { display: block; margin-top: var(--gg-spacing-2xs); text-align: left; }
   }
 ''' + culture_css()
 
@@ -713,6 +754,7 @@ def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, la
         </div>'''
         issue_body = f'''{render_issue_contents(issue)}
         {content}
+        {render_source_coverage_receipt(issue['sourceCoverage']) if is_draft and issue.get('sourceCoverage') else ''}
         {utility}
         {render_retrospectives(issue['retrospectives'], issues, draft=is_draft)}
         {corrections}'''

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -173,7 +173,7 @@ def render_source_coverage_receipt(coverage: dict[str, Any]) -> str:
     return f'''<aside class="gw-coverage" id="source-coverage">
       <span>PRIVATE COLLECTION RECEIPT — NOT PUBLIC COPY</span>
       <h2>{esc(coverage['status'].upper())} COVERAGE</h2>
-      <p>{coverage['runCount']} collection run{'s' if coverage['runCount'] != 1 else ''}; latest completed {esc(coverage['latestSweepCompletedAt'])}. A partial receipt keeps every gap visible for the human quiet-issue decision.</p>
+      <p>{coverage['runCount']} collection run{'s' if coverage['runCount'] != 1 else ''}; latest completed {esc(coverage['latestSweepCompletedAt'])}. {"A partial receipt keeps every gap visible for the human quiet-issue decision." if coverage['status'] == 'partial' else "Complete means every configured lane and named source reported successfully; it does not claim sources outside the registry were watched."}</p>
       <ul class="gw-coverage-lanes">{lanes}</ul>
       <details><summary>SOURCES ATTEMPTED ({len(coverage['discoverySources'])})</summary><ul>{sources}</ul></details>
       {error_block}


### PR DESCRIPTION
## What changed\n- require a valid source-coverage receipt before bridging a Gravel Weekly review into a draft\n- carry the receipt into the hash-bound issue snapshot\n- expose named source and lane coverage in the private draft preview\n- preserve partial-coverage gaps for Matti's explicit quiet-week decision\n- keep collection internals off published pages\n\n## Verification\n- python3 -m pytest tests/test_gravel_weekly.py -q (120 passed)\n- python3 -m pytest tests/ -q (7,403 passed, 331 skipped)\n- python3 scripts/preflight_quality.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens the editorial pipeline gate and extends issue snapshots/content hashes with sourceCoverage; behavior is contract-tested but changes when weekly drafts can be prepared.
> 
> **Overview**
> Gravel Weekly can no longer bridge a review into a draft unless the review carries a **source-coverage receipt** that proves the locked window was actually watched (usable public-discovery lane, at least one successful RSS/sitemap source, and coherent per-source stats). Missing, `unavailable`, or public-outage coverage fails closed with explicit errors; **`partial`** coverage with documented `sourceErrors` still allows a quiet-week draft so humans can decide with gaps visible.
> 
> The validated receipt is copied onto the hash-bound issue as **`sourceCoverage`**, with **`validate_source_coverage`** enforcing the publication contract when that field is present. Draft previews add a private **“COLLECTION RECEIPT”** aside (lanes, sources, gaps); sealed/published pages omit it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c157b98b3a10c1c6da5a7efa5b1855ee2db1f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->