### PR TITLE
Scope Gravel Weekly coverage to gravel sources

### DIFF
--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -64,6 +64,14 @@ stale content-hashed prose verdict excludes the packet even when every story
 gate passes. Draft, approved, and published issue files are all re-audited by
 the publication validator; human approval remains a separate requirement.
 
+New reviews use `gravel-weekly-source-coverage/v2`. Its completeness verdict
+is scoped to sources that declare the gravel vertical or to official
+observations bound to a `gravel:` race ID. Failures from road, Nordic, or
+unscoped infrastructure remain preserved as `infrastructureWarnings` in the
+private receipt, but they cannot downgrade the gravel verdict. Legacy v1
+receipts remain valid historical inputs and retain their original all-vertical
+semantics.
+
 Apply Matti's explicit approval packet without making anything deployable:
 
 ```bash

--- a/scripts/prepare_gravel_weekly_issue.py
+++ b/scripts/prepare_gravel_weekly_issue.py
@@ -150,7 +150,10 @@ def _validate_source_coverage(review: dict[str, Any]) -> dict[str, Any]:
             "the source-coverage receipt is missing"
         )
     coverage = coverage_value
-    if coverage.get("schemaVersion") != "gravel-weekly-source-coverage/v1":
+    if coverage.get("schemaVersion") not in {
+        "gravel-weekly-source-coverage/v1",
+        "gravel-weekly-source-coverage/v2",
+    }:
         raise ValueError("unsupported Gravel Weekly source-coverage schema")
     status = coverage.get("status")
     if status not in {"complete", "partial", "unavailable"}:

--- a/scripts/validate_gravel_weekly.py
+++ b/scripts/validate_gravel_weekly.py
@@ -52,11 +52,15 @@ CORRECTION_LEARNING_KEYS = {
     "failureKey", "originalClaim", "correctedClaim", "severity",
     "evidenceUrls", "recordedBy",
 }
-SOURCE_COVERAGE_KEYS = {
+SOURCE_COVERAGE_V1_KEYS = {
     "schemaVersion", "status", "runCount", "sweepRunIds",
     "latestSweepCompletedAt", "latestSourceHealth", "aggregateSourceHealth",
     "discoverySources", "sourceErrors",
 }
+SOURCE_COVERAGE_V2_KEYS = SOURCE_COVERAGE_V1_KEYS | {
+    "scope", "infrastructureWarnings",
+}
+SOURCE_COVERAGE_SCOPE_KEYS = {"vertical", "method"}
 SOURCE_COVERAGE_SOURCE_KEYS = {
     "sourceId", "publisher", "purpose", "connector", "attempts",
     "successes", "failures", "parsedItems", "emittedItems", "latestStatus",
@@ -185,14 +189,36 @@ def _sweep_source_health(value: Any, name: str) -> dict[str, dict[str, int]]:
 
 def validate_source_coverage(value: Any, name: str = "sourceCoverage") -> dict[str, Any]:
     coverage = _record(value, name)
-    unknown = set(coverage) - SOURCE_COVERAGE_KEYS
-    missing = SOURCE_COVERAGE_KEYS - set(coverage)
+    schema = coverage.get("schemaVersion")
+    if schema not in {
+        "gravel-weekly-source-coverage/v1",
+        "gravel-weekly-source-coverage/v2",
+    }:
+        raise IssueValidationError(f"{name}.schemaVersion is invalid")
+    expected_keys = (
+        SOURCE_COVERAGE_V2_KEYS
+        if schema == "gravel-weekly-source-coverage/v2"
+        else SOURCE_COVERAGE_V1_KEYS
+    )
+    unknown = set(coverage) - expected_keys
+    missing = expected_keys - set(coverage)
     if unknown or missing:
         raise IssueValidationError(
             f"{name} fields are invalid; missing={sorted(missing)}, extra={sorted(unknown)}"
         )
-    if coverage.get("schemaVersion") != "gravel-weekly-source-coverage/v1":
-        raise IssueValidationError(f"{name}.schemaVersion is invalid")
+    if schema == "gravel-weekly-source-coverage/v2":
+        scope = _record(coverage.get("scope"), f"{name}.scope")
+        unknown_scope = set(scope) - SOURCE_COVERAGE_SCOPE_KEYS
+        missing_scope = SOURCE_COVERAGE_SCOPE_KEYS - set(scope)
+        if unknown_scope or missing_scope:
+            raise IssueValidationError(
+                f"{name}.scope fields are invalid; missing={sorted(missing_scope)}, "
+                f"extra={sorted(unknown_scope)}"
+            )
+        if scope.get("vertical") != "gravel":
+            raise IssueValidationError(f"{name}.scope.vertical must be gravel")
+        if scope.get("method") != "declared_source_vertical_or_race_id":
+            raise IssueValidationError(f"{name}.scope.method is invalid")
     if coverage.get("status") not in {"complete", "partial"}:
         raise IssueValidationError(f"{name}.status must be complete or partial")
     run_count = coverage.get("runCount")
@@ -263,6 +289,14 @@ def validate_source_coverage(value: Any, name: str = "sourceCoverage") -> dict[s
     errors = _list(coverage.get("sourceErrors"), f"{name}.sourceErrors", 500)
     for index, error in enumerate(errors):
         _text(error, f"{name}.sourceErrors[{index}]", 2_000)
+    if schema == "gravel-weekly-source-coverage/v2":
+        infrastructure_warnings = _list(
+            coverage.get("infrastructureWarnings"),
+            f"{name}.infrastructureWarnings",
+            500,
+        )
+        for index, warning in enumerate(infrastructure_warnings):
+            _text(warning, f"{name}.infrastructureWarnings[{index}]", 2_000)
     if coverage["status"] == "complete" and (
         errors
         or has_latest_failure

--- a/scripts/validate_gravel_weekly.py
+++ b/scripts/validate_gravel_weekly.py
@@ -58,7 +58,7 @@ SOURCE_COVERAGE_V1_KEYS = {
     "discoverySources", "sourceErrors",
 }
 SOURCE_COVERAGE_V2_KEYS = SOURCE_COVERAGE_V1_KEYS | {
-    "scope", "infrastructureWarnings",
+    "scope", "scopedRunCount", "infrastructureWarnings",
 }
 SOURCE_COVERAGE_SCOPE_KEYS = {"vertical", "method"}
 SOURCE_COVERAGE_SOURCE_KEYS = {
@@ -224,6 +224,16 @@ def validate_source_coverage(value: Any, name: str = "sourceCoverage") -> dict[s
     run_count = coverage.get("runCount")
     if not isinstance(run_count, int) or isinstance(run_count, bool) or run_count < 1:
         raise IssueValidationError(f"{name}.runCount must be positive")
+    if schema == "gravel-weekly-source-coverage/v2":
+        scoped_run_count = coverage.get("scopedRunCount")
+        if (
+            not isinstance(scoped_run_count, int)
+            or isinstance(scoped_run_count, bool)
+            or not 1 <= scoped_run_count <= run_count
+        ):
+            raise IssueValidationError(
+                f"{name}.scopedRunCount must be between 1 and runCount"
+            )
     run_ids = _list(coverage.get("sweepRunIds"), f"{name}.sweepRunIds", 100)
     if len(run_ids) != run_count:
         raise IssueValidationError(f"{name}.sweepRunIds must match runCount")

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -33,6 +33,7 @@ from validate_gravel_weekly import (  # noqa: E402
     load_issues,
     load_public_issues,
     validate_issue,
+    validate_source_coverage,
 )
 from validate_gravel_weekly_history import (  # noqa: E402
     compute_history_content_hash,
@@ -192,6 +193,21 @@ def sample_source_coverage(status="complete"):
         }],
         "sourceErrors": [],
     }
+
+
+def sample_scoped_source_coverage(status="complete"):
+    coverage = sample_source_coverage(status)
+    coverage.update({
+        "schemaVersion": "gravel-weekly-source-coverage/v2",
+        "scope": {
+            "vertical": "gravel",
+            "method": "declared_source_vertical_or_race_id",
+        },
+        "infrastructureWarnings": [
+            "run_coverage: observation:nordic:example-race: fetch failed",
+        ],
+    })
+    return coverage
 
 
 def sample_control_plane_run(run_id=33243938367):
@@ -815,6 +831,29 @@ def test_review_prepares_a_draft_but_cannot_imply_approval():
     assert "Cyclingnews" in preview
     assert culture_artifact["reviewReason"] in preview
     assert "application/ld+json" not in preview
+
+
+def test_scoped_coverage_keeps_other_vertical_failures_visible_without_downgrading_gravel():
+    coverage = sample_scoped_source_coverage("complete")
+    assert validate_source_coverage(coverage)["status"] == "complete"
+    receipt = render_source_coverage_receipt(coverage)
+    assert "COMPLETE COVERAGE" in receipt
+    assert "GRAVEL OFFICIAL RACE/RESULTS" in receipt
+    assert "OTHER VERTICAL / INFRASTRUCTURE WARNINGS (1 TOTAL)" in receipt
+    assert "did not change the gravel coverage verdict" not in receipt
+    assert "observation:nordic:example-race" in receipt
+
+    review = sample_quiet_review()
+    review["sourceCoverage"] = coverage
+    issue = prepare_issue(review, "2026-08-28", 1, now="2026-08-29T09:00:00Z")
+    assert issue["sourceCoverage"]["schemaVersion"] == "gravel-weekly-source-coverage/v2"
+
+
+def test_scoped_coverage_rejects_a_non_gravel_scope():
+    coverage = sample_scoped_source_coverage()
+    coverage["scope"]["vertical"] = "nordic"
+    with pytest.raises(IssueValidationError, match="scope.vertical must be gravel"):
+        validate_source_coverage(coverage)
 
 
 def test_control_plane_run_validation_binds_the_exact_producer_and_artifact():

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -203,6 +203,7 @@ def sample_scoped_source_coverage(status="complete"):
             "vertical": "gravel",
             "method": "declared_source_vertical_or_race_id",
         },
+        "scopedRunCount": 1,
         "infrastructureWarnings": [
             "run_coverage: observation:nordic:example-race: fetch failed",
         ],
@@ -839,6 +840,7 @@ def test_scoped_coverage_keeps_other_vertical_failures_visible_without_downgradi
     receipt = render_source_coverage_receipt(coverage)
     assert "COMPLETE COVERAGE" in receipt
     assert "GRAVEL OFFICIAL RACE/RESULTS" in receipt
+    assert "1 carried vertical-scoped health" in receipt
     assert "OTHER VERTICAL / INFRASTRUCTURE WARNINGS (1 TOTAL)" in receipt
     assert "did not change the gravel coverage verdict" not in receipt
     assert "observation:nordic:example-race" in receipt
@@ -854,6 +856,11 @@ def test_scoped_coverage_rejects_a_non_gravel_scope():
     coverage["scope"]["vertical"] = "nordic"
     with pytest.raises(IssueValidationError, match="scope.vertical must be gravel"):
         validate_source_coverage(coverage)
+
+    invalid_count = sample_scoped_source_coverage()
+    invalid_count["scopedRunCount"] = 2
+    with pytest.raises(IssueValidationError, match="scopedRunCount must be between"):
+        validate_source_coverage(invalid_count)
 
 
 def test_control_plane_run_validation_binds_the_exact_producer_and_artifact():

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -152,10 +152,11 @@ def render_quiet_issue(quiet: dict[str, Any], *, draft: bool) -> str:
 
 def render_source_coverage_receipt(coverage: dict[str, Any]) -> str:
     latest = coverage["latestSourceHealth"]
+    scoped = coverage.get("schemaVersion") == "gravel-weekly-source-coverage/v2"
     lane_labels = (
-        ("OFFICIAL RACE/RESULTS", latest["officialObservation"]),
-        ("PUBLIC NEWS/BLOGS/FORUMS", latest["publicDiscovery"]),
-        ("SOCIAL/CULTURE APIS", latest["officialSocial"]),
+        (("GRAVEL OFFICIAL RACE/RESULTS" if scoped else "OFFICIAL RACE/RESULTS"), latest["officialObservation"]),
+        (("GRAVEL NEWS/BLOGS/FORUMS" if scoped else "PUBLIC NEWS/BLOGS/FORUMS"), latest["publicDiscovery"]),
+        (("GRAVEL SOCIAL/CULTURE APIS" if scoped else "SOCIAL/CULTURE APIS"), latest["officialSocial"]),
     )
     lanes = "".join(
         f'''<li><b>{esc(label)}</b><span>{health['succeeded']}/{health['attempted']} succeeded{f" · {health['failed']} failed" if health['failed'] else ""}</span></li>'''
@@ -176,13 +177,29 @@ def render_source_coverage_receipt(coverage: dict[str, Any]) -> str:
         f'''<details><summary>MOST RECENT COLLECTION GAPS ({len(coverage['sourceErrors'])} TOTAL)</summary>{error_notice}<ul>{errors}</ul></details>'''
         if errors else ""
     )
+    warnings = coverage.get("infrastructureWarnings", [])
+    visible_warnings = warnings[-20:]
+    warning_notice = (
+        f"<p>Showing the 20 most recent of {len(warnings)}; these did not change the gravel coverage verdict.</p>"
+        if len(warnings) > len(visible_warnings) else ""
+    )
+    warning_items = "".join(f"<li>{esc(warning)}</li>" for warning in visible_warnings)
+    warning_block = (
+        f'''<details><summary>OTHER VERTICAL / INFRASTRUCTURE WARNINGS ({len(warnings)} TOTAL)</summary>{warning_notice}<ul>{warning_items}</ul></details>'''
+        if warning_items else ""
+    )
+    scope_note = (
+        " The verdict is scoped to configured gravel sources; other-vertical failures remain visible below but cannot make gravel coverage partial."
+        if scoped else ""
+    )
     return f'''<aside class="gw-coverage" id="source-coverage">
       <span>PRIVATE COLLECTION RECEIPT — NOT PUBLIC COPY</span>
       <h2>{esc(coverage['status'].upper())} COVERAGE</h2>
-      <p>{coverage['runCount']} collection run{'s' if coverage['runCount'] != 1 else ''}; latest completed {esc(coverage['latestSweepCompletedAt'])}. {"A partial receipt keeps every gap visible for the human quiet-issue decision." if coverage['status'] == 'partial' else "Complete means every configured lane and named source reported successfully; it does not claim sources outside the registry were watched."}</p>
+      <p>{coverage['runCount']} collection run{'s' if coverage['runCount'] != 1 else ''}; latest completed {esc(coverage['latestSweepCompletedAt'])}. {"A partial receipt keeps every gravel-relevant gap visible for the human quiet-issue decision." if coverage['status'] == 'partial' else "Complete means every configured gravel lane and named source reported successfully; it does not claim sources outside the registry were watched."}{esc(scope_note)}</p>
       <ul class="gw-coverage-lanes">{lanes}</ul>
       <details><summary>SOURCES ATTEMPTED ({len(coverage['discoverySources'])})</summary><ul>{sources}</ul></details>
       {error_block}
+      {warning_block}
     </aside>'''
 
 

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -195,7 +195,7 @@ def render_source_coverage_receipt(coverage: dict[str, Any]) -> str:
     return f'''<aside class="gw-coverage" id="source-coverage">
       <span>PRIVATE COLLECTION RECEIPT — NOT PUBLIC COPY</span>
       <h2>{esc(coverage['status'].upper())} COVERAGE</h2>
-      <p>{coverage['runCount']} collection run{'s' if coverage['runCount'] != 1 else ''}; latest completed {esc(coverage['latestSweepCompletedAt'])}. {"A partial receipt keeps every gravel-relevant gap visible for the human quiet-issue decision." if coverage['status'] == 'partial' else "Complete means every configured gravel lane and named source reported successfully; it does not claim sources outside the registry were watched."}{esc(scope_note)}</p>
+      <p>{coverage['runCount']} collection run{'s' if coverage['runCount'] != 1 else ''}{f"; {coverage['scopedRunCount']} carried vertical-scoped health" if scoped else ""}; latest completed {esc(coverage['latestSweepCompletedAt'])}. {"A partial receipt keeps every gravel-relevant gap visible for the human quiet-issue decision." if coverage['status'] == 'partial' else "Complete means every configured gravel lane and named source reported successfully; it does not claim sources outside the registry were watched."}{esc(scope_note)}</p>
       <ul class="gw-coverage-lanes">{lanes}</ul>
       <details><summary>SOURCES ATTEMPTED ({len(coverage['discoverySources'])})</summary><ul>{sources}</ul></details>
       {error_block}


### PR DESCRIPTION
## What changed
- accept a v2 source-coverage receipt explicitly scoped to gravel
- keep legacy v1 snapshots valid
- render gravel-scoped lane labels and separate cross-vertical/infrastructure warnings
- allow unrelated road or Nordic failures to remain visible without downgrading the gravel completeness verdict

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` — 140 passed
- Python compile and `git diff --check` passed

This lands publication compatibility before the control plane begins emitting v2 receipts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes editorial gate semantics for when an issue can be "complete" versus partial, which affects quiet-week and draft preparation; backward compatibility with v1 limits blast radius.
> 
> **Overview**
> Adds **`gravel-weekly-source-coverage/v2`** so completeness is judged only on gravel-declared sources and `gravel:` race observations, while road/Nordic/unscoped failures stay visible as **`infrastructureWarnings`** without forcing partial gravel coverage. **v1** receipts remain valid with their original all-vertical semantics.
> 
> **`validate_source_coverage`** and the issue-prepare bridge now accept both schema versions; v2 adds required **`scope`**, **`scopedRunCount`**, and **`infrastructureWarnings`** with fail-closed checks (e.g. `scope.vertical` must be `gravel`). The private collection receipt renderer uses gravel-scoped lane labels, shows the warnings block, and clarifies that those gaps do not change the gravel verdict. README documents the new contract; tests cover complete coverage with cross-vertical warnings and invalid v2 scope/counts.
> 
> This is publication-side compatibility ahead of the control plane emitting v2 receipts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9b9fcf20d4f41f1f5ef141c7982a5b1eff2cbb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->