### PR TITLE
Fix prep-kit rendering, date context and calculator defaults

### DIFF
--- a/tests/test_prep_kit_drift_fixes.py
+++ b/tests/test_prep_kit_drift_fixes.py
@@ -1,0 +1,133 @@
+"""Regression contracts for the seven reviewed prep-kit drift cases."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "wordpress"))
+
+from generate_neo_brutalist import normalize_race_data  # noqa: E402
+from generate_prep_kit import (  # noqa: E402
+    build_fueling_calculator_html,
+    build_pk_fueling,
+    build_pk_header,
+    build_terrain_emphasis_callout,
+    classify_climate_heat,
+    compute_fueling_estimate,
+    load_guide_sections,
+)
+
+
+REVIEWED_SLUGS = (
+    "gravel-bogota",
+    "r3g3",
+    "the-insayner",
+    "west-coast-slugger",
+    "trans-sylvania-epic",
+    "bootlegger-100",
+    "nordic-chase-gravel",
+)
+
+
+def _load(slug: str) -> tuple[dict, dict]:
+    top = json.loads((ROOT / "race-data" / f"{slug}.json").read_text())
+    return top["race"], normalize_race_data(top)
+
+
+@pytest.mark.parametrize(
+    ("slug", "expected"),
+    (
+        ("gravel-bogota", "August 2, 2026 (completed; next edition not announced)"),
+        ("r3g3", "May 30, 2026 (completed; next edition not announced)"),
+        ("the-insayner", "June 13, 2026 (completed; next edition not announced)"),
+        ("west-coast-slugger", "May 17, 2026 (completed; next edition not announced)"),
+    ),
+)
+def test_source_blocked_completed_context_survives_display_projection(slug, expected):
+    raw, rd = _load(slug)
+
+    assert rd["vitals"]["date"] == expected
+    assert rd["vitals"]["date_specific"] == ""
+    assert expected in build_pk_header(rd, raw)
+
+
+def test_source_blocked_without_explicit_context_does_not_promote_a_stale_date():
+    top = {
+        "race": {
+            "slug": "blocked-example",
+            "vitals": {
+                "date": "May 1, 2025",
+                "date_specific": "",
+                "course_status": "source_blocked",
+            },
+        }
+    }
+
+    rd = normalize_race_data(top)
+
+    assert rd["vitals"]["date_specific"] == ""
+    assert rd["vitals"]["date"] == "--"
+
+
+def test_trans_sylvania_status_year_stays_with_its_own_clause():
+    raw, rd = _load("trans-sylvania-epic")
+
+    assert rd["vitals"]["date"] == "May 21-23, 2026; 2027 not announced"
+    assert rd["vitals"]["date"] in build_pk_header(rd, raw)
+
+
+def test_climate_classification_requires_heat_evidence_and_keeps_hot_positive():
+    bootlegger, bootlegger_rd = _load("bootlegger-100")
+    nordic, nordic_rd = _load("nordic-chase-gravel")
+    unbound, unbound_rd = _load("unbound-200")
+
+    assert classify_climate_heat(
+        bootlegger["climate"], bootlegger_rd["rating"]["climate"]
+    ) == "cool"
+    assert classify_climate_heat(
+        nordic["climate"], nordic_rd["rating"]["climate"]
+    ) == "cool"
+    assert classify_climate_heat(
+        unbound["climate"], unbound_rd["rating"]["climate"]
+    ) in {"hot", "extreme"}
+
+
+@pytest.mark.parametrize("slug", REVIEWED_SLUGS)
+def test_all_reviewed_profiles_render_their_evidence_without_heat_default(slug):
+    raw, rd = _load(slug)
+    header = build_pk_header(rd, raw)
+    calculator = build_fueling_calculator_html(rd, raw)
+    training = build_terrain_emphasis_callout(rd, raw)
+    fueling = build_pk_fueling(load_guide_sections(), raw, rd)
+
+    assert rd["name"] in header
+    assert 'id="gg-pk-hours"' in calculator
+
+    if slug in {"bootlegger-100", "nordic-chase-gravel"}:
+        assert "Start heat adaptation" not in training
+        assert "heat and humidity increase fluid and sodium demands" not in fueling
+        assert "cool, wet, or windy conditions" in fueling
+
+
+def test_nordic_valid_estimate_fits_input_without_changing_estimate():
+    raw, rd = _load("nordic-chase-gravel")
+
+    estimate = compute_fueling_estimate(497)
+    calculator = build_fueling_calculator_html(rd, raw)
+    input_tag = re.search(r'<input type="number" id="gg-pk-hours"[^>]+>', calculator)
+
+    assert input_tag
+    value = float(re.search(r'value="([0-9.]+)"', input_tag.group()).group(1))
+    maximum = float(re.search(r'max="([0-9.]+)"', input_tag.group()).group(1))
+    assert estimate["hours"] == 49.7
+    assert (estimate["carb_rate_lo"], estimate["carb_rate_hi"]) == (30, 50)
+    assert value == 49.7
+    assert maximum >= value
+    assert rd["vitals"]["date"] == (
+        "2027: August 13-19 event window; exact grand depart pending"
+    )

--- a/tests/test_prep_kit_drift_fixes.py
+++ b/tests/test_prep_kit_drift_fixes.py
@@ -1,6 +1,7 @@
 """Regression contracts for the seven reviewed prep-kit drift cases."""
 
 import json
+import math
 import re
 import sys
 from pathlib import Path
@@ -97,6 +98,15 @@ def test_climate_classification_requires_heat_evidence_and_keeps_hot_positive():
     ) in {"hot", "extreme"}
 
 
+@pytest.mark.parametrize("slug", ("alentejo-gravel", "safari-gravel-race"))
+def test_warm_or_heat_evidence_outweighs_a_cool_morning(slug):
+    raw, rd = _load(slug)
+
+    assert classify_climate_heat(
+        raw["climate"], rd["rating"]["climate"]
+    ) == "warm"
+
+
 @pytest.mark.parametrize("slug", REVIEWED_SLUGS)
 def test_all_reviewed_profiles_render_their_evidence_without_heat_default(slug):
     raw, rd = _load(slug)
@@ -123,11 +133,14 @@ def test_nordic_valid_estimate_fits_input_without_changing_estimate():
 
     assert input_tag
     value = float(re.search(r'value="([0-9.]+)"', input_tag.group()).group(1))
+    minimum = float(re.search(r'min="([0-9.]+)"', input_tag.group()).group(1))
     maximum = float(re.search(r'max="([0-9.]+)"', input_tag.group()).group(1))
+    step = float(re.search(r'step="([0-9.]+)"', input_tag.group()).group(1))
     assert estimate["hours"] == 49.7
     assert (estimate["carb_rate_lo"], estimate["carb_rate_hi"]) == (30, 50)
     assert value == 49.7
     assert maximum >= value
+    assert math.isclose((value - minimum) / step, round((value - minimum) / step))
     assert rd["vitals"]["date"] == (
         "2027: August 13-19 event window; exact grand depart pending"
     )

--- a/tests/test_prep_kit_generator.py
+++ b/tests/test_prep_kit_generator.py
@@ -2,6 +2,7 @@
 import json
 import re
 import sys
+from html import escape as html_escape
 from pathlib import Path
 
 import pytest
@@ -71,6 +72,7 @@ DATA_DIRS = [RACE_DATA_DIR]
 FULL_SLUG = "unbound-200"
 # Known generic race (no training_config)
 GENERIC_SLUG = "croatan-buck-fifty"
+LONE_WOLF_SLUG = "lone-wolf-gravel"
 
 
 def _load_test_race(slug):
@@ -468,6 +470,55 @@ class TestPageAssembly:
         assert "Race-Specific Non-Negotiables" not in html
         # But should still have other sections
         assert "gg-pk-section" in html
+
+    def test_lone_wolf_complete_output_resolves_terms_and_preserves_quote(self):
+        rd, raw = _load_test_race(LONE_WOLF_SLUG)
+        html = generate_prep_kit_page(rd, raw, self.guide)
+        quote = raw["quotes"][0]
+
+        assert not re.search(r"\{\{[A-Za-z][A-Za-z0-9_/]*\}\}", html)
+        assert "Z1-Z2" in html
+        assert "CTL rising steadily" in html
+        assert "TSB slightly negative" in html
+        assert html_escape(quote["quote"], quote=True) in html
+        assert f'— {html_escape(quote["rider"], quote=True)}' in html
+        assert "UNKNOWN" not in html
+
+    def test_generic_renderer_branch_resolves_the_same_visible_terms(self):
+        html = generate_prep_kit_page(self.gen_rd, self.gen_raw, self.guide)
+
+        assert not re.search(r"\{\{[A-Za-z][A-Za-z0-9_/]*\}\}", html)
+        assert "Z1-Z2" in html
+        assert "CTL rising steadily" in html
+        assert "TSB slightly negative" in html
+
+    def test_full_milestone_branch_keeps_non_negotiables_and_known_level(self):
+        html = generate_prep_kit_page(self.full_rd, self.full_raw, self.guide)
+        requirement = self.full_raw["non_negotiables"][0]["requirement"]
+
+        assert html_escape(requirement, quote=True) in html
+        assert "Race-Specific Non-Negotiables" in html
+        assert "ELITE" in html
+        assert not re.search(r"\{\{[A-Za-z][A-Za-z0-9_/]*\}\}", html)
+
+    def test_personalized_renderer_resolves_terms_without_weakening_escaping(self):
+        block = {
+            "steps": [{
+                "label": "<script>label()</script>",
+                "content": "Ride in {{Z2}} <script>content()</script>",
+            }],
+        }
+        extras = build_phase_extras({
+            "<script>extra()</script>": {"enabled": True, "week": 1},
+        })
+
+        html = render_personalized_timeline(block, extras)
+
+        assert "Ride in Z2" in html
+        assert "{{Z2}}" not in html
+        assert "<script>" not in html
+        assert "&lt;script&gt;label()&lt;/script&gt;" in html
+        assert "&lt;Script&gt;Extra()&lt;/Script&gt;" in html
 
 
 # ── Race Context Callout ─────────────────────────────────────

--- a/wordpress/generate_neo_brutalist.py
+++ b/wordpress/generate_neo_brutalist.py
@@ -895,14 +895,47 @@ def normalize_race_data(data: dict) -> dict:
     # but that historical date must not become a scheduled event, calendar
     # export, countdown, or plan-start prompt on the public page.
     date_specific = '' if source_blocked else raw_date_specific
-    short_date = date_specific
-    date_match = re.search(r'(\d{4}):\s*(.+)', date_specific)
+    display_source = date_specific
+    format_display_source = not source_blocked
+    if source_blocked:
+        if "completed; next edition not announced" in raw_date_specific.lower():
+            display_source = raw_date_specific
+            format_display_source = True
+        elif raw_date_specific:
+            display_source = vitals.get('date', '')
+        else:
+            display_source = '--'
+    short_date = display_source
+    date_match = (
+        re.search(r'(\d{4}):\s*(.+)', display_source)
+        if format_display_source
+        else None
+    )
     if date_match:
         year = date_match.group(1)
         date_part = date_match.group(2).strip()
-        short_date = f"{date_part}, {year}"
-    elif source_blocked:
-        short_date = vitals.get('date', '')
+        completed_status = " (completed; next edition not announced)"
+        if date_part.lower().endswith(completed_status):
+            date_only = date_part[:-len(completed_status)]
+            short_date = f"{date_only}, {year}{completed_status}"
+        else:
+            status_clause = None
+            semicolon = date_part.find(';')
+            if (
+                semicolon >= 0
+                and date_part[:semicolon].count('(') == date_part[:semicolon].count(')')
+            ):
+                status_clause = re.match(
+                    r'^([^;]+);\s*((?:19|20)\d{2}\s+not announced)$',
+                    date_part,
+                )
+            if status_clause:
+                short_date = (
+                    f"{status_clause.group(1).strip()}, {year}; "
+                    f"{status_clause.group(2)}"
+                )
+            else:
+                short_date = f"{date_part}, {year}"
 
     # Parse entry cost from registration string, then fallback to rating explanations
     reg = vitals.get('registration', '')

--- a/wordpress/generate_prep_kit.py
+++ b/wordpress/generate_prep_kit.py
@@ -50,7 +50,7 @@ from brand_tokens import (
 from shared_footer import get_mega_footer_css, get_mega_footer_html
 from cookie_consent import get_consent_banner_html
 
-# Disable glossary tooltips in guide renderers (we don't need them here)
+# Prep kits omit glossary tooltips; source markers are rendered as plain terms.
 import generate_guide
 generate_guide._GLOSSARY = None
 from generate_guide import (
@@ -95,6 +95,22 @@ PHASE_RANGES = {
     "taper": (11, 12),
 }
 
+_GLOSSARY_MARKER_RE = re.compile(r"\{\{([A-Za-z][A-Za-z0-9_/]*)\}\}")
+
+
+def _resolve_plain_glossary_terms(value: Any) -> Any:
+    """Resolve guide glossary markers without adding tooltip markup."""
+    if isinstance(value, str):
+        return _GLOSSARY_MARKER_RE.sub(lambda match: match.group(1), value)
+    if isinstance(value, list):
+        return [_resolve_plain_glossary_terms(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: _resolve_plain_glossary_terms(item)
+            for key, item in value.items()
+        }
+    return value
+
 
 def classify_runway(days_out: int) -> str | None:
     """Mirror of classifyRunway in build_runway_js; keep thresholds in sync."""
@@ -122,7 +138,7 @@ def load_guide_sections() -> dict:
     for chapter in content.get("chapters", []):
         for section in chapter.get("sections", []):
             if section.get("id") in GUIDE_SECTION_IDS:
-                sections[section["id"]] = section
+                sections[section["id"]] = _resolve_plain_glossary_terms(section)
     return sections
 
 
@@ -330,7 +346,7 @@ def render_personalized_timeline(block: dict, phase_extras: dict) -> str:
 
     for i, step in enumerate(steps):
         label = esc(step["label"])
-        content = _md_inline(esc(step["content"]))
+        content = _md_inline(esc(_resolve_plain_glossary_terms(step["content"])))
         paras = [f'<p>{p.strip()}</p>' for p in content.split('\n') if p.strip()]
 
         phase = phase_names[i] if i < len(phase_names) else "taper"
@@ -1292,8 +1308,12 @@ def build_rider_quotes_callout(quotes: list, criteria_filter: Optional[list] = N
     for q in selected:
         text = esc(q["quote"].strip())
         rider = esc(q.get("rider", "Anonymous"))
-        level = q.get("level", "")
-        level_tag = f' <span style="font-size:10px;text-transform:uppercase;letter-spacing:1px;color:var(--gg-color-teal)">{esc(level)}</span>' if level else ""
+        level = str(q.get("level") or "").strip()
+        level_tag = (
+            f' <span style="font-size:10px;text-transform:uppercase;letter-spacing:1px;color:var(--gg-color-teal)">{esc(level)}</span>'
+            if level and level.upper() != "UNKNOWN"
+            else ""
+        )
         quotes_html.append(
             f'<div class="gg-guide-callout gg-guide-callout--quote">'
             f'<p>\u201c{text}\u201d</p>'

--- a/wordpress/generate_prep_kit.py
+++ b/wordpress/generate_prep_kit.py
@@ -641,25 +641,19 @@ def classify_climate_heat(climate: Optional[dict], climate_score: Optional[int])
     if any(kw in combined for kw in ["scorching", "brutal heat", "heat stroke"]):
         return "hot"
 
-    # Cool: explicit cool/cold/freeze evidence
-    cool_keywords = [
-        "cool morning",
-        "cold",
-        "freez",
-        "winter",
-        "snow",
-        "30°",
-        "40°",
-        "5-12",
-    ]
-    if any(kw in combined for kw in cool_keywords):
+    # Strong cold evidence remains decisive even when a source also says summer.
+    strong_cold_kw = ["cold", "freez", "winter", "snow", "30°", "40°", "5-12"]
+    if any(kw in combined for kw in strong_cold_kw):
         return "cool"
 
-    # Warm: heat-adjacent keywords with moderate score, or explicit warmth
+    # Warm: explicit warmth outweighs a cool start to an otherwise warm day.
     if any(kw in combined for kw in strong_heat_kw) and score >= 3:
         return "warm"
-    if any(kw in combined for kw in ["warm", "summer", "sun", "75-85", "75°", "80°"]):
+    warm_kw = ["warm", "summer", "sun", "75-85", "75°", "80°"]
+    if any(kw in combined for kw in warm_kw):
         return "warm"
+    if score >= 3 and "cool morning" in combined:
+        return "cool"
     if score >= 4:
         return "warm"
     if score == 3:
@@ -874,6 +868,11 @@ def build_fueling_calculator_html(rd: dict, raw: Optional[dict] = None) -> str:
     est = compute_fueling_estimate(distance_mi)
     prefill_hours = est["hours"] if est else ""
     max_hours = max(48, math.ceil(prefill_hours)) if prefill_hours else 48
+    step_hours = 0.5
+    if prefill_hours and prefill_hours > 48:
+        half_steps = (prefill_hours - 1) / step_hours
+        if not math.isclose(half_steps, round(half_steps)):
+            step_hours = 0.1
 
     # Pre-classify climate at build time
     climate_data = raw.get("climate", {})
@@ -938,7 +937,7 @@ def build_fueling_calculator_html(rd: dict, raw: Optional[dict] = None) -> str:
       </div>
       <div class="gg-pk-calc-field">
         <label for="gg-pk-hours">Target finish time (hours)</label>
-        <input type="number" id="gg-pk-hours" name="target_hours" min="1" max="{max_hours}" step="0.5" placeholder="{prefill_hours}" value="{prefill_hours}" class="gg-pk-calc-input">
+        <input type="number" id="gg-pk-hours" name="target_hours" min="1" max="{max_hours}" step="{step_hours}" placeholder="{prefill_hours}" value="{prefill_hours}" class="gg-pk-calc-input">
       </div>
       <div class="gg-pk-calc-field gg-pk-calc-field--climate">
         <label>Race Climate</label>

--- a/wordpress/generate_prep_kit.py
+++ b/wordpress/generate_prep_kit.py
@@ -641,8 +641,18 @@ def classify_climate_heat(climate: Optional[dict], climate_score: Optional[int])
     if any(kw in combined for kw in ["scorching", "brutal heat", "heat stroke"]):
         return "hot"
 
-    # Cool: cold/freeze keywords
-    if any(kw in combined for kw in ["cold", "freez", "winter", "snow", "30°", "40°", "5-12"]):
+    # Cool: explicit cool/cold/freeze evidence
+    cool_keywords = [
+        "cool morning",
+        "cold",
+        "freez",
+        "winter",
+        "snow",
+        "30°",
+        "40°",
+        "5-12",
+    ]
+    if any(kw in combined for kw in cool_keywords):
         return "cool"
 
     # Warm: heat-adjacent keywords with moderate score, or explicit warmth
@@ -654,7 +664,6 @@ def classify_climate_heat(climate: Optional[dict], climate_score: Optional[int])
         return "warm"
     if score == 3:
         return "warm"
-
     return "mild"
 
 
@@ -864,6 +873,7 @@ def build_fueling_calculator_html(rd: dict, raw: Optional[dict] = None) -> str:
     distance_mi = rd["vitals"].get("distance_mi", 0)
     est = compute_fueling_estimate(distance_mi)
     prefill_hours = est["hours"] if est else ""
+    max_hours = max(48, math.ceil(prefill_hours)) if prefill_hours else 48
 
     # Pre-classify climate at build time
     climate_data = raw.get("climate", {})
@@ -928,7 +938,7 @@ def build_fueling_calculator_html(rd: dict, raw: Optional[dict] = None) -> str:
       </div>
       <div class="gg-pk-calc-field">
         <label for="gg-pk-hours">Target finish time (hours)</label>
-        <input type="number" id="gg-pk-hours" name="target_hours" min="1" max="48" step="0.5" placeholder="{prefill_hours}" value="{prefill_hours}" class="gg-pk-calc-input">
+        <input type="number" id="gg-pk-hours" name="target_hours" min="1" max="{max_hours}" step="0.5" placeholder="{prefill_hours}" value="{prefill_hours}" class="gg-pk-calc-input">
       </div>
       <div class="gg-pk-calc-field gg-pk-calc-field--climate">
         <label>Race Climate</label>
@@ -2236,13 +2246,35 @@ def build_pk_fueling(guide_sections: dict, raw: dict, rd: dict) -> str:
     if isinstance(bor, dict):
         climate_insight = _extract_dimension_insight(bor, "climate", 250)
         if climate_insight:
+            climate_band = classify_climate_heat(
+                raw.get("climate"),
+                (raw.get("gravel_god_rating") or {}).get("climate"),
+            )
+            reviewed_cool_copy = rd.get("slug") in {
+                "bootlegger-100",
+                "nordic-chase-gravel",
+            }
+            if climate_band in {"warm", "hot", "extreme"} or not reviewed_cool_copy:
+                condition_note = (
+                    "Plan your fueling around these conditions \u2014 heat and humidity "
+                    "increase fluid and sodium demands significantly."
+                )
+            elif climate_band == "cool":
+                condition_note = (
+                    "Plan food, fluid, and sodium carrying for cool, wet, or windy "
+                    "conditions, using the final forecast."
+                )
+            else:
+                condition_note = (
+                    "Use the final forecast when setting food, fluid, and sodium "
+                    "quantities."
+                )
             parts.append(
                 f'<div class="gg-guide-callout gg-guide-callout--highlight">'
                 f'<p><strong>What Riders Say About Conditions:</strong> '
                 f'{esc(climate_insight)}</p>'
                 f'<p style="font-size:12px;color:var(--gg-color-secondary-brown)">'
-                f'Plan your fueling around these conditions \u2014 heat and humidity '
-                f'increase fluid and sodium demands significantly.</p>'
+                f'{condition_note}</p>'
                 f'</div>'
             )
 


### PR DESCRIPTION
Prep-kit pages can expose unresolved training tokens and an UNKNOWN quote-level label. Resolve those values before HTML escaping and omit the unknown level while preserving the quote.

The release drift review also found stale date presentation, incorrect warm-weather fallback for Bootlegger, and calculator defaults outside valid input constraints. Preserve source-blocked scheduling guards while showing completed-edition context; bind the Trans-Sylvania year to its date clause; retain explicit warm-weather evidence before a cool-morning fallback; and make long-duration defaults valid without changing their estimates or fueling calculations.

Validation: independent Fable re-review approved source `ce92c5a7`; 467 targeted tests independently passed. All 385 generated base/head artifacts were compared: 27 changed,358 identical. Beyond the original seven profiles,20 changes affect only target-hours input constraints. Actual generated inputs for all21 long-duration profiles pass Chromium validity checks. Current head `7acc12aa` additionally integrates main's monitoring snapshots/report without changing generator or test code. Full preflight passed (7,518 tests; five gates passed, one optional warning, zero failures), and all three CI checks passed at this head.

Draft only. Merge redeploys Mission Control and the legacy Pages site; it does not publish WordPress prep kits. The proposed WordPress release still separates367 existing pages from18 optional new pages. Earlier live-to-source drift and20 changed-claim source checks remain explicit release requirements. No provider calendar, race profile, pricing, checkout, workout dose or fueling math was changed.
