### PR TITLE
Make Gravel Weekly email delivery fail closed

### DIFF
--- a/.github/workflows/weekly-broadcast.yml
+++ b/.github/workflows/weekly-broadcast.yml
@@ -32,6 +32,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Require the canonical main branch
+        env:
+          DEPLOY_REF: ${{ github.ref }}
+        run: |
+          if [[ "$DEPLOY_REF" != "refs/heads/main" ]]; then
+            echo "::error::Gravel Weekly publication must run from main, not $DEPLOY_REF"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
@@ -178,7 +187,8 @@ jobs:
       - name: Send approved issue
         if: ${{ inputs.send_email }}
         env:
+          ISSUE_DATE: ${{ inputs.issue_date }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: python scripts/send_gravel_weekly.py
+        run: python scripts/send_gravel_weekly.py --issue-date "$ISSUE_DATE"

--- a/scripts/send_gravel_weekly.py
+++ b/scripts/send_gravel_weekly.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+import argparse
 import html
 import json
 import os
 import sys
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -19,10 +21,11 @@ from brand_tokens import COLORS  # noqa: E402
 from validate_gravel_weekly import load_public_issues  # noqa: E402
 
 RESEND_API = "https://api.resend.com"
-AUDIENCE_NAMES = ("Gravel Weekly", "Gravel TV")
+SEGMENT_NAMES = ("Gravel Weekly", "Gravel TV")
 FROM_ADDR = "Gravel Weekly <weekly@gravelgodcycling.com>"
 ISSUE_BASE_URL = "https://gravelgodcycling.com/gravel-weekly/"
 SUBSCRIBER_SOURCES = ("gravel_weekly_subscribe", "gravel_tv_subscribe")
+ACTIVE_BROADCAST_STATUSES = frozenset({"queued", "scheduled", "sent"})
 
 
 def _req(url: str, method: str = "GET", body: dict | None = None,
@@ -63,13 +66,102 @@ def fetch_subscribers() -> list[str]:
     return sorted(subscribers)
 
 
-def find_or_create_audience() -> str | None:
-    audiences = resend("/audiences").get("data", [])
-    for preferred_name in AUDIENCE_NAMES:
-        for audience in audiences:
-            if audience.get("name") == preferred_name:
-                return audience["id"]
-    return resend("/audiences", "POST", {"name": AUDIENCE_NAMES[0]}).get("id")
+def find_or_create_segment() -> str | None:
+    segments = resend("/segments").get("data", [])
+    if not isinstance(segments, list):
+        raise RuntimeError("Resend segment list returned an invalid response")
+    for preferred_name in SEGMENT_NAMES:
+        for segment in segments:
+            if segment.get("name") == preferred_name:
+                return segment["id"]
+    return resend("/segments", "POST", {"name": SEGMENT_NAMES[0]}).get("id")
+
+
+def ensure_segment_contact(segment_id: str, email_address: str) -> bool:
+    """Ensure segment membership without changing an existing unsubscribe state."""
+    encoded_email = urllib.parse.quote(email_address, safe="")
+    try:
+        existing = resend(f"/contacts/{encoded_email}")
+        if not existing.get("id") and existing.get("email") != email_address:
+            raise RuntimeError(f"Resend returned an invalid contact for {email_address}")
+    except urllib.error.HTTPError as exc:
+        if exc.code != 404:
+            raise
+        created = resend(
+            "/contacts",
+            "POST",
+            {"email": email_address, "segments": [{"id": segment_id}]},
+        )
+        if not created.get("id"):
+            raise RuntimeError(f"Resend contact creation returned no id for {email_address}")
+        return True
+
+    memberships = resend(f"/contacts/{encoded_email}/segments").get("data", [])
+    if not isinstance(memberships, list):
+        raise RuntimeError(f"Resend returned invalid segment membership for {email_address}")
+    if any(item.get("id") == segment_id for item in memberships if isinstance(item, dict)):
+        return False
+    added = resend(
+        f"/contacts/{encoded_email}/segments/{segment_id}",
+        "POST",
+        {},
+    )
+    if added.get("id") != segment_id:
+        raise RuntimeError(f"Resend did not confirm segment membership for {email_address}")
+    return True
+
+
+def broadcast_name(issue: dict) -> str:
+    """Bind a Resend broadcast to one immutable published issue snapshot."""
+    return (
+        f"Gravel Weekly #{issue['issueNumber']:03d} · "
+        f"{issue['publicationDate']} · {issue['contentHash']}"
+    )
+
+
+def find_existing_broadcast(name: str) -> dict | None:
+    """Find a prior API broadcast by its content-hash-bound internal name."""
+    summaries = resend("/broadcasts").get("data", [])
+    if not isinstance(summaries, list):
+        raise RuntimeError("Resend broadcast list returned an invalid response")
+    for summary in summaries:
+        broadcast_id = summary.get("id") if isinstance(summary, dict) else None
+        if not broadcast_id:
+            continue
+        detail = resend(f"/broadcasts/{broadcast_id}")
+        if detail.get("name") == name:
+            return detail
+    return None
+
+
+def send_broadcast_once(issue: dict, segment_id: str, subject: str, email_html: str) -> dict:
+    """Start exactly one broadcast for an immutable issue, safe across workflow reruns."""
+    name = broadcast_name(issue)
+    existing = find_existing_broadcast(name)
+    if existing:
+        status = existing.get("status")
+        broadcast_id = existing.get("id")
+        if not broadcast_id:
+            raise RuntimeError("Existing Resend broadcast has no id")
+        if status in ACTIVE_BROADCAST_STATUSES:
+            return {"id": broadcast_id, "status": status, "reused": True}
+        if status == "draft":
+            resend(f"/broadcasts/{broadcast_id}/send", "POST", {})
+            return {"id": broadcast_id, "status": "queued", "reused": True}
+        raise RuntimeError(f"Existing Resend broadcast has unsafe status: {status!r}")
+
+    created = resend("/broadcasts", "POST", {
+        "segment_id": segment_id,
+        "from": FROM_ADDR,
+        "name": name,
+        "subject": subject,
+        "html": email_html,
+        "send": True,
+    })
+    broadcast_id = created.get("id")
+    if not broadcast_id:
+        raise RuntimeError("Resend create-and-send returned no broadcast id")
+    return {"id": broadcast_id, "status": "queued", "reused": False}
 
 
 def _paragraphs(value: str) -> str:
@@ -112,49 +204,63 @@ def build_email_html(issue: dict) -> str:
 </div>'''
 
 
-def main() -> int:
+def select_issue(issues: list[dict], issue_date: str | None) -> dict:
+    if not issues:
+        raise RuntimeError("No sealed Gravel Weekly issue is available")
+    if issue_date is None:
+        return issues[0]
+    selected = next(
+        (issue for issue in issues if issue["publicationDate"] == issue_date),
+        None,
+    )
+    if selected is None:
+        raise RuntimeError(f"No sealed Gravel Weekly issue exists for {issue_date}")
+    return selected
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--issue-date",
+        help="Exact sealed issue date to send (YYYY-MM-DD); defaults to latest",
+    )
+    args = parser.parse_args(argv)
     missing = [key for key in ("RESEND_API_KEY", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY") if not os.environ.get(key)]
     if missing:
-        print(f"Missing {missing} — skipping Gravel Weekly send")
-        return 0
-    issues = load_public_issues()
-    if not issues:
-        print("No sealed Gravel Weekly issue — refusing to send")
-        return 0
-    issue = issues[0]
+        print(f"Missing {missing} — refusing to claim Gravel Weekly was sent", file=sys.stderr)
+        return 1
+    try:
+        issue = select_issue(load_public_issues(), args.issue_date)
+    except RuntimeError as exc:
+        print(f"{exc} — refusing to send", file=sys.stderr)
+        return 1
     try:
         subscribers = fetch_subscribers()
         if not subscribers:
-            print("No Gravel Weekly subscribers — nothing to send")
-            return 0
-        audience_id = find_or_create_audience()
-        if not audience_id:
-            print("Could not resolve the existing publication audience — skipping")
-            return 0
-        for email_address in subscribers:
-            try:
-                resend(f"/audiences/{audience_id}/contacts", "POST", {"email": email_address})
-            except Exception:
-                pass
+            raise RuntimeError("No Gravel Weekly subscribers were found")
+        segment_id = find_or_create_segment()
+        if not segment_id:
+            raise RuntimeError("Could not resolve the existing publication segment")
+        added_memberships = sum(
+            ensure_segment_contact(segment_id, email_address)
+            for email_address in subscribers
+        )
         current = next((story for story in issue["stories"] if story["candidateId"] == issue.get("currentThingStoryId")), None)
         subject = f"Gravel Weekly #{issue['issueNumber']:03d}"
         if current:
             subject += f": {current['headline']}"
         elif issue.get("quietIssue"):
             subject += f": {issue['quietIssue']['headline']}"
-        broadcast = resend("/broadcasts", "POST", {
-            "audience_id": audience_id,
-            "from": FROM_ADDR,
-            "subject": subject,
-            "html": build_email_html(issue),
-        })
-        broadcast_id = broadcast.get("id")
-        if not broadcast_id:
-            raise RuntimeError("broadcast creation returned no id")
-        resend(f"/broadcasts/{broadcast_id}/send", "POST", {})
-        print(f"Sent Gravel Weekly #{issue['issueNumber']:03d} to {len(subscribers)} subscriber(s)")
+        receipt = send_broadcast_once(issue, segment_id, subject, build_email_html(issue))
+        action = "Verified existing" if receipt["reused"] else "Started"
+        print(
+            f"{action} Gravel Weekly #{issue['issueNumber']:03d} broadcast "
+            f"{receipt['id']} ({receipt['status']}) for {len(subscribers)} subscriber(s); "
+            f"{added_memberships} new segment membership(s)"
+        )
     except Exception as exc:
-        print(f"Gravel Weekly send failed softly: {exc}")
+        print(f"Gravel Weekly send failed: {exc}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -3,6 +3,7 @@
 import copy
 import json
 import sys
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -65,7 +66,16 @@ from validate_gravel_weekly_backfill import validate_backfill_ledger  # noqa: E4
 from no_ai_slop import audit_no_ai_slop  # noqa: E402
 from prepare_gravel_weekly_backfill_ledger import build_initial_backfill_ledger  # noqa: E402
 from prepare_gravel_weekly_history_culture import prepare_history_culture_proposal  # noqa: E402
-from send_gravel_weekly import SUBSCRIBER_SOURCES, build_email_html  # noqa: E402
+import send_gravel_weekly  # noqa: E402
+from send_gravel_weekly import (  # noqa: E402
+    SUBSCRIBER_SOURCES,
+    broadcast_name,
+    build_email_html,
+    ensure_segment_contact,
+    find_or_create_segment,
+    select_issue,
+    send_broadcast_once,
+)
 from prepare_gravel_weekly_issue import prepare_issue  # noqa: E402
 from approve_gravel_weekly_issue import approve_issue, build_decision_receipt  # noqa: E402
 from seal_gravel_weekly_issue import main as seal_issue_main, seal_issue  # noqa: E402
@@ -2648,11 +2658,13 @@ def test_deploy_path_and_legacy_redirect_are_wired():
     assert not (ROOT / "scripts" / "send_broadcast_email.py").exists()
     workflow = (ROOT / ".github" / "workflows" / "weekly-broadcast.yml").read_text()
     assert "issues: write" in workflow
+    assert "refs/heads/main" in workflow
     assert "render_gravel_weekly_race_impact_review.py" in workflow
     assert "meaningful-race-impact-count: 0" in workflow
     assert "validate_decision_receipt" in workflow
     assert "record_gravel_weekly_decisions.py" in workflow
     assert "CONTROL_PLANE_INGEST_SECRET" in workflow
+    assert 'send_gravel_weekly.py --issue-date "$ISSUE_DATE"' in workflow
     history_workflow = (ROOT / ".github" / "workflows" / "gravel-weekly-history-publish.yml").read_text()
     assert "workflow_dispatch:" in history_workflow
     assert 'group: gravel-weekly-publish' in history_workflow
@@ -2682,6 +2694,152 @@ def test_email_preserves_legacy_subscribers_and_renders_a_sealed_issue():
     assert "Unbound changed the course" in email
     assert "/gravel-weekly/2026-08-28/" in email
     assert "RESEND_UNSUBSCRIBE_URL" in email
+
+
+def test_email_broadcast_name_binds_the_exact_published_issue_hash():
+    issue = sample_issue()
+    name = broadcast_name(issue)
+    assert name == (
+        f"Gravel Weekly #001 · 2026-08-28 · {issue['contentHash']}"
+    )
+
+
+def test_email_send_reuses_an_existing_sent_broadcast(monkeypatch):
+    issue = sample_issue()
+    calls = []
+
+    def fake_resend(path, method="GET", body=None):
+        calls.append((path, method, body))
+        if path == "/broadcasts":
+            return {"data": [{"id": "broadcast_existing", "status": "sent"}]}
+        if path == "/broadcasts/broadcast_existing":
+            return {
+                "id": "broadcast_existing",
+                "name": broadcast_name(issue),
+                "status": "sent",
+            }
+        raise AssertionError(f"unexpected request: {path}")
+
+    monkeypatch.setattr(send_gravel_weekly, "resend", fake_resend)
+    receipt = send_broadcast_once(issue, "segment_1", "Subject", "<p>Body</p>")
+    assert receipt == {
+        "id": "broadcast_existing", "status": "sent", "reused": True
+    }
+    assert [call[0] for call in calls] == [
+        "/broadcasts", "/broadcasts/broadcast_existing"
+    ]
+
+
+def test_email_send_creates_and_sends_once_with_a_content_bound_name(monkeypatch):
+    issue = sample_issue()
+    calls = []
+
+    def fake_resend(path, method="GET", body=None):
+        calls.append((path, method, body))
+        if path == "/broadcasts" and method == "GET":
+            return {"data": []}
+        if path == "/broadcasts" and method == "POST":
+            return {"id": "broadcast_new"}
+        raise AssertionError(f"unexpected request: {path}")
+
+    monkeypatch.setattr(send_gravel_weekly, "resend", fake_resend)
+    receipt = send_broadcast_once(issue, "segment_1", "Subject", "<p>Body</p>")
+    assert receipt == {
+        "id": "broadcast_new", "status": "queued", "reused": False
+    }
+    body = calls[-1][2]
+    assert body["name"] == broadcast_name(issue)
+    assert body["send"] is True
+    assert body["segment_id"] == "segment_1"
+
+
+def test_email_contact_sync_preserves_existing_segment_membership(monkeypatch):
+    calls = []
+
+    def fake_resend(path, method="GET", body=None):
+        calls.append((path, method, body))
+        if path.endswith("/segments"):
+            return {"data": [{"id": "segment_1", "name": "Gravel Weekly"}]}
+        return {"id": "contact_1", "email": "rider+weekly@example.com"}
+
+    monkeypatch.setattr(send_gravel_weekly, "resend", fake_resend)
+    assert ensure_segment_contact(
+        "segment_1", "rider+weekly@example.com"
+    ) is False
+    assert [call[0] for call in calls] == [
+        "/contacts/rider%2Bweekly%40example.com",
+        "/contacts/rider%2Bweekly%40example.com/segments",
+    ]
+
+
+def test_email_contact_sync_creates_only_after_a_real_404(monkeypatch):
+    calls = []
+
+    def fake_resend(path, method="GET", body=None):
+        calls.append((path, method, body))
+        if method == "GET":
+            raise urllib.error.HTTPError(path, 404, "Not Found", {}, None)
+        return {"id": "contact_new"}
+
+    monkeypatch.setattr(send_gravel_weekly, "resend", fake_resend)
+    assert ensure_segment_contact("segment_1", "new@example.com") is True
+    assert calls[-1] == (
+        "/contacts",
+        "POST",
+        {"email": "new@example.com", "segments": [{"id": "segment_1"}]},
+    )
+
+
+def test_email_contact_sync_adds_existing_contact_to_missing_segment(monkeypatch):
+    calls = []
+
+    def fake_resend(path, method="GET", body=None):
+        calls.append((path, method, body))
+        if path == "/contacts/rider%40example.com":
+            return {"id": "contact_1", "email": "rider@example.com"}
+        if path == "/contacts/rider%40example.com/segments":
+            return {"data": []}
+        if path == "/contacts/rider%40example.com/segments/segment_1":
+            return {"id": "segment_1"}
+        raise AssertionError(f"unexpected request: {path}")
+
+    monkeypatch.setattr(send_gravel_weekly, "resend", fake_resend)
+    assert ensure_segment_contact("segment_1", "rider@example.com") is True
+    assert calls[-1][1] == "POST"
+
+
+def test_email_segment_lookup_reuses_the_legacy_publication_group(monkeypatch):
+    def fake_resend(path, method="GET", body=None):
+        assert path == "/segments"
+        assert method == "GET"
+        return {"data": [{"id": "segment_legacy", "name": "Gravel TV"}]}
+
+    monkeypatch.setattr(send_gravel_weekly, "resend", fake_resend)
+    assert find_or_create_segment() == "segment_legacy"
+
+
+def test_email_contact_sync_propagates_provider_failures(monkeypatch):
+    def fake_resend(path, method="GET", body=None):
+        raise urllib.error.HTTPError(path, 503, "Unavailable", {}, None)
+
+    monkeypatch.setattr(send_gravel_weekly, "resend", fake_resend)
+    with pytest.raises(urllib.error.HTTPError):
+        ensure_segment_contact("segment_1", "rider@example.com")
+
+
+def test_email_send_fails_closed_when_delivery_secrets_are_missing(monkeypatch):
+    for key in ("RESEND_API_KEY", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    assert send_gravel_weekly.main([]) == 1
+
+
+def test_email_sender_selects_the_workflow_issue_date_not_merely_latest():
+    latest = sample_issue()
+    older = copy.deepcopy(latest)
+    older["publicationDate"] = "2026-08-21"
+    assert select_issue([latest, older], "2026-08-21") is older
+    with pytest.raises(RuntimeError, match="No sealed Gravel Weekly issue exists"):
+        select_issue([latest, older], "2026-08-14")
 
 
 def test_only_sealed_issue_snapshots_cross_the_public_loader(tmp_path):


### PR DESCRIPTION
## Summary\n- migrate publication delivery to Resend's current Segments + global Contacts contract\n- preserve existing unsubscribe state while ensuring segment membership\n- bind each broadcast to the immutable issue content hash\n- reuse queued, scheduled, sent, or draft broadcasts on workflow reruns\n- use Resend's atomic create-and-send path for new issues\n- bind sending to the exact workflow issue date and require canonical main\n- fail the publish workflow on missing delivery secrets, empty segments, contact-sync failures, or provider errors\n\n## Verification\n- focused Gravel Weekly tests: 131 passed\n- full repository suite before the final Resend-contract additions: 7,411 passed, 331 skipped; CI reruns the complete suite on this exact head\n- quality preflight: passed (7 existing environment/backlog warnings)\n- Python compile, workflow YAML parse, and diff checks passed\n\n## Provider basis\nResend officially targets broadcasts to segments and models contacts globally. Broadcast idempotency keys remain unavailable, so this uses a content-hash-bound internal broadcast name plus status readback to provide application-level rerun safety.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscriber-facing email delivery and Resend API usage; misconfiguration or idempotency bugs could block sends or duplicate broadcasts, though behavior is heavily tested and fails closed on errors.
> 
> **Overview**
> **Gravel Weekly email sending** is tightened so publish workflows cannot silently skip or double-send, and delivery matches Resend’s segments/contacts model.
> 
> The **weekly publish workflow** now aborts unless the run is on `main`, and the send step passes the dispatched `issue_date` into `send_gravel_weekly.py` so the email matches the issue being published—not just “latest sealed.”
> 
> **`send_gravel_weekly.py`** switches from legacy Resend audiences to **segments + global contacts**, syncing subscribers into a segment without blindly re-adding contacts (404-only create; add membership only when missing). Each broadcast is named with issue number, publication date, and **content hash**; reruns **reuse** queued/scheduled/sent broadcasts or send a stuck draft instead of creating duplicates. New sends use create-and-send in one API call. Missing secrets, bad issue selection, empty lists, or provider errors **exit non-zero** (replacing prior soft skips).
> 
> **Tests** lock in broadcast reuse, segment/contact sync, fail-closed `main`, workflow wiring, and `--issue-date` selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb0547b956dd772687c7b3dcf663a11fbded399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->