### PR TITLE
Add chronological Gravel Weekly race arcs

### DIFF
--- a/docs/gravel-weekly-manual-for-speed-reference.md
+++ b/docs/gravel-weekly-manual-for-speed-reference.md
@@ -131,6 +131,14 @@ reader should always know where they are, what the point is, what is evidence,
 and what is Matti's approved take—even when the page is allowed to misbehave
 visually.
 
+The first production translation of the `More from this series` mechanic is
+deliberately narrower than semantic recommendations. A historical entry gets a
+`MORE FROM THIS RACE'S STORY` rail only when another approved change-point carries
+the same exact vertical-qualified `raceId`. The rail is chronological, includes
+the active entry as a visible `YOU ARE HERE` position, and never uses engagement,
+model similarity, or generic topic affinity. Entries without that reviewed join
+stay unlinked rather than receiving an inferred series.
+
 ## What made it cultural coverage
 
 Manual for Speed ran two records at the same time:

--- a/docs/gravel-weekly-visual-system.md
+++ b/docs/gravel-weekly-visual-system.md
@@ -48,6 +48,15 @@ show the pressure moving. It gets one restrained loop, remains intelligible as a
 still, and stops under reduced-motion preferences. Decorative perpetual motion is
 not a substitute for a point.
 
+## Race-arc navigation
+
+The historical timeline may expose up to five nearby change-points that share an
+exact reviewed `raceId` with the active entry. This is a serial-navigation aid,
+not a recommendation system: entries are ordered by their active date, the
+current entry remains visibly marked, and the renderer neither ranks by attention
+nor infers a relationship from prose or theme. No shared reviewed race ID means
+no rail.
+
 ## Story-graphic gate
 
 Before labeling a visual explanatory, the review desk must answer yes to all of the

--- a/tests/test_gravel_weekly.py
+++ b/tests/test_gravel_weekly.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(ROOT / "wordpress"))
 
 from generate_gravel_weekly import (  # noqa: E402
     build_page,
+    render_history_arc_navigation,
     render_history_timeline,
     render_source_coverage_receipt,
 )
@@ -2678,6 +2679,89 @@ def test_historical_timeline_groups_change_points_into_accessible_year_chapters(
     assert html.count('href="#gravel-history-years"') == 2
     assert "1 approved change-point" in html
     assert "innerHTML" not in html
+
+
+def test_history_race_arc_uses_exact_race_ids_and_chronology_not_attention():
+    entries = []
+    for year in range(2021, 2027):
+        entry = copy.deepcopy(sample_history_entry())
+        entry.update({
+            "entryId": f"history-unbound-{year}",
+            "activeFrom": f"{year}-06-01",
+            "activeThrough": f"{year}-06-02",
+            "headline": f"The Unbound turn in {year}",
+            "raceImpacts": [{
+                "impactKind": "editorial_review",
+                "raceId": "gravel:unbound-200",
+                "fieldPath": "race.biased_opinion",
+                "claimIds": ["claim_team_1"],
+                "confidence": 0.9,
+                "owner": "Gravel God race editorial review",
+                "autoFixAllowed": False,
+            }],
+        })
+        entries.append(entry)
+    unrelated = copy.deepcopy(sample_history_entry())
+    unrelated.update({
+        "entryId": "history-leadville-2024",
+        "activeFrom": "2024-08-10",
+        "activeThrough": "2024-08-10",
+        "headline": "A Leadville turn that does not belong here",
+        "raceImpacts": [{
+            **entries[0]["raceImpacts"][0],
+            "raceId": "gravel:leadville-trail-100",
+        }],
+    })
+
+    html = render_history_arc_navigation(entries[3], [unrelated, *reversed(entries)])
+
+    assert 'aria-labelledby="arc-label-history-unbound-2024"' in html
+    assert "MORE FROM THIS RACE&rsquo;S STORY" in html
+    assert "UNBOUND 200 THROUGH TIME" in html
+    assert "Chronological, never engagement-ranked." in html
+    assert 'aria-current="location"' in html
+    assert 'href="#history-unbound-2024"' not in html
+    assert html.count("The Unbound turn in") == 5
+    assert "The Unbound turn in 2021" not in html
+    assert "A Leadville turn that does not belong here" not in html
+    assert html.index("The Unbound turn in 2022") < html.index("The Unbound turn in 2026")
+    assert "innerHTML" not in html
+
+
+def test_history_race_arc_stays_absent_without_a_reviewed_shared_race_id():
+    entry = sample_history_entry()
+    other = copy.deepcopy(entry)
+    other["entryId"] = "history-other-2025"
+    other["activeFrom"] = "2025-01-01"
+    other["activeThrough"] = "2025-01-01"
+
+    assert render_history_arc_navigation(entry, [entry, other]) == ""
+
+
+def test_historical_timeline_places_race_arc_after_the_judgment_when_available():
+    newer = sample_history_entry()
+    newer["raceImpacts"] = [{
+        "impactKind": "editorial_review",
+        "raceId": "gravel:unbound-200",
+        "fieldPath": "race.biased_opinion",
+        "claimIds": ["claim_team_1"],
+        "confidence": 0.9,
+        "owner": "Gravel God race editorial review",
+        "autoFixAllowed": False,
+    }]
+    older = copy.deepcopy(newer)
+    older.update({
+        "entryId": "history-unbound-2025",
+        "activeFrom": "2025-06-01",
+        "activeThrough": "2025-06-02",
+        "headline": "The previous Unbound turn",
+    })
+
+    html = render_history_timeline([newer, older])
+
+    first_entry = html.split('id="history-teamification-2026"', 1)[1]
+    assert first_entry.index("WHAT CHANGED:") < first_entry.index('class="gw-story-arc"')
+    assert first_entry.index('class="gw-story-arc"') < first_entry.index("WHAT WAS KNOWABLE THEN")
 
 
 def test_historical_culture_artifacts_are_hash_bound_context_not_evidence():

--- a/wordpress/generate_gravel_weekly.py
+++ b/wordpress/generate_gravel_weekly.py
@@ -431,6 +431,81 @@ def render_issue_neighbors(issue: dict[str, Any], issues: list[dict[str, Any]]) 
     </nav>'''
 
 
+def _history_race_ids(entry: dict[str, Any]) -> set[str]:
+    return {
+        str(impact["raceId"])
+        for impact in entry.get("raceImpacts", [])
+        if impact.get("raceId")
+    }
+
+
+def _race_arc_name(race_id: str) -> str:
+    _, slug = race_id.split(":", 1)
+    return slug.replace("-", " ").upper()
+
+
+def render_history_arc_navigation(
+    entry: dict[str, Any], entries: list[dict[str, Any]]
+) -> str:
+    """Expose reviewed change-points sharing a race record, never inferred affinity."""
+    race_ids = _history_race_ids(entry)
+    if not race_ids:
+        return ""
+    related = sorted(
+        (
+            candidate
+            for candidate in entries
+            if race_ids & _history_race_ids(candidate)
+        ),
+        key=lambda candidate: (
+            candidate["activeFrom"],
+            candidate["activeThrough"],
+            candidate["entryId"],
+        ),
+    )
+    if len(related) < 2:
+        return ""
+    active_index = next(
+        index
+        for index, candidate in enumerate(related)
+        if candidate["entryId"] == entry["entryId"]
+    )
+    start = max(0, active_index - 2)
+    end = min(len(related), start + 5)
+    start = max(0, end - 5)
+    visible = related[start:end]
+    shared_ids = sorted(
+        race_id
+        for race_id in race_ids
+        if any(
+            candidate["entryId"] != entry["entryId"]
+            and race_id in _history_race_ids(candidate)
+            for candidate in related
+        )
+    )
+    arc_name = " + ".join(_race_arc_name(race_id) for race_id in shared_ids[:2])
+    if len(shared_ids) > 2:
+        arc_name += " + MORE"
+    label_id = f'arc-label-{entry["entryId"]}'
+    cards = []
+    for candidate in visible:
+        date = display_date(candidate["activeFrom"]).upper()
+        body = f'''<span>{esc(date)}</span><b>{esc(candidate['headline'])}</b>'''
+        if candidate["entryId"] == entry["entryId"]:
+            cards.append(
+                f'<li><span class="gw-story-arc-current" aria-current="location">'
+                f'<em>YOU ARE HERE</em>{body}</span></li>'
+            )
+        else:
+            cards.append(
+                f'<li><a href="#{esc(candidate["entryId"])}">{body}</a></li>'
+            )
+    return f'''<nav class="gw-story-arc" aria-labelledby="{esc(label_id)}">
+      <header><span>MORE FROM THIS RACE&rsquo;S STORY</span><h4 id="{esc(label_id)}">{esc(arc_name)} THROUGH TIME</h4><p>Reviewed change-points sharing the same race record. Chronological, never engagement-ranked.</p></header>
+      <ol>{"".join(cards)}</ol>
+    </nav>'''
+
+
 def render_history_timeline(entries: list[dict[str, Any]]) -> str:
     if not entries:
         return '''<section class="gw-history" id="season-story">
@@ -473,6 +548,7 @@ def render_history_timeline(entries: list[dict[str, Any]]) -> str:
             <section class="gw-history-take"><h4>THE TAKE</h4>{prose(entry['take'])}</section>
           </div>
           <div class="gw-history-judgment"><b>WHAT CHANGED:</b> {esc(entry['priorJudgment'])} → {esc(entry['changedJudgment'])}</div>
+          {render_history_arc_navigation(entry, entries)}
           <details class="gw-details"><summary>WHAT WAS KNOWABLE THEN · {len(entry['contemporaryReceipts'])}</summary>{render_receipts(entry['contemporaryReceipts'])}</details>
           {render_culture_artifacts(entry.get('cultureArtifacts', []))}
           {later}
@@ -687,6 +763,20 @@ def page_css() -> str:
   .gw-history-grid p { font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-relaxed); }
   .gw-history-take { border-left: var(--gg-border-standard); background: var(--gg-color-sand); font-weight: var(--gg-font-weight-semibold); }
   .gw-history-judgment, .gw-history-uncertainty { margin: 0; padding: var(--gg-spacing-sm) var(--gg-spacing-md); border-top: var(--gg-border-standard); font-family: var(--gg-font-editorial); line-height: var(--gg-line-height-normal); }
+  .gw-story-arc { border-top: var(--gg-border-heavy); background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }
+  .gw-story-arc > header { display: grid; grid-template-columns: minmax(0, 1fr) minmax(260px, .75fr); gap: var(--gg-spacing-2xs) var(--gg-spacing-lg); padding: var(--gg-spacing-sm) var(--gg-spacing-md); border-bottom: var(--gg-border-subtle); }
+  .gw-story-arc > header > span { grid-column: 1 / -1; color: var(--gg-color-gold); font-size: var(--gg-font-size-xs); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wider); }
+  .gw-story-arc h4 { margin: 0; font-size: var(--gg-font-size-md); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-story-arc > header p { margin: 0; color: var(--gg-color-tan); font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-xs); }
+  .gw-story-arc ol { display: flex; margin: 0; padding: 0; overflow-x: auto; list-style: none; scroll-snap-type: x proximity; }
+  .gw-story-arc li { flex: 1 1 180px; min-width: 180px; border-right: var(--gg-border-subtle); scroll-snap-align: start; }
+  .gw-story-arc a, .gw-story-arc-current { display: grid; align-content: start; gap: var(--gg-spacing-2xs); min-height: 100%; padding: var(--gg-spacing-sm) var(--gg-spacing-md); color: inherit; text-decoration: none; }
+  .gw-story-arc a:hover, .gw-story-arc a:focus-visible { background: var(--gg-color-teal); outline: var(--gg-border-gold); outline-offset: calc(var(--gg-border-width-standard) * -1); }
+  .gw-story-arc-current { background: var(--gg-color-gold); color: var(--gg-color-near-black); }
+  .gw-story-arc-current em { font-size: var(--gg-font-size-xs); font-style: normal; font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-story-arc li span:not(.gw-story-arc-current) { color: var(--gg-color-tan); font-size: var(--gg-font-size-xs); letter-spacing: var(--gg-letter-spacing-wide); }
+  .gw-story-arc-current > span { color: var(--gg-color-near-black); }
+  .gw-story-arc b { font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-sm); line-height: var(--gg-line-height-tight); }
   .gw-history-later { border-top: var(--gg-border-heavy); background: var(--gg-color-near-black); color: var(--gg-color-warm-paper); }
   .gw-history-later summary { cursor: pointer; padding: var(--gg-spacing-sm) var(--gg-spacing-md); font-weight: var(--gg-font-weight-black); letter-spacing: var(--gg-letter-spacing-wide); }
   .gw-history-later a { color: var(--gg-color-gold); }
@@ -746,6 +836,8 @@ def page_css() -> str:
     .gw-take { border-left: 0; border-top: var(--gg-border-standard); }
     .gw-memory-grid section + section { border-left: 0; border-top: var(--gg-border-standard); }
     .gw-history-take { border-left: 0; border-top: var(--gg-border-standard); }
+    .gw-story-arc > header { grid-template-columns: 1fr; }
+    .gw-story-arc li { flex: 0 0 min(76vw, 240px); min-width: 0; }
     .gw-story-head, .gw-story-grid section, .gw-utility, .gw-sub { padding: var(--gg-spacing-md); }
     .gw-coverage li { display: block; }
     .gw-coverage li span { display: block; margin-top: var(--gg-spacing-2xs); text-align: left; }


### PR DESCRIPTION
## What changed
- translate Manual for Speed’s “more from this series” mechanic into an exact race-ID join
- render up to five chronological change-points with a visible current position
- keep the rail absent when no reviewed race relationship exists
- add responsive, accessible neo-brutalist presentation and documentation

## Guardrails
- no semantic inference or engagement ranking
- no race-data writes or publication-state changes
- only public/sealed entries can appear in the public renderer

## Verification
- `python3 -m pytest tests/test_gravel_weekly.py -q` (144 passed)
- `python3 scripts/validate_gravel_weekly_history.py` (82 validated)
- `python3 scripts/validate_gravel_weekly.py` (0 public issues validated)
- `python3 scripts/preflight_quality.py` (passed, existing warnings only)
- desktop and 390px browser QA against an 82-entry private fixture

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only HTML from existing `raceImpacts` joins; no auth, data writes, or recommendation logic—wrong `raceId` links would be the main failure mode, covered by tests.
> 
> **Overview**
> Adds a **Manual for Speed–style “more from this series” rail** on historical change-points, wired only through an exact reviewed `raceId` on `raceImpacts`—not topic similarity or engagement.
> 
> **`render_history_arc_navigation`** builds a **MORE FROM THIS RACE'S STORY** nav when at least two entries share a race ID: up to five neighbors in **active-date order**, the current entry marked **YOU ARE HERE** (`aria-current="location"`), siblings as in-page `#entryId` links. No shared ID → empty string (no inferred series). The rail is inserted in **`render_history_timeline`** after **WHAT CHANGED** and before contemporary receipts, with new **`.gw-story-arc`** styling (horizontal scroll on small screens).
> 
> Docs in the MFS reference and visual-system guides spell out the same guardrails. Tests lock chronology, filtering, absence without a peer, and DOM order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730eee50f63be3d54b75ba3b82317f6a2a75deca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->