### PR TITLE
Automate Gravel Weekly private draft staging

### DIFF
--- a/.github/workflows/gravel-weekly-draft-staging.yml
+++ b/.github/workflows/gravel-weekly-draft-staging.yml
@@ -1,0 +1,197 @@
+name: "Gravel Weekly Draft Staging"
+
+# The control plane owns evidence collection and model drafting. This workflow
+# closes the artifact handoff, but its token and permissions cannot approve,
+# commit, deploy, email, or mutate race data.
+on:
+  schedule:
+    - cron: "0 18 * * 5"
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "Optional successful control-plane review run ID; blank selects the latest trusted producer"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: gravel-weekly-draft-staging
+  cancel-in-progress: false
+
+jobs:
+  stage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SOURCE_REPOSITORY: wattgod/race-intelligence-control-plane
+    steps:
+      - name: Resolve a trusted source run
+        id: source
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          REQUESTED_RUN_ID: ${{ inputs.source_run_id }}
+          TRIGGER_EVENT: ${{ github.event_name }}
+        run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error::GH_PAT is required for read-only cross-repository artifact access"
+            exit 1
+          fi
+          if [[ -n "$REQUESTED_RUN_ID" ]] && ! [[ "$REQUESTED_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "::error::source_run_id must be a GitHub Actions run ID"
+            exit 1
+          fi
+          if [[ -n "$REQUESTED_RUN_ID" ]]; then
+            run_id="$REQUESTED_RUN_ID"
+          else
+            gh api "repos/$SOURCE_REPOSITORY/actions/workflows/race-intelligence.yml/runs?branch=main&status=success&per_page=10" > "$RUNNER_TEMP/weekly-runs.json"
+            if [[ "$TRIGGER_EVENT" = "workflow_dispatch" ]]; then
+              gh api "repos/$SOURCE_REPOSITORY/actions/workflows/gravel-weekly-editorial-replay.yml/runs?branch=main&status=success&per_page=10" > "$RUNNER_TEMP/replay-runs.json"
+            else
+              printf '%s\n' '{"workflow_runs":[]}' > "$RUNNER_TEMP/replay-runs.json"
+            fi
+            run_id="$(python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          root = Path(os.environ["RUNNER_TEMP"])
+          runs = []
+          for filename in ("weekly-runs.json", "replay-runs.json"):
+              runs.extend(json.loads((root / filename).read_text())["workflow_runs"])
+          if os.environ["TRIGGER_EVENT"] == "schedule":
+              runs = [run for run in runs if run.get("event") == "schedule"]
+              now = datetime.now(timezone.utc)
+              runs = [
+                  run for run in runs
+                  if 0 <= (now - datetime.fromisoformat(run["created_at"].replace("Z", "+00:00"))).total_seconds() <= 12 * 3600
+              ]
+          if not runs:
+              raise SystemExit("no recent trusted Gravel Weekly producer run is available")
+          runs.sort(key=lambda run: run["created_at"], reverse=True)
+          print(runs[0]["id"])
+          PY
+            )"
+          fi
+          gh api "repos/$SOURCE_REPOSITORY/actions/runs/$run_id" > "$RUNNER_TEMP/source-run.json"
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          run = json.loads((Path(os.environ["RUNNER_TEMP"]) / "source-run.json").read_text())
+          accepted = {
+              ".github/workflows/race-intelligence.yml": ("Race intelligence review", f"race-intelligence-{run.get('id')}"),
+              ".github/workflows/gravel-weekly-editorial-replay.yml": ("Gravel Weekly fast editorial replay", f"gravel-weekly-editorial-{run.get('id')}"),
+          }
+          path = str(run.get("path", "")).split("@", 1)[0]
+          expected = accepted.get(path)
+          failures = []
+          if run.get("repository", {}).get("full_name") != os.environ["SOURCE_REPOSITORY"]: failures.append("repository")
+          if run.get("head_branch") != "main": failures.append("head_branch")
+          if run.get("conclusion") != "success": failures.append("conclusion")
+          if run.get("event") not in {"schedule", "workflow_dispatch"}: failures.append("event")
+          if expected is None or run.get("name") != expected[0]: failures.append("workflow")
+          if failures:
+              raise SystemExit(f"source workflow is not an accepted successful main run: {', '.join(failures)}")
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a") as handle:
+              handle.write(f"run_id={run['id']}\nartifact={expected[1]}\n")
+          print({"run_id": run["id"], "workflow": run["name"], "head_sha": run["head_sha"]})
+          PY
+
+      - name: Download the exact source artifact
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.run_id }}
+          SOURCE_ARTIFACT: ${{ steps.source.outputs.artifact }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/source"
+          gh run download "$SOURCE_RUN_ID" \
+            --repo "$SOURCE_REPOSITORY" \
+            --name "$SOURCE_ARTIFACT" \
+            --dir "$RUNNER_TEMP/source"
+          test -s "$RUNNER_TEMP/source/gravel-weekly-review.json"
+          test -s "$RUNNER_TEMP/source/gravel-weekly-review.md"
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install canonical runtime
+        run: pip install -r requirements.txt
+
+      - name: Stage a private, non-publishable issue
+        id: draft
+        run: |
+          python scripts/stage_gravel_weekly_review.py \
+            "$RUNNER_TEMP/source/gravel-weekly-review.json" \
+            --source-run "$RUNNER_TEMP/source-run.json" \
+            --output-dir artifacts/gravel-weekly-stage \
+            | tee "$RUNNER_TEMP/stage-result.json"
+          python wordpress/generate_gravel_weekly.py \
+            --preview-draft artifacts/gravel-weekly-stage/draft.json \
+            --preview-output artifacts/gravel-weekly-stage/preview.html
+          cp "$RUNNER_TEMP/source/gravel-weekly-review.md" artifacts/gravel-weekly-stage/source-review.md
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          result = json.loads((Path(os.environ["RUNNER_TEMP"]) / "stage-result.json").read_text().splitlines()[-1])
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+              output.write(f"date={result['publicationDate']}\nnumber={result['issueNumber']}\nhash={result['contentHash']}\n")
+          PY
+
+      - name: Prove the staging boundary
+        run: |
+          python scripts/validate_gravel_weekly.py artifacts/gravel-weekly-stage/draft.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          draft = json.loads(Path("artifacts/gravel-weekly-stage/draft.json").read_text())
+          manifest = json.loads(Path("artifacts/gravel-weekly-stage/manifest.json").read_text())
+          assert draft["status"] == "draft"
+          assert draft["editorialApproval"] is None
+          assert draft["publishedAt"] is None
+          assert manifest["humanApprovalRequired"] is True
+          assert manifest["autoPublishAllowed"] is False
+          preview = Path("artifacts/gravel-weekly-stage/preview.html").read_text()
+          assert "DRAFT — NOT PUBLISHED" in preview
+          assert "application/ld+json" not in preview
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: gravel-weekly-draft-${{ steps.draft.outputs.date }}-${{ github.run_id }}
+          path: artifacts/gravel-weekly-stage/
+          retention-days: 90
+
+      - name: Update the private decision desk
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_DATE: ${{ steps.draft.outputs.date }}
+          ISSUE_NUMBER: ${{ steps.draft.outputs.number }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.run_id }}
+        run: |
+          cat >> artifacts/gravel-weekly-stage/review-summary.md <<EOF
+
+          [Download the private draft, preview, manifest, and source review](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          Source review run: [$SOURCE_RUN_ID](https://github.com/$SOURCE_REPOSITORY/actions/runs/$SOURCE_RUN_ID)
+          EOF
+          gh label create gravel-weekly-draft --color d4a017 --description "Private Gravel Weekly draft awaiting human decision" --force
+          title="Gravel Weekly #$(printf '%03d' "$ISSUE_NUMBER") private draft — $ISSUE_DATE"
+          issue="$(gh issue list --label gravel-weekly-draft --state open --limit 100 --json number,title --jq ".[] | select(.title == \"$title\") | .number" | head -1)"
+          if [[ -n "$issue" ]]; then
+            gh issue edit "$issue" --body-file artifacts/gravel-weekly-stage/review-summary.md
+          else
+            gh issue create --title "$title" --label gravel-weekly-draft --body-file artifacts/gravel-weekly-stage/review-summary.md
+          fi

--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -34,6 +34,21 @@ python3 scripts/prepare_gravel_weekly_issue.py REVIEW.json \
   --publication-date 2026-08-28 --issue-number 1
 ```
 
+The `Gravel Weekly Draft Staging` workflow automates that artifact handoff. At
+18:00 UTC Friday it uses the repository's existing cross-repository read token
+to select that day's successful scheduled control-plane review. A manual run
+may instead name a successful `Race intelligence review` or `Gravel Weekly
+fast editorial replay` run ID. The workflow verifies the source repository,
+workflow path and name, main-branch commit, event, conclusion, exact artifact
+name, seven-day window, and Friday 15:30 UTC close before staging anything.
+
+Its output is a 90-day private artifact containing `draft.json`, a rendered
+`preview.html`, a source-run manifest, the source review, and a short decision
+summary. One hash-bound GitHub issue is updated for the date. The staging
+workflow has read-only content permission and no approval, sealing, deploy,
+email, or race-data step. A scheduled run can therefore remove the download
+and copy/paste chore without turning a cron job into Matti's opinion.
+
 The bridge refuses any review carrying model errors or deterministic-fallback
 packets. An incomplete evaluation remains a usable evidence record, but it is
 not proof of a quiet week and cannot generate quiet-issue copy. Replay the same

--- a/scripts/stage_gravel_weekly_review.py
+++ b/scripts/stage_gravel_weekly_review.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Stage one trusted control-plane review as a private Gravel Weekly draft."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from prepare_gravel_weekly_issue import prepare_issue
+from validate_gravel_weekly import ISSUE_DIR, load_issues
+
+SOURCE_REPOSITORY = "wattgod/race-intelligence-control-plane"
+ACCEPTED_SOURCE_WORKFLOWS = {
+    ".github/workflows/race-intelligence.yml": (
+        "Race intelligence review",
+        "race-intelligence-{run_id}",
+    ),
+    ".github/workflows/gravel-weekly-editorial-replay.yml": (
+        "Gravel Weekly fast editorial replay",
+        "gravel-weekly-editorial-{run_id}",
+    ),
+}
+
+
+def _record(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be an object")
+    return value
+
+
+def _utc(value: Any, name: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be an ISO timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an ISO timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{name} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def validate_source_run(value: Any) -> dict[str, Any]:
+    """Accept only successful main-branch runs from the two editorial workflows."""
+    run = _record(value, "source run")
+    repository = _record(run.get("repository"), "source run.repository")
+    if repository.get("full_name") != SOURCE_REPOSITORY:
+        raise ValueError("source run repository is not trusted")
+    run_id = run.get("id")
+    if not isinstance(run_id, int) or isinstance(run_id, bool) or run_id < 1:
+        raise ValueError("source run id must be a positive integer")
+    if run.get("head_branch") != "main" or run.get("conclusion") != "success":
+        raise ValueError("source workflow must be a successful main-branch run")
+    if run.get("event") not in {"schedule", "workflow_dispatch"}:
+        raise ValueError("source workflow event is not accepted")
+    head_sha = run.get("head_sha")
+    if not isinstance(head_sha, str) or not re.fullmatch(r"[0-9a-f]{40}", head_sha):
+        raise ValueError("source run head SHA is invalid")
+    raw_path = run.get("path")
+    if not isinstance(raw_path, str):
+        raise ValueError("source workflow path is missing")
+    workflow_path = raw_path.split("@", 1)[0]
+    accepted = ACCEPTED_SOURCE_WORKFLOWS.get(workflow_path)
+    if accepted is None:
+        raise ValueError("source workflow is not an accepted Gravel Weekly producer")
+    expected_name, artifact_template = accepted
+    if run.get("name") != expected_name:
+        raise ValueError("source workflow name does not match its trusted path")
+    html_url = run.get("html_url")
+    expected_url = f"https://github.com/{SOURCE_REPOSITORY}/actions/runs/{run_id}"
+    if html_url != expected_url:
+        raise ValueError("source run URL is invalid")
+    return {
+        "repository": SOURCE_REPOSITORY,
+        "runId": run_id,
+        "workflow": expected_name,
+        "workflowPath": workflow_path,
+        "artifactName": artifact_template.format(run_id=run_id),
+        "headSha": head_sha,
+        "event": run["event"],
+        "createdAt": _utc(run.get("created_at"), "source run.created_at").isoformat().replace("+00:00", "Z"),
+        "htmlUrl": html_url,
+    }
+
+
+def derive_weekly_identity(
+    review_value: Any,
+    *,
+    issue_dir: Path = ISSUE_DIR,
+) -> tuple[str, int]:
+    """Bind the draft date and serial number to the locked Friday window."""
+    review = _record(review_value, "review")
+    started = _utc(review.get("windowStartedAt"), "review.windowStartedAt")
+    ended = _utc(review.get("windowEndedAt"), "review.windowEndedAt")
+    if ended - started != timedelta(days=7):
+        raise ValueError("Gravel Weekly staging requires an exact seven-day window")
+    if ended.weekday() != 4 or (ended.hour, ended.minute, ended.second, ended.microsecond) != (15, 30, 0, 0):
+        raise ValueError("Gravel Weekly staging requires the locked Friday 15:30 UTC close")
+    publication_date = ended.date().isoformat()
+    issues = load_issues(issue_dir)
+    if any(issue["publicationDate"] == publication_date for issue in issues):
+        raise ValueError(
+            f"a canonical Gravel Weekly snapshot already exists for {publication_date}; "
+            "a replay cannot replace publication history"
+        )
+    issue_number = max((issue["issueNumber"] for issue in issues), default=0) + 1
+    return publication_date, issue_number
+
+
+def stage_review(
+    review_value: Any,
+    source_run_value: Any,
+    *,
+    issue_dir: Path = ISSUE_DIR,
+    now: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    source = validate_source_run(source_run_value)
+    publication_date, issue_number = derive_weekly_identity(
+        review_value,
+        issue_dir=issue_dir,
+    )
+    issue = prepare_issue(
+        review_value,
+        publication_date,
+        issue_number,
+        now=now,
+    )
+    review = _record(review_value, "review")
+    review_run_id = review.get("runId")
+    if not isinstance(review_run_id, str) or not review_run_id.strip():
+        raise ValueError("review.runId is required for the staging receipt")
+    manifest = {
+        "schemaVersion": "gravel-weekly-stage/v1",
+        "source": source,
+        "reviewRunId": review_run_id,
+        "publicationDate": publication_date,
+        "issueId": issue["issueId"],
+        "issueNumber": issue_number,
+        "draftContentHash": issue["contentHash"],
+        "storyCount": len(issue["stories"]),
+        "currentThingStoryId": issue["currentThingStoryId"],
+        "sourceCoverageStatus": issue["sourceCoverage"]["status"],
+        "status": "draft",
+        "humanApprovalRequired": True,
+        "autoPublishAllowed": False,
+    }
+    return issue, manifest
+
+
+def render_stage_summary(issue: dict[str, Any], manifest: dict[str, Any]) -> str:
+    source = manifest["source"]
+    current = next(
+        (story for story in issue["stories"] if story["candidateId"] == issue["currentThingStoryId"]),
+        None,
+    )
+    if current is None:
+        decision = "**QUIET ISSUE CANDIDATE.** No story cleared every publication gate."
+        next_action = (
+            f"Review the private preview, then explicitly choose `APPROVE QUIET #{issue['issueNumber']:03d}` "
+            "or `WAIT`."
+        )
+    else:
+        decision = f"**CURRENT THING CANDIDATE:** {current['headline']} ({current['score']}/100)."
+        next_action = (
+            "Review the private preview, then approve, edit, reject, or hold the exact hash-bound copy."
+        )
+    return "\n".join([
+        f"<!-- gravel-weekly-draft-date: {issue['publicationDate']} -->",
+        f"<!-- gravel-weekly-draft-hash: {issue['contentHash']} -->",
+        f"# Gravel Weekly #{issue['issueNumber']:03d} private draft",
+        "",
+        "> **DRAFT — NOT MATTI-APPROVED, PUBLISHED, EMAILED, OR AUTHORIZED TO ALTER RACE DATA.**",
+        "",
+        decision,
+        "",
+        f"- Publication window: `{issue['publicationDate']}`",
+        f"- Draft hash: `{issue['contentHash']}`",
+        f"- Stories staged: {len(issue['stories'])}",
+        f"- Source coverage: `{issue['sourceCoverage']['status']}`",
+        f"- Trusted producer: [{source['workflow']} run {source['runId']}]({source['htmlUrl']})",
+        f"- Producer commit: `{source['headSha']}`",
+        "",
+        next_action,
+        "Approval remains a separate immutable decision. Publication remains a second separate instruction.",
+        "",
+    ])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("review", type=Path)
+    parser.add_argument("--source-run", required=True, type=Path)
+    parser.add_argument("--issue-dir", type=Path, default=ISSUE_DIR)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    args = parser.parse_args()
+    review = json.loads(args.review.read_text(encoding="utf-8"))
+    source_run = json.loads(args.source_run.read_text(encoding="utf-8"))
+    issue, manifest = stage_review(review, source_run, issue_dir=args.issue_dir)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    draft_path = args.output_dir / "draft.json"
+    manifest_path = args.output_dir / "manifest.json"
+    summary_path = args.output_dir / "review-summary.md"
+    draft_path.write_text(f"{json.dumps(issue, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
+    manifest_path.write_text(f"{json.dumps(manifest, indent=2, ensure_ascii=False)}\n", encoding="utf-8")
+    summary_path.write_text(render_stage_summary(issue, manifest), encoding="utf-8")
+    print(json.dumps({
+        "draft": str(draft_path),
+        "manifest": str(manifest_path),
+        "summary": str(summary_path),
+        "publicationDate": issue["publicationDate"],
+        "issueNumber": issue["issueNumber"],
+        "contentHash": issue["contentHash"],
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -4,6 +4,7 @@ import copy
 import json
 import sys
 import urllib.error
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -77,6 +78,12 @@ from send_gravel_weekly import (  # noqa: E402
     send_broadcast_once,
 )
 from prepare_gravel_weekly_issue import prepare_issue  # noqa: E402
+from stage_gravel_weekly_review import (  # noqa: E402
+    derive_weekly_identity,
+    render_stage_summary,
+    stage_review,
+    validate_source_run,
+)
 from approve_gravel_weekly_issue import approve_issue, build_decision_receipt  # noqa: E402
 from seal_gravel_weekly_issue import main as seal_issue_main, seal_issue  # noqa: E402
 from render_gravel_weekly_race_impact_review import render_review  # noqa: E402
@@ -184,6 +191,35 @@ def sample_source_coverage(status="complete"):
             "lastError": None,
         }],
         "sourceErrors": [],
+    }
+
+
+def sample_control_plane_run(run_id=33243938367):
+    return {
+        "id": run_id,
+        "name": "Gravel Weekly fast editorial replay",
+        "path": ".github/workflows/gravel-weekly-editorial-replay.yml@refs/heads/main",
+        "head_branch": "main",
+        "head_sha": "a" * 40,
+        "event": "workflow_dispatch",
+        "conclusion": "success",
+        "created_at": "2026-08-29T08:46:31Z",
+        "html_url": f"https://github.com/wattgod/race-intelligence-control-plane/actions/runs/{run_id}",
+        "repository": {"full_name": "wattgod/race-intelligence-control-plane"},
+    }
+
+
+def sample_quiet_review(publication_date="2026-08-28"):
+    end = datetime.fromisoformat(f"{publication_date}T15:30:00+00:00")
+    return {
+        "schemaVersion": "gravel-weekly-review/v1",
+        "runId": "editorial_test",
+        "windowStartedAt": (end - timedelta(days=7)).isoformat().replace("+00:00", "Z"),
+        "windowEndedAt": end.isoformat().replace("+00:00", "Z"),
+        "sourceCoverage": sample_source_coverage(),
+        "modelErrors": [],
+        "candidates": [],
+        "packets": [],
     }
 
 
@@ -779,6 +815,77 @@ def test_review_prepares_a_draft_but_cannot_imply_approval():
     assert "Cyclingnews" in preview
     assert culture_artifact["reviewReason"] in preview
     assert "application/ld+json" not in preview
+
+
+def test_control_plane_run_validation_binds_the_exact_producer_and_artifact():
+    source = validate_source_run(sample_control_plane_run())
+    assert source["repository"] == "wattgod/race-intelligence-control-plane"
+    assert source["workflowPath"] == ".github/workflows/gravel-weekly-editorial-replay.yml"
+    assert source["artifactName"] == "gravel-weekly-editorial-33243938367"
+    assert source["headSha"] == "a" * 40
+
+    untrusted = sample_control_plane_run()
+    untrusted["path"] = ".github/workflows/arbitrary.yml"
+    with pytest.raises(ValueError, match="not an accepted Gravel Weekly producer"):
+        validate_source_run(untrusted)
+
+
+def test_automatic_staging_derives_serial_identity_and_stays_private(tmp_path):
+    review = sample_quiet_review()
+    issue, manifest = stage_review(
+        review,
+        sample_control_plane_run(),
+        issue_dir=tmp_path,
+        now="2026-08-29T09:00:00Z",
+    )
+    assert issue["issueId"] == "gravel-weekly-001"
+    assert issue["publicationDate"] == "2026-08-28"
+    assert issue["status"] == "draft"
+    assert issue["editorialApproval"] is None
+    assert issue["publishedAt"] is None
+    assert issue["quietIssue"]["provenance"] == "model_draft"
+    assert manifest["draftContentHash"] == issue["contentHash"]
+    assert manifest["humanApprovalRequired"] is True
+    assert manifest["autoPublishAllowed"] is False
+    summary = render_stage_summary(issue, manifest)
+    assert "QUIET ISSUE CANDIDATE" in summary
+    assert "APPROVE QUIET #001" in summary
+    assert "NOT MATTI-APPROVED, PUBLISHED, EMAILED" in summary
+
+
+def test_automatic_staging_advances_after_an_immutable_issue_and_never_replaces_it(tmp_path):
+    existing = sample_issue()
+    (tmp_path / "2026-08-28.json").write_text(json.dumps(existing))
+    assert derive_weekly_identity(sample_quiet_review("2026-09-04"), issue_dir=tmp_path) == (
+        "2026-09-04",
+        2,
+    )
+    with pytest.raises(ValueError, match="cannot replace publication history"):
+        derive_weekly_identity(sample_quiet_review("2026-08-28"), issue_dir=tmp_path)
+
+
+def test_automatic_staging_rejects_a_noncanonical_weekly_window(tmp_path):
+    review = sample_quiet_review()
+    review["windowEndedAt"] = "2026-08-28T16:00:00Z"
+    with pytest.raises(ValueError, match="exact seven-day window"):
+        derive_weekly_identity(review, issue_dir=tmp_path)
+
+
+def test_draft_staging_workflow_cannot_cross_the_publication_boundary():
+    workflow = (ROOT / ".github" / "workflows" / "gravel-weekly-draft-staging.yml").read_text()
+    assert 'cron: "0 18 * * 5"' in workflow
+    assert "contents: read" in workflow
+    assert "issues: write" in workflow
+    assert "stage_gravel_weekly_review.py" in workflow
+    assert "gravel-weekly-review.json" in workflow
+    assert "DRAFT — NOT PUBLISHED" in workflow
+    assert "GH_PAT" in workflow
+    assert "contents: write" not in workflow
+    assert "git push" not in workflow
+    assert "approve_gravel_weekly_issue.py" not in workflow
+    assert "seal_gravel_weekly_issue.py" not in workflow
+    assert "send_gravel_weekly.py" not in workflow
+    assert "push_wordpress.py" not in workflow
 
 
 def test_human_approval_bridge_changes_only_editorial_copy_and_stays_non_deployable():


### PR DESCRIPTION
## What changed
- add a Friday 18:00 UTC staging workflow that reads the latest trusted control-plane review artifact
- verify repository, workflow identity, successful main run, artifact name, and locked Friday window
- derive the immutable issue date/number and render a private draft, preview, manifest, source review, and decision summary
- update one private GitHub decision-desk issue without committing, approving, publishing, emailing, deploying, or changing race data
- support a manual exact source run ID for fast editorial replays

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` — 138 passed
- `python3 -m pytest tests/ -q` — 7,421 passed, 331 skipped
- `python3 scripts/preflight_quality.py` — passed with seven existing warnings
- real source replay `33243938367` staged as Issue #001 quiet candidate, validated, and rendered locally
- workflow YAML parse, Python compile, and `git diff --check` passed

## Safety boundary
The workflow has `contents: read` and `issues: write` only. It cannot approve copy, seal a snapshot, deploy WordPress, send email, or alter race data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New scheduled cross-repo artifact ingestion and issue updates affect the weekly editorial path, but staging is intentionally read-only on repo content and cannot approve or publish.
> 
> **Overview**
> Adds a **Gravel Weekly Draft Staging** GitHub Actions workflow that closes the handoff from `wattgod/race-intelligence-control-plane` without crossing the publication boundary.
> 
> On **Fridays at 18:00 UTC** (or via manual dispatch with an optional source run ID), the job resolves a trusted successful `main` run from `race-intelligence.yml` or `gravel-weekly-editorial-replay.yml`, downloads the bound review artifact, and runs new **`scripts/stage_gravel_weekly_review.py`** to build `draft.json`, a staging manifest, and a decision summary. It also renders a non-public `preview.html`, validates draft-only invariants, uploads a 90-day private artifact, and creates or updates a labeled **decision-desk** GitHub issue. Permissions stay **`contents: read`** and **`issues: write`** only—no approve, seal, deploy, email, or race-data steps.
> 
> The staging script enforces trusted producer metadata, the locked **seven-day window ending Friday 15:30 UTC**, issue date/serial derivation (no replacing existing publication dates), and manifest flags **`humanApprovalRequired`** / **`autoPublishAllowed: false`**. **`data/gravel-weekly/README.md`** documents the automated path, and **`tests/test_gravel_weekly.py`** adds contract tests plus a workflow guard that blocks publication scripts from this job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 158bdb5ded39f317c3d638a64f6fc3fc651151c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->