### PR TITLE
intel: XC Ski gated checkout 400 is intentional, not broken

### DIFF
--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -259,6 +259,13 @@ def collect_checkout(brand: str) -> dict:
                    "date": race_date}],
     }, headers={"Origin": BRANDS[brand]["origin"]})
     stripe_ok = ccode == 200 and "checkout.stripe.com" in body
+    # A 400 from the brand gate (training_plan_generation_enabled: false in
+    # brands.yaml) is an intentional product state, not breakage — keep probing
+    # so monitoring flips back on its own if the gate ever opens.
+    if ccode == 400 and "does not support training-plan generation" in body:
+        return {"health_ok": health_ok, "stripe_checkout_ok": True,
+                "ok": health_ok, "plans_gated": True,
+                "error": "" if health_ok else f"health={code}"}
     return {"health_ok": health_ok, "stripe_checkout_ok": stripe_ok,
             "ok": health_ok and stripe_ok,
             "error": "" if (health_ok and stripe_ok) else f"health={code} checkout={ccode}"}

--- a/tests/test_daily_intel.py
+++ b/tests/test_daily_intel.py
@@ -275,6 +275,35 @@ def test_safe_render_survives_shape_drift(collected):
     assert "report rendering crashed" in out
 
 
+def test_collect_checkout_gated_brand_is_not_broken(monkeypatch):
+    from scripts import daily_intel
+
+    def fake_http(url, data=None, headers=None, timeout=25):
+        if url.endswith("/health"):
+            return 200, "ok"
+        return 400, '{"error": "XC Ski Labs does not support training-plan generation yet"}'
+
+    monkeypatch.setattr(daily_intel, "_http", fake_http)
+    out = daily_intel.collect_checkout("xcski")
+    assert out["ok"] is True
+    assert out["plans_gated"] is True
+    assert out["error"] == ""
+
+
+def test_collect_checkout_real_400_still_fails(monkeypatch):
+    from scripts import daily_intel
+
+    def fake_http(url, data=None, headers=None, timeout=25):
+        if url.endswith("/health"):
+            return 200, "ok"
+        return 400, '{"error": "Valid email is required"}'
+
+    monkeypatch.setattr(daily_intel, "_http", fake_http)
+    out = daily_intel.collect_checkout("gravelgod")
+    assert out["ok"] is False
+    assert "checkout=400" in out["error"]
+
+
 def test_load_prior_snapshots_skips_non_dict(tmp_path, monkeypatch):
     from scripts import daily_intel
     monkeypatch.setattr(daily_intel, "SNAPSHOT_DIR", tmp_path)


### PR DESCRIPTION
The daily 'checkout XC Ski Labs FAIL: health=200 checkout=400' line (#121) is the monitor mislabeling a deliberate product state: `athletes/config/brands.yaml` in the pipeline repo sets `training_plan_generation_enabled: false` for xcskilabs (comment in the yaml: automated XC-ski plan generation stays gated until ski workout/zone adaptation passes release criteria), and `create_checkout` returns 400 for it by design.

This teaches `collect_checkout` to classify that specific 400 as healthy (`plans_gated: true`) while keeping the probe live — if the gate ever opens, monitoring resumes automatically. Any other 400 still reports FAIL.

Tests: 2 new unit tests; full `tests/test_daily_intel.py` suite green (20 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrGEC6HTQdaVUGjE94QmN7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow monitoring logic change in daily intel with tests; no auth, payments, or fulfillment paths touched.
> 
> **Overview**
> **Morning Intel** was flagging XC Ski Labs checkout as broken (`checkout=400`) even when the webhook intentionally rejects plan checkout because training-plan generation is disabled for that brand.
> 
> `collect_checkout` now recognizes that specific **400** response (body mentions not supporting training-plan generation) as an expected **gated** state: it sets `plans_gated: true`, treats Stripe checkout as satisfied for monitoring purposes, and marks the probe **ok** when `/health` passes—while still calling `create-checkout` so alerts recover automatically if the gate opens. Any other **400** (e.g. validation errors) still fails the probe.
> 
> Two unit tests cover the gated path vs a real checkout failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf9fc71630a1b75b679d2780dbfe018e663025ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->