### PR TITLE
docs: clarify Manual for Speed archive availability

### DIFF
--- a/docs/gravel-weekly-manual-for-speed-reference.md
+++ b/docs/gravel-weekly-manual-for-speed-reference.md
@@ -26,12 +26,14 @@ tables of contents, recurring departments, character credits, and deliberately
 over-specific field notes. The durable lesson is the editorial structure, not
 either skin.
 
-On August 29, 2026, a temporary Internet Archive outage made the visual captures
-unavailable. The 2014 and 2015 interface structure was independently cross-checked
-against the preserved Common Crawl HTML, while the surviving 2021 site and the
+On August 29, 2026, the Internet Archive captures were intermittently available:
+the document structure and copy loaded, but several captured stylesheets and
+images did not. The 2014 and 2015 interface structure was therefore independently
+cross-checked against the preserved Common Crawl HTML, while the surviving 2021
+site and the
 [1000% Studio retrospective](https://thousandpercent.studio/work/manual-for-speed/)
-remained available for visual inspection. This fallback recovered document
-structure and original asset references, not permission to reuse the assets.
+provided the reliable visual reference. This recovered document structure and
+original asset references, not permission to reuse the assets.
 
 ## Three useful interface eras
 


### PR DESCRIPTION
## Summary
- record the partial Wayback recovery observed on 2026-08-29
- distinguish preserved document structure from missing archived styles/images
- retain the no-copy and rights boundary

## Verification
- 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the **Archive sample** provenance note to match what was actually observed on 2026-08-29: Wayback was **partially** usable (HTML/copy and structure loaded) rather than a full visual outage, with **missing archived CSS and images**.
> 
> It still says 2014–2015 structure was verified via **Common Crawl HTML**, and that **2021 captures plus the 1000% Studio retrospective** supplied dependable visuals. The **no reuse / rights** boundary is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8df5ebfbf6ec6b424853ddb607e8ac6b8838d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->