### PR TITLE
Align custom-plan offer with accepted delivery and support terms

### DIFF
--- a/tests/test_training_plans.py
+++ b/tests/test_training_plans.py
@@ -142,10 +142,18 @@ class TestHero:
 
     def test_four_stats(self):
         hero = build_hero()
-        assert "Same Day" in hero
+        assert "24 Hours" in hero
+        assert "Plan or Delivery Update" in hero
         assert "Matched" in hero
         assert "$2/day" in hero
         assert "5 min" in hero
+
+    def test_delivery_clock_and_blocker_are_visible(self):
+        hero = build_hero()
+        assert "payment, your complete questionnaire, and your TrainingPeaks connection" in hero
+        assert "specific blocker" in hero
+        assert "revised delivery time" in hero
+        assert "Same Day" not in hero
 
     def test_no_coffee_cliche(self):
         hero = build_hero()
@@ -354,6 +362,27 @@ class TestPricing:
         assert "6-week plan = $90" in section
         assert "12-week plan = $180" in section
         assert "16-week plan = $240" in section
+
+    def test_support_and_adjustment_boundary(self):
+        section = build_pricing()
+        assert "Email support and two plan adjustments" in section
+        assert "schedule, available training hours, or equipment" in section
+        assert "does not use an adjustment" in section
+        assert "first rescale after the scheduled FTP test" in section
+        assert "Weekly review and recurring changes are part of Coaching" in section
+
+
+class TestQuestionnaireReferenceContract:
+    def test_reference_matches_accepted_delivery_and_support_terms(self):
+        reference = (Path(__file__).parent.parent / "web" / "training-plans-questionnaire.html").read_text()
+        assert "Personally reviewed. Your plan or a delivery update within 24 hours." in reference
+        assert "payment, your complete questionnaire, and your TrainingPeaks connection" in reference
+        assert "specific blocker" in reference
+        assert "revised delivery time" in reference
+        assert "Email support and two plan adjustments" in reference
+        assert "first rescale after the scheduled FTP test" in reference
+        assert "Same-Day Delivery" not in reference
+        assert "same-day delivery" not in reference.lower()
 
 
 # ── 10. FAQ ──────────────────────────────────────────────────

--- a/web/training-plans-questionnaire.html
+++ b/web/training-plans-questionnaire.html
@@ -508,6 +508,17 @@
   padding: 0.4rem 0.75rem;
 }
 
+.gg-trust-terms {
+  margin: 1rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: inherit;
+}
+
+.gg-trust-terms + .gg-trust-terms {
+  margin-top: 0.65rem;
+}
+
 @media (max-width: 700px) {
   .gg-trust-quotes {
     flex-direction: column;
@@ -544,14 +555,15 @@
   <div class="tp-questionnaire-hero">
     <h1>Build Your Plan</h1>
     <p>Five minutes. Be thorough. The plan is only as good as the data.
-    Same-day delivery to your TrainingPeaks calendar.</p>
+    Personally reviewed. Your plan or a delivery update within 24 hours.</p>
+    <p>The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. If something prevents delivery, I will explain the specific blocker, what is needed, and give you a revised delivery time.</p>
   </div>
 
   <div class="gg-form-container">
     <div class="gg-form-header">
       <span class="gg-form-badge">Custom Training Plan</span>
       <h2>Build Your Plan</h2>
-      <p>Fill out this form, pay securely via Stripe, and your plan will be delivered to your TrainingPeaks calendar same day.</p>
+      <p>Fill out this form and pay securely via Stripe. The 24-hour clock starts once payment, your complete questionnaire, and your TrainingPeaks connection are all in place.</p>
     </div>
 
     <form id="gg-training-form">
@@ -957,8 +969,10 @@
         <div class="gg-trust-badges">
           <span class="gg-trust-badge">7-Day Full Refund</span>
           <span class="gg-trust-badge">Secure Checkout via Stripe</span>
-          <span class="gg-trust-badge">Same-Day Delivery</span>
+          <span class="gg-trust-badge">Plan or Delivery Update in 24 Hours</span>
         </div>
+        <p class="gg-trust-terms">The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I will deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time.</p>
+        <p class="gg-trust-terms">Email support and two plan adjustments are included during the dates covered by your plan for changes to your schedule, available training hours, or equipment. Correcting a plan that does not match your order does not use an adjustment. The first rescale after the scheduled FTP test is included separately. Weekly review and recurring changes are part of Coaching.</p>
       </div>
 
       <button type="submit" class="gg-submit-btn">Submit &amp; Pay</button>

--- a/web/training-plans.html
+++ b/web/training-plans.html
@@ -206,6 +206,12 @@
   color: #59473C;
   font-weight: 600;
 }
+.tp-delivery-terms {
+  font-family: Georgia, serif;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin: 0.75rem 0 0;
+}
 
 /* ================================================================
    WHAT YOU GET — The 5 deliverables
@@ -639,6 +645,13 @@
   font-weight: 700;
   color: #59473C;
 }
+.tp-support-terms {
+  font-family: Georgia, serif;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0.75rem 1.5rem;
+}
 
 .tp-pricing-cta {
   padding: 1rem 1.5rem 1.25rem;
@@ -1008,8 +1021,8 @@
     </div>
     <div class="tp-hero-bar">
       <div class="tp-hero-bar-item">
-        <strong>Same Day</strong>
-        <span>Delivery</span>
+        <strong>24 Hours</strong>
+        <span>Plan or Delivery Update</span>
       </div>
       <div class="tp-hero-bar-item">
         <strong>Matched</strong>
@@ -1024,6 +1037,7 @@
         <span>To Start</span>
       </div>
     </div>
+    <p class="tp-delivery-terms">The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I will deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time.</p>
   </div>
 
   <!-- ============================================================
@@ -1133,7 +1147,7 @@
        ============================================================ -->
   <div class="tp-section tp-section-cream" id="how-it-works">
     <div class="tp-section-label">How It Works</div>
-    <h2>Four Steps. You Start Training Today.</h2>
+    <h2>Four Steps. Then You Train.</h2>
     <div class="tp-process">
       <div class="tp-process-step">
         <div class="tp-process-num">01</div>
@@ -1156,7 +1170,7 @@
       <div class="tp-process-step">
         <div class="tp-process-num">04</div>
         <h4>You Train</h4>
-        <p>Same day delivery</p>
+        <p>Plan or update within 24 hours</p>
       </div>
     </div>
     <div class="tp-steps">
@@ -1191,9 +1205,10 @@
         <div class="tp-step-num">04</div>
         <div>
           <h3>Plan Drops Into Your Calendar</h3>
-          <p>I push the plan directly into your TrainingPeaks calendar. Every
-          workout. Every phase. Open your app &mdash; it's there. Syncs to Zwift,
-          Wahoo, Garmin. You start training. Delivered same day.</p>
+          <p>The 24-hour clock starts when payment, your complete questionnaire,
+          and your TrainingPeaks connection are all in place. Within that window,
+          I deliver your personally reviewed plan in TrainingPeaks or email you
+          with the specific blocker, what is needed, and a revised delivery time.</p>
         </div>
       </div>
     </div>
@@ -1279,8 +1294,9 @@
           <li>Race-optimized fueling plan</li>
           <li>Custom strength program</li>
           <li>Heat &amp; altitude protocols</li>
-          <li>Same-day delivery</li>
+          <li>Your plan or a delivery update within 24 hours</li>
         </ul>
+        <p class="tp-support-terms">The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I will deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time. Email support and two plan adjustments are included during the dates covered by your plan for changes to your schedule, available training hours, or equipment. Correcting a plan that does not match your order does not use an adjustment. The first rescale after the scheduled FTP test is included separately. Weekly review and recurring changes are part of Coaching.</p>
         <div class="tp-pricing-cta">
           <a href="https://gravelgodcycling.com/training-plans/questionnaire/" class="tp-btn">Build My Plan</a>
         </div>
@@ -1317,8 +1333,10 @@
           <span class="tp-faq-toggle">+</span>
         </div>
         <div class="tp-faq-a">
-          <p>Mark it unknown. Week 1 includes an FTP test protocol.
-          Once you have the number, every zone recalibrates.</p>
+          <p>Mark it unknown. Week 1 includes an FTP test protocol. Reply with the
+          result and I&rsquo;ll rescale the remaining workouts. The first rescale after
+          the scheduled FTP test is included separately and does not use one of
+          your two adjustments.</p>
         </div>
       </div>
 
@@ -1352,8 +1370,9 @@
           <span class="tp-faq-toggle">+</span>
         </div>
         <div class="tp-faq-a">
-          <p>No. This is a plan, not a relationship. You get the full plan up front
-          and execute it yourself. No weekly check-ins.</p>
+          <p>This is a plan to execute yourself. Email support and two plan
+          adjustments are included during the dates covered by your plan. Weekly
+          review and recurring changes are part of Coaching.</p>
         </div>
       </div>
 

--- a/wordpress/generate_training_plans.py
+++ b/wordpress/generate_training_plans.py
@@ -66,11 +66,12 @@ def build_hero() -> str:
     <a href="#how-it-works" class="gg-tp-btn gg-tp-btn-secondary" data-cta="hero_how">See How It Works</a>
   </div>
   <div class="gg-tp-hero-bar">
-    <div class="gg-tp-hero-bar-item"><strong>Same Day</strong><span>Delivery</span></div>
+    <div class="gg-tp-hero-bar-item"><strong>24 Hours</strong><span>Plan or Delivery Update</span></div>
     <div class="gg-tp-hero-bar-item"><strong>Matched</strong><span>Methodology</span></div>
     <div class="gg-tp-hero-bar-item"><strong>$2/day</strong><span>Less Than a Tube</span></div>
     <div class="gg-tp-hero-bar-item"><strong>5 min</strong><span>To Start</span></div>
   </div>
+  <p class="gg-tp-delivery-terms">The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I will deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time.</p>
 </section>'''
 
 
@@ -246,7 +247,7 @@ def build_how_it_works() -> str:
         ("01", "Questionnaire", "5 min form"),
         ("02", "TrainingPeaks", "Connect account"),
         ("03", "Plan Built", "Matched to you"),
-        ("04", "You Train", "Same day delivery"),
+        ("04", "You Train", "Plan or update within 24 hours"),
     ]
     cards_html = ""
     for num, title, desc in process_cards:
@@ -264,7 +265,7 @@ def build_how_it_works() -> str:
         ("03", "I Build Your Plan",
          "Your intake hits the methodology engine. The training approach gets selected based on your profile. Polarized for the time-crunched. Pyramidal for the balanced. Block for the serious. Matched to your availability and ability."),
         ("04", "Plan Drops Into Your Calendar",
-         "I push the plan directly into your TrainingPeaks calendar. Every workout. Every phase. Open your app &mdash; it&rsquo;s there. Syncs to Zwift, Wahoo, Garmin. You start training. Delivered same day."),
+         "The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time."),
     ]
     steps_html = ""
     for num, title, desc in steps:
@@ -278,7 +279,7 @@ def build_how_it_works() -> str:
 '''
     return f'''<section class="gg-tp-section gg-tp-section-alt" id="how-it-works">
   <div class="gg-tp-section-label">How It Works</div>
-  <h2>Four Steps. You Start Training Today.</h2>
+  <h2>Four Steps. Then You Train.</h2>
   <div class="gg-tp-process">
     {cards_html}
   </div>
@@ -382,8 +383,9 @@ def build_pricing() -> str:
         <li>Race-optimized fueling plan</li>
         <li>Custom strength program</li>
         <li>Heat &amp; altitude protocols</li>
-        <li>Same-day delivery</li>
+        <li>Your plan or a delivery update within 24 hours</li>
       </ul>
+      <p class="gg-tp-support-terms">The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I will deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time. Email support and two plan adjustments are included during the dates covered by your plan for changes to your schedule, available training hours, or equipment. Correcting a plan that does not match your order does not use an adjustment. The first rescale after the scheduled FTP test is included separately. Weekly review and recurring changes are part of Coaching.</p>
       <div class="gg-tp-pricing-cta">
         <a href="{QUESTIONNAIRE_URL}" class="gg-tp-btn" data-cta="pricing_build">Build My Plan</a>
       </div>
@@ -403,7 +405,7 @@ FAQ_ITEMS = [
     ),
     (
         "What if I don&rsquo;t know my FTP?",
-        "Mark it unknown. Week 1 includes an FTP test protocol. Once you have the number, every zone recalibrates.",
+        "Mark it unknown. Week 1 includes an FTP test protocol. Reply with the result and I&rsquo;ll rescale the remaining workouts. The first rescale after the scheduled FTP test is included separately and does not use one of your two adjustments.",
     ),
     (
         "How are workouts delivered?",
@@ -415,7 +417,7 @@ FAQ_ITEMS = [
     ),
     (
         "Is this coaching?",
-        "No. This is a plan, not a relationship. You get the full plan up front and execute it yourself. No weekly check-ins.",
+        "This is a plan to execute yourself. Email support and two plan adjustments are included during the dates covered by your plan. Weekly review and recurring changes are part of Coaching.",
     ),
     (
         "What if my race isn&rsquo;t in the database?",
@@ -609,6 +611,14 @@ def build_training_css() -> str:
   letter-spacing: var(--gg-letter-spacing-wider);
   color: var(--gg-color-primary-brown);
   font-weight: var(--gg-font-weight-semibold);
+}}
+.gg-tp-delivery-terms {{
+  font-family: var(--gg-font-editorial);
+  font-size: var(--gg-font-size-sm);
+  line-height: var(--gg-line-height-prose);
+  color: var(--gg-color-primary-brown);
+  margin: var(--gg-spacing-sm) 0 0;
+  max-width: 700px;
 }}
 
 /* ── What You Get — Deliverables ── */
@@ -1036,6 +1046,15 @@ def build_training_css() -> str:
   font-family: var(--gg-font-data);
   font-weight: var(--gg-font-weight-bold);
   color: var(--gg-color-primary-brown);
+}}
+.gg-tp-support-terms {{
+  font-family: var(--gg-font-editorial);
+  font-size: var(--gg-font-size-sm);
+  line-height: var(--gg-line-height-prose);
+  color: var(--gg-color-primary-brown);
+  padding: var(--gg-spacing-sm) var(--gg-spacing-lg);
+  margin: 0;
+  border-top: 1px solid var(--gg-color-tan);
 }}
 .gg-tp-pricing-cta {{
   padding: var(--gg-spacing-md) var(--gg-spacing-lg);

--- a/wordpress/generate_training_plans.py
+++ b/wordpress/generate_training_plans.py
@@ -316,6 +316,7 @@ def build_honest_check() -> str:
     return f'''<section class="gg-tp-section gg-tp-section-alt" id="honest-check">
   <div class="gg-tp-section-label">Honest Check</div>
   <h2>This Isn&rsquo;t For Everyone. Good.</h2>
+  <ul class="gg-tp-audience-list gg-tp-for-list"><li>Start with a published TrainingPeaks plan when the listed race, duration, and workload fit. Choose a custom plan when your race, schedule, or constraints need the calendar built around you. Choose coaching when you want ongoing review and adjustments.</li></ul>
   <div class="gg-tp-audience-grid">
     <div class="gg-tp-audience-col">
       <h3>Buy This If:</h3>


### PR DESCRIPTION
The product page and questionnaire reference currently promise unconditional same-day delivery. State the owner-accepted contract: personally reviewed delivery or a specific blocker notice with revised time within 24 hours after payment, the complete questionnaire and TrainingPeaks connection. Include email support and two adjustments, with corrections and the first scheduled FTP rescale outside that allowance. Preserve price, refund, existing fields and the prepared standard/custom/coaching comparison.

The generator, product reference and questionnaire reference are aligned. The live questionnaire is Elementor page 5017, widget 3f59420; this PR does not publish that widget or WordPress pages.

Validation: 113 product tests, compilation and diff checks passed. Independent Fable review approved exact head 407e9bc2dc70e1fe18692e34f9955b7c04726cbb. Mobile and desktop viewport previews inspected; strict writing gate passed. Voice grounding: writing-graph/self/voice-and-beliefs-profile.md and inbox/gravel-god/is-coaching-worth-it.md, plus owner-approved wording; pinned no-ai-slop workflow/eval applied. The raw piece supports the distinction between a plan and ongoing feedback; no anecdotes or quotes were imported.

Merge/publication remain unapproved. Coordinate release with the separate pipeline copy PR; pre-existing testimonials and other deliverable claims are outside this correction and are not certified by it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes customer-facing delivery and support commitments across product and questionnaire copy; incorrect or inconsistent wording could create expectation or support disputes even though checkout logic is unchanged.
> 
> **Overview**
> Replaces **same-day delivery** messaging with the accepted **24-hour** offer: a personally reviewed plan in TrainingPeaks or a **delivery update** (specific blocker, what’s needed, revised time) once **payment, a complete questionnaire, and TrainingPeaks connection** are all in place.
> 
> That language is added on the **hero**, **how-it-works**, **pricing**, **questionnaire** (hero, form intro, trust badges, and new `.gg-trust-terms` blocks), and mirrored in **`generate_training_plans.py`** plus **`web/training-plans.html`**, with styling for delivery/support term paragraphs.
> 
> **Support boundaries** are spelled out: included **email support and two plan adjustments** (schedule, hours, equipment); **order corrections** and the **first post–FTP-test rescale** are called out separately from adjustments; **coaching** is distinguished for weekly review and recurring changes. FAQ answers for unknown FTP and “Is this coaching?” match.
> 
> **Tests** assert the new hero stats, pricing/support copy, and that `training-plans-questionnaire.html` contains the contract strings and no same-day wording. The generator’s Honest Check section adds a **standard vs custom vs coaching** comparison line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407e9bc2dc70e1fe18692e34f9955b7c04726cbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->