### PR TITLE
Give Gravel Weekly a story-specific lead poster

### DIFF
--- a/docs/gravel-weekly-manual-for-speed-reference.md
+++ b/docs/gravel-weekly-manual-for-speed-reference.md
@@ -267,6 +267,14 @@ chapters with a keyboard-accessible jump rail and explicit return links. That
 keeps the backfilled record browsable as it grows without turning the page into
 an undifferentiated archive scroll.
 
+The live Current Thing now receives a distinct, hash-bound story poster rather
+than the generic category motif used by secondary stories. It uses the approved
+headline as the visual premise, preserves the Gravel God token and type system,
+and identifies itself as abstract automatic editorial art. This is the concrete
+translation of Manual for Speed's story-as-front-door mechanic; none of its
+trade dress, source photography, illustration style, or title treatment is
+copied.
+
 Dated issue pages now expose the adjacent older and newer issues immediately
 below the masthead. The rail names the chronological position, previews each
 neighbor's actual Current Thing or quiet-week premise, and uses ordinary

--- a/docs/gravel-weekly-visual-system.md
+++ b/docs/gravel-weekly-visual-system.md
@@ -13,6 +13,14 @@ Gravel Weekly must never wait for Matti to choose, license, crop, or approve an 
 
 The SVG is abstract editorial art, visibly labeled as such. It is never presented as a photograph or as evidence of an event.
 
+The live issue gives its approved Current Thing one story-specific editorial
+poster: the exact approved headline is the dominant element, the issue date and
+machine classification remain quiet metadata, and a small abstract motif carries
+the Gravel God visual grammar. Secondary stories keep the smaller permanent
+brand-art fallback. A timestamped verified source video still outranks both.
+This creates one deliberate front door without manufacturing a documentary
+image or forcing every card to shout at the same volume.
+
 ## Two jobs, clearly separated
 
 The existing procedural visual is the publication signature: fast, deterministic,

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -375,6 +375,47 @@ def test_historical_story_turn_visual_uses_only_supplied_before_after_copy():
     assert "<img" not in visual and "<iframe" not in visual
 
 
+def test_current_thing_visual_is_a_hash_bound_story_specific_poster():
+    kwargs = {
+        "item_id": "story_teamification",
+        "headline": "The privateer became gravel's unpaid control group",
+        "body_text": "Teams changed access to race-deciding support.",
+        "receipts": [],
+        "date_label": "August 28, 2026",
+        "stable_hash": "abc123",
+        "story_poster": True,
+    }
+    first = render_story_visual(**kwargs)
+    second = render_story_visual(**kwargs)
+    changed = render_story_visual(**{**kwargs, "stable_hash": "def456"})
+    assert first == second
+    assert first != changed
+    assert 'data-visual-role="story-poster"' in first
+    assert 'data-story-grammar="editorial-poster"' in first
+    assert "The privateer became" in first
+    assert "AUGUST 28, 2026" in first
+    assert "STORY POSTER // AUTO" in first
+    assert "not a news photo" in first.casefold()
+    assert "<img" not in first and "<iframe" not in first
+
+
+def test_timestamped_source_video_still_wins_over_story_poster():
+    visual = render_story_visual(
+        item_id="story_video_poster",
+        headline="A rider explained the change",
+        body_text="The reviewed clip starts at the cited passage.",
+        receipts=[{
+            "canonicalUrl": "https://www.youtube.com/watch?v=abcdefghijk",
+            "transcriptStartSeconds": 125,
+            "publisher": "Rider channel",
+        }],
+        date_label="August 28, 2026",
+        story_poster=True,
+    )
+    assert "VERIFIED SOURCE VIDEO" in visual
+    assert 'data-visual-role="story-poster"' not in visual
+
+
 def test_timestamped_video_visual_links_exact_claim_without_autoplay_or_embed():
     visual = render_story_visual(
         item_id="story_video",

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -290,7 +290,10 @@ def render_retrospectives(retrospectives: list[dict[str, Any]], issues: list[dic
     return f'<section class="gw-retrospectives" id="memory"><h2>THE RECEIPTS ON US</h2><p class="gw-retro-dek">Old takes do not disappear when the timeline moves on.</p>{"".join(cards)}</section>'
 
 
-def render_story(story: dict[str, Any], *, current: bool = False, draft: bool = False) -> str:
+def render_story(
+    story: dict[str, Any], *, current: bool = False, draft: bool = False,
+    date_label: str | None = None,
+) -> str:
     label = "THE CURRENT THING" if current else story["storyKind"].replace("_", " ").upper()
     take_label = "THE TAKE — MODEL DRAFT" if draft else "THE TAKE"
     visual = render_story_visual(
@@ -298,7 +301,8 @@ def render_story(story: dict[str, Any], *, current: bool = False, draft: bool = 
         headline=story["headline"],
         body_text=" ".join([story["dek"], story["whatHappened"], story["take"]]),
         receipts=story["receipts"],
-        date_label=story["storyKind"].replace("_", " "),
+        date_label=date_label or story["storyKind"].replace("_", " "),
+        story_poster=current,
     )
     return f'''<article class="gw-story{' gw-story--cover' if current else ''}" id="{esc(story['candidateId'])}">
       <header class="gw-story-head">
@@ -743,10 +747,22 @@ def build_page(issue: dict[str, Any] | None, issues: list[dict[str, Any]], *, la
         description = current["dek"] if current else issue["mastheadDeck"]
         quiet = issue.get("quietIssue")
         content = (
-            render_story(current, current=True, draft=is_draft)
+            render_story(
+                current,
+                current=True,
+                draft=is_draft,
+                date_label=display_date(issue["publicationDate"]),
+            )
             if current else render_quiet_issue(quiet, draft=is_draft)
         )
-        content += "".join(render_story(story, draft=is_draft) for story in other_stories)
+        content += "".join(
+            render_story(
+                story,
+                draft=is_draft,
+                date_label=display_date(issue["publicationDate"]),
+            )
+            for story in other_stories
+        )
         watch = "".join(f"<li>{esc(item)}</li>" for item in issue["calendarWatch"]) or '<li class="gw-empty">No calendar item cleared the gate.</li>'
         corrections = ""
         if issue["corrections"]:

--- a/wordpress/gravel_weekly_visuals.py
+++ b/wordpress/gravel_weekly_visuals.py
@@ -229,6 +229,7 @@ def render_story_visual(
     prior_judgment: str | None = None,
     changed_judgment: str | None = None,
     point: str | None = None,
+    story_poster: bool = False,
 ) -> str:
     """Render one automatic visual; factual source video wins over abstract art."""
     safe_id = _safe_id(item_id)
@@ -289,6 +290,32 @@ def render_story_visual(
           <figcaption><b>STORY TURN // AUTO</b><span>Hash-bound before → after; abstract editorial graphic, not a news photo.</span></figcaption>
         </figure>'''
 
+    if story_poster:
+        poster_context = " ".join(date_label.split()).upper()[:28].rstrip()
+        poster_title = _svg_text_block(
+            headline,
+            x=42,
+            y=108,
+            class_name="gw-poster-title",
+            max_chars=27,
+            max_lines=4,
+            line_height=43,
+        )
+        return f'''<figure class="gw-visual gw-visual--poster gw-visual--{esc(theme)}" data-visual-system="{VISUAL_SYSTEM_VERSION}" data-visual-role="story-poster" data-story-grammar="editorial-poster">
+          <svg viewBox="0 0 660 320" role="img" aria-labelledby="gw-visual-title-{safe_id}" focusable="false">
+            <title id="gw-visual-title-{safe_id}">Abstract Gravel Weekly story poster for {esc(headline)}. Not documentary imagery.</title>
+            <rect class="gw-visual-paper" x="0" y="0" width="660" height="320" />
+            <path class="gw-visual-route gw-visual-route--background" d="{_route_path(seed)}" pathLength="100" />
+            <rect class="gw-poster-band" x="0" y="0" width="660" height="52" />
+            <text class="gw-poster-kicker" x="24" y="34">THE CURRENT THING · {esc(poster_context)}</text>
+            <g class="gw-poster-motif" transform="translate(438 112) scale(1.08)" aria-hidden="true">{_motif(theme)}</g>
+            <rect class="gw-poster-title-panel" x="24" y="72" width="516" height="204" />
+            {poster_title}
+            <text class="gw-poster-meta" x="42" y="296">{esc(theme_label)} · {esc(seed[:8].upper())}</text>
+          </svg>
+          <figcaption><b>STORY POSTER // AUTO</b><span>Hash-bound Gravel Weekly art; abstract editorial graphic, not a news photo.</span></figcaption>
+        </figure>'''
+
     particles = "".join(
         f'<circle cx="{238 + (int(seed[index:index + 2], 16) % 390)}" '
         f'cy="{24 + (int(seed[index + 2:index + 4], 16) % 142)}" '
@@ -337,18 +364,30 @@ def visual_css() -> str:
   .gw-turn-label { font-size: 13px; font-weight: var(--gg-font-weight-black); letter-spacing: 2px; }
   .gw-turn-copy { font-size: 15px; font-weight: var(--gg-font-weight-bold); }
   .gw-turn-arrow { fill: none; stroke: var(--gg-color-teal); stroke-width: 9; stroke-linecap: square; stroke-linejoin: miter; }
+  .gw-poster-band { fill: var(--gg-color-teal); }
+  .gw-poster-title-panel { fill: var(--gg-color-warm-paper); stroke: var(--gg-color-near-black); stroke-width: var(--gg-border-width-heavy); }
+  .gw-poster-kicker, .gw-poster-title, .gw-poster-meta { fill: var(--gg-color-near-black); font-family: var(--gg-font-data); }
+  .gw-poster-kicker { font-size: 15px; font-weight: var(--gg-font-weight-black); letter-spacing: 2px; }
+  .gw-poster-title { font-size: 34px; font-weight: var(--gg-font-weight-black); letter-spacing: -1px; }
+  .gw-poster-meta { font-size: 12px; font-weight: var(--gg-font-weight-black); letter-spacing: 1px; }
+  .gw-poster-motif { opacity: .82; }
+  .gw-poster-motif .gw-visual-motif { stroke: var(--gg-color-primary-brown); }
+  .gw-poster-motif .gw-visual-accent { stroke: var(--gg-color-gold); }
   @media (prefers-reduced-motion: no-preference) {
     .gw-visual-route { animation: gw-route-pulse 1600ms linear 1 both; }
     .gw-turn-arrow { animation: gw-turn-reveal 1100ms var(--gg-animation-easing-sharp) 1 both; }
     .gw-turn-after { animation: gw-turn-land 520ms var(--gg-animation-easing-sharp) 850ms 1 both; }
+    .gw-poster-title-panel { animation: gw-poster-land 520ms var(--gg-animation-easing-sharp) 420ms 1 both; }
     .gw-video-facade:hover .gw-video-play { transform: translateX(5px); transform-origin: center; transition: transform 140ms linear; }
   }
   @keyframes gw-route-pulse { to { stroke-dashoffset: -100; } }
   @keyframes gw-turn-reveal { from { stroke-dasharray: 100; stroke-dashoffset: 100; } to { stroke-dasharray: 100; stroke-dashoffset: 0; } }
   @keyframes gw-turn-land { from { transform: translateX(-8px); } to { transform: translateX(0); } }
+  @keyframes gw-poster-land { from { transform: translateX(-10px); } to { transform: translateX(0); } }
   @media (max-width: 620px) {
     .gw-visual-word { font-size: 30px; }
     .gw-visual-kicker, .gw-visual-meta { display: none; }
     .gw-visual figcaption { display: grid; }
+    .gw-poster-title { font-size: 30px; }
   }
 '''


### PR DESCRIPTION
## What changed
- gives the approved Current Thing a deterministic, story-specific editorial poster
- keeps timestamped verified source video above the poster in the visual hierarchy
- leaves secondary stories on the quieter permanent brand-art fallback
- documents the Manual for Speed translation and explicit no-copy boundary
- verifies deterministic hashing, accessibility labels, rights-safe output, and source-video precedence

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` — 133 passed
- `python3 -m pytest tests/ -q` — 7416 passed, 331 skipped
- `python3 scripts/preflight_quality.py` — passed with 7 existing environment/backlog warnings
- Python 3.11 compile — passed
- desktop and 390px mobile browser inspection — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer SVG generation and issue HTML wiring only; no auth, data, or approval workflow changes.
> 
> **Overview**
> The live issue’s **Current Thing** now renders a dedicated **story-specific editorial poster** instead of the same compact procedural brand art used for secondary stories. The poster is hash-bound inline SVG: the approved **headline** dominates, the issue date and theme stay quiet metadata, and a small Gravel God motif carries the visual grammar—labeled as abstract auto art, not documentary imagery.
> 
> **Visual hierarchy** is unchanged at the top: a timestamped verified YouTube receipt still wins and renders the source-video facade; the poster applies only when that path does not.
> 
> Issue rendering passes **`story_poster=True`** only for the cover story and supplies the **publication date** as the poster context (replacing story-kind text for that visual). Poster styling and a restrained landing animation are added in the visual CSS; docs record the Manual for Speed “story as front door” translation and explicit no-copy boundary.
> 
> Tests lock in deterministic output, poster metadata/roles, rights-safe markup (no `img`/`iframe`), and video-over-poster precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aab550e52108ff7d9c200cb88c6730a53894ffd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->