### PR TITLE
Fix questionnaire race layout and clarify training-plan copy

### DIFF
--- a/tests/test_training_plans.py
+++ b/tests/test_training_plans.py
@@ -17,6 +17,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "wordpress"))
 
 from generate_training_plans import (
+    COACHING_URL,
     DELIVERABLES,
     FAQ_ITEMS,
     PRICE_CAP,
@@ -155,6 +156,11 @@ class TestHero:
         assert "revised delivery time" in hero
         assert "Same Day" not in hero
 
+    def test_hours_claim_is_specific_without_overstating_the_science(self):
+        hero = build_hero()
+        assert "a plan that fits five hours" in hero
+        assert "fundamentally different training" not in hero
+
     def test_no_coffee_cliche(self):
         hero = build_hero()
         hero_lower = hero.lower()
@@ -273,30 +279,36 @@ class TestRotatingQuote:
         # First quote should be present (HTML-escaped)
         assert "12-week plan" in section
 
+    def test_hours_and_altitude_checks_do_not_make_universal_claims(self):
+        combined = " ".join(REALITY_CHECKS)
+        assert "fundamentally different training" not in combined
+        assert "different science" not in combined
+        assert "different sport" not in combined
+        assert "altitude changes how you pace and prepare" in combined
+
 
 # ── 7. Honest Check ─────────────────────────────────────────
 
 
 class TestHonestCheck:
-    def test_buy_if_column(self):
+    def test_direct_coaching_headline_and_cta(self):
         section = build_honest_check()
-        assert "Buy This If:" in section
+        assert "Are You Actually Serious About Getting Fast?" in section
+        assert 'data-cta="honest_coaching"' in section
+        assert f'href="{COACHING_URL}"' in section
+        assert "Get Coaching" in section
 
-    def test_dont_buy_if_column(self):
+    def test_plan_value_and_coaching_boundary(self):
         section = build_honest_check()
-        assert "Buy This If:" in section
+        assert "A training plan gives you the structure" in section
+        assert "weekly review, direct feedback, and recurring adjustments" in section
+        assert "ChatGPT subscription" in section
 
-    def test_five_buy_items(self):
+    def test_old_qualification_grid_is_removed(self):
         section = build_honest_check()
-        assert section.count("gg-tp-for-list") >= 1
-
-    def test_five_dont_items(self):
-        section = build_honest_check()
-        assert section.count("gg-tp-not-list") >= 1
-
-    def test_two_column_grid(self):
-        section = build_honest_check()
-        assert "gg-tp-audience-grid" in section
+        assert "Buy This If:" not in section
+        assert "Don&rsquo;t Buy This If:" not in section
+        assert "gg-tp-audience-grid" not in section
 
 
 # ── 8. Testimonials ──────────────────────────────────────────

--- a/web/training-plans-questionnaire.html
+++ b/web/training-plans-questionnaire.html
@@ -297,6 +297,8 @@
   padding: 1rem;
   margin-bottom: 1rem;
   position: relative;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .gg-race-entry-header {
@@ -332,15 +334,28 @@
 
 .gg-race-fields {
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.75rem;
   align-items: end;
+  width: 100%;
+  min-width: 0;
 }
 
-.gg-race-fields .gg-form-group { margin-bottom: 0; }
+.gg-race-fields .gg-form-group {
+  margin-bottom: 0;
+  min-width: 0;
+}
+
+.gg-race-fields .gg-form-group:first-child {
+  grid-column: span 2;
+}
 
 .gg-race-fields input,
 .gg-race-fields select {
+  box-sizing: border-box;
+  inline-size: 100%;
+  min-inline-size: 0;
+  max-inline-size: 100%;
   padding: 0.6rem 0.75rem;
   font-size: 0.85rem;
 }
@@ -546,6 +561,7 @@
   .gg-radio-group { flex-direction: column; }
   .gg-submit-btn { box-shadow: 4px 4px 0 #000; }
   .gg-race-fields { grid-template-columns: 1fr; }
+  .gg-race-fields .gg-form-group:first-child { grid-column: auto; }
   .tp-questionnaire-hero h1 { font-size: 1.5rem; }
 }
 </style>

--- a/web/training-plans.html
+++ b/web/training-plans.html
@@ -526,59 +526,18 @@
 }
 
 /* ================================================================
-   WHO THIS IS FOR — Qualifying / Disqualifying
+   COACHING CTA
    ================================================================ */
 
-.tp-audience-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
-  margin-top: 1.5rem;
+.tp-coaching-copy {
+  max-width: 760px;
+  margin: 1rem 0;
+  font-size: 1rem;
+  line-height: 1.7;
 }
 
-.tp-audience-col h3 {
-  margin-bottom: 0.75rem;
-  font-size: 0.85rem;
-  color: #59473C;
-}
-
-.tp-audience-list {
-  list-style: none;
-  padding: 0;
-}
-
-.tp-audience-list li {
-  padding: 0.5rem 0;
-  padding-left: 1.5rem;
-  position: relative;
-  font-size: 0.8rem;
-  color: #000;
-  border-bottom: 1px solid #e0e0e0;
-  line-height: 1.5;
-}
-
-.tp-audience-list li:last-child {
-  border-bottom: none;
-}
-
-.tp-audience-list li::before {
-  position: absolute;
-  left: 0;
-  font-weight: 700;
-}
-
-.tp-for-list li::before {
-  content: ">";
-  color: #59473C;
-}
-
-.tp-not-list li::before {
-  content: "x";
-  color: #999;
-}
-
-.tp-not-for h3 {
-  color: #999;
+.tp-coaching-cta {
+  margin-top: 0.5rem;
 }
 
 /* ================================================================
@@ -943,15 +902,6 @@
   box-shadow: 8px 10px 0 #59473C;
 }
 
-/* Audience list hover */
-.tp-audience-list li {
-  transition: transform 0.15s ease;
-}
-
-.tp-audience-list li:hover {
-  transform: translateX(6px);
-}
-
 /* ================================================================
    RESPONSIVE
    ================================================================ */
@@ -983,10 +933,6 @@
     grid-template-columns: 1fr;
   }
 
-  .tp-audience-grid {
-    grid-template-columns: 1fr;
-  }
-
   .tp-landing {
     padding-bottom: 4rem; /* space for sticky cta */
   }
@@ -1011,7 +957,7 @@
     <h1>Your Race. Your Hours. Your Plan.</h1>
     <p class="tp-hero-sub">
       Most training plans assume you're average. A parent with 5 hours a week
-      needs fundamentally different training than someone with 15. This isn't a
+      needs a plan that fits five hours; someone with 15 has more room to work. This isn't a
       template with your name on it. It's a plan built from your schedule, your
       fitness, your race, and the specific demands of the course you're lining up for.
     </p>
@@ -1226,30 +1172,10 @@
        WHO THIS IS FOR
        ============================================================ -->
   <div class="tp-section tp-section-cream">
-    <div class="tp-section-label">Honest Check</div>
-    <h2>This Isn't For Everyone. Good.</h2>
-    <div class="tp-audience-grid">
-      <div class="tp-audience-col">
-        <h3>Buy This If:</h3>
-        <ul class="tp-audience-list tp-for-list">
-          <li>You have a race on the calendar and you're done winging it</li>
-          <li>You have 3-15 hours a week and need every session to count</li>
-          <li>You want structure that respects your actual life</li>
-          <li>You can follow a plan without someone texting you every morning</li>
-          <li>You're tired of generic plans that assume you're 25 with 20 hours</li>
-        </ul>
-      </div>
-      <div class="tp-audience-col tp-not-for">
-        <h3>Don't Buy This If:</h3>
-        <ul class="tp-audience-list tp-not-list">
-          <li>You want ongoing coaching with weekly adjustments</li>
-          <li>You don't have a target event</li>
-          <li>Your race is in 3 weeks &mdash; not enough time to build anything real</li>
-          <li>You need daily accountability to do the work</li>
-          <li>You just want someone to tell you you're doing great</li>
-        </ul>
-      </div>
-    </div>
+    <div class="tp-section-label">Coaching</div>
+    <h2>Are You Actually Serious About Getting Fast?</h2>
+    <p class="tp-coaching-copy">A training plan gives you the structure. If you want weekly review, direct feedback, and recurring adjustments as life and fitness change, you're going to need more than a training plan and a ChatGPT subscription.</p>
+    <a href="https://gravelgodcycling.com/coaching/" class="tp-btn tp-coaching-cta">Get Coaching</a>
   </div>
 
   <!-- ============================================================

--- a/wordpress/generate_training_plans.py
+++ b/wordpress/generate_training_plans.py
@@ -36,6 +36,7 @@ OUTPUT_DIR = Path(__file__).parent / "output"
 
 QUESTIONNAIRE_URL = f"{SITE_BASE_URL}/questionnaire/"
 TRAINING_PLANS_URL = f"{SITE_BASE_URL}/products/training-plans/"
+COACHING_URL = f"{SITE_BASE_URL}/coaching/"
 PRICE_PER_WEEK = "$15"
 PRICE_CAP = "$249"
 
@@ -60,7 +61,7 @@ def build_nav() -> str:
 def build_hero() -> str:
     return f'''<section class="gg-tp-hero" id="hero">
   <h1 class="gg-tp-hero-title">Your Race. Your Hours. Your Plan.</h1>
-  <p class="gg-tp-hero-sub">Most training plans assume you&rsquo;re average. A parent with 5 hours a week needs fundamentally different training than someone with 15. This isn&rsquo;t a template with your name on it. It&rsquo;s a plan built from your schedule, your fitness, your race, and the specific demands of the course you&rsquo;re lining up for.</p>
+  <p class="gg-tp-hero-sub">Most training plans assume you&rsquo;re average. A parent with 5 hours a week needs a plan that fits five hours; someone with 15 has more room to work. This isn&rsquo;t a template with your name on it. It&rsquo;s a plan built from your schedule, your fitness, your race, and the specific demands of the course you&rsquo;re lining up for.</p>
   <div class="gg-tp-hero-cta">
     <a href="{QUESTIONNAIRE_URL}" class="gg-tp-btn" data-cta="hero_build">Build My Plan</a>
     <a href="#how-it-works" class="gg-tp-btn gg-tp-btn-secondary" data-cta="hero_how">See How It Works</a>
@@ -171,7 +172,7 @@ SAMPLE_WEEK_BLOCKS = [
 REALITY_CHECKS = [
     "You downloaded a 12-week plan from the internet. It assumed you had 15 hours a week and zero injuries. How'd that go?",
     "Your buddy's training plan worked great. For your buddy. You're not your buddy.",
-    "A 50-year-old with 5 hours needs fundamentally different training than a 28-year-old with 15. Different hours demand different science.",
+    "A 50-year-old with 5 hours and a 28-year-old with 15 have different constraints. Their plans should reflect them.",
     "You know what a generic plan does at mile 80 of Unbound? Nothing. Because it doesn't know you're at Unbound.",
     "Every training plan is a bet. Most plans are betting you're a 25-year-old with unlimited time and perfect recovery. Are you?",
     "The plan said 'tempo ride, 2 hours.' You had 45 minutes before school pickup. So you skipped it. Then you skipped Tuesday too.",
@@ -185,7 +186,7 @@ REALITY_CHECKS = [
     "You told your last plan about your bad knee. It gave you plyometrics in week 3.",
     "Heat kills more gravel races than fitness. If your plan doesn't have an acclimatization protocol, it's not a plan. It's a wish.",
     "You tapered for 3 weeks because 'that's what the article said.' You lost fitness. Race day felt flat. Taper length is individual.",
-    "Your race starts at 7,000 feet. Your plan was written at sea level. That's a different sport and nobody told you.",
+    "Your race starts at 7,000 feet. Your plan was written at sea level. The altitude changes how you pace and prepare.",
     "Training without power zones is like cooking without measurements. You can do it. It's just worse.",
     "You finished your last race. You also bonked at mile 60, walked two climbs, and questioned your life choices. 'Finished' is a low bar.",
     "Somewhere right now, someone is doing their third 'base phase' of the year because they keep restarting the same generic plan.",
@@ -298,40 +299,11 @@ def build_rotating_quote() -> str:
 
 
 def build_honest_check() -> str:
-    buy_items = [
-        "You have a race on the calendar and you&rsquo;re done winging it",
-        "You have 3-15 hours a week and need every session to count",
-        "You want structure that respects your actual life",
-        "You can follow a plan without someone texting you every morning",
-        "You&rsquo;re tired of generic plans that assume you&rsquo;re 25 with 20 hours",
-    ]
-    dont_items = [
-        "You want ongoing coaching with weekly adjustments",
-        "You don&rsquo;t have a target event",
-        "Your race is in 3 weeks &mdash; not enough time to build anything real",
-        "You need daily accountability to do the work",
-        "You just want someone to tell you you&rsquo;re doing great",
-    ]
-    buy_li = "\n".join(f"          <li>{i}</li>" for i in buy_items)
-    dont_li = "\n".join(f"          <li>{i}</li>" for i in dont_items)
     return f'''<section class="gg-tp-section gg-tp-section-alt" id="honest-check">
-  <div class="gg-tp-section-label">Honest Check</div>
-  <h2>This Isn&rsquo;t For Everyone. Good.</h2>
-  <ul class="gg-tp-audience-list gg-tp-for-list"><li>Start with a published TrainingPeaks plan when the listed race, duration, and workload fit. Choose a custom plan when your race, schedule, or constraints need the calendar built around you. Choose coaching when you want ongoing review and adjustments.</li></ul>
-  <div class="gg-tp-audience-grid">
-    <div class="gg-tp-audience-col">
-      <h3>Buy This If:</h3>
-      <ul class="gg-tp-audience-list gg-tp-for-list">
-{buy_li}
-      </ul>
-    </div>
-    <div class="gg-tp-audience-col gg-tp-not-for">
-      <h3>Don&rsquo;t Buy This If:</h3>
-      <ul class="gg-tp-audience-list gg-tp-not-list">
-{dont_li}
-      </ul>
-    </div>
-  </div>
+  <div class="gg-tp-section-label">Coaching</div>
+  <h2>Are You Actually Serious About Getting Fast?</h2>
+  <p class="gg-tp-coaching-copy">A training plan gives you the structure. If you want weekly review, direct feedback, and recurring adjustments as life and fitness change, you&rsquo;re going to need more than a training plan and a ChatGPT subscription.</p>
+  <a href="{COACHING_URL}" class="gg-tp-btn gg-tp-coaching-cta" data-cta="honest_coaching">Get Coaching</a>
 </section>'''
 
 
@@ -919,47 +891,16 @@ def build_training_css() -> str:
   display: block;
 }}
 
-/* ── Honest Check (Audience) ── */
-.gg-tp-audience-grid {{
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--gg-spacing-lg);
-  margin-top: var(--gg-spacing-lg);
-}}
-.gg-tp-audience-col h3 {{
-  font-family: var(--gg-font-data);
-  font-size: var(--gg-font-size-sm);
-  font-weight: var(--gg-font-weight-bold);
-  text-transform: uppercase;
-  letter-spacing: var(--gg-letter-spacing-wide);
-  margin-bottom: var(--gg-spacing-sm);
-  color: var(--gg-color-primary-brown);
-}}
-.gg-tp-not-for h3 {{ color: var(--gg-color-secondary-brown); }}
-.gg-tp-audience-list {{
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}}
-.gg-tp-audience-list li {{
-  padding: var(--gg-spacing-xs) 0;
-  padding-left: var(--gg-spacing-lg);
-  position: relative;
+/* ── Coaching CTA ── */
+.gg-tp-coaching-copy {{
   font-family: var(--gg-font-editorial);
-  font-size: var(--gg-font-size-sm);
+  font-size: var(--gg-font-size-md);
   color: var(--gg-color-near-black);
-  border-bottom: 1px solid var(--gg-color-tan);
-  line-height: var(--gg-line-height-normal);
+  line-height: var(--gg-line-height-prose);
+  max-width: 760px;
+  margin: var(--gg-spacing-md) 0;
 }}
-.gg-tp-audience-list li:last-child {{ border-bottom: none; }}
-.gg-tp-audience-list li::before {{
-  position: absolute;
-  left: 0;
-  font-family: var(--gg-font-data);
-  font-weight: var(--gg-font-weight-bold);
-}}
-.gg-tp-for-list li::before {{ content: ">"; color: var(--gg-color-primary-brown); }}
-.gg-tp-not-list li::before {{ content: "x"; color: var(--gg-color-secondary-brown); }}
+.gg-tp-coaching-cta {{ margin-top: var(--gg-spacing-xs); }}
 
 /* ── Testimonials ── */
 .gg-tp-testimonials {{
@@ -1198,7 +1139,6 @@ def build_training_css() -> str:
   .gg-tp-section h2 {{ font-size: clamp(20px, 5vw, 28px); }}
   .gg-tp-sample-grid {{ grid-template-columns: repeat(4, 1fr); }}
   .gg-tp-testimonials {{ grid-template-columns: 1fr; }}
-  .gg-tp-audience-grid {{ grid-template-columns: 1fr; }}
   .gg-tp-process {{ flex-direction: column; gap: var(--gg-spacing-sm); }}
   .gg-neo-brutalist-page {{ padding-bottom: var(--gg-spacing-2xl); }}
 }}


### PR DESCRIPTION
The questionnaire’s race priority field escaped its card at tablet and desktop widths. Give race name/date their own row, contain native controls, and stack the fields on mobile.

Correct the plan page’s claims about different science and altitude, and replace the confusing qualification section with an optional coaching pitch and a direct coaching link. Preserve pricing, delivery/support terms, form contracts, and live asset references.

Validation: 113 training-page tests passed; quick quality preflight passed with eight existing environment/output warnings. Headless Chrome exercised public form JavaScript at 390/768/1024/1440, including add/remove/renumbering three races and individual card containment. Guarded publication candidates preserve existing live drift; exact public readback follows publication.

Voice basis: Matti’s direct correction and suggested coaching pitch, canonical writing profile, and writing-graph `inbox/gravel-god/is-coaching-worth-it.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy, layout CSS, and static HTML generator changes only; pricing, delivery terms, and form contracts are unchanged per tests.
> 
> **Overview**
> Fixes **race calendar** layout on the questionnaire so fields stay inside each card at tablet/desktop widths: a 3-column grid with the race name spanning two columns, full-width constrained inputs, and a single-column stack on mobile.
> 
> **Training plan** marketing copy is toned down so it does not overclaim—hero and rotating “Reality Check” lines drop phrases like “fundamentally different training” / “different science” / “different sport” in favor of constraint- and altitude-specific wording. The old **Buy This If / Don’t Buy This If** block is replaced by a **Coaching** section with headline, plan-vs-coaching boundary copy, and a **Get Coaching** link (`COACHING_URL` + `data-cta="honest_coaching"`). The same changes land in `generate_training_plans.py`, `web/training-plans.html`, and updated pytest guards for hero, quotes, and the new section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46cf375bed3c5cdcabed13fb881ba41271006eee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->