### PR TITLE
Report GA4 activity without false conversion rates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,10 @@ jobs:
         run: |
           pytest tests/ -q --tb=short
           pytest \
+            mission_control/tests/test_analytics.py \
             mission_control/tests/test_provider_ingestion.py \
             mission_control/tests/test_stripe_provider_ingestion.py \
+            mission_control/tests/test_triage.py \
             -q --tb=short
 
       - name: Validate citations

--- a/mission_control/routers/analytics.py
+++ b/mission_control/routers/analytics.py
@@ -6,7 +6,7 @@ from fastapi.templating import Jinja2Templates
 
 from mission_control.config import WEB_TEMPLATES_DIR
 from mission_control.services.ga4 import (
-    get_conversion_events,
+    get_conversion_event_report,
     get_daily_sessions,
     get_top_pages,
     get_traffic_sources,
@@ -24,7 +24,8 @@ async def analytics_index(request: Request):
     top_pages = get_top_pages(days=30, limit=20)
     sources = get_traffic_sources(days=30)
     daily = get_daily_sessions(days=90)
-    event_totals = get_conversion_events(days=30)
+    event_report = get_conversion_event_report(days=30)
+    event_totals = event_report["events"]
 
     # Calculate totals
     total_sessions = sum(d["sessions"] for d in daily) if daily else 0
@@ -39,6 +40,8 @@ async def analytics_index(request: Request):
         "daily": daily,
         "event_totals": event_totals,
         "event_summary": event_summary,
+        "event_data_available": event_report["available"],
+        "event_error": event_report["error"],
         "total_sessions": total_sessions,
         "total_pageviews": total_pageviews,
     })

--- a/mission_control/routers/analytics.py
+++ b/mission_control/routers/analytics.py
@@ -11,6 +11,7 @@ from mission_control.services.ga4 import (
     get_top_pages,
     get_traffic_sources,
     refresh_cache,
+    summarize_event_totals,
 )
 
 router = APIRouter(prefix="/analytics")
@@ -23,12 +24,12 @@ async def analytics_index(request: Request):
     top_pages = get_top_pages(days=30, limit=20)
     sources = get_traffic_sources(days=30)
     daily = get_daily_sessions(days=90)
-    conversions = get_conversion_events(days=30)
+    event_totals = get_conversion_events(days=30)
 
     # Calculate totals
     total_sessions = sum(d["sessions"] for d in daily) if daily else 0
     total_pageviews = sum(p["pageviews"] for p in top_pages) if top_pages else 0
-    total_conversions = sum(e["count"] for e in conversions) if conversions else 0
+    event_summary = summarize_event_totals(event_totals)
 
     return templates.TemplateResponse(request, "analytics/index.html", {
         "request": request,
@@ -36,10 +37,10 @@ async def analytics_index(request: Request):
         "top_pages": top_pages,
         "sources": sources,
         "daily": daily,
-        "conversions": conversions,
+        "event_totals": event_totals,
+        "event_summary": event_summary,
         "total_sessions": total_sessions,
         "total_pageviews": total_pageviews,
-        "total_conversions": total_conversions,
     })
 
 

--- a/mission_control/services/ga4.py
+++ b/mission_control/services/ga4.py
@@ -26,6 +26,18 @@ logger = logging.getLogger(__name__)
 
 CACHE_TTL_HOURS = 4
 
+# Keep this list aligned with the events already emitted by the site and the
+# standard commerce lifecycle. These are independently aggregated event totals;
+# this service does not join them into a user, session, product, or order cohort.
+CONVERSION_EVENT_NAMES = frozenset({
+    "email_capture", "prep_kit_unlock", "quiz_complete", "plan_request",
+    "exit_intent_capture", "fueling_calculate", "review_submit",
+    "form_start", "tp_form_start", "form_submit", "tp_form_submit",
+    "view_item_list", "select_item", "view_item", "add_to_wishlist",
+    "add_to_cart", "remove_from_cart", "view_cart", "begin_checkout",
+    "add_shipping_info", "add_payment_info", "purchase", "refund",
+})
+
 
 def _get_cached(cache_key: str) -> dict | None:
     """Get cached data if fresh enough. Returns None if caching unavailable."""
@@ -211,8 +223,8 @@ def get_daily_sessions(days: int = 90) -> list[dict]:
 
 
 def get_conversion_events(days: int = 30) -> list[dict]:
-    """Key conversion events: email captures, plan requests, quiz completions."""
-    cache_key = f"conversion_events_{days}"
+    """Independent totals for lead and commerce events; no cohort join."""
+    cache_key = f"conversion_events_v2_{days}"
     cached = _get_cached(cache_key)
     if cached:
         return cached
@@ -225,6 +237,8 @@ def get_conversion_events(days: int = 30) -> list[dict]:
         from google.analytics.data_v1beta.types import (
             DateRange,
             Dimension,
+            Filter,
+            FilterExpression,
             Metric,
             RunReportRequest,
         )
@@ -234,20 +248,19 @@ def get_conversion_events(days: int = 30) -> list[dict]:
             dimensions=[Dimension(name="eventName")],
             metrics=[Metric(name="eventCount")],
             date_ranges=[DateRange(start_date=f"{days}daysAgo", end_date="today")],
+            dimension_filter=FilterExpression(filter=Filter(
+                field_name="eventName",
+                in_list_filter=Filter.InListFilter(
+                    values=sorted(CONVERSION_EVENT_NAMES),
+                ),
+            )),
         )
         response = client.run_report(request)
-
-        # Filter to conversion-relevant events
-        conversion_events = {
-            "email_capture", "prep_kit_unlock", "quiz_complete",
-            "plan_request", "exit_intent_capture", "fueling_calculate",
-            "review_submit",
-        }
 
         events = []
         for row in response.rows:
             name = row.dimension_values[0].value
-            if name in conversion_events:
+            if name in CONVERSION_EVENT_NAMES:
                 events.append({
                     "event": name,
                     "count": int(row.metric_values[0].value),

--- a/mission_control/services/ga4.py
+++ b/mission_control/services/ga4.py
@@ -39,6 +39,21 @@ CONVERSION_EVENT_NAMES = frozenset({
 })
 
 
+def summarize_event_totals(events: list[dict]) -> dict[str, int]:
+    """Return exact operational event counts without combining unlike events."""
+    counts: dict[str, int] = {}
+    for event in events:
+        name = str(event.get("event") or "")
+        counts[name] = counts.get(name, 0) + int(event.get("count") or 0)
+    return {
+        "email_capture_events": counts.get("email_capture", 0),
+        "plan_request_events": counts.get("plan_request", 0),
+        "checkout_start_events": counts.get("begin_checkout", 0),
+        "purchase_events": counts.get("purchase", 0),
+        "refund_events": counts.get("refund", 0),
+    }
+
+
 def _get_cached(cache_key: str) -> dict | None:
     """Get cached data if fresh enough. Returns None if caching unavailable."""
     if db is None:

--- a/mission_control/services/ga4.py
+++ b/mission_control/services/ga4.py
@@ -237,16 +237,20 @@ def get_daily_sessions(days: int = 90) -> list[dict]:
         return []
 
 
-def get_conversion_events(days: int = 30) -> list[dict]:
-    """Independent totals for lead and commerce events; no cohort join."""
+def get_conversion_event_report(days: int = 30) -> dict:
+    """Return event totals with an explicit GA4 availability state."""
     cache_key = f"conversion_events_v2_{days}"
     cached = _get_cached(cache_key)
-    if cached:
-        return cached
+    if cached is not None:
+        return {"available": True, "events": cached, "error": None}
 
     client = _get_client()
     if not client:
-        return []
+        return {
+            "available": False,
+            "events": [],
+            "error": "GA4 client unavailable",
+        }
 
     try:
         from google.analytics.data_v1beta.types import (
@@ -283,11 +287,20 @@ def get_conversion_events(days: int = 30) -> list[dict]:
 
         events.sort(key=lambda x: x["count"], reverse=True)
         _set_cached(cache_key, events)
-        return events
+        return {"available": True, "events": events, "error": None}
 
     except Exception as e:
         logger.error("GA4 conversion_events error: %s", e)
-        return []
+        return {
+            "available": False,
+            "events": [],
+            "error": "GA4 event query failed",
+        }
+
+
+def get_conversion_events(days: int = 30) -> list[dict]:
+    """Compatibility wrapper returning independent event totals as a list."""
+    return get_conversion_event_report(days=days)["events"]
 
 
 def refresh_cache() -> int:

--- a/mission_control/services/triage.py
+++ b/mission_control/services/triage.py
@@ -432,34 +432,33 @@ def triage_summary(
 # ---------------------------------------------------------------------------
 
 def get_triage_ga4_summary() -> dict:
-    """GA4 snapshot for triage — sessions, conversions, top source."""
+    """GA4 snapshot for triage with separate operational event totals."""
     try:
         from mission_control.services.ga4 import (
             get_conversion_events,
             get_daily_sessions,
             get_traffic_sources,
+            summarize_event_totals,
         )
         daily = get_daily_sessions(days=7)
-        conversions = get_conversion_events(days=7)
+        event_totals = get_conversion_events(days=7)
         sources = get_traffic_sources(days=7)
 
         sessions_7d = sum(d["sessions"] for d in daily) if daily else 0
-        total_conversions = sum(e["count"] for e in conversions) if conversions else 0
+        event_summary = summarize_event_totals(event_totals)
         top_source = sources[0]["channel"] if sources else None
         top_source_sessions = sources[0]["sessions"] if sources else 0
-
-        plan_requests = next((e["count"] for e in conversions if e["event"] == "plan_request"), 0)
-        email_captures = next((e["count"] for e in conversions if e["event"] == "email_capture"), 0)
 
         return {
             "configured": True,
             "sessions_7d": sessions_7d,
-            "total_conversions": total_conversions,
-            "plan_requests": plan_requests,
-            "email_captures": email_captures,
+            "purchase_events": event_summary["purchase_events"],
+            "refund_events": event_summary["refund_events"],
+            "plan_requests": event_summary["plan_request_events"],
+            "email_captures": event_summary["email_capture_events"],
             "top_source": top_source,
             "top_source_sessions": top_source_sessions,
-            "conversions": conversions,
+            "event_totals": event_totals,
         }
     except Exception:
         logger.exception("Failed to fetch GA4 triage summary")

--- a/mission_control/services/triage.py
+++ b/mission_control/services/triage.py
@@ -435,13 +435,14 @@ def get_triage_ga4_summary() -> dict:
     """GA4 snapshot for triage with separate operational event totals."""
     try:
         from mission_control.services.ga4 import (
-            get_conversion_events,
+            get_conversion_event_report,
             get_daily_sessions,
             get_traffic_sources,
             summarize_event_totals,
         )
         daily = get_daily_sessions(days=7)
-        event_totals = get_conversion_events(days=7)
+        event_report = get_conversion_event_report(days=7)
+        event_totals = event_report["events"]
         sources = get_traffic_sources(days=7)
 
         sessions_7d = sum(d["sessions"] for d in daily) if daily else 0
@@ -451,11 +452,17 @@ def get_triage_ga4_summary() -> dict:
 
         return {
             "configured": True,
+            "event_data_available": event_report["available"],
+            "event_error": event_report["error"],
             "sessions_7d": sessions_7d,
-            "purchase_events": event_summary["purchase_events"],
-            "refund_events": event_summary["refund_events"],
-            "plan_requests": event_summary["plan_request_events"],
-            "email_captures": event_summary["email_capture_events"],
+            "purchase_events": (
+                event_summary["purchase_events"] if event_report["available"] else None),
+            "refund_events": (
+                event_summary["refund_events"] if event_report["available"] else None),
+            "plan_requests": (
+                event_summary["plan_request_events"] if event_report["available"] else None),
+            "email_captures": (
+                event_summary["email_capture_events"] if event_report["available"] else None),
             "top_source": top_source,
             "top_source_sessions": top_source_sessions,
             "event_totals": event_totals,

--- a/mission_control/templates/analytics/index.html
+++ b/mission_control/templates/analytics/index.html
@@ -29,19 +29,19 @@
         <div class="gg-stat-card__label">Top 20 Pageviews (30d)</div>
     </div>
     <div class="gg-stat-card">
-        <div class="gg-stat-card__value mc-text-teal">{{ "{:,}".format(event_summary.checkout_start_events) }}</div>
+        <div class="gg-stat-card__value mc-text-teal">{% if event_data_available %}{{ "{:,}".format(event_summary.checkout_start_events) }}{% else %}Unavailable{% endif %}</div>
         <div class="gg-stat-card__label">Checkout starts (30d)</div>
     </div>
     <div class="gg-stat-card">
-        <div class="gg-stat-card__value mc-text-teal">{{ "{:,}".format(event_summary.purchase_events) }}</div>
+        <div class="gg-stat-card__value mc-text-teal">{% if event_data_available %}{{ "{:,}".format(event_summary.purchase_events) }}{% else %}Unavailable{% endif %}</div>
         <div class="gg-stat-card__label">Purchase events (30d)</div>
     </div>
     <div class="gg-stat-card">
-        <div class="gg-stat-card__value">{{ "{:,}".format(event_summary.refund_events) }}</div>
+        <div class="gg-stat-card__value">{% if event_data_available %}{{ "{:,}".format(event_summary.refund_events) }}{% else %}Unavailable{% endif %}</div>
         <div class="gg-stat-card__label">Refund events (30d)</div>
     </div>
     <div class="gg-stat-card">
-        <div class="gg-stat-card__value">{{ "{:,}".format(event_summary.email_capture_events) }}</div>
+        <div class="gg-stat-card__value">{% if event_data_available %}{{ "{:,}".format(event_summary.email_capture_events) }}{% else %}Unavailable{% endif %}</div>
         <div class="gg-stat-card__label">Email capture events (30d)</div>
     </div>
 </div>
@@ -91,7 +91,9 @@
         </div>
         <div class="mc-card__body">
             <p class="mc-text-muted" style="font-size:var(--gg-font-size-sm)">Independent event counts; no cross-stage conversion rate.</p>
-            {% if event_totals %}
+            {% if not event_data_available %}
+            <p class="mc-text-muted" style="font-size:var(--gg-font-size-sm)">GA4 event data unavailable. Counts are not shown as zero.</p>
+            {% elif event_totals %}
             <table class="gg-table gg-table--compact">
                 <thead>
                     <tr>
@@ -109,7 +111,7 @@
                 </tbody>
             </table>
             {% else %}
-            <p class="mc-text-muted" style="font-size:var(--gg-font-size-sm)">No lead or commerce event data available.</p>
+            <p class="mc-text-muted" style="font-size:var(--gg-font-size-sm)">No lead or commerce events observed in this period.</p>
             {% endif %}
         </div>
     </div>

--- a/mission_control/templates/analytics/index.html
+++ b/mission_control/templates/analytics/index.html
@@ -7,7 +7,7 @@
     <div>
         <span class="mc-page-header__kicker">Marketing</span>
         <h1 class="mc-page-header__title">Analytics</h1>
-        <p class="mc-page-header__desc">GA4 traffic, conversions, and top pages. Cached 4 hours.</p>
+        <p class="mc-page-header__desc">GA4 traffic and independently counted lead and commerce events. Cached 4 hours.</p>
     </div>
     <div class="mc-page-header__actions">
         <form hx-post="/analytics/refresh" hx-target="#refresh-result" hx-swap="innerHTML">
@@ -29,12 +29,20 @@
         <div class="gg-stat-card__label">Top 20 Pageviews (30d)</div>
     </div>
     <div class="gg-stat-card">
-        <div class="gg-stat-card__value mc-text-teal">{{ "{:,}".format(total_conversions) }}</div>
-        <div class="gg-stat-card__label">Conversions (30d)</div>
+        <div class="gg-stat-card__value mc-text-teal">{{ "{:,}".format(event_summary.checkout_start_events) }}</div>
+        <div class="gg-stat-card__label">Checkout starts (30d)</div>
     </div>
     <div class="gg-stat-card">
-        <div class="gg-stat-card__value">{{ sources|length }}</div>
-        <div class="gg-stat-card__label">Traffic Channels</div>
+        <div class="gg-stat-card__value mc-text-teal">{{ "{:,}".format(event_summary.purchase_events) }}</div>
+        <div class="gg-stat-card__label">Purchase events (30d)</div>
+    </div>
+    <div class="gg-stat-card">
+        <div class="gg-stat-card__value">{{ "{:,}".format(event_summary.refund_events) }}</div>
+        <div class="gg-stat-card__label">Refund events (30d)</div>
+    </div>
+    <div class="gg-stat-card">
+        <div class="gg-stat-card__value">{{ "{:,}".format(event_summary.email_capture_events) }}</div>
+        <div class="gg-stat-card__label">Email capture events (30d)</div>
     </div>
 </div>
 
@@ -76,13 +84,14 @@
         </div>
     </div>
 
-    <!-- Conversion Events -->
+    <!-- Lead and commerce event totals -->
     <div class="mc-card">
         <div class="mc-card__header">
-            <h3 class="mc-card__title">Conversion Events (30 days)</h3>
+            <h3 class="mc-card__title">Lead and commerce event totals (30 days)</h3>
         </div>
         <div class="mc-card__body">
-            {% if conversions %}
+            <p class="mc-text-muted" style="font-size:var(--gg-font-size-sm)">Independent event counts; no cross-stage conversion rate.</p>
+            {% if event_totals %}
             <table class="gg-table gg-table--compact">
                 <thead>
                     <tr>
@@ -91,7 +100,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for ev in conversions %}
+                    {% for ev in event_totals %}
                     <tr>
                         <td class="mc-text-mono" style="font-size:var(--gg-font-size-2xs)">{{ ev.event }}</td>
                         <td class="mc-text-right mc-text-teal" style="font-weight:600">{{ "{:,}".format(ev.count) }}</td>
@@ -100,7 +109,7 @@
                 </tbody>
             </table>
             {% else %}
-            <p class="mc-text-muted" style="font-size:var(--gg-font-size-sm)">No conversion data available.</p>
+            <p class="mc-text-muted" style="font-size:var(--gg-font-size-sm)">No lead or commerce event data available.</p>
             {% endif %}
         </div>
     </div>

--- a/mission_control/templates/triage.html
+++ b/mission_control/templates/triage.html
@@ -304,8 +304,12 @@
                 <div class="gg-stat-card__label">Sessions (7d)</div>
             </div>
             <div class="gg-stat-card">
-                <div class="gg-stat-card__value">{{ ga4.total_conversions }}</div>
-                <div class="gg-stat-card__label">Conversions (7d)</div>
+                <div class="gg-stat-card__value">{{ ga4.purchase_events }}</div>
+                <div class="gg-stat-card__label">Purchase Events</div>
+            </div>
+            <div class="gg-stat-card">
+                <div class="gg-stat-card__value">{{ ga4.refund_events }}</div>
+                <div class="gg-stat-card__label">Refund Events</div>
             </div>
             <div class="gg-stat-card">
                 <div class="gg-stat-card__value">{{ ga4.email_captures }}</div>

--- a/mission_control/templates/triage.html
+++ b/mission_control/templates/triage.html
@@ -304,22 +304,25 @@
                 <div class="gg-stat-card__label">Sessions (7d)</div>
             </div>
             <div class="gg-stat-card">
-                <div class="gg-stat-card__value">{{ ga4.purchase_events }}</div>
+                <div class="gg-stat-card__value">{% if ga4.event_data_available %}{{ ga4.purchase_events }}{% else %}Unavailable{% endif %}</div>
                 <div class="gg-stat-card__label">Purchase Events</div>
             </div>
             <div class="gg-stat-card">
-                <div class="gg-stat-card__value">{{ ga4.refund_events }}</div>
+                <div class="gg-stat-card__value">{% if ga4.event_data_available %}{{ ga4.refund_events }}{% else %}Unavailable{% endif %}</div>
                 <div class="gg-stat-card__label">Refund Events</div>
             </div>
             <div class="gg-stat-card">
-                <div class="gg-stat-card__value">{{ ga4.email_captures }}</div>
+                <div class="gg-stat-card__value">{% if ga4.event_data_available %}{{ ga4.email_captures }}{% else %}Unavailable{% endif %}</div>
                 <div class="gg-stat-card__label">Email Captures</div>
             </div>
             <div class="gg-stat-card">
-                <div class="gg-stat-card__value">{{ ga4.plan_requests }}</div>
+                <div class="gg-stat-card__value">{% if ga4.event_data_available %}{{ ga4.plan_requests }}{% else %}Unavailable{% endif %}</div>
                 <div class="gg-stat-card__label">Plan Requests</div>
             </div>
         </div>
+        {% if not ga4.event_data_available %}
+        <p class="mc-text-muted triage-source-hint">GA4 event data unavailable. Counts are not shown as zero.</p>
+        {% endif %}
         {% if ga4.top_source %}
         <p class="mc-text-muted triage-source-hint">
             Top source: <strong>{{ ga4.top_source }}</strong> ({{ ga4.top_source_sessions }} sessions)

--- a/mission_control/tests/test_analytics.py
+++ b/mission_control/tests/test_analytics.py
@@ -1,0 +1,27 @@
+import re
+from unittest.mock import patch
+
+
+def test_analytics_page_renders_distinct_event_counts_without_combined_kpi(
+        client, fake_db):
+    event_totals = [
+        {"event": "add_to_cart", "count": 90},
+        {"event": "email_capture", "count": 7},
+        {"event": "begin_checkout", "count": 4},
+        {"event": "purchase", "count": 2},
+        {"event": "refund", "count": 5},
+    ]
+    with patch("mission_control.routers.analytics.get_top_pages", return_value=[]), \
+         patch("mission_control.routers.analytics.get_traffic_sources", return_value=[]), \
+         patch("mission_control.routers.analytics.get_daily_sessions", return_value=[]), \
+         patch("mission_control.routers.analytics.get_conversion_events",
+               return_value=event_totals):
+        response = client.get("/analytics/")
+
+    assert response.status_code == 200
+    assert "Lead and commerce event totals (30 days)" in response.text
+    assert "Independent event counts; no cross-stage conversion rate." in response.text
+    assert "Conversions (30d)" not in response.text
+    assert re.search(r">2</div>\s*<div[^>]*>Purchase events \(30d\)</div>", response.text)
+    assert re.search(r">5</div>\s*<div[^>]*>Refund events \(30d\)</div>", response.text)
+    assert ">108</div>" not in response.text

--- a/mission_control/tests/test_analytics.py
+++ b/mission_control/tests/test_analytics.py
@@ -14,8 +14,8 @@ def test_analytics_page_renders_distinct_event_counts_without_combined_kpi(
     with patch("mission_control.routers.analytics.get_top_pages", return_value=[]), \
          patch("mission_control.routers.analytics.get_traffic_sources", return_value=[]), \
          patch("mission_control.routers.analytics.get_daily_sessions", return_value=[]), \
-         patch("mission_control.routers.analytics.get_conversion_events",
-               return_value=event_totals):
+         patch("mission_control.routers.analytics.get_conversion_event_report",
+               return_value={"available": True, "events": event_totals, "error": None}):
         response = client.get("/analytics/")
 
     assert response.status_code == 200
@@ -25,3 +25,34 @@ def test_analytics_page_renders_distinct_event_counts_without_combined_kpi(
     assert re.search(r">2</div>\s*<div[^>]*>Purchase events \(30d\)</div>", response.text)
     assert re.search(r">5</div>\s*<div[^>]*>Refund events \(30d\)</div>", response.text)
     assert ">108</div>" not in response.text
+
+
+def test_analytics_page_distinguishes_ga4_failure_from_verified_zero(client, fake_db):
+    common = (
+        patch("mission_control.routers.analytics.get_top_pages", return_value=[]),
+        patch("mission_control.routers.analytics.get_traffic_sources", return_value=[]),
+        patch("mission_control.routers.analytics.get_daily_sessions", return_value=[]),
+    )
+    with common[0], common[1], common[2], \
+         patch("mission_control.services.ga4._get_cached", return_value=None), \
+         patch("mission_control.services.ga4._get_client", return_value=None):
+        failed = client.get("/analytics/")
+
+    assert failed.status_code == 200
+    assert "GA4 event data unavailable" in failed.text
+    assert re.search(r">Unavailable</div>\s*<div[^>]*>Purchase events", failed.text)
+    assert re.search(r">Unavailable</div>\s*<div[^>]*>Refund events", failed.text)
+
+    with patch("mission_control.routers.analytics.get_top_pages", return_value=[]), \
+         patch("mission_control.routers.analytics.get_traffic_sources", return_value=[]), \
+         patch("mission_control.routers.analytics.get_daily_sessions", return_value=[]), \
+         patch(
+             "mission_control.routers.analytics.get_conversion_event_report",
+             return_value={"available": True, "events": [], "error": None},
+         ):
+        empty = client.get("/analytics/")
+
+    assert empty.status_code == 200
+    assert re.search(r">0</div>\s*<div[^>]*>Purchase events", empty.text)
+    assert re.search(r">0</div>\s*<div[^>]*>Refund events", empty.text)
+    assert "No lead or commerce events observed in this period." in empty.text

--- a/mission_control/tests/test_triage.py
+++ b/mission_control/tests/test_triage.py
@@ -512,10 +512,13 @@ class TestTriageGA4Integration:
         mock_sources = [{"channel": "organic / search", "sessions": 200}]
 
         with patch("mission_control.services.ga4.get_daily_sessions", return_value=mock_daily), \
-             patch("mission_control.services.ga4.get_conversion_events", return_value=mock_conversions), \
+             patch("mission_control.services.ga4.get_conversion_event_report", return_value={
+                 "available": True, "events": mock_conversions, "error": None,
+             }), \
              patch("mission_control.services.ga4.get_traffic_sources", return_value=mock_sources):
             result = get_triage_ga4_summary()
             assert result["configured"] is True
+            assert result["event_data_available"] is True
             assert result["sessions_7d"] == 250
             assert "total_conversions" not in result
             assert result["purchase_events"] == 2
@@ -523,6 +526,30 @@ class TestTriageGA4Integration:
             assert result["plan_requests"] == 3
             assert result["email_captures"] == 10
             assert result["top_source"] == "organic / search"
+
+    def test_ga4_summary_preserves_unavailable_event_state(self, fake_db):
+        from mission_control.services.triage import get_triage_ga4_summary
+
+        with patch("mission_control.services.ga4.get_daily_sessions", return_value=[]), \
+             patch("mission_control.services.ga4._get_cached", return_value=None), \
+             patch("mission_control.services.ga4._get_client", return_value=None), \
+             patch("mission_control.services.ga4.get_traffic_sources", return_value=[]):
+            result = get_triage_ga4_summary()
+
+        assert result["configured"] is True
+        assert result["event_data_available"] is False
+        assert result["purchase_events"] is None
+        assert result["refund_events"] is None
+        assert result["event_error"] == "GA4 client unavailable"
+
+    def test_triage_page_renders_event_failure_as_unavailable(self, client, fake_db):
+        with patch("mission_control.services.ga4._get_cached", return_value=None), \
+             patch("mission_control.services.ga4._get_client", return_value=None):
+            response = client.get("/triage")
+
+        assert response.status_code == 200
+        assert response.text.count("Unavailable</div>") >= 4
+        assert "GA4 event data unavailable" in response.text
 
     def test_triage_page_shows_ga4_section(self, client, fake_db):
         resp = client.get("/triage")

--- a/mission_control/tests/test_triage.py
+++ b/mission_control/tests/test_triage.py
@@ -506,6 +506,8 @@ class TestTriageGA4Integration:
             {"event": "email_capture", "count": 10},
             {"event": "plan_request", "count": 3},
             {"event": "quiz_complete", "count": 5},
+            {"event": "purchase", "count": 2},
+            {"event": "refund", "count": 7},
         ]
         mock_sources = [{"channel": "organic / search", "sessions": 200}]
 
@@ -515,7 +517,9 @@ class TestTriageGA4Integration:
             result = get_triage_ga4_summary()
             assert result["configured"] is True
             assert result["sessions_7d"] == 250
-            assert result["total_conversions"] == 18
+            assert "total_conversions" not in result
+            assert result["purchase_events"] == 2
+            assert result["refund_events"] == 7
             assert result["plan_requests"] == 3
             assert result["email_captures"] == 10
             assert result["top_source"] == "organic / search"

--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -79,6 +79,7 @@ FUNNEL_STAGES = {
     "form_submit": ["form_submit", "tp_form_submit"],
     "begin_checkout": ["begin_checkout"],
     "purchase": ["purchase"],
+    "refund": ["refund"],
 }
 FUNNEL_EVENTS = [e for evs in FUNNEL_STAGES.values() for e in evs]
 
@@ -212,8 +213,8 @@ def collect_ga4(brand: str) -> dict:
     top_pages = [{"path": r.dimension_values[0].value,
                   "views": int(r.metric_values[0].value)} for r in pages.rows]
 
-    # 28-day aggregates for the constraint math (precomputed — the
-    # interpreter must never do arithmetic itself)
+    # 28-day event totals for measurement context. They remain independent
+    # aggregates and cannot identify a causal bottleneck.
     m_ago = (date.today() - timedelta(days=28)).isoformat()
     agg = run(["sessions"], date_from=m_ago, date_to=y)
     sessions_28d = int(agg.rows[0].metric_values[0].value) if agg.rows else 0
@@ -238,8 +239,6 @@ def collect_ga4(brand: str) -> dict:
         "sessions_7d_avg": round(week_sessions / 7, 1),
         "funnel": {stage: sum(ev.get(e, 0) for e in evs)
                    for stage, evs in FUNNEL_STAGES.items()},
-        "abandoned_submits": max(0, sum(ev.get(e, 0) for e in FUNNEL_STAGES["form_submit"])
-                                    - ev.get("purchase", 0)),
         "top_pages": top_pages,
         "channel_mix": channel_mix,
         "top_landing": top_landing,
@@ -285,40 +284,21 @@ def collect_commerce_ledger() -> dict:
 
 
 def compute_constraint(ga4_gravel: dict) -> dict:
-    """Name the funnel's binding constraint from 28-day rates. Pure math,
-    precomputed here so the interpreter only narrates."""
+    """Describe why aggregate GA4 totals cannot identify a causal bottleneck."""
     if not ga4_gravel.get("ok"):
         return {"ok": False, "error": "no GA4 data"}
     s28 = ga4_gravel.get("sessions_28d") or 0
-    f = ga4_gravel.get("funnel_28d") or {}
-    cta, sub, pur = f.get("cta_click", 0), f.get("form_submit", 0), f.get("purchase", 0)
-    days = 28
-    rates = {
-        "sessions_per_day": round(s28 / days, 1),
-        "cta_rate_pct": round(100 * cta / s28, 2) if s28 else 0,
-        "cta_to_submit_pct": round(100 * sub / cta, 1) if cta else 0,
-        "submit_to_purchase_pct": round(100 * pur / sub, 1) if sub else 0,
-        "purchases_28d": pur, "submits_28d": sub, "ctas_28d": cta,
+    totals = ga4_gravel.get("funnel_28d") or {}
+    return {
+        "ok": True,
+        "assessment": "data_insufficient",
+        "reason": "independent event totals do not establish a causal bottleneck",
+        "sessions_28d": s28,
+        "event_totals_28d": {
+            stage: int(totals.get(stage, 0) or 0)
+            for stage in FUNNEL_STAGES
+        },
     }
-    # sessions/day needed for 1 purchase/day at current observed rates
-    # (fall back through the funnel when a stage has no data yet)
-    chain = (cta / s28 if s28 else 0) * (sub / cta if cta else 0) * (pur / sub if sub else 0)
-    rates["sessions_per_day_needed_for_1_sale"] = (
-        round(1 / chain) if chain > 0 else None)
-    # binding constraint heuristic, top-down
-    if s28 / days < 100:
-        binding = ("traffic — at these volumes no funnel rate is even "
-                   "measurable; nothing downstream is worth optimizing yet")
-    elif cta == 0:
-        binding = "cta_rate — sessions exist but nobody clicks toward a plan"
-    elif sub == 0:
-        binding = "form completion — clicks exist but nobody finishes intake"
-    elif pur == 0:
-        binding = "close rate — completed intakes aren't converting to payment"
-    else:
-        binding = "scaling — every stage has signal; grow the top"
-    rates["binding_constraint"] = binding
-    return {"ok": True, **rates}
 
 
 def collect_mission_control() -> dict:
@@ -759,13 +739,14 @@ def _path(value) -> str:
     return str(value)
 
 
-def _funnel_line(funnel: dict) -> str:
+def _event_totals_line(event_totals: dict) -> str:
     return (
-        f"cta {_display(funnel.get('cta_click'))} → "
-        f"form_start {_display(funnel.get('form_start'))} → "
-        f"submit {_display(funnel.get('form_submit'))} → "
-        f"checkout {_display(funnel.get('begin_checkout'))} → "
-        f"purchase {_display(funnel.get('purchase'))}"
+        f"cta {_display(event_totals.get('cta_click'))}; "
+        f"form_start {_display(event_totals.get('form_start'))}; "
+        f"submit {_display(event_totals.get('form_submit'))}; "
+        f"checkout {_display(event_totals.get('begin_checkout'))}; "
+        f"purchase {_display(event_totals.get('purchase'))}; "
+        f"refund {_display(event_totals.get('refund'))}"
     )
 
 
@@ -848,7 +829,7 @@ def render_report(collected: dict) -> str:
     """Render the factual report sections without network calls or inference."""
     lines = [
         "## NUMBERS",
-        "| Brand | Sessions (vs 7d avg) | Funnel | Leads |",
+        "| Brand | Sessions (vs 7d avg) | Independent event totals | Leads |",
         "|---|---:|---|---:|",
     ]
     ga4 = collected.get("ga4") or {}
@@ -860,18 +841,19 @@ def render_report(collected: dict) -> str:
             sessions = _display(g.get("sessions"))
             avg = _display(g.get("sessions_7d_avg"))
             session_cell = f"{sessions} (vs {avg})"
-            funnel = _funnel_line(g.get("funnel") or {})
+            event_totals = _event_totals_line(g.get("funnel") or {})
         else:
             session_cell = "unavailable"
-            funnel = "unavailable"
+            event_totals = "unavailable"
         if mc.get("ok"):
             leads = _display(leads_by_brand.get(brand), "unavailable")
         else:
             leads = "unavailable"
-        lines.append(f"| {meta['label']} | {session_cell} | {funnel} | {leads} |")
+        lines.append(f"| {meta['label']} | {session_cell} | {event_totals} | {leads} |")
     lines.extend(
         f"- {warning}" for warning in _measurement_warnings(collected, 7)
     )
+    lines.append("- GA4 event totals are independent; they do not form a joined funnel.")
 
     lines.extend(["", "## TRAFFIC"])
     for brand, meta in BRANDS.items():
@@ -945,20 +927,23 @@ def render_report(collected: dict) -> str:
     if not constraint.get("ok"):
         lines.append("- constraint unavailable.")
     else:
-        binding = _display(constraint.get("binding_constraint"), "not available")
-        lines.append(f"- binding constraint: {binding}.")
         lines.append(
-            "- 28d rates: "
-            f"CTA {_display(constraint.get('cta_rate_pct'))}%; "
-            f"CTA→submit {_display(constraint.get('cta_to_submit_pct'))}%; "
-            f"submit→purchase {_display(constraint.get('submit_to_purchase_pct'))}%."
+            "- causal bottleneck: data insufficient — independent GA4 event totals "
+            "do not establish a shared cohort or event order."
         )
-        needed = constraint.get("sessions_per_day_needed_for_1_sale")
-        needed_text = _display(needed, "not measurable")
-        actual = _display(constraint.get("sessions_per_day"), "not available")
-        lines.append(f"- sessions/day needed for 1 sale/day: {needed_text}; actual: {actual}.")
+        totals = constraint.get("event_totals_28d") or {}
+        lines.append(
+            "- 28d observed totals: "
+            f"sessions {_display(constraint.get('sessions_28d'))}; "
+            f"cta {_display(totals.get('cta_click'))}; "
+            f"form_start {_display(totals.get('form_start'))}; "
+            f"submit {_display(totals.get('form_submit'))}; "
+            f"checkout {_display(totals.get('begin_checkout'))}; "
+            f"purchase {_display(totals.get('purchase'))}; "
+            f"refund {_display(totals.get('refund'))}."
+        )
         lines.extend(
-            f"- {warning} (28d sessions, funnel, and constraint rates)."
+            f"- {warning} (28d sessions and independent event totals)."
             for warning in _measurement_warnings(collected, 28)
         )
 
@@ -1222,8 +1207,9 @@ The commerce ledger is ground truth and overrides GA4. The factual report is alr
 rendered; do not repeat its sections or add new facts.
 
 Measurement epochs in DATA mark analytics collection changes, not demand changes. If a \
-comparison straddles one, explicitly treat the apparent session jump and affected funnel \
-or constraint rates as not like-for-like; do not report them as increased demand.
+comparison straddles one, explicitly treat the apparent session jump and affected event \
+totals as not like-for-like; do not report them as increased demand. Do not infer \
+conversion rates or a causal bottleneck from independent GA4 event totals.
 
 Write EXACTLY this structure (markdown):
 Line 1: `SUBJECT: intel {date}: <hook under 60 chars — the single most important fact>`

--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -176,7 +176,7 @@ def _safe(fn):
 def collect_ga4(brand: str) -> dict:
     from google.analytics.data_v1beta import BetaAnalyticsDataClient
     from google.analytics.data_v1beta.types import (
-        DateRange, Dimension, Metric, RunReportRequest,
+        DateRange, Dimension, Filter, FilterExpression, Metric, RunReportRequest,
     )
 
     creds = os.environ.get("GA4_CREDENTIALS", str(PROJECT_ROOT / "ga4-credentials.json"))
@@ -191,21 +191,30 @@ def collect_ga4(brand: str) -> dict:
     y = (date.today() - timedelta(days=1)).isoformat()
     week_ago = (date.today() - timedelta(days=7)).isoformat()  # 7 full days ending yesterday
 
-    def run(metrics, dimensions=None, date_from=y, date_to=y, limit=100):
-        return client.run_report(RunReportRequest(
+    def run(metrics, dimensions=None, date_from=y, date_to=y, limit=100,
+            dimension_filter=None):
+        request_args = dict(
             property=f"properties/{prop}",
             date_ranges=[DateRange(start_date=date_from, end_date=date_to)],
             metrics=[Metric(name=m) for m in metrics],
             dimensions=[Dimension(name=d) for d in (dimensions or [])],
             limit=limit,
-        ))
+        )
+        if dimension_filter is not None:
+            request_args["dimension_filter"] = dimension_filter
+        return client.run_report(RunReportRequest(**request_args))
+
+    event_filter = FilterExpression(filter=Filter(
+        field_name="eventName",
+        in_list_filter=Filter.InListFilter(values=sorted(FUNNEL_EVENTS)),
+    ))
 
     totals = run(["sessions", "totalUsers", "screenPageViews"])
     t = totals.rows[0].metric_values if totals.rows else None
     week = run(["sessions"], date_from=week_ago, date_to=y)
     week_sessions = int(week.rows[0].metric_values[0].value) if week.rows else 0
 
-    events = run(["eventCount"], ["eventName"])
+    events = run(["eventCount"], ["eventName"], dimension_filter=event_filter)
     ev = {r.dimension_values[0].value: int(r.metric_values[0].value)
           for r in events.rows}
 
@@ -218,7 +227,10 @@ def collect_ga4(brand: str) -> dict:
     m_ago = (date.today() - timedelta(days=28)).isoformat()
     agg = run(["sessions"], date_from=m_ago, date_to=y)
     sessions_28d = int(agg.rows[0].metric_values[0].value) if agg.rows else 0
-    ev28 = run(["eventCount"], ["eventName"], date_from=m_ago, date_to=y)
+    ev28 = run(
+        ["eventCount"], ["eventName"], date_from=m_ago, date_to=y,
+        dimension_filter=event_filter,
+    )
     ev28d = {r.dimension_values[0].value: int(r.metric_values[0].value)
              for r in ev28.rows}
     funnel_28d = {stage: sum(ev28d.get(e, 0) for e in evs)
@@ -335,11 +347,6 @@ def collect_mission_control() -> dict:
     clicked = sum(1 for s in sends if (s.get("clicked_at") or "") >= cutoff)
     bounced = sum(1 for s in new_sends if s.get("status") == "bounced")
 
-    # NOTE: gg_athletes is NOT written by the purchase path (verified Jul 2026
-    # — real June sales never appeared there). Orders truth = GA4 purchase
-    # events (see ga4 collector) + the [GG] FAILED emails for fulfillment.
-    new_orders = []
-
     audit = db.get_audit_log(limit=200)
     errors = [
         {"action": a.get("action"), "details": (a.get("details") or "")[:160]}
@@ -393,7 +400,6 @@ def collect_mission_control() -> dict:
         "countdown_enrollments": countdown,
         "emails_sent_24h": len(new_sends),
         "opens_24h": opened, "clicks_24h": clicked, "bounces_24h": bounced,
-        "new_orders_24h_UNRELIABLE": "use ga4 purchase counts — gg_athletes is not written by purchases",
         "errors_24h": errors[:10],
     }
 
@@ -706,19 +712,32 @@ def load_trend(days: int = 7) -> list[dict]:
             compact = {"date": f.stem}
             for b in BRANDS:
                 g = snap.get("ga4", {}).get(b, {})
-                compact[b] = {"sessions": g.get("sessions"),
-                              "purchases": (g.get("funnel") or {}).get("purchase")}
+                funnel = g.get("funnel") or {}
+                compact[b] = {
+                    "sessions": g.get("sessions"),
+                    "purchase_events": funnel.get("purchase"),
+                    "refund_events": funnel.get("refund"),
+                }
             mc = snap.get("mission_control", {})
             compact["leads"] = mc.get("new_leads_24h")
-            purchases = []
-            for b in BRANDS:
-                value = (((snap.get("ga4") or {}).get(b) or {}).get("funnel") or {}).get(
-                    "purchase", 0)
-                try:
-                    purchases.append(int(value or 0))
-                except (TypeError, ValueError):
-                    purchases.append(0)
-            compact["orders"] = sum(purchases)
+            for event in ("purchase", "refund"):
+                values = []
+                for b in BRANDS:
+                    value = (((snap.get("ga4") or {}).get(b) or {}).get("funnel") or {}).get(
+                        event, 0)
+                    try:
+                        values.append(int(value or 0))
+                    except (TypeError, ValueError):
+                        values.append(0)
+                compact[f"{event}_events"] = sum(values)
+            ledger = snap.get("commerce_ledger") or {}
+            if ledger.get("ok"):
+                compact["provider_orders"] = sum(
+                    1 for order in (ledger.get("orders") or [])
+                    if isinstance(order, dict)
+                )
+            else:
+                compact["provider_orders"] = None
             trend.append(compact)
         except Exception:
             continue
@@ -1203,7 +1222,9 @@ this started (Jun 2026): ~35 users/day, ~1 sale/month.
 
 Register: deadpan, terse, zero hype, zero filler. Like a good analyst who respects the \
 reader's time. NEVER invent or extrapolate a number not present in the context below. \
-The commerce ledger is ground truth and overrides GA4. The factual report is already \
+Only the commerce ledger establishes provider orders and fulfillment outcomes. GA4 \
+purchase and refund counts are behavioral events, not orders; never use them as order \
+counts or infer revenue from them. The factual report is already \
 rendered; do not repeat its sections or add new facts.
 
 Measurement epochs in DATA mark analytics collection changes, not demand changes. If a \

--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -283,8 +283,11 @@ def collect_checkout(brand: str) -> dict:
 
 
 def collect_commerce_ledger() -> dict:
-    """Ground truth from the webhook's /api/intel-stats (Railway volume logs):
-    orders WITH fulfillment outcomes, cart recoveries, questionnaire starts."""
+    """Local processing records from /api/intel-stats (Railway volume logs).
+
+    These records expose processing attempts and failures for operations. They
+    are not provider payment receipts or proof of customer fulfillment.
+    """
     secret = os.environ.get("CRON_SECRET", "")
     if not secret:
         return {"ok": False, "error": "CRON_SECRET not set"}
@@ -713,31 +716,35 @@ def load_trend(days: int = 7) -> list[dict]:
             for b in BRANDS:
                 g = snap.get("ga4", {}).get(b, {})
                 funnel = g.get("funnel") or {}
+                available = g.get("ok") is True and isinstance(funnel, dict)
                 compact[b] = {
-                    "sessions": g.get("sessions"),
-                    "purchase_events": funnel.get("purchase"),
-                    "refund_events": funnel.get("refund"),
+                    "sessions": g.get("sessions") if available else None,
+                    "purchase_events": (
+                        funnel.get("purchase")
+                        if available and "purchase" in funnel else None
+                    ),
+                    "refund_events": (
+                        funnel.get("refund")
+                        if available and "refund" in funnel else None
+                    ),
                 }
             mc = snap.get("mission_control", {})
             compact["leads"] = mc.get("new_leads_24h")
             for event in ("purchase", "refund"):
-                values = []
-                for b in BRANDS:
-                    value = (((snap.get("ga4") or {}).get(b) or {}).get("funnel") or {}).get(
-                        event, 0)
-                    try:
-                        values.append(int(value or 0))
-                    except (TypeError, ValueError):
-                        values.append(0)
-                compact[f"{event}_events"] = sum(values)
+                values = [compact[b][f"{event}_events"] for b in BRANDS]
+                if all(isinstance(value, int) and not isinstance(value, bool)
+                       for value in values):
+                    compact[f"{event}_events"] = sum(values)
+                else:
+                    compact[f"{event}_events"] = None
             ledger = snap.get("commerce_ledger") or {}
             if ledger.get("ok"):
-                compact["provider_orders"] = sum(
+                compact["order_processing_records"] = sum(
                     1 for order in (ledger.get("orders") or [])
                     if isinstance(order, dict)
                 )
             else:
-                compact["provider_orders"] = None
+                compact["order_processing_records"] = None
             trend.append(compact)
         except Exception:
             continue
@@ -791,7 +798,7 @@ def _collector_failures(collected: dict) -> list[str]:
                 broken.append(f"GA4 {label} collector failed: {error}")
     for key, label in (
         ("mission_control", "Mission Control"),
-        ("commerce_ledger", "commerce ledger"),
+        ("commerce_ledger", "order processing records"),
         ("social", "social"),
         ("workflows", "workflows"),
     ):
@@ -906,36 +913,39 @@ def render_report(collected: dict) -> str:
             f"- **{meta['label']} top landing:** {landing}.",
         ])
 
-    lines.extend(["", "## COMMERCE (GROUND TRUTH)"])
+    lines.extend(["", "## ORDER PROCESSING (LOCAL RECORDS)"])
     ledger = collected.get("commerce_ledger") or {}
     if not ledger.get("ok"):
-        lines.append("- commerce ledger unavailable.")
+        lines.append("- order processing records unavailable.")
     else:
         orders = list(ledger.get("orders") or [])
-        failed_orders = list(ledger.get("failed_orders") or [])
-        failed_orders.extend(o for o in orders if o.get("success") is False)
+        if not orders:
+            orders = list(ledger.get("failed_orders") or [])
+        failed_orders = [o for o in orders if o.get("success") is False]
         successful_orders = [o for o in orders if o.get("success") is not False]
         recoveries = list(ledger.get("recoveries") or [])
         starts = ledger.get("questionnaire_starts") or 0
         if not failed_orders and not successful_orders and not recoveries and not starts:
-            lines.append("- no orders, cart recoveries, or questionnaire starts.")
+            lines.append(
+                "- no processing attempts, cart recoveries, or questionnaire starts."
+            )
         else:
-            seen_failures = set()
             for order in failed_orders:
-                identity = (order.get("timestamp"), order.get("email"), order.get("error"))
-                if identity in seen_failures:
-                    continue
-                seen_failures.add(identity)
                 product = order.get("product_type") or order.get("product") or "order"
-                error = _display(order.get("error"), "unknown fulfillment error")
+                error = _display(order.get("error"), "unknown processing error")
                 lines.append(
-                    f"- **FAILED ORDER:** {_person(order)} — {product}; "
-                    f"fulfillment FAILED: {error}."
+                    f"- **PROCESSING FAILURE:** {_person(order)} — {product}; "
+                    f"processing FAILED: {error}."
                 )
             for order in successful_orders:
                 product = order.get("product_type") or order.get("product") or "order"
-                outcome = "fulfilled" if order.get("success") is True else "outcome unknown"
-                lines.append(f"- order: {_person(order)} — {product}; fulfillment {outcome}.")
+                outcome = (
+                    "processing succeeded"
+                    if order.get("success") is True else "processing outcome unknown"
+                )
+                lines.append(
+                    f"- processing record: {_person(order)} — {product}; {outcome}."
+                )
             for recovery in recoveries:
                 product = recovery.get("product") or recovery.get("product_type") or "order"
                 lines.append(f"- cart recovery: {_person(recovery)} — {product}.")
@@ -1098,17 +1108,15 @@ def render_report(collected: dict) -> str:
 
     lines.extend(["", "## BROKEN"])
     broken = []
-    failed_for_broken = list(ledger.get("failed_orders") or [])
-    failed_for_broken.extend(
-        order for order in (ledger.get("orders") or []) if order.get("success") is False)
-    seen_failures = set()
+    processing_records = list(ledger.get("orders") or [])
+    failed_for_broken = [
+        order for order in processing_records if order.get("success") is False
+    ]
+    if not processing_records:
+        failed_for_broken = list(ledger.get("failed_orders") or [])
     for order in failed_for_broken:
-        identity = (order.get("timestamp"), order.get("email"), order.get("error"))
-        if identity in seen_failures:
-            continue
-        seen_failures.add(identity)
-        error = _display(order.get("error"), "unknown fulfillment error")
-        broken.append(f"FAILED ORDER: {_person(order)} — {error}")
+        error = _display(order.get("error"), "unknown processing error")
+        broken.append(f"PROCESSING FAILURE: {_person(order)} — {error}")
     broken.extend(_collector_failures(collected))
     if mc.get("ok"):
         for error in mc.get("errors_24h") or []:
@@ -1222,9 +1230,13 @@ this started (Jun 2026): ~35 users/day, ~1 sale/month.
 
 Register: deadpan, terse, zero hype, zero filler. Like a good analyst who respects the \
 reader's time. NEVER invent or extrapolate a number not present in the context below. \
-Only the commerce ledger establishes provider orders and fulfillment outcomes. GA4 \
-purchase and refund counts are behavioral events, not orders; never use them as order \
-counts or infer revenue from them. The factual report is already \
+GA4 purchase and refund counts are behavioral events, not orders; never use them as \
+order counts or infer revenue from them. The `commerce_ledger` key is a legacy name \
+for local order-processing log records. Those records may contain retries, duplicate \
+attempts, failures, or synthetic traffic. A successful processing record does not \
+establish payment or customer fulfillment. Provider payments, refunds, distinct orders, \
+and customer fulfillment are unavailable without a separate provider reconciliation. \
+The factual report is already \
 rendered; do not repeat its sections or add new facts.
 
 Measurement epochs in DATA mark analytics collection changes, not demand changes. If a \

--- a/scripts/daily_report.py
+++ b/scripts/daily_report.py
@@ -228,7 +228,6 @@ def collect_ga4_metrics() -> dict:
     """GA4 analytics — requires credentials."""
     try:
         from mission_control.services.ga4 import (
-            get_conversion_events,
             get_daily_sessions,
             get_top_pages,
             get_traffic_sources,
@@ -251,8 +250,6 @@ def collect_ga4_metrics() -> dict:
 
         top_pages = get_top_pages(days=7, limit=5)
         sources = get_traffic_sources(days=7)
-        conversions = get_conversion_events(days=7)
-
         pct_change = None
         if prev_7 and prev_7 > 0:
             pct_change = round((recent_7 - prev_7) / prev_7 * 100, 1)
@@ -264,7 +261,6 @@ def collect_ga4_metrics() -> dict:
             "sessions_pct_change": pct_change,
             "top_pages": top_pages[:5],
             "sources": sources[:5],
-            "conversions": conversions[:5],
         }
     except Exception:
         return {"configured": False}

--- a/scripts/funnel_report.py
+++ b/scripts/funnel_report.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 """
-Conversion funnel analysis — queries GA4 Data API for stage-by-stage drop-off.
+GA4 event-total report for journey-related events.
 
-Reports two funnels:
-  1. Training Plan funnel: race page_view → cta_click → tp_form_start →
-     tp_form_submit → begin_checkout → purchase
-  2. Coaching funnel: coaching page_view → coaching_cta_click →
-     coaching_scroll_depth (87_faq or 100_final_cta)
+Rows are independently aggregated event counts in a useful reading order. They
+do not identify a common user, session, product, race, or event sequence, so the
+report deliberately does not calculate drop-off or conversion percentages.
 
 Prerequisites:
   - Google Analytics Data API credentials (service account JSON)
@@ -34,36 +32,83 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
-# ── Funnel definitions ──────────────────────────────────────────────────
+# ── Observed event groups ───────────────────────────────────────────────
+
+MEASUREMENT_METADATA = {
+    "kind": "independent_event_totals",
+    "joined": False,
+    "denominator": None,
+    "evidence_gap": (
+        "The GA4 requests return aggregate eventCount values without a shared "
+        "user, session, product, race, order identifier, or event sequence."
+    ),
+    "limitations": [
+        "Each row is counted independently; rows are not a sequential cohort.",
+        "Query scope can differ by row and is declared on every row.",
+        "Purchase events are behavioral evidence until reconciled to provider transactions.",
+    ],
+    "joined_measurement_path": {
+        "session_cohort": (
+            "Use event-level GA4 export or a GA4 funnel report with ordered steps "
+            "after the same race/product dimensions are present on every step."
+        ),
+        "order_cohort": (
+            "Carry a common order and offer identifier through checkout and purchase, "
+            "then reconcile purchase transaction_id to the provider ledger."
+        ),
+    },
+}
+
+RACE_SCOPE = "race pages (/race/*)"
+QUESTIONNAIRE_SCOPE = "questionnaire (/questionnaire/*)"
+COACHING_SCOPE = "coaching pages (/coaching/*)"
+ARTICLE_SCOPE = "article pages (/articles/*)"
+PROPERTY_SCOPE = "property-wide purchase events"
 
 TRAINING_PLAN_FUNNEL = [
-    {"stage": "page_view",       "event": "page_view",      "label": "Race page views",
-     "filter_field": "pagePath", "filter_prefix": "/race/"},
-    {"stage": "cta_click",       "event": "cta_click",      "label": "CTA clicks"},
-    {"stage": "tp_form_start",   "event": "tp_form_start",  "label": "Form started"},
-    {"stage": "tp_form_submit",  "event": "tp_form_submit", "label": "Form submitted"},
-    {"stage": "begin_checkout",  "event": "begin_checkout",  "label": "Checkout initiated"},
-    {"stage": "purchase",        "event": "purchase",        "label": "Purchase completed"},
+    {"stage": "page_view", "events": ["page_view"], "label": "Race page views",
+     "filter_field": "pagePath", "filter_prefix": "/race/", "scope": RACE_SCOPE},
+    {"stage": "cta_click", "events": ["cta_click"], "label": "Race-page CTA clicks",
+     "filter_field": "pagePath", "filter_prefix": "/race/", "scope": RACE_SCOPE},
+    {"stage": "tp_form_start", "events": ["form_start", "tp_form_start"],
+     "label": "Form starts", "filter_field": "pagePath", "filter_prefix": "/questionnaire/",
+     "scope": QUESTIONNAIRE_SCOPE},
+    {"stage": "tp_form_submit", "events": ["form_submit", "tp_form_submit"],
+     "label": "Form submissions", "filter_field": "pagePath", "filter_prefix": "/questionnaire/",
+     "scope": QUESTIONNAIRE_SCOPE},
+    {"stage": "begin_checkout", "events": ["begin_checkout"],
+     "label": "Checkout starts", "filter_field": "pagePath", "filter_prefix": "/questionnaire/",
+     "scope": QUESTIONNAIRE_SCOPE},
+    {"stage": "purchase", "events": ["purchase"], "label": "Purchase events",
+     "scope": PROPERTY_SCOPE},
 ]
 
 COACHING_FUNNEL = [
-    {"stage": "page_view",              "event": "page_view",              "label": "Coaching page views",
-     "filter_field": "pagePath", "filter_prefix": "/coaching/"},
-    {"stage": "coaching_cta_click",     "event": "coaching_cta_click",     "label": "CTA clicks"},
-    {"stage": "coaching_scroll_depth",  "event": "coaching_scroll_depth",  "label": "Deep scroll (FAQ/final CTA)"},
+    {"stage": "page_view", "events": ["page_view"], "label": "Coaching page views",
+     "filter_field": "pagePath", "filter_prefix": "/coaching/", "scope": COACHING_SCOPE},
+    {"stage": "coaching_cta_click", "events": ["cta_click", "coaching_cta_click"],
+     "label": "CTA clicks", "filter_field": "pagePath", "filter_prefix": "/coaching/",
+     "scope": COACHING_SCOPE},
+    {"stage": "coaching_scroll_depth", "events": ["coaching_scroll_depth"],
+     "label": "Deep scroll (FAQ/final CTA)", "filter_field": "pagePath",
+     "filter_prefix": "/coaching/", "scope": COACHING_SCOPE},
 ]
 
 ARTICLE_FUNNEL = [
-    {"stage": "page_view",          "event": "page_view",          "label": "Article page views",
-     "filter_field": "pagePath", "filter_prefix": "/articles/"},
-    {"stage": "article_deep_read",  "event": "article_deep_read",  "label": "Deep read (75%+ scroll)"},
-    {"stage": "article_cta_click",  "event": "article_cta_click",  "label": "CTA clicks (coaching/plans/substack)"},
+    {"stage": "page_view", "events": ["page_view"], "label": "Article page views",
+     "filter_field": "pagePath", "filter_prefix": "/articles/", "scope": ARTICLE_SCOPE},
+    {"stage": "article_deep_read", "events": ["article_deep_read"],
+     "label": "Deep reads (75%+ scroll)", "filter_field": "pagePath",
+     "filter_prefix": "/articles/", "scope": ARTICLE_SCOPE},
+    {"stage": "article_cta_click", "events": ["article_cta_click"],
+     "label": "CTA clicks (coaching/plans/substack)", "filter_field": "pagePath",
+     "filter_prefix": "/articles/", "scope": ARTICLE_SCOPE},
 ]
 
 
 def get_funnel_data(property_id: str, credentials_path: str, days: int,
                     funnel: list[dict]) -> list[dict]:
-    """Query GA4 Data API for event counts at each funnel stage."""
+    """Query GA4 Data API for independent event totals in display order."""
     try:
         from google.analytics.data_v1beta import BetaAnalyticsDataClient
         from google.analytics.data_v1beta.types import (
@@ -88,10 +133,19 @@ def get_funnel_data(property_id: str, credentials_path: str, days: int,
 
     stages = []
     for stage_def in funnel:
-        event_filter = Filter(
-            field_name="eventName",
-            string_filter=Filter.StringFilter(value=stage_def["event"]),
-        )
+        event_expressions = [
+            FilterExpression(filter=Filter(
+                field_name="eventName",
+                string_filter=Filter.StringFilter(value=event_name),
+            ))
+            for event_name in stage_def["events"]
+        ]
+        if len(event_expressions) == 1:
+            event_expression = event_expressions[0]
+        else:
+            event_expression = FilterExpression(
+                or_group=FilterExpressionList(expressions=event_expressions)
+            )
 
         # If the stage has a page path filter, combine with AND
         if "filter_field" in stage_def:
@@ -105,13 +159,13 @@ def get_funnel_data(property_id: str, credentials_path: str, days: int,
             dimension_filter = FilterExpression(
                 and_group=FilterExpressionList(
                     expressions=[
-                        FilterExpression(filter=event_filter),
+                        event_expression,
                         FilterExpression(filter=path_filter),
                     ]
                 )
             )
         else:
-            dimension_filter = FilterExpression(filter=event_filter)
+            dimension_filter = event_expression
 
         request = RunReportRequest(
             property=f"properties/{property_id}",
@@ -131,101 +185,79 @@ def get_funnel_data(property_id: str, credentials_path: str, days: int,
             "stage": stage_def["stage"],
             "label": stage_def["label"],
             "count": count,
+            "scope": stage_def["scope"],
+            "event_names": list(stage_def["events"]),
         })
 
     return stages
 
 
-def compute_funnel_metrics(stages: list[dict]) -> list[dict]:
-    """Add drop-off and cumulative conversion percentages to stage data."""
-    if not stages or stages[0]["count"] == 0:
-        for s in stages:
-            s["dropoff_pct"] = None
-            s["cumulative_pct"] = None
-        return stages
-
-    top_count = stages[0]["count"]
-
-    for i, s in enumerate(stages):
-        # Cumulative conversion from top of funnel
-        s["cumulative_pct"] = round(s["count"] / top_count * 100, 2)
-
-        # Drop-off from previous stage
-        if i == 0:
-            s["dropoff_pct"] = None
-        else:
-            prev = stages[i - 1]["count"]
-            if prev > 0:
-                s["dropoff_pct"] = round((1 - s["count"] / prev) * 100, 2)
-            else:
-                s["dropoff_pct"] = None
-
-    return stages
-
-
-def print_funnel(title: str, stages: list[dict]):
-    """Print a single funnel as a formatted table."""
+def print_event_totals(title: str, stages: list[dict]):
+    """Print independently aggregated events without cross-stage rates."""
     print(f"\n{'─' * 70}")
     print(f"  {title}")
     print(f"{'─' * 70}")
 
-    # Header
-    print(f"  {'Stage':<28} {'Count':>8}  {'Drop-off':>9}  {'Cumulative':>11}")
-    print(f"  {'─' * 28} {'─' * 8}  {'─' * 9}  {'─' * 11}")
+    print(f"  {'Observed event group':<38} {'Count':>8}  Scope")
+    print(f"  {'─' * 38} {'─' * 8}  {'─' * 30}")
 
     for s in stages:
-        dropoff = f"{s['dropoff_pct']:>8.1f}%" if s["dropoff_pct"] is not None else f"{'—':>9}"
-        cumul = f"{s['cumulative_pct']:>10.1f}%" if s["cumulative_pct"] is not None else f"{'—':>11}"
-        print(f"  {s['label']:<28} {s['count']:>8,}  {dropoff}  {cumul}")
-
-    # Overall conversion
-    if len(stages) >= 2 and stages[0]["count"] > 0:
-        overall = stages[-1]["count"] / stages[0]["count"] * 100
-        print(f"\n  Overall conversion: {overall:.2f}% "
-              f"({stages[-1]['count']:,} / {stages[0]['count']:,})")
+        print(f"  {s['label']:<38} {s['count']:>8,}  {s['scope']}")
 
 
 def print_report(tp_stages: list[dict], coaching_stages: list[dict], days: int,
                  article_stages: list[dict] | None = None):
-    """Print human-readable funnel report to stdout."""
+    """Print human-readable independent event totals to stdout."""
     print("=" * 70)
-    print(f"CONVERSION FUNNEL REPORT — last {days} days")
+    print(f"INDEPENDENT GA4 EVENT TOTALS — last {days} days")
     print("=" * 70)
+    print("No shared session, user, product, or event order is established.")
+    print("Counts are observations, not conversion-rate denominators.")
 
-    print_funnel("TRAINING PLAN FUNNEL", tp_stages)
-    print_funnel("COACHING FUNNEL", coaching_stages)
+    print_event_totals("TRAINING PLAN JOURNEY EVENTS", tp_stages)
+    print_event_totals("COACHING JOURNEY EVENTS", coaching_stages)
     if article_stages:
-        print_funnel("ARTICLE FUNNEL", article_stages)
+        print_event_totals("ARTICLE JOURNEY EVENTS", article_stages)
 
     print(f"\n{'=' * 70}")
 
 
+def build_report_payload(days: int, tp_stages: list[dict],
+                         coaching_stages: list[dict],
+                         article_stages: list[dict]) -> dict:
+    """Build machine-readable output with an explicit measurement contract."""
+    return {
+        "schema": "ga4_event_totals/v2",
+        "days": days,
+        "measurement": MEASUREMENT_METADATA,
+        "training_plan_totals": tp_stages,
+        "coaching_totals": coaching_stages,
+        "article_totals": article_stages,
+    }
+
+
 def get_mock_data() -> tuple[list[dict], list[dict], list[dict]]:
     """Return hardcoded sample data for testing without credentials."""
-    tp_stages = [
-        {"stage": "page_view",       "label": "Race page views",     "count": 12480},
-        {"stage": "cta_click",       "label": "CTA clicks",          "count": 1870},
-        {"stage": "tp_form_start",   "label": "Form started",        "count": 624},
-        {"stage": "tp_form_submit",  "label": "Form submitted",      "count": 287},
-        {"stage": "begin_checkout",  "label": "Checkout initiated",   "count": 143},
-        {"stage": "purchase",        "label": "Purchase completed",   "count": 52},
-    ]
-    coaching_stages = [
-        {"stage": "page_view",              "label": "Coaching page views",          "count": 3200},
-        {"stage": "coaching_cta_click",     "label": "CTA clicks",                   "count": 480},
-        {"stage": "coaching_scroll_depth",  "label": "Deep scroll (FAQ/final CTA)",  "count": 1120},
-    ]
-    article_stages = [
-        {"stage": "page_view",          "label": "Article page views",                    "count": 850},
-        {"stage": "article_deep_read",  "label": "Deep read (75%+ scroll)",               "count": 340},
-        {"stage": "article_cta_click",  "label": "CTA clicks (coaching/plans/substack)",  "count": 68},
-    ]
+    def rows(definitions: list[dict], counts: list[int]) -> list[dict]:
+        return [{
+            "stage": definition["stage"],
+            "label": definition["label"],
+            "count": count,
+            "scope": definition["scope"],
+            "event_names": list(definition["events"]),
+        } for definition, count in zip(definitions, counts)]
+
+    # The purchase total intentionally exceeds checkout starts. Independent
+    # aggregates can do this when event scope, attribution, or sources differ.
+    tp_stages = rows(TRAINING_PLAN_FUNNEL, [12480, 1870, 624, 287, 143, 180])
+    coaching_stages = rows(COACHING_FUNNEL, [3200, 480, 1120])
+    article_stages = rows(ARTICLE_FUNNEL, [850, 340, 68])
     return tp_stages, coaching_stages, article_stages
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Conversion funnel analysis — stage-by-stage drop-off report"
+        description="GA4 journey-event totals with explicit scope and denominator limits"
     )
     parser.add_argument("--days", type=int, default=30,
                         help="Lookback days (default: 30)")
@@ -263,17 +295,10 @@ def main():
             property_id, credentials_path, args.days, ARTICLE_FUNNEL
         )
 
-    tp_stages = compute_funnel_metrics(tp_stages)
-    coaching_stages = compute_funnel_metrics(coaching_stages)
-    article_stages = compute_funnel_metrics(article_stages)
-
     if args.json:
-        output = {
-            "days": args.days,
-            "training_plan_funnel": tp_stages,
-            "coaching_funnel": coaching_stages,
-            "article_funnel": article_stages,
-        }
+        output = build_report_payload(
+            args.days, tp_stages, coaching_stages, article_stages
+        )
         print(json.dumps(output, indent=2))
     else:
         print_report(tp_stages, coaching_stages, args.days, article_stages)

--- a/tests/test_daily_intel.py
+++ b/tests/test_daily_intel.py
@@ -8,6 +8,7 @@ import pytest
 from scripts.daily_intel import (
     INTERPRET_PROMPT,
     combine_report,
+    compute_constraint,
     detect_tracking_regression,
     measurement_epochs_for_report,
     measurement_epochs_in_window,
@@ -68,12 +69,17 @@ def collected():
         },
         "constraint": {
             "ok": True,
-            "binding_constraint": "traffic",
-            "cta_rate_pct": 4.05,
-            "cta_to_submit_pct": 60.5,
-            "submit_to_purchase_pct": 11.5,
-            "sessions_per_day_needed_for_1_sale": 354,
-            "sessions_per_day": 37.9,
+            "assessment": "data_insufficient",
+            "reason": "independent event totals do not establish a causal bottleneck",
+            "sessions_28d": 1061,
+            "event_totals_28d": {
+                "cta_click": 43,
+                "form_start": 20,
+                "form_submit": 10,
+                "begin_checkout": 3,
+                "purchase": 2,
+                "refund": 4,
+            },
         },
         "social": {"ok": True, "accounts_live": False},
         "workflows": {"ok": True, "latest": {"regression-tests.yml": "success"}},
@@ -85,15 +91,16 @@ def test_render_report_has_deterministic_sections_and_readable_funnel(collected)
     report = render_report(collected)
 
     assert report.startswith("## NUMBERS")
-    assert "cta 2 → form_start 2 → submit 1 → checkout 0 → purchase 0" in report
+    assert "cta 2; form_start 2; submit 1; checkout 0; purchase 0; refund 0" in report
     assert "{'cta_click'" not in report
     assert "## TRAFFIC" in report
     assert "Gravel God top pages" in report
     assert "Roadie Labs:** 3 sessions; near-zero traffic" in report
     assert "## COMMERCE (GROUND TRUTH)" in report
     assert "no orders, cart recoveries, or questionnaire starts" in report
-    assert "binding constraint: traffic" in report
-    assert "354; actual: 37.9" in report
+    assert "causal bottleneck: data insufficient" in report
+    assert "sessions 1061; cta 43; form_start 20; submit 10; checkout 3; purchase 2; refund 4" in report
+    assert "CTA→submit" not in report
     assert "Ada Rider <ada@example.com> — Test Gravel; welcome_v1 step 2" in report
     assert "## SOCIAL" not in report
     assert "###" not in report
@@ -123,7 +130,7 @@ def test_measurement_window_straddle_is_annotated_and_serializable(collected):
         "⚠ measurement regime change 2026-07-26 — comparison not like-for-like"
     )
     assert report.count(warning) == 2
-    assert "(28d sessions, funnel, and constraint rates)." in report
+    assert "(28d sessions and independent event totals)." in report
     assert snapshot["measurement_epochs"] == [{
         "date": "2026-07-26",
         "scope": "sessions",
@@ -134,6 +141,39 @@ def test_measurement_window_straddle_is_annotated_and_serializable(collected):
     }]
     assert warning in snapshot["report"]
     assert "analytics collection changes, not demand changes" in INTERPRET_PROMPT
+    assert "Do not infer conversion rates or a causal bottleneck" in INTERPRET_PROMPT
+
+
+def test_compute_constraint_refuses_rates_for_nonmonotonic_event_totals():
+    result = compute_constraint({
+        "ok": True,
+        "sessions_28d": 500,
+        "funnel_28d": {
+            "cta_click": 4,
+            "form_start": 3,
+            "form_submit": 1,
+            "begin_checkout": 1,
+            "purchase": 2,
+            "refund": 7,
+        },
+    })
+
+    assert result == {
+        "ok": True,
+        "assessment": "data_insufficient",
+        "reason": "independent event totals do not establish a causal bottleneck",
+        "sessions_28d": 500,
+        "event_totals_28d": {
+            "cta_click": 4,
+            "form_start": 3,
+            "form_submit": 1,
+            "begin_checkout": 1,
+            "purchase": 2,
+            "refund": 7,
+        },
+    }
+    assert not any(key.endswith("_pct") for key in result)
+    assert "binding_constraint" not in result
 
 
 def test_empty_epoch_list_preserves_report_behavior(collected):

--- a/tests/test_daily_intel.py
+++ b/tests/test_daily_intel.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import json
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -174,6 +177,105 @@ def test_compute_constraint_refuses_rates_for_nonmonotonic_event_totals():
     }
     assert not any(key.endswith("_pct") for key in result)
     assert "binding_constraint" not in result
+
+
+def test_collect_ga4_filters_both_event_queries_before_limit(monkeypatch):
+    from scripts import daily_intel
+
+    class Message:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class Filter(Message):
+        class InListFilter(Message):
+            pass
+
+    def row(name, count):
+        return SimpleNamespace(
+            dimension_values=[SimpleNamespace(value=name)],
+            metric_values=[SimpleNamespace(value=str(count))],
+        )
+
+    class Client:
+        def __init__(self):
+            self.event_requests = []
+
+        def run_report(self, request):
+            dimensions = [item.name for item in request.dimensions]
+            if dimensions == ["eventName"]:
+                self.event_requests.append(request)
+                if getattr(request, "dimension_filter", None):
+                    return SimpleNamespace(rows=[row("purchase", 2), row("refund", 7)])
+                return SimpleNamespace(rows=[row(f"unrelated_{i}", 1) for i in range(100)])
+            return SimpleNamespace(rows=[])
+
+    client = Client()
+    fake_api = ModuleType("google.analytics.data_v1beta")
+    fake_api.BetaAnalyticsDataClient = lambda: client
+    fake_types = ModuleType("google.analytics.data_v1beta.types")
+    for name, value in {
+        "DateRange": Message,
+        "Dimension": Message,
+        "Filter": Filter,
+        "FilterExpression": Message,
+        "Metric": Message,
+        "RunReportRequest": Message,
+    }.items():
+        setattr(fake_types, name, value)
+    monkeypatch.setitem(sys.modules, "google.analytics.data_v1beta", fake_api)
+    monkeypatch.setitem(sys.modules, "google.analytics.data_v1beta.types", fake_types)
+    monkeypatch.setenv(daily_intel.BRANDS["gravelgod"]["property_env"], "123")
+
+    result = daily_intel.collect_ga4("gravelgod")
+
+    assert result["funnel"]["purchase"] == 2
+    assert result["funnel"]["refund"] == 7
+    assert result["funnel_28d"]["purchase"] == 2
+    assert result["funnel_28d"]["refund"] == 7
+    assert len(client.event_requests) == 2
+    for request in client.event_requests:
+        event_filter = request.dimension_filter.filter
+        assert event_filter.field_name == "eventName"
+        assert set(event_filter.in_list_filter.values) == set(daily_intel.FUNNEL_EVENTS)
+
+
+def test_load_trend_keeps_ga4_events_distinct_from_provider_orders(tmp_path, monkeypatch):
+    from scripts import daily_intel
+
+    snapshot = {
+        "ga4": {
+            "gravelgod": {
+                "sessions": 10,
+                "funnel": {"purchase": 9, "refund": 4},
+            },
+            "roadielabs": {
+                "sessions": 5,
+                "funnel": {"purchase": 2, "refund": 1},
+            },
+        },
+        "commerce_ledger": {
+            "ok": True,
+            "orders": [{"id": "provider-order-1", "success": True}],
+            "failed_orders": [],
+        },
+        "mission_control": {
+            "new_orders_24h_UNRELIABLE": "use ga4 purchase counts",
+        },
+    }
+    (tmp_path / "2026-09-07.json").write_text(json.dumps(snapshot))
+    monkeypatch.setattr(daily_intel, "SNAPSHOT_DIR", tmp_path)
+
+    [trend] = daily_intel.load_trend()
+
+    assert trend["purchase_events"] == 11
+    assert trend["refund_events"] == 5
+    assert trend["provider_orders"] == 1
+    assert "orders" not in trend
+    assert trend["gravelgod"]["purchase_events"] == 9
+    assert trend["gravelgod"]["refund_events"] == 4
+    assert "purchases" not in trend["gravelgod"]
+    assert "GA4 purchase and refund counts are behavioral events, not orders" in daily_intel.INTERPRET_PROMPT
+    assert "Only the commerce ledger establishes provider orders" in daily_intel.INTERPRET_PROMPT
 
 
 def test_empty_epoch_list_preserves_report_behavior(collected):
@@ -467,6 +569,7 @@ def test_collect_mission_control_reads_newest_rows_past_the_1000_row_cap(monkeyp
     assert out["clicks_24h"] == 1
     assert out["new_leads_24h"] == 2
     assert out["leads_by_brand"] == {"gravelgod": 1, "roadielabs": 1}
+    assert "new_orders_24h_UNRELIABLE" not in out
     hot = {lead["email"]: lead for lead in out["hot_leads_14d"]}
     assert set(hot) == {"new@example.com", "new2@example.com"}
     assert hot["new@example.com"]["opens"] == 1

--- a/tests/test_daily_intel.py
+++ b/tests/test_daily_intel.py
@@ -99,8 +99,8 @@ def test_render_report_has_deterministic_sections_and_readable_funnel(collected)
     assert "## TRAFFIC" in report
     assert "Gravel God top pages" in report
     assert "Roadie Labs:** 3 sessions; near-zero traffic" in report
-    assert "## COMMERCE (GROUND TRUTH)" in report
-    assert "no orders, cart recoveries, or questionnaire starts" in report
+    assert "## ORDER PROCESSING (LOCAL RECORDS)" in report
+    assert "no processing attempts, cart recoveries, or questionnaire starts" in report
     assert "causal bottleneck: data insufficient" in report
     assert "sessions 1061; cta 43; form_start 20; submit 10; checkout 3; purchase 2; refund 4" in report
     assert "CTA→submit" not in report
@@ -239,23 +239,33 @@ def test_collect_ga4_filters_both_event_queries_before_limit(monkeypatch):
         assert set(event_filter.in_list_filter.values) == set(daily_intel.FUNNEL_EVENTS)
 
 
-def test_load_trend_keeps_ga4_events_distinct_from_provider_orders(tmp_path, monkeypatch):
+def test_load_trend_keeps_events_distinct_from_processing_records(tmp_path, monkeypatch):
     from scripts import daily_intel
 
     snapshot = {
         "ga4": {
             "gravelgod": {
+                "ok": True,
                 "sessions": 10,
                 "funnel": {"purchase": 9, "refund": 4},
             },
             "roadielabs": {
+                "ok": True,
                 "sessions": 5,
                 "funnel": {"purchase": 2, "refund": 1},
+            },
+            "xcski": {
+                "ok": True,
+                "sessions": 0,
+                "funnel": {"purchase": 0, "refund": 0},
             },
         },
         "commerce_ledger": {
             "ok": True,
-            "orders": [{"id": "provider-order-1", "success": True}],
+            "orders": [
+                {"id": "cs_test_same", "success": True},
+                {"id": "cs_test_same", "success": True},
+            ],
             "failed_orders": [],
         },
         "mission_control": {
@@ -269,13 +279,80 @@ def test_load_trend_keeps_ga4_events_distinct_from_provider_orders(tmp_path, mon
 
     assert trend["purchase_events"] == 11
     assert trend["refund_events"] == 5
-    assert trend["provider_orders"] == 1
+    assert trend["order_processing_records"] == 2
+    assert "provider_orders" not in trend
     assert "orders" not in trend
     assert trend["gravelgod"]["purchase_events"] == 9
     assert trend["gravelgod"]["refund_events"] == 4
     assert "purchases" not in trend["gravelgod"]
     assert "GA4 purchase and refund counts are behavioral events, not orders" in daily_intel.INTERPRET_PROMPT
-    assert "Only the commerce ledger establishes provider orders" in daily_intel.INTERPRET_PROMPT
+    assert "may contain retries, duplicate attempts, failures, or synthetic traffic" in daily_intel.INTERPRET_PROMPT
+    assert "does not establish payment or customer fulfillment" in daily_intel.INTERPRET_PROMPT
+
+
+@pytest.mark.parametrize(
+    "unavailable_brand",
+    [None, {"ok": False, "funnel": {"purchase": 0, "refund": 0}}],
+)
+def test_load_trend_keeps_aggregate_unknown_for_missing_or_failed_brand(
+        tmp_path, monkeypatch, unavailable_brand):
+    from scripts import daily_intel
+
+    ga4 = {
+        "gravelgod": {
+            "ok": True,
+            "sessions": 10,
+            "funnel": {"purchase": 2, "refund": 1},
+        },
+        "roadielabs": {
+            "ok": True,
+            "sessions": 5,
+            "funnel": {"purchase": 0, "refund": 0},
+        },
+    }
+    if unavailable_brand is not None:
+        ga4["xcski"] = unavailable_brand
+    (tmp_path / "2026-09-05.json").write_text(json.dumps({"ga4": ga4}))
+    monkeypatch.setattr(daily_intel, "SNAPSHOT_DIR", tmp_path)
+
+    [trend] = daily_intel.load_trend()
+
+    assert trend["purchase_events"] is None
+    assert trend["refund_events"] is None
+    assert trend["xcski"]["purchase_events"] is None
+
+
+def test_load_trend_keeps_refunds_unknown_before_refund_epoch(tmp_path, monkeypatch):
+    from scripts import daily_intel
+
+    ga4 = {
+        brand: {"ok": True, "funnel": {"purchase": 0}}
+        for brand in daily_intel.BRANDS
+    }
+    (tmp_path / "2026-06-30.json").write_text(json.dumps({"ga4": ga4}))
+    monkeypatch.setattr(daily_intel, "SNAPSHOT_DIR", tmp_path)
+
+    [trend] = daily_intel.load_trend()
+
+    assert trend["purchase_events"] == 0
+    assert trend["refund_events"] is None
+    assert all(trend[brand]["refund_events"] is None for brand in daily_intel.BRANDS)
+
+
+def test_load_trend_preserves_true_complete_zero(tmp_path, monkeypatch):
+    from scripts import daily_intel
+
+    ga4 = {
+        brand: {"ok": True, "funnel": {"purchase": 0, "refund": 0}}
+        for brand in daily_intel.BRANDS
+    }
+    (tmp_path / "2026-09-06.json").write_text(json.dumps({"ga4": ga4}))
+    monkeypatch.setattr(daily_intel, "SNAPSHOT_DIR", tmp_path)
+
+    [trend] = daily_intel.load_trend()
+
+    assert trend["purchase_events"] == 0
+    assert trend["refund_events"] == 0
 
 
 def test_empty_epoch_list_preserves_report_behavior(collected):
@@ -288,20 +365,24 @@ def test_empty_epoch_list_preserves_report_behavior(collected):
 
 
 def test_render_report_failed_orders_are_first_and_broken_is_complete(collected):
+    failed_record = {
+        "name": "Failed Rider",
+        "email": "failed@example.com",
+        "product_type": "training_plan",
+        "success": False,
+        "error": "delivery timeout",
+    }
     collected["commerce_ledger"].update({
-        "failed_orders": [{
-            "name": "Failed Rider",
-            "email": "failed@example.com",
-            "product_type": "training_plan",
-            "success": False,
-            "error": "delivery timeout",
-        }],
-        "orders": [{
-            "name": "Paid Rider",
-            "email": "paid@example.com",
-            "product_type": "training_plan",
-            "success": True,
-        }],
+        "failed_orders": [failed_record],
+        "orders": [
+            failed_record,
+            {
+                "name": "Paid Rider",
+                "email": "paid@example.com",
+                "product_type": "training_plan",
+                "success": True,
+            },
+        ],
         "recoveries": [{"email": "cart@example.com", "product": "training_plan"}],
         "questionnaire_starts": 2,
     })
@@ -313,11 +394,14 @@ def test_render_report_failed_orders_are_first_and_broken_is_complete(collected)
     collected["report_issues"] = ["possible tracking regression"]
 
     report = render_report(collected)
-    commerce = report.split("## COMMERCE (GROUND TRUTH)\n", 1)[1].split("\n\n## CONSTRAINT", 1)[0]
+    commerce = report.split("## ORDER PROCESSING (LOCAL RECORDS)\n", 1)[1].split(
+        "\n\n## CONSTRAINT", 1)[0]
 
-    assert commerce.index("**FAILED ORDER:**") < commerce.index("- order: Paid Rider")
-    assert "fulfillment FAILED: delivery timeout" in commerce
-    assert "fulfillment fulfilled" in commerce
+    assert commerce.index("**PROCESSING FAILURE:**") < commerce.index(
+        "- processing record: Paid Rider")
+    assert "processing FAILED: delivery timeout" in commerce
+    assert "processing succeeded" in commerce
+    assert "fulfilled" not in commerce
     assert "cart recovery: cart@example.com" in commerce
     assert "questionnaire starts: 2" in commerce
     assert "checkout Roadie Labs FAIL: checkout=500" in report

--- a/tests/test_funnel_report.py
+++ b/tests/test_funnel_report.py
@@ -2,26 +2,28 @@
 
 Covers:
 - Mock data output format
-- Funnel stage ordering
-- Drop-off calculation
-- Cumulative conversion calculation
-- Edge cases (zero counts, single stage)
+- Observed stage ordering and query scope
+- Independent-total measurement semantics
+- Human and JSON disclosure of denominator limits
 """
 from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 # Ensure scripts/ is importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
+import funnel_report
 from funnel_report import (
+    ARTICLE_FUNNEL,
     COACHING_FUNNEL,
     TRAINING_PLAN_FUNNEL,
-    compute_funnel_metrics,
     get_mock_data,
+    print_report,
 )
 
 
@@ -43,6 +45,7 @@ class TestMockData:
             assert "stage" in stage
             assert "label" in stage
             assert "count" in stage
+            assert "scope" in stage
             assert isinstance(stage["count"], int)
 
     def test_coaching_stages_have_required_keys(self):
@@ -51,6 +54,7 @@ class TestMockData:
             assert "stage" in stage
             assert "label" in stage
             assert "count" in stage
+            assert "scope" in stage
             assert isinstance(stage["count"], int)
 
     def test_article_stages_have_required_keys(self):
@@ -59,6 +63,7 @@ class TestMockData:
             assert "stage" in stage
             assert "label" in stage
             assert "count" in stage
+            assert "scope" in stage
             assert isinstance(stage["count"], int)
 
     def test_training_plan_has_six_stages(self):
@@ -82,8 +87,8 @@ class TestMockData:
 # ── Funnel stage ordering ──────────────────────────────────
 
 
-class TestFunnelStageOrdering:
-    """Funnel stages must be in correct sequential order."""
+class TestObservedStageOrdering:
+    """Rows retain a useful journey-like reading order without claiming a cohort."""
 
     def test_training_plan_funnel_order(self):
         expected_stages = [
@@ -100,138 +105,88 @@ class TestFunnelStageOrdering:
         actual = [s["stage"] for s in COACHING_FUNNEL]
         assert actual == expected_stages
 
-    def test_mock_data_counts_decrease_through_training_funnel(self):
-        """Each stage should have fewer or equal events than the previous."""
+    def test_mock_data_need_not_decrease_through_training_totals(self):
+        """Mock totals may rise because the rows are independent event totals."""
         tp, _, _ = get_mock_data()
-        for i in range(1, len(tp)):
-            # Coaching scroll might be higher than CTA clicks (passive vs active),
-            # but training plan funnel should monotonically decrease
-            assert tp[i]["count"] <= tp[i - 1]["count"], (
-                f"Stage {tp[i]['stage']} ({tp[i]['count']}) > "
-                f"{tp[i - 1]['stage']} ({tp[i - 1]['count']})"
-            )
+        assert tp[-1]["count"] > tp[-2]["count"]
+
+    def test_every_stage_declares_its_query_scope(self):
+        for stage in TRAINING_PLAN_FUNNEL + COACHING_FUNNEL + ARTICLE_FUNNEL:
+            assert stage["scope"]
+
+    def test_race_cta_is_scoped_to_race_pages(self):
+        cta = next(s for s in TRAINING_PLAN_FUNNEL if s["stage"] == "cta_click")
+        assert cta["filter_field"] == "pagePath"
+        assert cta["filter_prefix"] == "/race/"
+
+    def test_form_stage_counts_both_deployed_event_generations(self):
+        start = next(s for s in TRAINING_PLAN_FUNNEL if s["stage"] == "tp_form_start")
+        submit = next(s for s in TRAINING_PLAN_FUNNEL if s["stage"] == "tp_form_submit")
+        assert set(start["events"]) == {"form_start", "tp_form_start"}
+        assert set(submit["events"]) == {"form_submit", "tp_form_submit"}
 
 
-# ── Drop-off calculation ───────────────────────────────────
+# ── Measurement semantics ──────────────────────────────────
 
 
-class TestDropoffCalculation:
-    """Tests for compute_funnel_metrics drop-off percentages."""
+class TestIndependentTotalSemantics:
+    def test_metadata_refuses_unavailable_denominators(self):
+        metadata = getattr(funnel_report, "MEASUREMENT_METADATA", {})
+        assert metadata.get("kind") == "independent_event_totals"
+        assert metadata.get("joined") is False
+        assert metadata.get("denominator", "missing") is None
 
-    def test_basic_dropoff(self):
-        stages = [
-            {"stage": "a", "label": "A", "count": 100},
-            {"stage": "b", "label": "B", "count": 50},
-        ]
-        result = compute_funnel_metrics(stages)
-        assert result[0]["dropoff_pct"] is None  # first stage has no drop-off
-        assert result[1]["dropoff_pct"] == 50.0  # 50% drop from 100 to 50
-
-    def test_zero_dropoff(self):
-        stages = [
-            {"stage": "a", "label": "A", "count": 100},
-            {"stage": "b", "label": "B", "count": 100},
-        ]
-        result = compute_funnel_metrics(stages)
-        assert result[1]["dropoff_pct"] == 0.0
-
-    def test_full_dropoff(self):
-        stages = [
-            {"stage": "a", "label": "A", "count": 100},
-            {"stage": "b", "label": "B", "count": 0},
-        ]
-        result = compute_funnel_metrics(stages)
-        assert result[1]["dropoff_pct"] == 100.0
-
-    def test_multi_stage_dropoff(self):
-        stages = [
-            {"stage": "a", "label": "A", "count": 1000},
-            {"stage": "b", "label": "B", "count": 500},
-            {"stage": "c", "label": "C", "count": 250},
-        ]
-        result = compute_funnel_metrics(stages)
-        assert result[1]["dropoff_pct"] == 50.0
-        assert result[2]["dropoff_pct"] == 50.0
-
-    def test_dropoff_with_zero_previous(self):
-        stages = [
-            {"stage": "a", "label": "A", "count": 100},
-            {"stage": "b", "label": "B", "count": 0},
-            {"stage": "c", "label": "C", "count": 0},
-        ]
-        result = compute_funnel_metrics(stages)
-        assert result[2]["dropoff_pct"] is None  # 0/0 = undefined
-
-    def test_first_stage_dropoff_is_none(self):
-        stages = [{"stage": "a", "label": "A", "count": 500}]
-        result = compute_funnel_metrics(stages)
-        assert result[0]["dropoff_pct"] is None
-
-
-# ── Cumulative conversion ──────────────────────────────────
-
-
-class TestCumulativeConversion:
-    """Tests for compute_funnel_metrics cumulative conversion percentages."""
-
-    def test_first_stage_is_100_percent(self):
-        stages = [
-            {"stage": "a", "label": "A", "count": 100},
-            {"stage": "b", "label": "B", "count": 50},
-        ]
-        result = compute_funnel_metrics(stages)
-        assert result[0]["cumulative_pct"] == 100.0
-
-    def test_basic_cumulative(self):
-        stages = [
-            {"stage": "a", "label": "A", "count": 100},
-            {"stage": "b", "label": "B", "count": 50},
-        ]
-        result = compute_funnel_metrics(stages)
-        assert result[1]["cumulative_pct"] == 50.0
-
-    def test_multi_stage_cumulative(self):
-        stages = [
-            {"stage": "a", "label": "A", "count": 1000},
-            {"stage": "b", "label": "B", "count": 500},
-            {"stage": "c", "label": "C", "count": 100},
-        ]
-        result = compute_funnel_metrics(stages)
-        assert result[0]["cumulative_pct"] == 100.0
-        assert result[1]["cumulative_pct"] == 50.0
-        assert result[2]["cumulative_pct"] == 10.0
-
-    def test_zero_top_of_funnel(self):
-        stages = [
-            {"stage": "a", "label": "A", "count": 0},
-            {"stage": "b", "label": "B", "count": 0},
-        ]
-        result = compute_funnel_metrics(stages)
-        assert result[0]["cumulative_pct"] is None
-        assert result[1]["cumulative_pct"] is None
-
-    def test_empty_stages_list(self):
-        result = compute_funnel_metrics([])
-        assert result == []
-
-    def test_mock_data_cumulative_first_is_100(self):
+    def test_json_payload_contains_limits_and_no_cross_stage_rates(self):
         tp, coaching, articles = get_mock_data()
-        tp = compute_funnel_metrics(tp)
-        coaching = compute_funnel_metrics(coaching)
-        articles = compute_funnel_metrics(articles)
-        assert tp[0]["cumulative_pct"] == 100.0
-        assert coaching[0]["cumulative_pct"] == 100.0
-        assert articles[0]["cumulative_pct"] == 100.0
+        build_report_payload = getattr(funnel_report, "build_report_payload", None)
+        assert callable(build_report_payload)
+        payload = build_report_payload(30, tp, coaching, articles)
+        assert payload["measurement"] == funnel_report.MEASUREMENT_METADATA
+        assert payload["schema"] == "ga4_event_totals/v2"
+        for rows in (
+            payload["training_plan_totals"],
+            payload["coaching_totals"],
+            payload["article_totals"],
+        ):
+            for row in rows:
+                assert "dropoff_pct" not in row
+                assert "cumulative_pct" not in row
 
-    def test_mock_data_last_stage_overall_conversion(self):
-        tp, _, _ = get_mock_data()
-        tp = compute_funnel_metrics(tp)
-        # Last stage cumulative = purchases / page views * 100
-        expected = round(tp[-1]["count"] / tp[0]["count"] * 100, 2)
-        assert tp[-1]["cumulative_pct"] == expected
+    def test_query_applies_declared_scope_and_event_aliases(self, monkeypatch):
+        from google.analytics import data_v1beta
 
-    def test_output_has_dropoff_and_cumulative_keys(self):
-        stages = [{"stage": "x", "label": "X", "count": 42}]
-        result = compute_funnel_metrics(stages)
-        assert "dropoff_pct" in result[0]
-        assert "cumulative_pct" in result[0]
+        requests = []
+
+        class Client:
+            def run_report(self, request):
+                requests.append(request)
+                return SimpleNamespace(rows=[])
+
+        monkeypatch.setattr(data_v1beta, "BetaAnalyticsDataClient", Client)
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "test-sentinel")
+        rows = funnel_report.get_funnel_data(
+            "123", "/tmp/test-ga4.json", 30, TRAINING_PLAN_FUNNEL
+        )
+
+        assert len(requests) == len(TRAINING_PLAN_FUNNEL)
+        assert [row["scope"] for row in rows] == [
+            stage["scope"] for stage in TRAINING_PLAN_FUNNEL
+        ]
+        race_path_filter = requests[1].dimension_filter.and_group.expressions[1]
+        assert race_path_filter.filter.string_filter.value == "/race/"
+        form_events = requests[2].dimension_filter.and_group.expressions[0]
+        assert {
+            expression.filter.string_filter.value
+            for expression in form_events.or_group.expressions
+        } == {"form_start", "tp_form_start"}
+        assert not requests[-1].dimension_filter.and_group.expressions
+
+    def test_human_report_labels_totals_and_omits_conversion_claims(self, capsys):
+        tp, coaching, articles = get_mock_data()
+        print_report(tp, coaching, 30, articles)
+        output = capsys.readouterr().out
+        assert "INDEPENDENT GA4 EVENT TOTALS" in output
+        assert "No shared session, user, product, or event order" in output
+        assert "Overall conversion" not in output
+        assert "Drop-off" not in output
+        assert "Cumulative" not in output

--- a/tests/test_ga4_service_events.py
+++ b/tests/test_ga4_service_events.py
@@ -4,6 +4,30 @@ from types import ModuleType, SimpleNamespace
 from mission_control.services import ga4
 
 
+class Message:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class Filter(Message):
+    class InListFilter(Message):
+        pass
+
+
+def _install_fake_ga4_types(monkeypatch):
+    fake_types = ModuleType("google.analytics.data_v1beta.types")
+    for name, value in {
+        "DateRange": Message,
+        "Dimension": Message,
+        "Filter": Filter,
+        "FilterExpression": Message,
+        "Metric": Message,
+        "RunReportRequest": Message,
+    }.items():
+        setattr(fake_types, name, value)
+    monkeypatch.setitem(sys.modules, "google.analytics.data_v1beta.types", fake_types)
+
+
 def test_conversion_event_allowlist_includes_commerce_lifecycle():
     assert {
         "view_item",
@@ -34,25 +58,7 @@ def test_conversion_cache_key_changes_with_expanded_event_contract(monkeypatch):
 
 
 def test_conversion_query_filters_and_returns_commerce_events(monkeypatch):
-    class Message:
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    class Filter(Message):
-        class InListFilter(Message):
-            pass
-
-    fake_types = ModuleType("google.analytics.data_v1beta.types")
-    for name, value in {
-        "DateRange": Message,
-        "Dimension": Message,
-        "Filter": Filter,
-        "FilterExpression": Message,
-        "Metric": Message,
-        "RunReportRequest": Message,
-    }.items():
-        setattr(fake_types, name, value)
-    monkeypatch.setitem(sys.modules, "google.analytics.data_v1beta.types", fake_types)
+    _install_fake_ga4_types(monkeypatch)
 
     def row(name, count):
         return SimpleNamespace(
@@ -84,6 +90,69 @@ def test_conversion_query_filters_and_returns_commerce_events(monkeypatch):
     event_filter = client.request.dimension_filter.filter
     assert event_filter.field_name == "eventName"
     assert set(event_filter.in_list_filter.values) == ga4.CONVERSION_EVENT_NAMES
+
+
+def test_conversion_event_report_marks_missing_client_unavailable(monkeypatch):
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: None)
+    monkeypatch.setattr(ga4, "_get_client", lambda: None)
+
+    assert ga4.get_conversion_event_report(days=7) == {
+        "available": False,
+        "events": [],
+        "error": "GA4 client unavailable",
+    }
+
+
+def test_conversion_event_report_does_not_cache_api_failure(monkeypatch):
+    _install_fake_ga4_types(monkeypatch)
+    cached = []
+
+    class Client:
+        def run_report(self, request):
+            raise RuntimeError("temporary GA4 failure")
+
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: None)
+    monkeypatch.setattr(ga4, "_set_cached", lambda key, data: cached.append(data))
+    monkeypatch.setattr(ga4, "_get_client", lambda: Client())
+
+    assert ga4.get_conversion_event_report(days=7) == {
+        "available": False,
+        "events": [],
+        "error": "GA4 event query failed",
+    }
+    assert cached == []
+
+
+def test_conversion_event_report_preserves_successful_empty_cache(monkeypatch):
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: [])
+    monkeypatch.setattr(
+        ga4, "_get_client", lambda: (_ for _ in ()).throw(AssertionError("cache miss")))
+
+    assert ga4.get_conversion_event_report(days=7) == {
+        "available": True,
+        "events": [],
+        "error": None,
+    }
+
+
+def test_conversion_event_report_caches_successful_empty_response(monkeypatch):
+    _install_fake_ga4_types(monkeypatch)
+    cached = []
+
+    class Client:
+        def run_report(self, request):
+            return SimpleNamespace(rows=[])
+
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: None)
+    monkeypatch.setattr(ga4, "_set_cached", lambda key, data: cached.append((key, data)))
+    monkeypatch.setattr(ga4, "_get_client", lambda: Client())
+
+    assert ga4.get_conversion_event_report(days=7) == {
+        "available": True,
+        "events": [],
+        "error": None,
+    }
+    assert cached == [("conversion_events_v2_7", [])]
 
 
 def test_event_summary_keeps_refunds_out_of_purchase_and_lead_counts():

--- a/tests/test_ga4_service_events.py
+++ b/tests/test_ga4_service_events.py
@@ -84,3 +84,22 @@ def test_conversion_query_filters_and_returns_commerce_events(monkeypatch):
     event_filter = client.request.dimension_filter.filter
     assert event_filter.field_name == "eventName"
     assert set(event_filter.in_list_filter.values) == ga4.CONVERSION_EVENT_NAMES
+
+
+def test_event_summary_keeps_refunds_out_of_purchase_and_lead_counts():
+    events = [
+        {"event": "email_capture", "count": 7},
+        {"event": "plan_request", "count": 3},
+        {"event": "begin_checkout", "count": 4},
+        {"event": "purchase", "count": 2},
+        {"event": "refund", "count": 5},
+        {"event": "add_to_cart", "count": 90},
+    ]
+
+    assert ga4.summarize_event_totals(events) == {
+        "email_capture_events": 7,
+        "plan_request_events": 3,
+        "checkout_start_events": 4,
+        "purchase_events": 2,
+        "refund_events": 5,
+    }

--- a/tests/test_ga4_service_events.py
+++ b/tests/test_ga4_service_events.py
@@ -1,0 +1,86 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+from mission_control.services import ga4
+
+
+def test_conversion_event_allowlist_includes_commerce_lifecycle():
+    assert {
+        "view_item",
+        "add_to_cart",
+        "begin_checkout",
+        "add_payment_info",
+        "purchase",
+        "refund",
+    } <= getattr(ga4, "CONVERSION_EVENT_NAMES", set())
+
+
+def test_conversion_event_allowlist_keeps_both_deployed_form_generations():
+    assert {
+        "form_start",
+        "tp_form_start",
+        "form_submit",
+        "tp_form_submit",
+    } <= getattr(ga4, "CONVERSION_EVENT_NAMES", set())
+
+
+def test_conversion_cache_key_changes_with_expanded_event_contract(monkeypatch):
+    seen = []
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: seen.append(key) or None)
+    monkeypatch.setattr(ga4, "_get_client", lambda: None)
+
+    assert ga4.get_conversion_events(days=14) == []
+    assert seen == ["conversion_events_v2_14"]
+
+
+def test_conversion_query_filters_and_returns_commerce_events(monkeypatch):
+    class Message:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class Filter(Message):
+        class InListFilter(Message):
+            pass
+
+    fake_types = ModuleType("google.analytics.data_v1beta.types")
+    for name, value in {
+        "DateRange": Message,
+        "Dimension": Message,
+        "Filter": Filter,
+        "FilterExpression": Message,
+        "Metric": Message,
+        "RunReportRequest": Message,
+    }.items():
+        setattr(fake_types, name, value)
+    monkeypatch.setitem(sys.modules, "google.analytics.data_v1beta.types", fake_types)
+
+    def row(name, count):
+        return SimpleNamespace(
+            dimension_values=[SimpleNamespace(value=name)],
+            metric_values=[SimpleNamespace(value=str(count))],
+        )
+
+    class Client:
+        request = None
+
+        def run_report(self, request):
+            self.request = request
+            return SimpleNamespace(rows=[
+                row("email_capture", 3),
+                row("purchase", 2),
+                row("refund", 1),
+            ])
+
+    client = Client()
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: None)
+    monkeypatch.setattr(ga4, "_set_cached", lambda key, data: None)
+    monkeypatch.setattr(ga4, "_get_client", lambda: client)
+
+    assert ga4.get_conversion_events(days=7) == [
+        {"event": "email_capture", "count": 3},
+        {"event": "purchase", "count": 2},
+        {"event": "refund", "count": 1},
+    ]
+    event_filter = client.request.dimension_filter.filter
+    assert event_filter.field_name == "eventName"
+    assert set(event_filter.in_list_filter.values) == ga4.CONVERSION_EVENT_NAMES


### PR DESCRIPTION
Reporting currently divides independently counted GA4 stages into apparent conversion rates and can mistake activity or purchase events for orders. This change reports scoped event totals, distinguishes checkout/purchase/refund activity, and removes unsupported cross-stage rates.

Unavailable GA4 reads remain distinct from successful zero results in the dashboard, triage, and historical trends. Both Daily Intel event queries filter the event allowlist before their row limit. Aggregate purchase/refund totals remain unknown if any required brand or historical event field is unavailable.

Daily Intel now labels `/api/intel-stats` data as local processing records. These rows may include retries, duplicate attempts, failures, or synthetic traffic; processing success does not prove payment or customer fulfillment. The report preserves operational failures, and the interpretation prompt requires separate provider reconciliation for financial claims.

Validation: the previous head passed 137 independently run focused tests and CI. For the latest correction, 28 Daily Intel tests independently passed; the author reports 7,506 root tests passed (331 skipped) and 119 Mission Control tests passed. Independent Fable re-review approved exact head `00017586769f48b437b1d638595f385f91a15da9`, including the full PR context, canonical processing-log producer, and 67 historical snapshots. Fresh CI passed at that head: Run Tests34313815377, Regression Tests34313815442, and Immune Check34313808693. Prior Fable findings and their corrections are retained in the review evidence.

This draft does not implement native ordered-funnel reporting, transaction-level provider joins, new event emitters, or a production deployment. Those remain separate work.
