### PR TITLE
intel-fix: /llms.txt sg-captcha false-positive retry

### DIFF
--- a/scripts/aeo_weekly.py
+++ b/scripts/aeo_weekly.py
@@ -15,6 +15,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -493,6 +494,25 @@ def _merge_unknown_candidates(
     )[:MAX_UNKNOWN_CANDIDATES]
 
 
+# SiteGround answers some requests with an sg-captcha meta-refresh page
+# instead of the real response (see scripts/check_links.py's identical
+# 202-challenge handling). A single-shot check_llms_marker request that
+# lands during a challenge window reads as "displaced" even though the
+# real file is fine — issue #53 traced a week of false BROKEN flags to
+# exactly this. Retry with backoff, same convention as check_links.py,
+# before concluding the marker is really gone.
+LLMS_CHALLENGE_BACKOFF = (20, 45)  # seconds to wait before each retry
+
+
+def _fetch_llms_head(url: str, timeout: int) -> str:
+    import urllib.request
+
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "gg-aeo-weekly/1 (self-check)"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read(4096).decode("utf-8", "replace")
+
+
 def check_llms_marker(brand: str, timeout: int = 20) -> dict[str, Any]:
     """Verify the live /llms.txt still serves OUR database file.
 
@@ -503,16 +523,20 @@ def check_llms_marker(brand: str, timeout: int = 20) -> dict[str, Any]:
     catches the next silent displacement (renders as BROKEN in Morning
     Intel via the stale/invalid path).
     """
-    import urllib.request
-
     meta = BRANDS[brand]
     url = f"https://{meta['domain']}/llms.txt"
-    req = urllib.request.Request(
-        url, headers={"User-Agent": "gg-aeo-weekly/1 (self-check)"})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        head = resp.read(4096).decode("utf-8", "replace")
     marker = str(meta["llms_marker"])
-    ok = head.lstrip("﻿\n\r ").startswith(marker)
+
+    head = _fetch_llms_head(url, timeout)
+    stripped = head.lstrip("﻿\n\r ")
+    for pause in LLMS_CHALLENGE_BACKOFF:
+        if stripped.startswith(marker) or "sgcaptcha" not in stripped:
+            break
+        time.sleep(pause)
+        head = _fetch_llms_head(url, timeout)
+        stripped = head.lstrip("﻿\n\r ")
+
+    ok = stripped.startswith(marker)
     return {
         "status": "ok" if ok else "displaced",
         "marker": marker,

--- a/tests/test_aeo_weekly.py
+++ b/tests/test_aeo_weekly.py
@@ -121,6 +121,56 @@ def test_log_collector_mocks_one_ssh_call_with_timeout(monkeypatch):
     assert kwargs["timeout"] == 270
 
 
+def test_check_llms_marker_retries_through_sgcaptcha_then_succeeds(monkeypatch):
+    challenge_page = (
+        '<html><head><link rel="icon" href="data:;">'
+        '<meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?r=%2Fllms.txt&y">'
+    )
+    real_body = "# Gravel God Race Database\nlast_updated: 2026-09-07\n"
+    responses = iter([challenge_page, challenge_page, real_body])
+    sleeps = []
+
+    monkeypatch.setattr(aeo_weekly, "_fetch_llms_head", lambda url, timeout: next(responses))
+    monkeypatch.setattr(aeo_weekly.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    result = aeo_weekly.check_llms_marker("gravelgod")
+
+    assert result["status"] == "ok"
+    assert sleeps == list(aeo_weekly.LLMS_CHALLENGE_BACKOFF[:2])
+
+
+def test_check_llms_marker_reports_displaced_when_challenge_never_clears(monkeypatch):
+    challenge_page = (
+        '<html><head><link rel="icon" href="data:;">'
+        '<meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?r=%2Fllms.txt&y">'
+    )
+    monkeypatch.setattr(aeo_weekly, "_fetch_llms_head", lambda url, timeout: challenge_page)
+    monkeypatch.setattr(aeo_weekly.time, "sleep", lambda seconds: None)
+
+    result = aeo_weekly.check_llms_marker("gravelgod")
+
+    assert result["status"] == "displaced"
+
+
+def test_check_llms_marker_does_not_retry_a_real_displacement(monkeypatch):
+    aioseo_body = "AIOSEO generated content, not our marker\n"
+    calls = []
+
+    def fake_fetch(url, timeout):
+        calls.append(url)
+        return aioseo_body
+
+    monkeypatch.setattr(aeo_weekly, "_fetch_llms_head", fake_fetch)
+    monkeypatch.setattr(
+        aeo_weekly.time, "sleep",
+        lambda seconds: pytest.fail("should not sleep on a non-challenge displacement"))
+
+    result = aeo_weekly.check_llms_marker("gravelgod")
+
+    assert result["status"] == "displaced"
+    assert len(calls) == 1
+
+
 def test_ga4_collector_uses_two_reports_and_filters_sources_in_python(
         monkeypatch):
     class Value:


### PR DESCRIPTION
auto-authored by morning-intel-triage

**Linked intel issue:** #53 (reopened today — signal recurred)

**Evidence:**
- Today's (2026-09-07) intel snapshot flags `llms_serving_status: displaced` for all 3 brands (gravelgod, roadie, xcski) with the identical sg-captcha meta-refresh signature originally diagnosed in #53: `<html><head>...<meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?r=%2Fllms.txt&y...`.
- Reproduced live from this session's sandbox with `check_llms_marker`'s exact self-check UA (`gg-aeo-weekly/1 (self-check)`) — all 3 domains currently return the sg-captcha challenge page on `/llms.txt`, not real content or AIOSEO-plugin content. That confirms this is a WAF challenge, not the original Jul 24 AIOSEO-clobber regression.
- #53 diagnosed this exact pattern in August and closed once the signal cleared, but the proposed fix (draft PR #54: port `check_links.py`'s sg-captcha retry-with-backoff into `check_llms_marker`) was never merged — it was orphaned when `main`'s history was force-rewritten (tracked in #36) and nobody re-created it. `scripts/aeo_weekly.py` on current `main` still has zero retry logic in `check_llms_marker` (confirmed via `grep -n CHALLENGE_BACKOFF` — no match before this PR). The underlying bug was never actually fixed; the signal just went quiet for a few weeks until the WAF challenged the weekly run again today.

**What changed and why:**
- `scripts/aeo_weekly.py`: extracted the `/llms.txt` fetch into `_fetch_llms_head()`, added a `LLMS_CHALLENGE_BACKOFF = (20, 45)` constant (same values `check_links.py` uses for its sg-captcha retries), and made `check_llms_marker()` retry through the backoff *only* when the response looks like an sg-captcha challenge (contains `"sgcaptcha"`) and hasn't yet matched the brand's real marker. A genuine displacement (e.g. AIOSEO plugin content with no `sgcaptcha` string) is reported immediately with no wasted retries.
- `tests/test_aeo_weekly.py`: 3 new regression tests — retries through a transient challenge then succeeds, still reports `displaced` if the challenge never clears within the backoff budget, and does not retry (single fetch) on a real non-challenge displacement.

**Test output:**
- Targeted file: `python3 -m pytest tests/test_aeo_weekly.py -v` → **28 passed** (25 pre-existing + 3 new), 0 failed.
- Full suite: `python3 -m pytest tests/` (14 files with pre-existing missing-dependency import errors in this sandbox — `dotenv`/`ddgs`/`PIL`/`anthropic` — skipped via `--ignore`, same as this repo's own CLAUDE.md guidance) → **6743 passed, 330 skipped, 4 failed**. The 4 failures (`test_generate_llms_txt.py::test_unavailable_plan_slugs_are_detected_from_canonical_profiles`, `test_homepage_generator.py::test_page_size_reasonable`, `test_whitepaper_fueling.py::test_sync_whitepaper_exists`, `test_whitepaper_fueling.py::test_sync_whitepaper_is_callable`) are unrelated to this change (none touch `aeo_weekly.py` or `check_llms_marker`) and match the same "4 pre-existing unrelated failures" baseline #53's own draft PR #54 reported in August.
- Live smoke test (this session's sandbox, currently sg-captcha-challenged for raw curls): `python3 -c "from scripts import aeo_weekly; print(aeo_weekly.check_llms_marker('gravelgod'))"` → **`{'status': 'ok', ...}`** — the retry cleared the exact challenge this PR exists to handle, on the exact IP/environment that was failing moments before.

**Rollback:** revert this commit; `check_llms_marker` returns to the single-shot check (no behavior change to any other function, no data/schema changes, no deploy/publish surface touched).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkTW1mrvfmot2y1TTvH6B1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to weekly AEO self-check timing and false-positive reduction; no auth, data, or deploy surface changes.
> 
> **Overview**
> **`check_llms_marker`** no longer treats a one-off SiteGround **sg-captcha** meta-refresh as a real `/llms.txt` displacement. The fetch is split into **`_fetch_llms_head`**, and when the response body contains `sgcaptcha` but not the brand marker, the checker waits **`LLMS_CHALLENGE_BACKOFF` (20s, 45s)**—matching **`check_links.py`**—and refetches before reporting **`displaced`**.
> 
> Responses that look like genuine displacement (wrong content without `sgcaptcha`) still fail on the first fetch with no sleeps. Three unit tests cover success after transient challenge, persistent challenge, and no-retry on real displacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48600829ca7e0ad89f9ca589386eefcf432ee16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->