### PR TITLE
fix: keep approved Gravel Weekly copy off homepage

### DIFF
--- a/data/gravel-weekly/README.md
+++ b/data/gravel-weekly/README.md
@@ -124,10 +124,10 @@ Generate the latest page and dated archive:
 python3 wordpress/generate_gravel_weekly.py
 ```
 
-The public generator and sender both use the same fail-closed loader: only a
-sealed `status=published` snapshot can cross the publication boundary.
-`status=approved` remains private staging even if a file is placed in the
-canonical issue directory by mistake.
+The public issue generator, homepage teaser, and sender all use the same
+fail-closed loader: only a sealed `status=published` snapshot can cross the
+publication boundary. `status=approved` remains private staging even if a file
+is placed in the canonical issue directory by mistake.
 
 Render the controlled race-profile review for a published issue:
 

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -26,6 +26,7 @@ from gravel_weekly_visuals import (  # noqa: E402
     visual_css,
     youtube_video_id,
 )
+import generate_homepage as homepage_module  # noqa: E402
 from generate_homepage import build_gravel_weekly_band  # noqa: E402
 from validate_gravel_weekly import (  # noqa: E402
     IssueValidationError,
@@ -2878,6 +2879,29 @@ def test_homepage_surfaces_gravel_weekly_without_a_gravel_tv_content_path():
     assert 'href="/gravel-weekly/"' in band
     assert "GRAVEL <em>WEEKLY</em>" in band
     assert "Gravel TV" not in band
+
+
+def test_homepage_never_teases_an_approved_but_unpublished_issue(monkeypatch):
+    published = sample_issue()
+    approved = copy.deepcopy(published)
+    approved.update({
+        "issueId": "gravel-weekly-002",
+        "issueNumber": 2,
+        "publicationDate": "2026-09-04",
+        "slug": "2026-09-04",
+        "status": "approved",
+        "publishedAt": None,
+        "updatedAt": "2026-09-04T16:00:00Z",
+    })
+    approved["stories"][0]["headline"] = "PRIVATE APPROVED HEADLINE"
+    approved["contentHash"] = compute_content_hash(approved)
+    monkeypatch.setattr(homepage_module, "load_issues", lambda: [approved, published], raising=False)
+    monkeypatch.setattr(homepage_module, "load_public_issues", lambda: [published])
+
+    band = build_gravel_weekly_band()
+
+    assert "Unbound changed the course" in band
+    assert "PRIVATE APPROVED HEADLINE" not in band
 
 
 def test_email_preserves_legacy_subscribers_and_renders_a_sealed_issue():

--- a/wordpress/generate_homepage.py
+++ b/wordpress/generate_homepage.py
@@ -45,7 +45,7 @@ from shared_header import get_site_header_css, get_site_header_html, get_site_he
 from scroll_animations import get_scroll_animation_css, get_scroll_animation_js
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-from validate_gravel_weekly import load_issues  # noqa: E402
+from validate_gravel_weekly import load_public_issues  # noqa: E402
 
 OUTPUT_DIR = Path(__file__).parent / "output"
 RACE_INDEX_PATH = Path(__file__).parent.parent / "web" / "race-index.json"
@@ -538,9 +538,8 @@ def build_guide_preview(chapters: list) -> str:
 
 
 def build_gravel_weekly_band() -> str:
-    """Compact teaser for the latest approved Gravel Weekly issue."""
-    issues = [issue for issue in load_issues()
-              if issue["status"] in {"approved", "published"}]
+    """Compact teaser for the latest sealed Gravel Weekly issue."""
+    issues = load_public_issues()
     latest = issues[0] if issues else None
     current = None
     if latest and latest.get("currentThingStoryId"):


### PR DESCRIPTION
## Summary
- route the homepage Gravel Weekly teaser through the sealed-only public issue loader
- prevent status=approved copy from appearing before a separate publication instruction
- add a regression proving the homepage cannot leak an approved-but-unpublished headline
- document the shared public boundary across issue pages, homepage, and email

## Verification
- Gravel Weekly tests: 141 passed
- Full repository tests: 7424 passed, 331 skipped
- preflight_quality.py: passed with environmental warnings only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow homepage data-source change with a regression test; no auth or payment paths, only aligns teaser copy with existing publication rules.
> 
> **Overview**
> Fixes a **publication leak** where the homepage Gravel Weekly band could surface copy from `status=approved` issues before sealing.
> 
> `build_gravel_weekly_band()` now calls **`load_public_issues()`** instead of filtering `load_issues()` for approved or published. That matches the issue pages and email sender: only **`status=published`** snapshots cross the public boundary. The README states that the homepage teaser shares that fail-closed loader.
> 
> A regression test asserts that when a newer approved-but-unpublished issue exists alongside a published one, the band shows the published headline and never the private approved headline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea52ea4694d2831fca43588c307cd24e8b831e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->