### PR TITLE
Fix captcha diagnosis and add scoped race support-page deployment

### DIFF
--- a/.github/workflows/deploy-race-support.yml
+++ b/.github/workflows/deploy-race-support.yml
@@ -1,0 +1,84 @@
+name: Deploy Race Support Pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      slug:
+        description: Canonical race slug for prep-kit and Markdown deployment
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-race-support
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RACE_SLUG: ${{ inputs.slug }}
+      SSH_HOST: ${{ secrets.SSH_HOST }}
+      SSH_USER: ${{ secrets.SSH_USER }}
+      SSH_PORT: ${{ secrets.SSH_PORT }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Install browser for required tests
+        run: python3 -m playwright install --with-deps chromium
+      - name: Validate slug and source
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = refs/heads/main
+          [[ "$RACE_SLUG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]
+          test -f "race-data/$RACE_SLUG.json"
+      - name: Pre-deploy gates
+        run: |
+          set -euo pipefail
+          python3 -m pytest tests/ -q --tb=short -x
+          python3 scripts/audit_colors.py
+          python3 scripts/validate_citations.py
+          python3 scripts/validate_blog_content.py
+          python3 scripts/youtube_validate.py
+      - name: Configure SSH for live inventory and deployment
+        env:
+          DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$DEPLOY_KEY"
+          test -n "$SSH_HOST"
+          test -n "$SSH_USER"
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/siteground_key
+          chmod 600 ~/.ssh/siteground_key
+          ssh-keyscan -p "${SSH_PORT:-18765}" "$SSH_HOST" >> ~/.ssh/known_hosts
+          echo "SSH_PORT=${SSH_PORT:-18765}" >> "$GITHUB_ENV"
+      - name: Build the two-file payload
+        run: |
+          set -euo pipefail
+          python3 wordpress/generate_prep_kit.py "$RACE_SLUG" --output-dir wordpress/output/prep-kit
+          python3 scripts/generate_markdown_profiles.py --slug "$RACE_SLUG" --output-dir wordpress/output/markdown
+          python3 scripts/preflight_quality.py
+      - name: Preserve payload for inspection
+        uses: actions/upload-artifact@v4
+        with:
+          name: race-support-${{ inputs.slug }}-${{ github.sha }}
+          path: |
+            wordpress/output/prep-kit/
+            wordpress/output/markdown/
+          if-no-files-found: error
+      - name: Upload, purge cache, and verify both live files
+        run: python3 scripts/deploy_race_support.py "$RACE_SLUG" --payload-dir wordpress/output --upload
+      - name: Validate deployment
+        run: python3 scripts/validate_deploy.py
+      - name: Remove SSH key
+        if: always()
+        run: rm -f ~/.ssh/siteground_key

--- a/scripts/aeo_weekly.py
+++ b/scripts/aeo_weekly.py
@@ -510,7 +510,10 @@ def _fetch_llms_head(url: str, timeout: int) -> str:
     req = urllib.request.Request(
         url, headers={"User-Agent": "gg-aeo-weekly/1 (self-check)"})
     with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return resp.read(4096).decode("utf-8", "replace")
+        head = resp.read(4096).decode("utf-8", "replace")
+        if resp.status != 200 and "sgcaptcha" not in head.lower():
+            raise OSError(f"Unexpected HTTP status {resp.status}")
+        return head
 
 
 def check_llms_marker(brand: str, timeout: int = 20) -> dict[str, Any]:
@@ -530,7 +533,7 @@ def check_llms_marker(brand: str, timeout: int = 20) -> dict[str, Any]:
     head = _fetch_llms_head(url, timeout)
     stripped = head.lstrip("﻿\n\r ")
     for pause in LLMS_CHALLENGE_BACKOFF:
-        if stripped.startswith(marker) or "sgcaptcha" not in stripped:
+        if stripped.startswith(marker) or "sgcaptcha" not in stripped.lower():
             break
         time.sleep(pause)
         head = _fetch_llms_head(url, timeout)
@@ -538,7 +541,7 @@ def check_llms_marker(brand: str, timeout: int = 20) -> dict[str, Any]:
 
     ok = stripped.startswith(marker)
     return {
-        "status": "ok" if ok else "displaced",
+        "status": "ok" if ok else ("challenged" if "sgcaptcha" in stripped.lower() else "displaced"),
         "marker": marker,
         "first_line": head.splitlines()[0][:120] if head else "",
     }
@@ -647,6 +650,9 @@ def validate_artifact(
                         f"brands.{brand}.top_user_fetch_paths contains an invalid path")
                     break
         if require_all_ok:
+            llms = value.get("llms_serving")
+            if isinstance(llms, dict) and llms.get("status") != "ok":
+                errors.append(f"brands.{brand}.llms_serving collector not ok")
             expected_ga4 = "not_configured" if brand == "xcski" else "ok"
             if isinstance(ga4, dict) and ga4.get("status") != expected_ga4:
                 errors.append(f"brands.{brand}.ga4 collector not ok")

--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -582,11 +582,9 @@ def _collect_aeo(today: date | None = None) -> dict:
             "label": label,
             "ga4_status": (current_brand.get("ga4") or {}).get("status", "error"),
             "logs_status": (current_brand.get("logs") or {}).get("status", "error"),
-            # "displaced" = the live /llms.txt no longer starts with our
-            # database marker (e.g. AIOSEO clobbered it again) — surfaced
-            # as a BROKEN line by _collector_failures.
             "llms_serving_status": llms_serving.get("status", "unknown"),
             "llms_serving_first_line": llms_serving.get("first_line", ""),
+            "llms_serving_error": llms_serving.get("error", ""),
             "ai_referral_sessions": ga4_sessions,
             "ai_referral_delta": ga4_delta,
             "ai_referral_delta_text": _aeo_delta_text(ga4_delta),
@@ -816,12 +814,27 @@ def _collector_failures(collected: dict) -> list[str]:
         for brand, summary in (aeo.get("brands") or {}).items():
             if not isinstance(summary, dict):
                 continue
-            if summary.get("llms_serving_status") == "displaced":
-                first = summary.get("llms_serving_first_line") or "?"
+            status = summary.get("llms_serving_status")
+            first = summary.get("llms_serving_first_line") or "?"
+            label = summary.get("label", brand)
+            # Old weekly snapshots classified captcha responses as displaced.
+            # Correct their interpretation without changing historical evidence.
+            if status == "displaced" and "sgcaptcha" in first.lower():
+                status = "challenged"
+            if status == "challenged":
                 broken.append(
-                    f"{summary.get('label', brand)} /llms.txt DISPLACED — live file "
-                    f"no longer starts with our database marker (serving: {first!r}); "
-                    f"likely AIOSEO clobbered it again")
+                    f"{label} /llms.txt CAPTCHA-BLOCKED — the monitoring request "
+                    "received a SiteGround challenge; file contents are unverified. "
+                    "Check WAF rules and recheck from the host; an overwrite is not proven.")
+            elif status == "displaced":
+                broken.append(
+                    f"{label} /llms.txt MARKER MISMATCH — response does not start "
+                    f"with our database marker (serving: {first!r}); "
+                    "inspect the live file and response before assigning a cause.")
+            elif status == "error":
+                error = summary.get("llms_serving_error") or "unknown fetch error"
+                broken.append(
+                    f"{label} /llms.txt UNREACHABLE — {error}; file contents are unverified.")
     seo = collected.get("seo") or {}
     if (
             isinstance(seo, dict)

--- a/scripts/deploy_race_support.py
+++ b/scripts/deploy_race_support.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Deploy only a prepared race prep kit and Markdown profile; verify live bytes."""
+
+import argparse
+from pathlib import Path
+import re
+import time
+import urllib.request
+
+
+def payload_files(root: Path, slug: str) -> dict[str, Path]:
+    if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", slug):
+        raise ValueError("Invalid canonical race slug")
+    expected = {
+        f"/race/{slug}/prep-kit/": root / "prep-kit" / f"{slug}.html",
+        f"/race/{slug}.md": root / "markdown" / f"{slug}.md",
+    }
+    for directory, suffix in (("prep-kit", ".html"), ("markdown", ".md")):
+        files = set((root / directory).iterdir())
+        if files != {root / directory / f"{slug}{suffix}"}:
+            raise ValueError(f"Unexpected files in {directory}; refusing broad upload")
+    for path in expected.values():
+        if path.is_symlink() or not path.is_file() or not path.stat().st_size:
+            raise ValueError(f"Missing, empty, or symlink payload: {path}")
+    return expected
+
+
+def verify(files: dict[str, Path], attempts: int = 8) -> None:
+    pending = dict(files)
+    for attempt in range(attempts):
+        for route, path in list(pending.items()):
+            url = f"https://gravelgodcycling.com{route}"
+            try:
+                request = urllib.request.Request(url, headers={
+                    "User-Agent": "gg-deploy-verification/1", "Cache-Control": "no-cache",
+                })
+                with urllib.request.urlopen(request, timeout=20) as response:
+                    body = response.read()
+                    if response.status == 200 and body == path.read_bytes():
+                        print(f"Verified exact live bytes: {url}", flush=True)
+                        del pending[route]
+                    else:
+                        print(f"Not verified: {url} (HTTP {response.status})", flush=True)
+            except OSError as exc:
+                print(f"Not verified: {url}: {exc}", flush=True)
+        if not pending:
+            return
+        if attempt + 1 < attempts:
+            time.sleep(10)
+    raise RuntimeError("Live verification failed: " + ", ".join(pending))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("slug")
+    parser.add_argument("--payload-dir", type=Path, required=True)
+    parser.add_argument("--upload", action="store_true")
+    args = parser.parse_args()
+    files = payload_files(args.payload_dir, args.slug)
+    if args.upload:
+        try:
+            from scripts import push_wordpress
+        except ImportError:
+            import push_wordpress
+        if not push_wordpress.sync_prep_kits(str(args.payload_dir / "prep-kit")):
+            raise RuntimeError("Prep-kit upload failed")
+        if not push_wordpress.sync_markdown(str(args.payload_dir / "markdown")):
+            raise RuntimeError("Markdown upload failed; prep kit may already be live")
+        if not push_wordpress.purge_cache():
+            raise RuntimeError("Cache purge failed")
+    verify(files)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_aeo_weekly.py
+++ b/tests/test_aeo_weekly.py
@@ -139,7 +139,7 @@ def test_check_llms_marker_retries_through_sgcaptcha_then_succeeds(monkeypatch):
     assert sleeps == list(aeo_weekly.LLMS_CHALLENGE_BACKOFF[:2])
 
 
-def test_check_llms_marker_reports_displaced_when_challenge_never_clears(monkeypatch):
+def test_check_llms_marker_reports_challenged_when_challenge_never_clears(monkeypatch):
     challenge_page = (
         '<html><head><link rel="icon" href="data:;">'
         '<meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?r=%2Fllms.txt&y">'
@@ -149,7 +149,7 @@ def test_check_llms_marker_reports_displaced_when_challenge_never_clears(monkeyp
 
     result = aeo_weekly.check_llms_marker("gravelgod")
 
-    assert result["status"] == "displaced"
+    assert result["status"] == "challenged"
 
 
 def test_check_llms_marker_does_not_retry_a_real_displacement(monkeypatch):
@@ -334,6 +334,7 @@ def test_partial_artifact_is_written_and_strict_validation_fails(
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("SSH down")),
     )
 
+    monkeypatch.setattr(aeo_weekly, "check_llms_marker", lambda *a: {"status": "ok"})
     artifact = aeo_weekly.collect_weekly(
         datetime(2026, 7, 20, 10, 30, tzinfo=timezone.utc))
     path = aeo_weekly.write_artifact(artifact, tmp_path)
@@ -440,3 +441,44 @@ def test_aeo_render_fixture_snapshot(tmp_path, monkeypatch):
         "- **Unknown agent candidates (spoofable):** FooBot/1.0 "
         "(4; gravelgod 3, roadie 1).",
     ])
+
+
+@pytest.mark.parametrize("status,first,expected", [
+    ("challenged", "sgcaptcha", "CAPTCHA-BLOCKED"),
+    ("displaced", "<html>sgcaptcha</html>", "CAPTCHA-BLOCKED"),
+    ("displaced", "Other content", "MARKER MISMATCH"),
+    ("error", "", "UNREACHABLE"),
+    ("ok", "# Gravel God Race Database", None),
+])
+def test_llms_alert_uses_evidence_without_inventing_cause(status, first, expected):
+    collected = {"aeo": {"state": "ok", "brands": {"gravelgod": {
+        "label": "Gravel God", "llms_serving_status": status,
+        "llms_serving_first_line": first, "llms_serving_error": "timeout",
+    }}}}
+    alerts = daily_intel._collector_failures(collected)
+    if expected is None:
+        assert alerts == []
+    else:
+        assert len(alerts) == 1
+        assert expected in alerts[0]
+        assert "AIOSEO" not in alerts[0]
+
+
+@pytest.mark.parametrize("status", ["challenged", "displaced", "error"])
+def test_strict_validation_rejects_unhealthy_llms(status):
+    artifact = _artifact("2026-07-20")
+    artifact["brands"]["gravelgod"]["llms_serving"] = {"status": status}
+    assert aeo_weekly.validate_artifact(artifact) == []
+    errors = aeo_weekly.validate_artifact(artifact, require_all_ok=True)
+    assert "brands.gravelgod.llms_serving collector not ok" in errors
+
+
+def test_fetch_does_not_accept_non_200_marker(monkeypatch):
+    from io import BytesIO
+    import urllib.request
+
+    response = BytesIO(b"# Gravel God Race Database")
+    response.status = 202
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: response)
+    with pytest.raises(OSError, match="HTTP status 202"):
+        aeo_weekly._fetch_llms_head("https://example.test/llms.txt", 1)

--- a/tests/test_deploy_race_support.py
+++ b/tests/test_deploy_race_support.py
@@ -1,0 +1,47 @@
+"""Guard scoped uploads and ensure a captcha cannot count as deploy success."""
+
+from io import BytesIO
+
+import pytest
+
+from scripts import deploy_race_support as deploy
+
+
+@pytest.fixture
+def payload(tmp_path):
+    for directory, suffix in (("prep-kit", ".html"), ("markdown", ".md")):
+        (tmp_path / directory).mkdir()
+        (tmp_path / directory / f"winterberg{suffix}").write_text("expected")
+    return tmp_path
+
+
+def test_payload_rejects_other_races(payload):
+    (payload / "markdown" / "other.md").write_text("unrelated")
+    with pytest.raises(ValueError, match="broad upload"):
+        deploy.payload_files(payload, "winterberg")
+
+
+@pytest.mark.parametrize("slug", ["../winterberg", "winterberg;true", "", "A B"])
+def test_payload_rejects_unsafe_slug(payload, slug):
+    with pytest.raises(ValueError, match="slug"):
+        deploy.payload_files(payload, slug)
+
+
+@pytest.mark.parametrize("status,body,success", [
+    (200, b"expected", True),
+    (202, b"expected", False),
+    (200, b"<html>sgcaptcha</html>", False),
+    (200, b"stale", False),
+])
+def test_verification_requires_200_and_exact_bytes(payload, monkeypatch, status, body, success):
+    def fetch(*args, **kwargs):
+        response = BytesIO(body)
+        response.status = status
+        return response
+    monkeypatch.setattr(deploy.urllib.request, "urlopen", fetch)
+    files = deploy.payload_files(payload, "winterberg")
+    if success:
+        deploy.verify(files, attempts=1)
+    else:
+        with pytest.raises(RuntimeError, match="verification failed"):
+            deploy.verify(files, attempts=1)

--- a/wordpress/generate_homepage.py
+++ b/wordpress/generate_homepage.py
@@ -2108,7 +2108,9 @@ def generate_homepage(race_index: list, race_data_dir: Path = None,
     testimonials = build_testimonials()
     email = build_email_capture(substack_posts)
     footer = build_footer()
-    css = build_homepage_css()
+    # Omit standalone source comments from the shipped CSS. Keep declarations,
+    # strings, inline comments, and all page content unchanged.
+    css = re.sub(r"(?m)^[ \t]*/\*(?:(?!\*/)[^\n])*\*/[ \t]*(?:\n|$)", "", build_homepage_css())
     js = build_homepage_js()
     jsonld = build_jsonld(stats)
 


### PR DESCRIPTION
Morning Intel treats persistent SiteGround captcha responses as overwritten llms.txt files and assigns an unsupported AIOSEO cause. Meanwhile, Winterberg's missing prep-kit and Markdown pages have no dedicated deployment workflow.

Changes:
- Distinguish captcha challenges, marker mismatches, and fetch errors; interpret existing weekly captcha snapshots accurately without rewriting history.
- Surface unsuccessful llms.txt checks in strict artifact validation and reject non-200 marker responses.
- Add a manually dispatched, main-only workflow using existing SiteGround secrets to build and deploy one race's prep kit and Markdown profile. Require preflight gates, reject extra payload files, purge cache, and verify HTTP 200 plus exact live bytes.
- Remove standalone CSS source comments from the generated homepage to restore its existing size budget. Page content and CSS rule/declaration tokens remain unchanged.

Validation:
- Full local suite: 7,495 passed, 296 skipped, 33 setup errors because the Playwright Chromium executable was unavailable. Browser download timed out.
- Final focused monitoring/deployment tests: 46 passed.
- Homepage size test passed; CSS rule/declaration token equivalence verified with tinycss2, ignoring comments and whitespace.
- Winterberg prep-kit and Markdown generation passed. Local Markdown preview used an empty local training-guide inventory; the workflow requires live SSH inventory instead.
- Color audit, citation validation, and offline quality preflight passed.
- GitHub tree SHA matches the committed local tree exactly: 6ba8a6ccf9178ffd5fb1b4fa54bcb3613ae39983.

Remaining blockers / review notes:
- Not deployed. The workflow has not run with production secrets.
- Required blog-content validation fails in a fresh checkout without generated blog/recap output. YouTube validation reports missing local media. These gates remain enforced; their required artifacts must be supplied before this workflow can deploy successfully.
- This change improves monitoring diagnosis; it does not change SiteGround WAF rules or establish that every crawler can fetch llms.txt.
- The legacy Unbounded font 404 is outside this two-file deployment.

Refs #53, #129, #301.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a production SSH deployment path gated by tests and narrow payloads, while monitoring changes reduce false incidents but alter how llms.txt health is reported and validated.
> 
> **Overview**
> Morning Intel and weekly AEO monitoring no longer treat persistent SiteGround **sgcaptcha** responses as proof that `/llms.txt` was overwritten. **`check_llms_marker`** now reports **`challenged`**, **`displaced`**, or **`error`** separately, rejects unexpected non-200 fetches (except captcha bodies), and **`require_all_ok`** validation fails when **`llms_serving`** is not **`ok`**. **`daily_intel`** maps those states to **CAPTCHA-BLOCKED**, **MARKER MISMATCH**, and **UNREACHABLE** alerts without blaming AIOSEO, and re-reads older weekly snapshots that stored captcha as **`displaced`**.
> 
> Adds a **main-only**, manually dispatched **`deploy-race-support`** workflow and **`deploy_race_support.py`** to build and upload exactly one race’s prep-kit HTML and Markdown profile via existing **`push_wordpress`** sync, with slug/payload guards, cache purge, and post-deploy checks for **HTTP 200** and **byte-identical** live content (captcha or wrong bytes cannot pass).
> 
> **`generate_homepage.py`** strips standalone block comments from generated homepage CSS so shipped size stays within budget without changing rules or page markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 707d208147eab09d0756cb914bd261a181923464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->