### PR TITLE
Compact private Gravel Weekly coverage errors

### DIFF
--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -11,7 +11,11 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "scripts"))
 sys.path.insert(0, str(ROOT / "wordpress"))
 
-from generate_gravel_weekly import build_page, render_history_timeline  # noqa: E402
+from generate_gravel_weekly import (  # noqa: E402
+    build_page,
+    render_history_timeline,
+    render_source_coverage_receipt,
+)
 from gravel_weekly_culture import culture_css, render_culture_artifacts  # noqa: E402
 from gravel_weekly_visuals import (  # noqa: E402
     classify_theme,
@@ -969,6 +973,17 @@ def test_review_excludes_missing_failed_or_stale_prose_gates(prose_mutation):
     }
     with pytest.raises(ValueError, match="passing premises require a prose rewrite"):
         prepare_issue(review, "2026-08-28", 1, now="2026-08-27T17:00:00Z")
+
+
+def test_private_collection_receipt_compacts_historical_errors():
+    coverage = sample_source_coverage("partial")
+    coverage["sourceErrors"] = [f"failure {index}" for index in range(1, 26)]
+    receipt = render_source_coverage_receipt(coverage)
+    assert "Showing the 20 most recent of 25" in receipt
+    assert "failure 5<" not in receipt
+    assert "failure 6<" in receipt
+    assert "failure 25<" in receipt
+    assert len(coverage["sourceErrors"]) == 25
 
 
 def test_quiet_issue_requires_explicit_human_copy_approval_and_has_a_durable_receipt():

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -165,9 +165,15 @@ def render_source_coverage_receipt(coverage: dict[str, Any]) -> str:
         f'''<li><b>{esc(source['publisher'])}</b><span>{esc(source['connector'])} · {esc(source['latestStatus'])} · {source['parsedItems']} parsed · {source['emittedItems']} new</span></li>'''
         for source in coverage["discoverySources"]
     )
-    errors = "".join(f"<li>{esc(error)}</li>" for error in coverage["sourceErrors"])
+    visible_errors = coverage["sourceErrors"][-20:]
+    hidden_error_count = len(coverage["sourceErrors"]) - len(visible_errors)
+    error_notice = (
+        f"<p>Showing the 20 most recent of {len(coverage['sourceErrors'])}; the complete receipt remains bound to this issue.</p>"
+        if hidden_error_count else ""
+    )
+    errors = "".join(f"<li>{esc(error)}</li>" for error in visible_errors)
     error_block = (
-        f'''<details><summary>COLLECTION GAPS ({len(coverage['sourceErrors'])})</summary><ul>{errors}</ul></details>'''
+        f'''<details><summary>MOST RECENT COLLECTION GAPS ({len(coverage['sourceErrors'])} TOTAL)</summary>{error_notice}<ul>{errors}</ul></details>'''
         if errors else ""
     )
     return f'''<aside class="gw-coverage" id="source-coverage">


### PR DESCRIPTION
## Summary\n- show the 20 most recent collection gaps in private Gravel Weekly previews\n- retain the full source receipt in the content-bound issue JSON\n- add regression coverage\n\n## Verification\n- python3 -m pytest tests/test_gravel_weekly.py -q (121 passed)\n- python3 -m py_compile wordpress/generate_gravel_weekly.py\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change for private draft previews; issue JSON and `sourceErrors` data are untouched.
> 
> **Overview**
> Limits how many **collection gap** entries appear in the **private draft preview** for Gravel Weekly source coverage, so long error histories do not blow up the HTML.
> 
> `render_source_coverage_receipt` now renders only the **20 most recent** `sourceErrors`, adds a notice when older gaps are hidden (while stating the full receipt stays on the issue), and renames the collapsible section to **MOST RECENT COLLECTION GAPS (N TOTAL)**. The underlying `coverage` object is unchanged—only the preview markup is trimmed.
> 
> Adds **`test_private_collection_receipt_compacts_historical_errors`** to lock in the slice behavior and the notice text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f0601e74498e857aded0a3a3b0be88dc42b539e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->