### PR TITLE
Add native ordered GA4 funnel with explicit evidence limits

### DIFF
--- a/mission_control/routers/analytics.py
+++ b/mission_control/routers/analytics.py
@@ -45,19 +45,26 @@ async def analytics_index(request: Request):
     funnel_report = get_ordered_funnel_report(days=30)
     event_totals = event_report["events"]
 
-    funnel_metadata = funnel_report.get("metadata") or {}
+    funnel_metadata = funnel_report.get("metadata")
+    if not isinstance(funnel_metadata, dict):
+        funnel_metadata = {}
     subreport_metadata = [
         item for item in (
             funnel_metadata.get("funnel_table"),
             funnel_metadata.get("funnel_visualization"),
         ) if isinstance(item, dict)
     ]
-    funnel_sampling = [
-        sample
-        for item in subreport_metadata
-        for sample in (item.get("samplingMetadatas") or [])
-        if isinstance(sample, dict)
-    ]
+    funnel_sampling = []
+    for item in subreport_metadata:
+        samples = item.get("samplingMetadatas")
+        if not isinstance(samples, list):
+            continue
+        funnel_sampling.extend(
+            sample for sample in samples
+            if (isinstance(sample, dict)
+                and isinstance(sample.get("samplesReadCount"), str)
+                and isinstance(sample.get("samplingSpaceSize"), str))
+        )
     funnel_thresholded = any(
         item.get("subjectToThresholding") is True
         for item in subreport_metadata

--- a/mission_control/routers/analytics.py
+++ b/mission_control/routers/analytics.py
@@ -1,5 +1,7 @@
 """Analytics router — GA4 dashboard."""
 
+from datetime import date
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
@@ -8,6 +10,7 @@ from mission_control.config import WEB_TEMPLATES_DIR
 from mission_control.services.ga4 import (
     get_conversion_event_report,
     get_daily_sessions,
+    get_ordered_funnel_report,
     get_top_pages,
     get_traffic_sources,
     refresh_cache,
@@ -18,6 +21,20 @@ router = APIRouter(prefix="/analytics")
 templates = Jinja2Templates(directory=str(WEB_TEMPLATES_DIR))
 
 
+def _funnel_period_label(report: dict) -> str | None:
+    period = report.get("period")
+    if not isinstance(period, dict):
+        return None
+    try:
+        start = date.fromisoformat(period["start_date"])
+        end = date.fromisoformat(period["end_date"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if start.year == end.year:
+        return f"{start:%b} {start.day}–{end:%b} {end.day}, {end.year}"
+    return f"{start:%b} {start.day}, {start.year}–{end:%b} {end.day}, {end.year}"
+
+
 @router.get("/")
 async def analytics_index(request: Request):
     """GA4 analytics dashboard."""
@@ -25,7 +42,26 @@ async def analytics_index(request: Request):
     sources = get_traffic_sources(days=30)
     daily = get_daily_sessions(days=90)
     event_report = get_conversion_event_report(days=30)
+    funnel_report = get_ordered_funnel_report(days=30)
     event_totals = event_report["events"]
+
+    funnel_metadata = funnel_report.get("metadata") or {}
+    subreport_metadata = [
+        item for item in (
+            funnel_metadata.get("funnel_table"),
+            funnel_metadata.get("funnel_visualization"),
+        ) if isinstance(item, dict)
+    ]
+    funnel_sampling = [
+        sample
+        for item in subreport_metadata
+        for sample in (item.get("samplingMetadatas") or [])
+        if isinstance(sample, dict)
+    ]
+    funnel_thresholded = any(
+        item.get("subjectToThresholding") is True
+        for item in subreport_metadata
+    )
 
     # Calculate totals
     total_sessions = sum(d["sessions"] for d in daily) if daily else 0
@@ -42,6 +78,10 @@ async def analytics_index(request: Request):
         "event_summary": event_summary,
         "event_data_available": event_report["available"],
         "event_error": event_report["error"],
+        "funnel_report": funnel_report,
+        "funnel_period_label": _funnel_period_label(funnel_report),
+        "funnel_sampling": funnel_sampling,
+        "funnel_thresholded": funnel_thresholded,
         "total_sessions": total_sessions,
         "total_pageviews": total_pageviews,
     })

--- a/mission_control/services/ga4.py
+++ b/mission_control/services/ga4.py
@@ -12,6 +12,7 @@ import hashlib
 import logging
 import math
 import os
+import re
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -46,6 +47,7 @@ NATIVE_FUNNEL_STEPS = (
     {"key": "training_plan_checkout", "name": "Training-plan checkout"},
     {"key": "training_plan_purchase", "name": "Training-plan purchase"},
 )
+_INTEGER_METRIC = re.compile(r"(?:0|[1-9][0-9]*)\Z")
 
 # Keep this list aligned with the events already emitted by the site and the
 # standard commerce lifecycle. These are independently aggregated event totals;
@@ -262,17 +264,39 @@ def _native_funnel_request(start_date: str, end_date: str) -> dict:
 
 
 def _parse_int(value) -> int:
-    parsed = int(value)
-    if parsed < 0:
-        raise ValueError("negative integer")
-    return parsed
+    if type(value) is not str or _INTEGER_METRIC.fullmatch(value) is None:
+        raise ValueError("invalid integer metric")
+    return int(value)
 
 
 def _parse_rate(value) -> float:
+    if type(value) is not str:
+        raise ValueError("invalid rate metric")
     parsed = float(value)
     if not math.isfinite(parsed) or parsed < 0 or parsed > 1:
         raise ValueError("rate outside [0, 1]")
     return parsed
+
+
+def _valid_subreport_metadata(metadata) -> bool:
+    if not isinstance(metadata, dict):
+        return False
+    if ("subjectToThresholding" in metadata
+            and type(metadata["subjectToThresholding"]) is not bool):
+        return False
+    if "samplingMetadatas" not in metadata:
+        return True
+    samples = metadata["samplingMetadatas"]
+    if not isinstance(samples, list):
+        return False
+    for sample in samples:
+        if not isinstance(sample, dict):
+            return False
+        for key in ("samplesReadCount", "samplingSpaceSize"):
+            value = sample.get(key)
+            if type(value) is not str or _INTEGER_METRIC.fullmatch(value) is None:
+                return False
+    return True
 
 
 def _subreport_headers(subreport: dict, expected_metrics: tuple[str, ...]) -> None:
@@ -288,7 +312,7 @@ def _subreport_headers(subreport: dict, expected_metrics: tuple[str, ...]) -> No
     if len(names) != len(headers) or names not in {
             expected_metrics, expected_metrics + expected_metrics}:
         raise ValueError("unexpected metric headers")
-    if not isinstance(subreport.get("metadata", {}), dict):
+    if not _valid_subreport_metadata(subreport.get("metadata", {})):
         raise ValueError("unexpected report metadata")
 
 
@@ -389,6 +413,10 @@ def _valid_cached_funnel(value, period: dict, property_ref: str) -> bool:
             and isinstance(value.get("steps"), list)
             and len(value["steps"]) == len(NATIVE_FUNNEL_STEPS)
             and isinstance(value.get("metadata"), dict)
+            and set(value["metadata"]) == {
+                "funnel_table", "funnel_visualization"}
+            and _valid_subreport_metadata(value["metadata"]["funnel_table"])
+            and _valid_subreport_metadata(value["metadata"]["funnel_visualization"])
             and isinstance(value.get("request_contract"), dict)
             and value["request_contract"].get("closed") is True
             and value["request_contract"].get("ordered") is True
@@ -410,13 +438,16 @@ def _valid_cached_funnel(value, period: dict, property_ref: str) -> bool:
             return False
         users = step.get("users")
         if step["present"]:
-            if not isinstance(users, int) or isinstance(users, bool) or users < 0:
+            if type(users) is not int or users < 0:
                 return False
-            try:
-                _parse_rate(step.get("completion_rate"))
-                _parse_int(step.get("abandonments"))
-                _parse_rate(step.get("abandonment_rate"))
-            except (TypeError, ValueError):
+            if (type(step.get("completion_rate")) is not float
+                    or not math.isfinite(step["completion_rate"])
+                    or not 0 <= step["completion_rate"] <= 1
+                    or type(step.get("abandonments")) is not int
+                    or step["abandonments"] < 0
+                    or type(step.get("abandonment_rate")) is not float
+                    or not math.isfinite(step["abandonment_rate"])
+                    or not 0 <= step["abandonment_rate"] <= 1):
                 return False
         elif users is not None:
             return False
@@ -510,7 +541,7 @@ def get_ordered_funnel_report(days: int = 30) -> dict:
 
     try:
         steps, metadata = _parse_native_funnel_response(body)
-    except (KeyError, TypeError, ValueError) as e:
+    except (KeyError, OverflowError, TypeError, ValueError) as e:
         logger.error("GA4 native funnel response shape failed: %s", e)
         return _unavailable_funnel(
             "GA4 native funnel response shape is unsupported",

--- a/mission_control/services/ga4.py
+++ b/mission_control/services/ga4.py
@@ -7,9 +7,13 @@ caching is skipped and data is fetched fresh every call.
 
 from __future__ import annotations
 
+import copy
+import hashlib
 import logging
+import math
 import os
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 try:
     from mission_control import supabase_client as db
@@ -25,6 +29,23 @@ except Exception:
 logger = logging.getLogger(__name__)
 
 CACHE_TTL_HOURS = 4
+GA4_DATA_API_ROOT = "https://analyticsdata.googleapis.com"
+NATIVE_FUNNEL_SCHEMA = "ga4_native_ordered_funnel/v1"
+NATIVE_FUNNEL_CACHE_VERSION = "v1"
+NATIVE_FUNNEL_METRICS = (
+    "activeUsers",
+    "funnelStepCompletionRate",
+    "funnelStepAbandonments",
+    "funnelStepAbandonmentRate",
+)
+NATIVE_FUNNEL_STEPS = (
+    {"key": "race_page_view", "name": "Race page view"},
+    {"key": "race_cta", "name": "Race CTA"},
+    {"key": "plan_form_start", "name": "Plan form start"},
+    {"key": "plan_form_submit", "name": "Plan form submit"},
+    {"key": "training_plan_checkout", "name": "Training-plan checkout"},
+    {"key": "training_plan_purchase", "name": "Training-plan purchase"},
+)
 
 # Keep this list aligned with the events already emitted by the site and the
 # standard commerce lifecycle. These are independently aggregated event totals;
@@ -103,6 +124,422 @@ def _get_client():
     except Exception as e:
         logger.error("Failed to create GA4 client: %s", e)
         return None
+
+
+def _get_funnel_session():
+    """Create the REST transport needed by the alpha funnel endpoint."""
+    if not GA4_PROPERTY_ID or not GA4_CREDENTIALS_PATH:
+        return None
+
+    try:
+        from google.auth.transport.requests import AuthorizedSession
+        from google.oauth2.service_account import Credentials
+
+        credentials = Credentials.from_service_account_file(
+            GA4_CREDENTIALS_PATH,
+            scopes=["https://www.googleapis.com/auth/analytics.readonly"],
+        )
+        return AuthorizedSession(credentials)
+    except Exception as e:
+        logger.error("Failed to create GA4 funnel session: %s", e)
+        return None
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _property_name() -> str | None:
+    raw = str(GA4_PROPERTY_ID or "").strip()
+    value = raw.removeprefix("properties/")
+    if not value.isdigit():
+        return None
+    return f"properties/{value}"
+
+
+def _property_ref(property_name: str) -> str:
+    return hashlib.sha256(property_name.encode()).hexdigest()[:12]
+
+
+def _valid_timezone_name(value) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        ZoneInfo(value)
+    except (ZoneInfoNotFoundError, ValueError):
+        return None
+    return value
+
+
+def _get_property_reporting_timezone(client, property_name: str) -> str | None:
+    """Read the property's IANA timezone from GA4 response metadata."""
+    property_ref = _property_ref(property_name)
+    cache_key = f"ga4_property_timezone_v1_{property_ref}"
+    cached = _get_cached(cache_key)
+    if isinstance(cached, dict):
+        timezone_name = _valid_timezone_name(cached.get("timezone"))
+        if timezone_name:
+            return timezone_name
+
+    try:
+        from google.analytics.data_v1beta.types import (
+            DateRange,
+            Metric,
+            RunReportRequest,
+        )
+
+        response = client.run_report(RunReportRequest(
+            property=property_name,
+            metrics=[Metric(name="activeUsers")],
+            date_ranges=[DateRange(start_date="yesterday", end_date="yesterday")],
+            limit=1,
+        ))
+        timezone_name = _valid_timezone_name(
+            getattr(getattr(response, "metadata", None), "time_zone", None))
+        if timezone_name:
+            _set_cached(cache_key, {"timezone": timezone_name})
+        return timezone_name
+    except Exception as e:
+        logger.error("GA4 property timezone query failed: %s", e)
+        return None
+
+
+def _funnel_event(name: str) -> dict:
+    return {"funnelEventFilter": {"eventName": name}}
+
+
+def _funnel_field(name: str, value: str, match_type: str) -> dict:
+    return {"funnelFieldFilter": {
+        "fieldName": name,
+        "stringFilter": {
+            "matchType": match_type,
+            "value": value,
+            "caseSensitive": True,
+        },
+    }}
+
+
+def _funnel_and(*expressions: dict) -> dict:
+    return {"andGroup": {"expressions": list(expressions)}}
+
+
+def _funnel_or(*expressions: dict) -> dict:
+    return {"orGroup": {"expressions": list(expressions)}}
+
+
+def _native_funnel_request(start_date: str, end_date: str) -> dict:
+    race_path = _funnel_field(
+        "unifiedPagePathScreen", "/race/", "BEGINS_WITH")
+    form_path = _funnel_field(
+        "unifiedPagePathScreen", "/questionnaire/", "BEGINS_WITH")
+    steps = (
+        _funnel_and(_funnel_event("page_view"), race_path),
+        _funnel_and(_funnel_event("cta_click"), race_path),
+        _funnel_and(_funnel_or(
+            _funnel_event("form_start"), _funnel_event("tp_form_start")),
+            form_path),
+        _funnel_and(_funnel_or(
+            _funnel_event("form_submit"), _funnel_event("tp_form_submit")),
+            form_path),
+        _funnel_and(
+            _funnel_event("begin_checkout"),
+            _funnel_field("itemCategory", "training_plan", "EXACT")),
+        _funnel_and(
+            _funnel_event("purchase"),
+            _funnel_field("itemCategory", "training_plan", "EXACT")),
+    )
+    return {
+        "dateRanges": [{"startDate": start_date, "endDate": end_date}],
+        "funnel": {
+            "isOpenFunnel": False,
+            "steps": [
+                {"name": definition["name"], "filterExpression": expression}
+                for definition, expression in zip(NATIVE_FUNNEL_STEPS, steps)
+            ],
+        },
+        "returnPropertyQuota": True,
+    }
+
+
+def _parse_int(value) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise ValueError("negative integer")
+    return parsed
+
+
+def _parse_rate(value) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0 or parsed > 1:
+        raise ValueError("rate outside [0, 1]")
+    return parsed
+
+
+def _subreport_headers(subreport: dict, expected_metrics: tuple[str, ...]) -> None:
+    if not isinstance(subreport, dict):
+        raise ValueError("subreport missing")
+    dimensions = subreport.get("dimensionHeaders")
+    if dimensions != [{"name": "funnelStepName"}]:
+        raise ValueError("unexpected dimension headers")
+    headers = subreport.get("metricHeaders")
+    if not isinstance(headers, list):
+        raise ValueError("metric headers missing")
+    names = tuple(item.get("name") for item in headers if isinstance(item, dict))
+    if len(names) != len(headers) or names not in {
+            expected_metrics, expected_metrics + expected_metrics}:
+        raise ValueError("unexpected metric headers")
+    if not isinstance(subreport.get("metadata", {}), dict):
+        raise ValueError("unexpected report metadata")
+
+
+def _parse_funnel_rows(subreport: dict, metric_count: int) -> list[dict]:
+    rows = subreport.get("rows", [])
+    if not isinstance(rows, list) or len(rows) > len(NATIVE_FUNNEL_STEPS):
+        raise ValueError("unexpected row count")
+    parsed = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError("unexpected row")
+        dimensions = row.get("dimensionValues")
+        metrics = row.get("metricValues")
+        expected_name = f"{index + 1}. {NATIVE_FUNNEL_STEPS[index]['name']}"
+        if (not isinstance(dimensions, list) or len(dimensions) != 1
+                or not isinstance(dimensions[0], dict)
+                or dimensions[0].get("value") != expected_name):
+            raise ValueError("unexpected step row")
+        if (not isinstance(metrics, list) or len(metrics) != metric_count
+                or any(not isinstance(item, dict) or "value" not in item
+                       for item in metrics)):
+            raise ValueError("unexpected metric row")
+        parsed.append({"name": expected_name, "values": [
+            item["value"] for item in metrics]})
+    return parsed
+
+
+def _parse_native_funnel_response(body: dict) -> tuple[list[dict], dict]:
+    if not isinstance(body, dict) or body.get("kind") != "analyticsData#runFunnelReport":
+        raise ValueError("unexpected response kind")
+    table = body.get("funnelTable")
+    visualization = body.get("funnelVisualization")
+    _subreport_headers(table, NATIVE_FUNNEL_METRICS)
+    _subreport_headers(visualization, ("activeUsers",))
+    table_rows = _parse_funnel_rows(table, 4)
+    visual_rows = _parse_funnel_rows(visualization, 1)
+    if len(table_rows) != len(visual_rows):
+        raise ValueError("subreport row counts differ")
+
+    steps = []
+    for index, definition in enumerate(NATIVE_FUNNEL_STEPS):
+        if index >= len(table_rows):
+            steps.append({
+                **definition,
+                "position": index + 1,
+                "present": False,
+                "users": None,
+                "completion_rate": None,
+                "abandonments": None,
+                "abandonment_rate": None,
+            })
+            continue
+        table_values = table_rows[index]["values"]
+        visual_values = visual_rows[index]["values"]
+        users = _parse_int(table_values[0])
+        if users != _parse_int(visual_values[0]):
+            raise ValueError("subreport active-user values differ")
+        steps.append({
+            **definition,
+            "position": index + 1,
+            "present": True,
+            "users": users,
+            "completion_rate": _parse_rate(table_values[1]),
+            "abandonments": _parse_int(table_values[2]),
+            "abandonment_rate": _parse_rate(table_values[3]),
+        })
+
+    metadata = {
+        "funnel_table": copy.deepcopy(table.get("metadata", {})),
+        "funnel_visualization": copy.deepcopy(visualization.get("metadata", {})),
+    }
+    return steps, metadata
+
+
+def _unavailable_funnel(error: str, error_code: str, *, period=None,
+                        attempted_at: str | None = None, provenance=None) -> dict:
+    return {
+        "schema": NATIVE_FUNNEL_SCHEMA,
+        "available": False,
+        "error": error,
+        "error_code": error_code,
+        "attempted_at": attempted_at,
+        "fetched_at": None,
+        "period": period,
+        "steps": [],
+        "metadata": {},
+        "provenance": provenance or {},
+    }
+
+
+def _valid_cached_funnel(value, period: dict, property_ref: str) -> bool:
+    if not (
+            isinstance(value, dict)
+            and value.get("schema") == NATIVE_FUNNEL_SCHEMA
+            and value.get("available") is True
+            and value.get("period") == period
+            and isinstance(value.get("fetched_at"), str)
+            and isinstance(value.get("steps"), list)
+            and len(value["steps"]) == len(NATIVE_FUNNEL_STEPS)
+            and isinstance(value.get("metadata"), dict)
+            and isinstance(value.get("request_contract"), dict)
+            and value["request_contract"].get("closed") is True
+            and value["request_contract"].get("ordered") is True
+            and value["request_contract"].get("directly_followed") is False
+            and value["request_contract"].get("steps") == list(NATIVE_FUNNEL_STEPS)
+            and isinstance(value.get("provenance"), dict)
+            and value["provenance"].get("request_version") == NATIVE_FUNNEL_CACHE_VERSION
+            and value["provenance"].get("property_ref") == property_ref
+            and value["provenance"].get("response_kind")
+            == "analyticsData#runFunnelReport"):
+        return False
+    for index, (step, definition) in enumerate(
+            zip(value["steps"], NATIVE_FUNNEL_STEPS), start=1):
+        if (not isinstance(step, dict)
+                or step.get("key") != definition["key"]
+                or step.get("name") != definition["name"]
+                or step.get("position") != index
+                or not isinstance(step.get("present"), bool)):
+            return False
+        users = step.get("users")
+        if step["present"]:
+            if not isinstance(users, int) or isinstance(users, bool) or users < 0:
+                return False
+            try:
+                _parse_rate(step.get("completion_rate"))
+                _parse_int(step.get("abandonments"))
+                _parse_rate(step.get("abandonment_rate"))
+            except (TypeError, ValueError):
+                return False
+        elif users is not None:
+            return False
+        elif any(step.get(key) is not None for key in (
+                "completion_rate", "abandonments", "abandonment_rate")):
+            return False
+    return True
+
+
+def get_ordered_funnel_report(days: int = 30) -> dict:
+    """Return GA4's closed, ordered active-user funnel for complete days."""
+    now = _utc_now()
+    attempted_at = now.isoformat()
+    if not isinstance(days, int) or isinstance(days, bool) or days < 1:
+        return _unavailable_funnel(
+            "Invalid funnel reporting window", "INVALID_WINDOW",
+            attempted_at=attempted_at)
+
+    property_name = _property_name()
+    if property_name is None:
+        return _unavailable_funnel(
+            "GA4 property is unavailable", "PROPERTY_UNAVAILABLE",
+            attempted_at=attempted_at)
+    property_ref = _property_ref(property_name)
+    provenance = {
+        "provider": "Google Analytics Data API",
+        "method": "v1alpha properties.runFunnelReport",
+        "request_version": NATIVE_FUNNEL_CACHE_VERSION,
+        "property_ref": property_ref,
+        "cache_hit": False,
+    }
+
+    client = _get_client()
+    if client is None:
+        return _unavailable_funnel(
+            "GA4 client unavailable", "CLIENT_UNAVAILABLE",
+            attempted_at=attempted_at, provenance=provenance)
+    timezone_name = _get_property_reporting_timezone(client, property_name)
+    if timezone_name is None:
+        return _unavailable_funnel(
+            "GA4 property timezone unavailable", "TIMEZONE_UNAVAILABLE",
+            attempted_at=attempted_at, provenance=provenance)
+
+    local_today = now.astimezone(ZoneInfo(timezone_name)).date()
+    end_date = local_today - timedelta(days=1)
+    start_date = end_date - timedelta(days=days - 1)
+    period = {
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "timezone": timezone_name,
+        "complete_days": days,
+    }
+    cache_key = (
+        f"native_ordered_funnel_{NATIVE_FUNNEL_CACHE_VERSION}_{property_ref}_"
+        f"{period['start_date']}_{period['end_date']}_{timezone_name}"
+    )
+    cached = _get_cached(cache_key)
+    if _valid_cached_funnel(cached, period, property_ref):
+        result = copy.deepcopy(cached)
+        result["provenance"]["cache_hit"] = True
+        return result
+
+    session = _get_funnel_session()
+    if session is None:
+        return _unavailable_funnel(
+            "GA4 funnel client unavailable", "CLIENT_UNAVAILABLE",
+            period=period, attempted_at=attempted_at, provenance=provenance)
+
+    request_body = _native_funnel_request(
+        period["start_date"], period["end_date"])
+    url = f"{GA4_DATA_API_ROOT}/v1alpha/{property_name}:runFunnelReport"
+    try:
+        response = session.post(url, json=request_body, timeout=60)
+        body = response.json()
+    except Exception as e:
+        logger.error("GA4 native funnel request failed: %s", e)
+        return _unavailable_funnel(
+            "GA4 native funnel query failed", "API_FAILURE",
+            period=period, attempted_at=attempted_at, provenance=provenance)
+
+    if response.status_code != 200:
+        provider_error = body.get("error") if isinstance(body, dict) else None
+        provider_status = (provider_error.get("status")
+                           if isinstance(provider_error, dict) else None)
+        error_code = (str(provider_status)[:80] if provider_status
+                      else f"HTTP_{response.status_code}")
+        return _unavailable_funnel(
+            "GA4 native funnel query failed", error_code,
+            period=period, attempted_at=attempted_at, provenance={
+                **provenance, "http_status": response.status_code})
+
+    try:
+        steps, metadata = _parse_native_funnel_response(body)
+    except (KeyError, TypeError, ValueError) as e:
+        logger.error("GA4 native funnel response shape failed: %s", e)
+        return _unavailable_funnel(
+            "GA4 native funnel response shape is unsupported",
+            "UNKNOWN_RESPONSE_SHAPE", period=period,
+            attempted_at=attempted_at, provenance=provenance)
+
+    result = {
+        "schema": NATIVE_FUNNEL_SCHEMA,
+        "available": True,
+        "error": None,
+        "error_code": None,
+        "attempted_at": attempted_at,
+        "fetched_at": attempted_at,
+        "period": period,
+        "steps": steps,
+        "metadata": metadata,
+        "request_contract": {
+            "closed": True,
+            "ordered": True,
+            "directly_followed": False,
+            "steps": copy.deepcopy(list(NATIVE_FUNNEL_STEPS)),
+        },
+        "provenance": {
+            **provenance,
+            "response_kind": body.get("kind"),
+        },
+    }
+    _set_cached(cache_key, result)
+    return result
 
 
 def get_top_pages(days: int = 30, limit: int = 20) -> list[dict]:
@@ -321,6 +758,8 @@ def refresh_cache() -> int:
     if get_daily_sessions():
         count += 1
     if get_conversion_events():
+        count += 1
+    if get_ordered_funnel_report().get("available") is True:
         count += 1
 
     return count

--- a/mission_control/templates/analytics/index.html
+++ b/mission_control/templates/analytics/index.html
@@ -2,6 +2,42 @@
 
 {% block title %}Analytics — Gravel God Mission Control{% endblock %}
 
+{% block head_extra %}
+<style>
+.mc-main,
+.mc-native-funnel,
+.mc-native-funnel__table {
+    min-width: 0;
+}
+.mc-native-funnel__table {
+    max-width: 100%;
+    overflow-x: auto;
+}
+.mc-native-funnel__mobile-label {
+    display: none;
+}
+@media (max-width: 700px) {
+    .mc-native-funnel__table .gg-table {
+        table-layout: fixed;
+    }
+    .mc-native-funnel__table th,
+    .mc-native-funnel__table td {
+        overflow-wrap: anywhere;
+    }
+    .mc-native-funnel__table th:first-child,
+    .mc-native-funnel__table td:first-child {
+        width: 44%;
+    }
+    .mc-native-funnel__desktop-label {
+        display: none;
+    }
+    .mc-native-funnel__mobile-label {
+        display: inline;
+    }
+}
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="mc-page-header mc-page-header--with-actions">
     <div>
@@ -58,7 +94,70 @@
 </div>
 {% endif %}
 
-<div style="display:grid;grid-template-columns:1fr 1fr;gap:var(--gg-spacing-lg)" class="mc-mt-lg">
+<!-- Native ordered user funnel -->
+<div class="mc-card mc-mt-lg mc-native-funnel">
+    <div class="mc-card__header">
+        <div>
+            <h3 class="mc-card__title">Ordered user funnel</h3>
+            <p class="mc-text-muted" style="font-size:var(--gg-font-size-xs);margin:4px 0 0">Closed, ordered behavioral user progression in GA4.</p>
+        </div>
+    </div>
+    <div class="mc-card__body">
+        {% if funnel_report.available %}
+        <div class="mc-flex-between" style="align-items:flex-start;gap:var(--gg-spacing-md);flex-wrap:wrap;margin-bottom:var(--gg-spacing-md)">
+            <div>
+                <div class="mc-text-mono" style="font-size:var(--gg-font-size-sm);font-weight:600">{{ funnel_period_label }}</div>
+                <div class="mc-text-muted" style="font-size:var(--gg-font-size-xs)">{{ funnel_report.period.complete_days }} complete days · {{ funnel_report.period.timezone }}</div>
+            </div>
+            <div class="mc-text-muted mc-text-mono" style="font-size:var(--gg-font-size-2xs);text-align:right">
+                Fetched {{ funnel_report.fetched_at }}{% if funnel_report.provenance.cache_hit %} · cached result{% endif %}
+            </div>
+        </div>
+        <div class="mc-native-funnel__table">
+            <table class="gg-table gg-table--striped gg-table--compact">
+                <thead>
+                    <tr>
+                        <th>Step</th>
+                        <th class="mc-text-right"><span class="mc-native-funnel__desktop-label">Active users</span><span class="mc-native-funnel__mobile-label">Users</span></th>
+                        <th class="mc-text-right"><span class="mc-native-funnel__desktop-label">Reached next step</span><span class="mc-native-funnel__mobile-label">Next step</span></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for step in funnel_report.steps %}
+                    <tr>
+                        <td>
+                            <span class="mc-text-muted mc-text-mono">{{ step.position }}.</span>
+                            {{ step.name }}
+                        </td>
+                        <td class="mc-text-right mc-text-mono" style="font-weight:600">
+                            {% if step.present %}{{ "{:,}".format(step.users) }}{% else %}<span class="mc-text-muted">Absent</span>{% endif %}
+                        </td>
+                        <td class="mc-text-right mc-text-mono mc-text-muted">
+                            {% if not loop.last and step.present and step.completion_rate is not none %}{{ "{:.1%}".format(step.completion_rate) }}{% else %}—{% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <p class="mc-text-muted" style="font-size:var(--gg-font-size-xs);margin:var(--gg-spacing-md) 0 0"><strong>Broad race-page CTA:</strong> this step includes every recorded CTA click on a race page. The current event does not identify an exact training-plan target.</p>
+        <p class="mc-text-muted" style="font-size:var(--gg-font-size-xs);margin:4px 0 0">Purchase is a GA4 event in this behavioral sequence. Payment and delivered-order evidence remain in their provider ledgers. An absent row is not displayed as zero.</p>
+        {% if funnel_sampling %}
+        <p class="mc-text-muted" style="font-size:var(--gg-font-size-xs);margin:4px 0 0">GA4 sampled this report{% for sample in funnel_sampling %}{% if sample.samplesReadCount and sample.samplingSpaceSize %}: {{ sample.samplesReadCount }} of {{ sample.samplingSpaceSize }} events read{% endif %}{% if not loop.last %}; {% endif %}{% endfor %}.</p>
+        {% endif %}
+        {% if funnel_thresholded %}
+        <p class="mc-text-muted" style="font-size:var(--gg-font-size-xs);margin:4px 0 0">This report is subject to GA4 thresholding.</p>
+        {% endif %}
+        {% else %}
+        <p class="mc-text-muted" style="font-size:var(--gg-font-size-sm);margin:0"><strong>Ordered user funnel unavailable.</strong> {{ funnel_report.error }}{% if funnel_report.error_code %} ({{ funnel_report.error_code }}){% endif %}</p>
+        {% if funnel_report.period %}
+        <p class="mc-text-muted" style="font-size:var(--gg-font-size-xs);margin:4px 0 0">Requested {{ funnel_report.period.start_date }} through {{ funnel_report.period.end_date }} in {{ funnel_report.period.timezone }}.</p>
+        {% endif %}
+        {% endif %}
+    </div>
+</div>
+
+<div class="mc-grid mc-grid--2 mc-mt-lg">
     <!-- Traffic Sources -->
     <div class="mc-card">
         <div class="mc-card__header">

--- a/mission_control/templates/analytics/index.html
+++ b/mission_control/templates/analytics/index.html
@@ -119,7 +119,7 @@
                     <tr>
                         <th>Step</th>
                         <th class="mc-text-right"><span class="mc-native-funnel__desktop-label">Active users</span><span class="mc-native-funnel__mobile-label">Users</span></th>
-                        <th class="mc-text-right"><span class="mc-native-funnel__desktop-label">Reached next step</span><span class="mc-native-funnel__mobile-label">Next step</span></th>
+                        <th class="mc-text-right"><span class="mc-native-funnel__desktop-label">Reached next step</span><span class="mc-native-funnel__mobile-label">Next</span></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/mission_control/tests/test_analytics.py
+++ b/mission_control/tests/test_analytics.py
@@ -2,6 +2,54 @@ import re
 from unittest.mock import patch
 
 
+def _native_funnel_report(*, available=True):
+    return {
+        "available": available,
+        "error": None if available else "GA4 native funnel query failed",
+        "error_code": None if available else "PERMISSION_DENIED",
+        "fetched_at": "2026-09-09T05:30:00+00:00" if available else None,
+        "period": {
+            "start_date": "2026-08-09", "end_date": "2026-09-07",
+            "timezone": "America/Denver", "complete_days": 30,
+        } if available else None,
+        "steps": [
+            {"position": 1, "name": "Race page view", "present": True, "users": 100,
+             "completion_rate": 0.2},
+            {"position": 2, "name": "Race CTA", "present": True, "users": 20,
+             "completion_rate": 0.25},
+            {"position": 3, "name": "Plan form start", "present": True, "users": 5,
+             "completion_rate": 0.4},
+            {"position": 4, "name": "Plan form submit", "present": True, "users": 2,
+             "completion_rate": 0.0},
+            {"position": 5, "name": "Training-plan checkout", "present": True, "users": 0,
+             "completion_rate": 0.0},
+            {"position": 6, "name": "Training-plan purchase", "present": False, "users": None,
+             "completion_rate": None},
+        ] if available else [],
+        "metadata": {
+            "funnel_table": {"subjectToThresholding": True},
+            "funnel_visualization": {},
+        } if available else {},
+        "provenance": {"cache_hit": False} if available else {},
+    }
+
+
+def _common_analytics_patches(funnel=None):
+    return (
+        patch("mission_control.routers.analytics.get_top_pages", return_value=[]),
+        patch("mission_control.routers.analytics.get_traffic_sources", return_value=[]),
+        patch("mission_control.routers.analytics.get_daily_sessions", return_value=[]),
+        patch(
+            "mission_control.routers.analytics.get_conversion_event_report",
+            return_value={"available": True, "events": [], "error": None},
+        ),
+        patch(
+            "mission_control.routers.analytics.get_ordered_funnel_report",
+            return_value=funnel or _native_funnel_report(),
+        ),
+    )
+
+
 def test_analytics_page_renders_distinct_event_counts_without_combined_kpi(
         client, fake_db):
     event_totals = [
@@ -15,7 +63,9 @@ def test_analytics_page_renders_distinct_event_counts_without_combined_kpi(
          patch("mission_control.routers.analytics.get_traffic_sources", return_value=[]), \
          patch("mission_control.routers.analytics.get_daily_sessions", return_value=[]), \
          patch("mission_control.routers.analytics.get_conversion_event_report",
-               return_value={"available": True, "events": event_totals, "error": None}):
+               return_value={"available": True, "events": event_totals, "error": None}), \
+         patch("mission_control.routers.analytics.get_ordered_funnel_report",
+               return_value=_native_funnel_report()):
         response = client.get("/analytics/")
 
     assert response.status_code == 200
@@ -35,7 +85,9 @@ def test_analytics_page_distinguishes_ga4_failure_from_verified_zero(client, fak
     )
     with common[0], common[1], common[2], \
          patch("mission_control.services.ga4._get_cached", return_value=None), \
-         patch("mission_control.services.ga4._get_client", return_value=None):
+         patch("mission_control.services.ga4._get_client", return_value=None), \
+         patch("mission_control.routers.analytics.get_ordered_funnel_report",
+               return_value=_native_funnel_report(available=False)):
         failed = client.get("/analytics/")
 
     assert failed.status_code == 200
@@ -49,6 +101,10 @@ def test_analytics_page_distinguishes_ga4_failure_from_verified_zero(client, fak
          patch(
              "mission_control.routers.analytics.get_conversion_event_report",
              return_value={"available": True, "events": [], "error": None},
+         ), \
+         patch(
+             "mission_control.routers.analytics.get_ordered_funnel_report",
+             return_value=_native_funnel_report(),
          ):
         empty = client.get("/analytics/")
 
@@ -56,3 +112,36 @@ def test_analytics_page_distinguishes_ga4_failure_from_verified_zero(client, fak
     assert re.search(r">0</div>\s*<div[^>]*>Purchase events", empty.text)
     assert re.search(r">0</div>\s*<div[^>]*>Refund events", empty.text)
     assert "No lead or commerce events observed in this period." in empty.text
+
+
+def test_analytics_page_renders_native_funnel_with_absent_distinct_from_zero(
+        client, fake_db):
+    patches = _common_analytics_patches()
+    with patches[0], patches[1], patches[2], patches[3], patches[4]:
+        response = client.get("/analytics/")
+
+    assert response.status_code == 200
+    assert "Ordered user funnel" in response.text
+    assert "Aug 9–Sep 7, 2026" in response.text
+    assert "America/Denver" in response.text
+    assert "complete days" in response.text
+    assert "Broad race-page CTA" in response.text
+    assert "behavioral user progression" in response.text
+    assert re.search(r"Training-plan checkout.*?>\s*0\s*<", response.text, re.DOTALL)
+    assert re.search(r"Training-plan purchase.*?>\s*Absent\s*<", response.text, re.DOTALL)
+    assert "paid customers" not in response.text.lower()
+    assert "exact-plan selection" not in response.text.lower()
+    assert "subject to GA4 thresholding" in response.text
+
+
+def test_analytics_page_renders_native_funnel_unavailable_without_zeroes(
+        client, fake_db):
+    patches = _common_analytics_patches(_native_funnel_report(available=False))
+    with patches[0], patches[1], patches[2], patches[3], patches[4]:
+        response = client.get("/analytics/")
+
+    assert response.status_code == 200
+    assert "Ordered user funnel unavailable" in response.text
+    assert "PERMISSION_DENIED" in response.text
+    funnel = response.text.split("Ordered user funnel", 1)[1].split("Traffic Sources", 1)[0]
+    assert ">0<" not in funnel

--- a/mission_control/tests/test_analytics.py
+++ b/mission_control/tests/test_analytics.py
@@ -145,3 +145,23 @@ def test_analytics_page_renders_native_funnel_unavailable_without_zeroes(
     assert "PERMISSION_DENIED" in response.text
     funnel = response.text.split("Ordered user funnel", 1)[1].split("Traffic Sources", 1)[0]
     assert ">0<" not in funnel
+
+
+def test_analytics_page_defensively_ignores_malformed_funnel_metadata(
+        client, fake_db):
+    report = _native_funnel_report()
+    report["metadata"] = {
+        "funnel_table": {
+            "samplingMetadatas": 7,
+            "subjectToThresholding": "true",
+        },
+        "funnel_visualization": {},
+    }
+    patches = _common_analytics_patches(report)
+    with patches[0], patches[1], patches[2], patches[3], patches[4]:
+        response = client.get("/analytics/")
+
+    assert response.status_code == 200
+    assert "Ordered user funnel" in response.text
+    assert "GA4 sampled this report" not in response.text
+    assert "subject to GA4 thresholding" not in response.text

--- a/tests/fixtures/ga4_native_closed_funnel.json
+++ b/tests/fixtures/ga4_native_closed_funnel.json
@@ -1,0 +1,268 @@
+{
+  "generated_at": "2026-09-09T04:30:56.429347+00:00",
+  "limitations": [
+    "Rows are aggregate active-user sequence evidence; no user or session identifiers are returned.",
+    "GA4 reporting identity and consent determine which people can be joined across steps.",
+    "Server purchases using the order-scoped fallback client ID cannot join earlier browser steps.",
+    "GA4 purchase evidence does not establish provider-collected cash.",
+    "The alpha API can change, and sampling is reported per subreport when applied."
+  ],
+  "ok": true,
+  "period": {
+    "end_date": "2026-09-07",
+    "start_date": "2026-07-01",
+    "timezone": "property_reporting_timezone"
+  },
+  "property_ref": "898abca13284",
+  "request_contract": {
+    "closed": true,
+    "directly_followed": false,
+    "ordered": true,
+    "steps": [
+      {
+        "events": [
+          "page_view"
+        ],
+        "name": "Race page view",
+        "page_prefix": "/race/"
+      },
+      {
+        "events": [
+          "cta_click"
+        ],
+        "name": "Race CTA",
+        "page_prefix": "/race/"
+      },
+      {
+        "events": [
+          "form_start",
+          "tp_form_start"
+        ],
+        "name": "Plan form start",
+        "page_prefix": "/questionnaire/"
+      },
+      {
+        "events": [
+          "form_submit",
+          "tp_form_submit"
+        ],
+        "name": "Plan form submit",
+        "page_prefix": "/questionnaire/"
+      },
+      {
+        "events": [
+          "begin_checkout"
+        ],
+        "itemCategory": "training_plan",
+        "name": "Training-plan checkout"
+      },
+      {
+        "events": [
+          "purchase"
+        ],
+        "itemCategory": "training_plan",
+        "name": "Training-plan purchase"
+      }
+    ]
+  },
+  "response": {
+    "funnel_table": {
+      "dimensionHeaders": [
+        {
+          "name": "funnelStepName"
+        }
+      ],
+      "metadata": {},
+      "metricHeaders": [
+        {
+          "name": "activeUsers",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "funnelStepCompletionRate",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "funnelStepAbandonments",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "funnelStepAbandonmentRate",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "activeUsers",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "funnelStepCompletionRate",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "funnelStepAbandonments",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "funnelStepAbandonmentRate",
+          "type": "TYPE_INTEGER"
+        }
+      ],
+      "rows": [
+        {
+          "dimensionValues": [
+            {
+              "value": "1. Race page view"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "4601"
+            },
+            {
+              "value": "0.040425994349054556"
+            },
+            {
+              "value": "4415"
+            },
+            {
+              "value": "0.95957400565094542"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "2. Race CTA"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "186"
+            },
+            {
+              "value": "0.053763440860215055"
+            },
+            {
+              "value": "176"
+            },
+            {
+              "value": "0.946236559139785"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "3. Plan form start"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "10"
+            },
+            {
+              "value": "0.2"
+            },
+            {
+              "value": "8"
+            },
+            {
+              "value": "0.8"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "4. Plan form submit"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "2"
+            },
+            {
+              "value": "0"
+            },
+            {
+              "value": "2"
+            },
+            {
+              "value": "1"
+            }
+          ]
+        }
+      ]
+    },
+    "funnel_visualization": {
+      "dimensionHeaders": [
+        {
+          "name": "funnelStepName"
+        }
+      ],
+      "metadata": {},
+      "metricHeaders": [
+        {
+          "name": "activeUsers",
+          "type": "TYPE_INTEGER"
+        },
+        {
+          "name": "activeUsers",
+          "type": "TYPE_INTEGER"
+        }
+      ],
+      "rows": [
+        {
+          "dimensionValues": [
+            {
+              "value": "1. Race page view"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "4601"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "2. Race CTA"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "186"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "3. Plan form start"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "10"
+            }
+          ]
+        },
+        {
+          "dimensionValues": [
+            {
+              "value": "4. Plan form submit"
+            }
+          ],
+          "metricValues": [
+            {
+              "value": "2"
+            }
+          ]
+        }
+      ]
+    },
+    "kind": "analyticsData#runFunnelReport"
+  },
+  "schema": "ga4_native_funnel_probe/v1"
+}

--- a/tests/test_ga4_service_events.py
+++ b/tests/test_ga4_service_events.py
@@ -1,7 +1,16 @@
+import copy
+import json
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
+import pytest
+
 from mission_control.services import ga4
+
+
+FUNNEL_FIXTURE = Path(__file__).parent / "fixtures" / "ga4_native_closed_funnel.json"
 
 
 class Message:
@@ -172,3 +181,326 @@ def test_event_summary_keeps_refunds_out_of_purchase_and_lead_counts():
         "purchase_events": 2,
         "refund_events": 5,
     }
+
+
+class _TimezoneClient:
+    def __init__(self, timezone_name="America/Denver"):
+        self.timezone_name = timezone_name
+        self.requests = []
+
+    def run_report(self, request):
+        self.requests.append(request)
+        return SimpleNamespace(metadata=SimpleNamespace(time_zone=self.timezone_name))
+
+
+class _HttpResponse:
+    def __init__(self, body, status_code=200):
+        self._body = body
+        self.status_code = status_code
+
+    def json(self):
+        return copy.deepcopy(self._body)
+
+
+class _FunnelSession:
+    def __init__(self, body, status_code=200):
+        self.body = body
+        self.status_code = status_code
+        self.calls = []
+
+    def post(self, url, *, json, timeout):
+        self.calls.append({"url": url, "json": json, "timeout": timeout})
+        return _HttpResponse(self.body, self.status_code)
+
+
+def _captured_response():
+    wrapped = json.loads(FUNNEL_FIXTURE.read_text())
+    response = wrapped["response"]
+    return {
+        "kind": response["kind"],
+        "funnelTable": response["funnel_table"],
+        "funnelVisualization": response["funnel_visualization"],
+    }
+
+
+def _install_funnel_boundaries(monkeypatch, body=None, *, status_code=200,
+                               timezone_name="America/Denver"):
+    client = _TimezoneClient(timezone_name)
+    session = _FunnelSession(body or _captured_response(), status_code)
+    writes = []
+    monkeypatch.setattr(ga4, "_get_client", lambda: client)
+    monkeypatch.setattr(ga4, "_get_funnel_session", lambda: session)
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: None)
+    monkeypatch.setattr(ga4, "_set_cached", lambda key, data: writes.append((key, data)))
+    monkeypatch.setattr(
+        ga4, "_utc_now",
+        lambda: datetime(2026, 9, 9, 5, 30, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(ga4, "GA4_PROPERTY_ID", "properties/123456")
+    return client, session, writes
+
+
+def test_native_funnel_parses_captured_repeated_headers_and_preserves_absence(
+        monkeypatch):
+    client, session, writes = _install_funnel_boundaries(monkeypatch)
+
+    report = ga4.get_ordered_funnel_report(days=30)
+
+    assert report["available"] is True
+    assert report["period"] == {
+        "start_date": "2026-08-09",
+        "end_date": "2026-09-07",
+        "timezone": "America/Denver",
+        "complete_days": 30,
+    }
+    assert [step["users"] for step in report["steps"]] == [4601, 186, 10, 2, None, None]
+    assert [step["present"] for step in report["steps"]] == [True] * 4 + [False] * 2
+    assert report["steps"][3]["completion_rate"] == 0.0
+    assert report["steps"][4]["completion_rate"] is None
+    assert report["fetched_at"] == "2026-09-09T05:30:00+00:00"
+    assert report["provenance"]["cache_hit"] is False
+    assert report["provenance"]["method"] == "v1alpha properties.runFunnelReport"
+    assert len(client.requests) == 1
+    assert client.requests[0].property == "properties/123456"
+    assert client.requests[0].date_ranges[0].start_date == "yesterday"
+    assert client.requests[0].date_ranges[0].end_date == "yesterday"
+    assert session.calls[0]["url"].endswith("/v1alpha/properties/123456:runFunnelReport")
+    payload = session.calls[0]["json"]
+    assert payload["dateRanges"] == [{"startDate": "2026-08-09", "endDate": "2026-09-07"}]
+    assert payload["funnel"]["isOpenFunnel"] is False
+    assert [step["name"] for step in payload["funnel"]["steps"]] == [
+        "Race page view", "Race CTA", "Plan form start", "Plan form submit",
+        "Training-plan checkout", "Training-plan purchase",
+    ]
+    assert "unifiedPagePathScreen" in json.dumps(payload)
+    assert '"itemCategory"' in json.dumps(payload)
+    assert '"training_plan"' in json.dumps(payload)
+    event_names = {
+        value
+        for value in (
+            "page_view", "cta_click", "form_start", "tp_form_start",
+            "form_submit", "tp_form_submit", "begin_checkout", "purchase",
+        )
+        if f'"eventName": "{value}"' in json.dumps(payload)
+    }
+    assert event_names == {
+        "page_view", "cta_click", "form_start", "tp_form_start",
+        "form_submit", "tp_form_submit", "begin_checkout", "purchase",
+    }
+    funnel_writes = [item for item in writes if item[0].startswith("native_ordered_funnel_")]
+    assert len(funnel_writes) == 1
+
+
+def test_native_funnel_preserves_provider_zero_as_present(monkeypatch):
+    body = _captured_response()
+    table_row = {
+        "dimensionValues": [{"value": "5. Training-plan checkout"}],
+        "metricValues": [
+            {"value": "0"}, {"value": "0"}, {"value": "0"}, {"value": "0"},
+        ],
+    }
+    visual_row = {
+        "dimensionValues": [{"value": "5. Training-plan checkout"}],
+        "metricValues": [{"value": "0"}],
+    }
+    body["funnelTable"]["rows"].append(table_row)
+    body["funnelVisualization"]["rows"].append(visual_row)
+    _install_funnel_boundaries(monkeypatch, body)
+
+    report = ga4.get_ordered_funnel_report()
+
+    assert report["steps"][4]["present"] is True
+    assert report["steps"][4]["users"] == 0
+    assert report["steps"][5]["present"] is False
+    assert report["steps"][5]["users"] is None
+
+
+def test_native_funnel_rejects_unknown_shape_without_caching(monkeypatch):
+    body = _captured_response()
+    body["funnelTable"]["metricHeaders"][0]["name"] = "sessions"
+    _client, _session, writes = _install_funnel_boundaries(monkeypatch, body)
+
+    report = ga4.get_ordered_funnel_report()
+
+    assert report["available"] is False
+    assert report["error_code"] == "UNKNOWN_RESPONSE_SHAPE"
+    assert not any(key.startswith("native_ordered_funnel_") for key, _data in writes)
+
+
+def test_native_funnel_distinguishes_api_failure_from_successful_empty(monkeypatch):
+    error = {"error": {"status": "PERMISSION_DENIED", "message": "denied"}}
+    _client, _session, writes = _install_funnel_boundaries(
+        monkeypatch, error, status_code=403)
+
+    failed = ga4.get_ordered_funnel_report()
+
+    assert failed["available"] is False
+    assert failed["error_code"] == "PERMISSION_DENIED"
+    assert not any(key.startswith("native_ordered_funnel_") for key, _data in writes)
+
+    empty = _captured_response()
+    empty["funnelTable"]["rows"] = []
+    empty["funnelVisualization"]["rows"] = []
+    _client, _session, writes = _install_funnel_boundaries(monkeypatch, empty)
+    valid_empty = ga4.get_ordered_funnel_report()
+
+    assert valid_empty["available"] is True
+    assert all(step["present"] is False and step["users"] is None
+               for step in valid_empty["steps"])
+    assert len([key for key, _data in writes
+                if key.startswith("native_ordered_funnel_")]) == 1
+
+
+def test_native_funnel_retains_sampling_and_threshold_metadata(monkeypatch):
+    body = _captured_response()
+    body["funnelTable"]["metadata"] = {
+        "samplingMetadatas": [{"samplesReadCount": "50", "samplingSpaceSize": "100"}],
+        "subjectToThresholding": True,
+    }
+    _install_funnel_boundaries(monkeypatch, body)
+
+    report = ga4.get_ordered_funnel_report()
+
+    assert report["metadata"]["funnel_table"] == body["funnelTable"]["metadata"]
+
+
+def test_native_funnel_cache_is_versioned_and_window_specific(monkeypatch):
+    seen = []
+    client = _TimezoneClient()
+    monkeypatch.setattr(ga4, "_get_client", lambda: client)
+    monkeypatch.setattr(
+        ga4, "_get_property_reporting_timezone",
+        lambda _client, _property: "America/Denver",
+    )
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: seen.append(key) or None)
+    monkeypatch.setattr(ga4, "_get_funnel_session", lambda: None)
+    monkeypatch.setattr(ga4, "GA4_PROPERTY_ID", "properties/123456")
+
+    monkeypatch.setattr(
+        ga4, "_utc_now",
+        lambda: datetime(2026, 9, 9, 5, 30, tzinfo=timezone.utc),
+    )
+    ga4.get_ordered_funnel_report(days=30)
+    monkeypatch.setattr(
+        ga4, "_utc_now",
+        lambda: datetime(2026, 9, 9, 6, 30, tzinfo=timezone.utc),
+    )
+    ga4.get_ordered_funnel_report(days=30)
+
+    assert len(seen) == 2
+    assert seen[0] != seen[1]
+    assert "2026-09-07" in seen[0]
+    assert "2026-09-08" in seen[1]
+
+
+def test_native_funnel_valid_cache_reports_hit_and_skips_transport(monkeypatch):
+    cached = {
+        "schema": "ga4_native_ordered_funnel/v1",
+        "available": True,
+        "fetched_at": "2026-09-09T05:30:00+00:00",
+        "period": {
+            "start_date": "2026-08-09", "end_date": "2026-09-07",
+            "timezone": "America/Denver", "complete_days": 30,
+        },
+        "steps": [
+            {
+                **definition,
+                "position": index,
+                "present": False,
+                "users": None,
+                "completion_rate": None,
+                "abandonments": None,
+                "abandonment_rate": None,
+            }
+            for index, definition in enumerate(ga4.NATIVE_FUNNEL_STEPS, start=1)
+        ],
+        "metadata": {"funnel_table": {}, "funnel_visualization": {}},
+        "request_contract": {
+            "closed": True,
+            "ordered": True,
+            "directly_followed": False,
+            "steps": copy.deepcopy(list(ga4.NATIVE_FUNNEL_STEPS)),
+        },
+        "provenance": {
+            "cache_hit": False,
+            "request_version": "v1",
+            "property_ref": "1f5aeb67e1f0",
+            "response_kind": "analyticsData#runFunnelReport",
+        },
+    }
+    monkeypatch.setattr(ga4, "_get_client", lambda: _TimezoneClient())
+    monkeypatch.setattr(
+        ga4, "_get_property_reporting_timezone",
+        lambda _client, _property: "America/Denver",
+    )
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: cached)
+    monkeypatch.setattr(
+        ga4, "_get_funnel_session",
+        lambda: (_ for _ in ()).throw(AssertionError("cache hit used transport")),
+    )
+    monkeypatch.setattr(
+        ga4, "_utc_now",
+        lambda: datetime(2026, 9, 9, 5, 30, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(ga4, "GA4_PROPERTY_ID", "properties/123456")
+
+    report = ga4.get_ordered_funnel_report()
+
+    assert report["provenance"]["cache_hit"] is True
+    assert cached["provenance"]["cache_hit"] is False
+
+
+@pytest.mark.parametrize("cached", [
+    {"schema": "ga4_native_ordered_funnel/v1", "available": False},
+    {
+        "schema": "ga4_native_ordered_funnel/v1",
+        "available": True,
+        "period": {
+            "start_date": "2026-08-08", "end_date": "2026-09-06",
+            "timezone": "America/Denver", "complete_days": 30,
+        },
+        "steps": [],
+        "provenance": {
+            "request_version": "v1", "property_ref": "1f5aeb67e1f0",
+        },
+    },
+])
+def test_native_funnel_failed_or_different_window_cache_cannot_masquerade(
+        monkeypatch, cached):
+    session = _FunnelSession(_captured_response())
+    monkeypatch.setattr(ga4, "GA4_PROPERTY_ID", "properties/123456")
+    monkeypatch.setattr(ga4, "_get_client", lambda: _TimezoneClient())
+    monkeypatch.setattr(
+        ga4, "_get_property_reporting_timezone",
+        lambda _client, _property: "America/Denver",
+    )
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: cached)
+    monkeypatch.setattr(ga4, "_set_cached", lambda key, data: None)
+    monkeypatch.setattr(ga4, "_get_funnel_session", lambda: session)
+    monkeypatch.setattr(
+        ga4, "_utc_now",
+        lambda: datetime(2026, 9, 9, 5, 30, tzinfo=timezone.utc),
+    )
+
+    report = ga4.get_ordered_funnel_report()
+
+    assert report["available"] is True
+    assert report["period"]["end_date"] == "2026-09-07"
+    assert report["provenance"]["cache_hit"] is False
+    assert len(session.calls) == 1
+
+
+def test_native_funnel_fails_unavailable_when_property_timezone_is_missing(
+        monkeypatch):
+    monkeypatch.setattr(ga4, "GA4_PROPERTY_ID", "properties/123456")
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: None)
+    monkeypatch.setattr(ga4, "_get_client", lambda: _TimezoneClient(""))
+    monkeypatch.setattr(
+        ga4, "_get_funnel_session",
+        lambda: (_ for _ in ()).throw(AssertionError("timezone must fail first")),
+    )
+
+    report = ga4.get_ordered_funnel_report()
+
+    assert report["available"] is False
+    assert report["error_code"] == "TIMEZONE_UNAVAILABLE"

--- a/tests/test_ga4_service_events.py
+++ b/tests/test_ga4_service_events.py
@@ -315,6 +315,28 @@ def test_native_funnel_preserves_provider_zero_as_present(monkeypatch):
     assert report["steps"][5]["users"] is None
 
 
+@pytest.mark.parametrize(("metric_index", "bad_value"), [
+    (0, True),
+    (0, 1.9),
+    (0, float("inf")),
+    (0, "1.9"),
+    (1, True),
+])
+def test_native_funnel_rejects_non_schema_provider_metrics_without_caching(
+        monkeypatch, metric_index, bad_value):
+    body = _captured_response()
+    body["funnelTable"]["rows"][0]["metricValues"][metric_index]["value"] = bad_value
+    if metric_index == 0:
+        body["funnelVisualization"]["rows"][0]["metricValues"][0]["value"] = bad_value
+    _client, _session, writes = _install_funnel_boundaries(monkeypatch, body)
+
+    report = ga4.get_ordered_funnel_report()
+
+    assert report["available"] is False
+    assert report["error_code"] == "UNKNOWN_RESPONSE_SHAPE"
+    assert not any(key.startswith("native_ordered_funnel_") for key, _data in writes)
+
+
 def test_native_funnel_rejects_unknown_shape_without_caching(monkeypatch):
     body = _captured_response()
     body["funnelTable"]["metricHeaders"][0]["name"] = "sessions"
@@ -364,6 +386,25 @@ def test_native_funnel_retains_sampling_and_threshold_metadata(monkeypatch):
     assert report["metadata"]["funnel_table"] == body["funnelTable"]["metadata"]
 
 
+@pytest.mark.parametrize("bad_metadata", [
+    {"samplingMetadatas": 7},
+    {"samplingMetadatas": [{"samplesReadCount": 50,
+                             "samplingSpaceSize": "100"}]},
+    {"subjectToThresholding": "true"},
+])
+def test_native_funnel_rejects_malformed_provider_metadata_without_caching(
+        monkeypatch, bad_metadata):
+    body = _captured_response()
+    body["funnelTable"]["metadata"] = bad_metadata
+    _client, _session, writes = _install_funnel_boundaries(monkeypatch, body)
+
+    report = ga4.get_ordered_funnel_report()
+
+    assert report["available"] is False
+    assert report["error_code"] == "UNKNOWN_RESPONSE_SHAPE"
+    assert not any(key.startswith("native_ordered_funnel_") for key, _data in writes)
+
+
 def test_native_funnel_cache_is_versioned_and_window_specific(monkeypatch):
     seen = []
     client = _TimezoneClient()
@@ -393,8 +434,8 @@ def test_native_funnel_cache_is_versioned_and_window_specific(monkeypatch):
     assert "2026-09-08" in seen[1]
 
 
-def test_native_funnel_valid_cache_reports_hit_and_skips_transport(monkeypatch):
-    cached = {
+def _valid_cached_funnel():
+    return {
         "schema": "ga4_native_ordered_funnel/v1",
         "available": True,
         "fetched_at": "2026-09-09T05:30:00+00:00",
@@ -428,6 +469,10 @@ def test_native_funnel_valid_cache_reports_hit_and_skips_transport(monkeypatch):
             "response_kind": "analyticsData#runFunnelReport",
         },
     }
+
+
+def test_native_funnel_valid_cache_reports_hit_and_skips_transport(monkeypatch):
+    cached = _valid_cached_funnel()
     monkeypatch.setattr(ga4, "_get_client", lambda: _TimezoneClient())
     monkeypatch.setattr(
         ga4, "_get_property_reporting_timezone",
@@ -448,6 +493,72 @@ def test_native_funnel_valid_cache_reports_hit_and_skips_transport(monkeypatch):
 
     assert report["provenance"]["cache_hit"] is True
     assert cached["provenance"]["cache_hit"] is False
+
+
+@pytest.mark.parametrize(("field", "bad_value"), [
+    ("users", True),
+    ("abandonments", True),
+    ("completion_rate", True),
+    ("abandonment_rate", True),
+])
+def test_native_funnel_rejects_cached_boolean_metrics_and_refetches(
+        monkeypatch, field, bad_value):
+    cached = _valid_cached_funnel()
+    cached["steps"][0].update({
+        "present": True,
+        "users": 1,
+        "completion_rate": 0.5,
+        "abandonments": 1,
+        "abandonment_rate": 0.5,
+    })
+    cached["steps"][0][field] = bad_value
+    session = _FunnelSession(_captured_response())
+    monkeypatch.setattr(ga4, "GA4_PROPERTY_ID", "properties/123456")
+    monkeypatch.setattr(ga4, "_get_client", lambda: _TimezoneClient())
+    monkeypatch.setattr(
+        ga4, "_get_property_reporting_timezone",
+        lambda _client, _property: "America/Denver",
+    )
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: cached)
+    monkeypatch.setattr(ga4, "_set_cached", lambda key, data: None)
+    monkeypatch.setattr(ga4, "_get_funnel_session", lambda: session)
+    monkeypatch.setattr(
+        ga4, "_utc_now",
+        lambda: datetime(2026, 9, 9, 5, 30, tzinfo=timezone.utc),
+    )
+
+    report = ga4.get_ordered_funnel_report()
+
+    assert report["available"] is True
+    assert report["provenance"]["cache_hit"] is False
+    assert report["steps"][0]["users"] == 4601
+    assert len(session.calls) == 1
+
+
+def test_native_funnel_rejects_cached_malformed_metadata_and_refetches(monkeypatch):
+    cached = _valid_cached_funnel()
+    cached["metadata"]["funnel_table"] = {"samplingMetadatas": 7}
+    session = _FunnelSession(_captured_response())
+    monkeypatch.setattr(ga4, "GA4_PROPERTY_ID", "properties/123456")
+    monkeypatch.setattr(ga4, "_get_client", lambda: _TimezoneClient())
+    monkeypatch.setattr(
+        ga4, "_get_property_reporting_timezone",
+        lambda _client, _property: "America/Denver",
+    )
+    monkeypatch.setattr(ga4, "_get_cached", lambda key: cached)
+    monkeypatch.setattr(ga4, "_set_cached", lambda key, data: None)
+    monkeypatch.setattr(ga4, "_get_funnel_session", lambda: session)
+    monkeypatch.setattr(
+        ga4, "_utc_now",
+        lambda: datetime(2026, 9, 9, 5, 30, tzinfo=timezone.utc),
+    )
+
+    report = ga4.get_ordered_funnel_report()
+
+    assert report["available"] is True
+    assert report["provenance"]["cache_hit"] is False
+    assert report["metadata"]["funnel_table"] == {}
+    assert len(session.calls) == 1
 
 
 @pytest.mark.parametrize("cached", [


### PR DESCRIPTION
Mission Control currently shows independent event totals, which cannot establish whether the same users progressed through the plan buying path. Add GA4's native closed, ordered six-step user funnel over complete property-timezone days, separately from those totals.

The existing event filters and aliases are preserved. Missing commerce rows stay absent, explicit zero stays zero, and unsupported responses render unavailable without being cached. The page identifies broad race-page CTA coverage and keeps GA4 purchase events separate from provider payment and delivery evidence.

Validation: independent Fable re-review approved head `2949dc40`; root and reviewer each reproduced 37 focused service/route tests. The exact request matches the preserved provider probe. Regression fixtures cover malformed numeric values, nested sampling metadata, invalid cache entries, and unavailable rendering. The corrected 390px preview fits all three table columns. The earlier full suite passed 7,516 tests with 331 skipped; the later bounded corrections were verified by the focused suite.

Dependency: this draft is based on PR #320 at `00017586`. Merge #320 first, then retarget this PR to main and revalidate integration. Do not merge this branch into #320 or treat #320 approval as approval for this feature.

Release limits: production service-account permission for GA4's v1alpha method remains unverified; failure displays unavailable. This change does not establish a cash/fulfillment join. Source merge/deployment requires a separate approval; no production settings, events, or caches were changed during implementation.
