### PR TITLE
Email process: prepare one briefing and reliable reply triage

### DIFF
--- a/.github/workflows/daily-intel.yml
+++ b/.github/workflows/daily-intel.yml
@@ -8,6 +8,14 @@ on:
   schedule:
     - cron: "0 12 * * *"   # 12:00 UTC = 06:00 MT
   workflow_dispatch:
+    inputs:
+      delivery:
+        description: "Delivery mode (snapshot-only requires verified Claude consumers)"
+        type: choice
+        options:
+          - email
+          - snapshot-only
+        default: email
 
 permissions:
   contents: write
@@ -30,6 +38,7 @@ jobs:
           GA4_CREDENTIALS_JSON: ${{ secrets.GA4_CREDENTIALS_JSON }}
       - name: Run Morning Intel
         env:
+          INTEL_DELIVERY_MODE: ${{ inputs.delivery || vars.INTEL_DELIVERY_MODE || 'email' }}
           GG_GA4_PROPERTY_ID: ${{ secrets.GG_GA4_PROPERTY_ID }}
           RL_GA4_PROPERTY_ID: ${{ secrets.RL_GA4_PROPERTY_ID }}
           XC_GA4_PROPERTY_ID: ${{ secrets.XC_GA4_PROPERTY_ID }}
@@ -39,7 +48,12 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
           GH_TOKEN: ${{ github.token }}
-        run: python3 scripts/daily_intel.py
+        run: |
+          case "$INTEL_DELIVERY_MODE" in
+            email) python3 scripts/daily_intel.py ;;
+            snapshot-only) python3 scripts/daily_intel.py --snapshot-only ;;
+            *) echo "Invalid INTEL_DELIVERY_MODE" >&2; exit 1 ;;
+          esac
       - name: Commit snapshot
         run: |
           git config user.name "github-actions[bot]"

--- a/docs/runbooks/email-triage.md
+++ b/docs/runbooks/email-triage.md
@@ -1,0 +1,135 @@
+# Email triage and briefing handoff
+
+Status: proposed migration, not a claim that live Claude routines were updated.
+Source audit: 2026-09-08. Scope verified: gravelgodcoaching@gmail.com only.
+Other accounts require separate access verification and queue audits.
+
+## Ownership and observed failures
+
+| Component | Verified source/control | Intended responsibility |
+| --- | --- | --- |
+| Morning Intel | `.github/workflows/daily-intel.yml`, daily 12:00 UTC | Collect and persist operational facts |
+| Intel triage | Claude routine `trig_01NsfF54ZZYauZTW7CtXeDpU`, listed in `wattgod/hq/STATE.md` | Turn facts into tracked work; report through Console |
+| Morning Console | Claude routine `trig_01KWri9idC3oRy7gbohFTDZj`, documented in `wattgod/hq` | Sole routine daily briefing to Matti |
+| Gmail reply drafter | Not located in indexed GitHub searches; live scheduler/prompt unverified | One owner for pending replies and draft creation |
+| Lead bridge | `integrations/gmail-lead-bridge/Code.gs`, deployed Apps Script state unverified | Sync known leads; create explicitly approved drafts; already refuses draft conflicts |
+
+Do not confuse Endure's in-app `review-drafts` cron with Gmail reply drafting.
+Do not replace the lead bridge with a second writer.
+
+Observed mailbox failures: unlabeled athlete replies were missed; `! Review`
+accumulated repeated build alerts; multiple drafts existed for one conversation;
+one draft answered questions the correspondent had explicitly withdrawn; another
+remained after Matti sent a reply. Do not copy private message bodies into this repo.
+
+## Replace the existing Gmail routine prompt with this procedure
+
+Verify the connected account. Scan all received inbox conversations and existing
+`! Reply`, `! Waiting`, and `@Action` queues, regardless of read status or labels.
+Include recently archived human conversations in the initial audit so old filters
+cannot silently exclude replies. Page through results; report incomplete coverage
+instead of saying there are zero replies. Reuse existing Gmail labels.
+
+For each human conversation:
+
+1. Read the entire relevant thread, with sent mail and drafts. Page older messages
+   when the recent window lacks the question being answered. Draft timestamps do
+   not count as replies. Read corrections and withdrawals before classifying.
+2. Check recent sent/received conversations with the same verified correspondent
+   when an old request may have been answered in a separate thread. A newer message
+   on an unrelated topic is not proof of resolution.
+3. Record the outstanding request and its source message ID. If Matti owes a
+   substantive response, apply `! Reply`; if the correspondent owes an explicit
+   answer, apply `! Waiting`. Remove the opposite state only after verifying the
+   transition. A thank-you, race result, or withdrawn request does not automatically
+   create a reply obligation. Preserve ambiguous items in `! Review` with a reason.
+4. Prioritize service/delivery failures, time-sensitive athlete decisions, warm
+   leads, then routine check-ins. Sort within those groups by deadline and age.
+   Give each item one next action. Do not infer completion of calendar changes,
+   refunds, payment recovery, or plan delivery from an email promising to do them.
+5. Before creating a draft, enumerate existing drafts for the thread. Never add a
+   second alternative. Preserve human edits. If a draft is stale, duplicated, or
+   contradicted by a later message, label it `Drafts/Needs correction` and explain
+   why in the review queue. Do not delete or overwrite it automatically.
+6. Create only drafts authorized by the existing workflow/user. Follow
+   `docs/AI_WRITING_POLICY.md` before writing as Matti. Ground every factual claim
+   in the current thread or verified coaching data. No invented calendar changes,
+   forced jokes, or sales pitch inserted into athlete support.
+7. Immediately before any authorized draft write, re-fetch the latest non-draft
+   message and existing drafts. If either changed since analysis, reclassify and
+   skip the write. Use one writer; parallel runs must not draft the same thread.
+   Use account + thread ID + latest inbound message ID as the idempotency key.
+8. Read back the draft and labels. Record source ID, disposition, draft ID if any,
+   reason, and verification result in restricted routine state. An uncertain write
+   result requires reconciliation, never a blind retry. Never send email.
+
+Retain unresolved items across runs; a search lookback expiring must not close a
+request. A daily pass returns changes and overdue work to Console, not another
+email. Report collector failures distinctly from an empty queue.
+
+## Technical mail handling
+
+- `GG/Ops`: build logs, PR CI failures, and routine reports. Do not make every
+  repeated notification a fresh `! Review` item.
+- Consolidate repeated preview failures by project and main-branch workflow
+  failures by repository + workflow + branch. Preserve a current actionable
+  representative and the historical evidence. A new project/branch/failure class
+  must not disappear through a sender-wide rule.
+- Keep security, payment failures, production incidents, and delivery failures
+  visible until resolved by evidence. A dev-project security alert is not cleared
+  by a clean production-project scan. A promised card update is not a paid invoice.
+- `GG/Money`: routine receipts. `Read & Offers`: newsletters and promotions.
+- Archive only classified noise or verified resolved conversations. Preserve
+  unread state. Do not delete mail, unsubscribe, or create broad sender filters.
+- Closure needs a receipt: a sent reply, confirmed transaction, verified fix, or
+  explicit withdrawal. A PR merge alone does not prove the production fix works.
+
+## Briefing migration: preserve the feeder before removing the email
+
+The current default remains email. `--snapshot-only` still collects and interprets
+the report, writes dated JSON and Markdown, and never calls Resend. Unlike email
+mode, a snapshot write failure exits nonzero because the snapshot is the delivery.
+The existing commit step publishes those files to GitHub.
+
+1. In Claude, inspect the two known routine IDs above and locate the Gmail drafter
+   by its Gmail-draft actions/run history. Save current prompts and schedules.
+   Also inventory any Daily Brief routine; do not assume it is retired merely
+   because it is absent from HQ's table.
+2. Update intel triage and Console to read this repo's dated
+   `data/intel-snapshots/YYYY-MM-DD.json` and `.md`, not depend on an inbox email.
+   Require today's committed snapshot; missing/stale snapshots are an explicit
+   feeder failure, never "all clear." Preserve tracked unresolved work on failure.
+   Have triage publish issues/results for Console rather than send its own email.
+3. Run the existing consumers against a committed snapshot and verify that known
+   failures are represented once with their issue/action links. Test a missing or
+   stale snapshot and require a visible failure. Verify the Gmail procedure below.
+4. Only after consumer verification, set repository Actions variable
+   `INTEL_DELIVERY_MODE=snapshot-only`. Manual dispatch has a delivery choice for
+   testing. Do not silently activate this mode before the Claude handoff works.
+5. Verify a scheduled run: successful JSON + Markdown commit, successful consumer
+   reads, one Console briefing, no separate Intel/triage/Daily Brief email.
+   Roll back the variable to `email` if consumers cannot retrieve the snapshots.
+
+This file is not automatically loaded by Claude's existing scheduler. Someone
+with that scheduler's controls must install the procedure in the existing jobs;
+merging this PR alone does not complete the migration.
+
+## Acceptance cases for the Gmail routine
+
+Use synthetic messages and a non-sending validation pass before live drafting:
+
+| Case | Required outcome |
+| --- | --- |
+| Unread or already-read human reply with no custom label | Both found and classified |
+| Question followed by "ignore those questions" | No draft answering the withdrawn questions |
+| Old inbound followed by Matti's sent answer | No new reply obligation for the answered request |
+| Unrelated newer sent email | Original unresolved request retained |
+| Existing draft; repeated run with no new inbound | No second draft, no human edit overwritten |
+| New inbound arrives between analysis and write | Skip write and reclassify |
+| Draft write times out after server accepts it | Reconcile by readback before any retry |
+| Thread exceeds the tool's message window | Fetch missing context or mark incomplete; never guess |
+| Repeated preview failures plus a new security alert | Consolidate previews; preserve security action |
+| Payment update promised but no receipt | Payment action remains unresolved |
+
+Completion means the source routines have these behaviors and have passed the
+cases, not that the inbox was archived once or another summary was created.

--- a/docs/specs/daily-intel-report.md
+++ b/docs/specs/daily-intel-report.md
@@ -1,6 +1,11 @@
 # Spec: Daily Intel Report ("Morning Intel")
 
 **Status:** PROPOSAL — not built (Jul 2026)
+**2026-09-08 update:** The workflow is now implemented. The staged migration to
+snapshot delivery and one Console email is specified in
+[`../runbooks/email-triage.md`](../runbooks/email-triage.md). Email remains the
+default until the Claude consumers are verified; the original proposal below
+describes email mode, not the migration's completed state.
 **Goal:** One email, every morning, that answers three questions in under two
 minutes of reading: *Is the machine working? Did we make money? What's the one
 thing to do today?* Interprets, doesn't just dump numbers. Both brands, one email.

--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -1390,6 +1390,8 @@ def send_email(subject: str, markdown: str) -> str:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--dry-run", action="store_true", help="skip the email send")
+    ap.add_argument("--snapshot-only", action="store_true",
+                    help="publish snapshots for the console, never email; fail if persistence fails")
     ap.add_argument("--no-llm", action="store_true", help="skip interpretation")
     args = ap.parse_args()
 
@@ -1446,9 +1448,12 @@ def main() -> int:
         print(f"snapshot: data/intel-snapshots/{today}.json")
     except Exception as e:
         report += f"\n- BROKEN: snapshot write failed: {type(e).__name__}: {e}"
+        if args.snapshot_only:
+            print(report, file=sys.stderr)
+            return 1
     print(f"subject:  {subject}")
 
-    if args.dry_run:
+    if args.dry_run or args.snapshot_only:
         print("\n" + report)
         return 0
     msg_id = send_email(subject, report)

--- a/tests/test_daily_intel.py
+++ b/tests/test_daily_intel.py
@@ -349,6 +349,40 @@ def test_main_sends_email_even_when_everything_downstream_breaks(
     assert "snapshot write failed" in sent["report"]
 
 
+@pytest.mark.parametrize("persistence_fails", [False, True])
+def test_snapshot_only_never_emails_and_requires_persistence(
+        tmp_path, monkeypatch, persistence_fails):
+    from scripts import daily_intel
+
+    for name in ("collect_ga4", "collect_checkout", "collect_mission_control",
+                 "collect_commerce_ledger", "collect_social", "collect_workflows",
+                 "collect_aeo", "collect_seo"):
+        monkeypatch.setattr(daily_intel, name, lambda *a, **k: {})
+    monkeypatch.setattr(daily_intel, "compute_constraint", lambda *a: {})
+    monkeypatch.setattr(daily_intel, "detect_tracking_regression", lambda *a: None)
+    monkeypatch.setattr(daily_intel, "load_prior_snapshots", lambda *a: [])
+    monkeypatch.setattr(daily_intel, "load_trend", lambda: [])
+    monkeypatch.setattr(daily_intel, "safe_render", lambda *a: "Facts")
+    monkeypatch.setattr(daily_intel, "interpret", lambda *a: (
+        "Intel", "## TOP LINE\nSummary\n\n## DO TODAY\nCheck facts"))
+    monkeypatch.setattr(daily_intel, "send_email",
+                        lambda *a: pytest.fail("snapshot-only must never send"))
+    destination = tmp_path / "snapshots"
+    if persistence_fails:
+        destination.write_text("blocks directory creation")
+    monkeypatch.setattr(daily_intel, "SNAPSHOT_DIR", destination)
+    monkeypatch.setattr("sys.argv", ["daily_intel.py", "--snapshot-only"])
+
+    assert daily_intel.main() == int(persistence_fails)
+    if not persistence_fails:
+        import json
+        today = daily_intel.date.today().isoformat()
+        snapshot = json.loads((destination / f"{today}.json").read_text())
+        assert snapshot["date"] == today
+        assert "Facts" in snapshot["report"]
+        assert "Summary" in (destination / f"{today}.md").read_text()
+
+
 def test_collect_mission_control_reads_newest_rows_past_the_1000_row_cap(monkeypatch):
     """Regression: gg_sequence_sends crossed 1000 rows on 2026-08-26 and the
     collector — which sorted ascending and capped at 1000 — stopped seeing


### PR DESCRIPTION
The inbox audit found overlapping routine reports, missed unlabeled human replies, and stale/duplicate Gmail drafts. HQ already specifies one daily Console briefing, but Morning Intel still sends its own email and the live Claude consumers are not yet verified against saved snapshots.

This PR adds:
- `--snapshot-only`: retain report collection, interpretation, JSON and Markdown publication, but never call Resend. Persistence failure exits nonzero so a failed feeder cannot look successful.
- Workflow delivery selection via manual input or `INTEL_DELIVERY_MODE` Actions variable. The default remains `email` until the Claude handoff is verified.
- A concrete runbook with verified routine ownership, replacement Gmail triage instructions, one-writer/idempotency and stale-thread checks, ten synthetic acceptance cases, and a staged consumer migration/rollback.

The Gmail drafter's live scheduler/prompt has not been located. Merging this does not install the Claude procedure or switch delivery. No customer messages or private email bodies are included.

Validation: 23 tests passed in `tests/test_daily_intel.py`, including snapshot delivery success/failure and the existing email fallback behavior; `git diff --check` passed. Full repository suite launched separately; result pending.

Rollout: install and test the existing Claude consumers first, then set `INTEL_DELIVERY_MODE=snapshot-only`, verify one Console email and the committed snapshots, and restore `email` if the handoff fails.