### PR TITLE
Restore the shared 1200px desktop layout

### DIFF
--- a/tests/test_homepage_generator.py
+++ b/tests/test_homepage_generator.py
@@ -1535,11 +1535,11 @@ class TestLatestTakesFullWidth:
         """Latest Takes should have its own max-width for full-width layout."""
         css = build_homepage_css()
         assert "gg-hp-latest-takes" in css
-        # Should have max-width: 1080px
+        # Should use the ratified desktop content measure.
         import re
         takes_rule = re.search(r'\.gg-hp-latest-takes\s*\{[^}]+\}', css)
         assert takes_rule is not None
-        assert "max-width: 1080px" in takes_rule.group(0)
+        assert "max-width: 1200px" in takes_rule.group(0)
 
     def test_latest_takes_three_card_layout(self):
         """Take cards should be 33.333% width for 3-card layout."""

--- a/tests/test_shared_footer.py
+++ b/tests/test_shared_footer.py
@@ -180,5 +180,5 @@ class TestMegaFooterCSS:
         for cls in classes:
             assert cls.startswith("gg-mega-footer"), f"Wrong prefix: .{cls}"
 
-    def test_max_width_960(self):
-        assert "max-width: 960px" in self.css
+    def test_max_width_1200(self):
+        assert "max-width: 1200px" in self.css

--- a/tests/test_shared_header.py
+++ b/tests/test_shared_header.py
@@ -157,9 +157,9 @@ class TestHeaderCSS:
         css = get_site_header_css()
         assert "@media" in css
 
-    def test_max_width_960(self):
+    def test_max_width_1200(self):
         css = get_site_header_css()
-        assert "max-width: 960px" in css
+        assert "max-width: 1200px" in css
 
     def test_dropdown_border(self):
         css = get_site_header_css()

--- a/tests/test_site_content_width.py
+++ b/tests/test_site_content_width.py
@@ -1,0 +1,123 @@
+"""Regression checks for the ratified 1200px desktop content measure."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "wordpress"))
+
+from generate_coaching import build_coaching_css  # noqa: E402
+from generate_homepage import build_homepage_css  # noqa: E402
+from generate_neo_brutalist import get_page_css  # noqa: E402
+from generate_training_plans import build_training_css  # noqa: E402
+from shared_footer import get_mega_footer_css  # noqa: E402
+from shared_header import get_site_header_css  # noqa: E402
+
+
+def _rule(css: str, selector: str) -> str:
+    match = re.search(re.escape(selector) + r"\s*\{([^}]+)\}", css)
+    assert match, f"Missing CSS rule for {selector}"
+    return match.group(1)
+
+
+def test_shared_chrome_uses_ratified_desktop_measure():
+    assert "max-width: 1200px" in _rule(get_site_header_css(), ".gg-site-header-inner")
+
+    footer_css = get_mega_footer_css()
+    for selector in (
+        ".gg-mega-footer-grid",
+        ".gg-mega-footer-legal",
+        ".gg-mega-footer-disclaimer",
+    ):
+        assert "max-width: 1200px" in _rule(footer_css, selector)
+
+
+def test_race_profile_uses_wide_frame_and_readable_prose():
+    css = get_page_css()
+    assert "max-width: 1200px" in _rule(css, ".gg-neo-brutalist-page")
+    assert "max-width: 1200px" in _rule(css, ".gg-sticky-cta-inner")
+    assert "max-width: 68ch" in _rule(css, ".gg-neo-brutalist-page .gg-prose")
+
+
+def test_homepage_major_sections_share_1200px_measure():
+    css = build_homepage_css()
+    selectors = (
+        ".gg-hp-hero-inner",
+        ".gg-hp-ladder-grid",
+        ".gg-hp-stats-inner",
+        ".gg-hp-content-grid",
+        ".gg-hp-how-it-works",
+    )
+    for selector in selectors:
+        assert "max-width: 1200px" in _rule(css, selector)
+    assert "max-width: 1080px" not in css
+
+
+def test_training_plan_page_widens_frame_without_stretching_copy():
+    css = build_training_css()
+    for selector in (".gg-breadcrumb", ".gg-tp-section", ".gg-tp-hero"):
+        assert "max-width: 1200px" in _rule(css, selector)
+    assert "max-width: none" in _rule(css, ".gg-tp-hero-title")
+    assert "max-width: 600px" in _rule(css, ".gg-tp-hero-sub")
+    assert "max-width: 760px" in _rule(css, ".gg-tp-coaching-copy")
+
+
+def test_coaching_reference_keeps_1200px_frame_and_68ch_prose():
+    css = build_coaching_css()
+    assert "max-width: 1200px" in _rule(css, ".gg-coach-inner")
+    assert css.count("max-width: 68ch") >= 2
+
+
+@pytest.mark.parametrize(
+    ("source", "selector"),
+    (
+        ("generate_state_hubs.py", ".gg-state-page"),
+        ("generate_tier_hubs.py", ".gg-hub-page"),
+        ("generate_series_hubs.py", ".gg-series-page"),
+        ("generate_vs_pages.py", ".gg-vs-page"),
+        ("generate_power_rankings.py", ".gg-pr-page"),
+        ("generate_insights.py", ".gg-insights-section"),
+        ("generate_calendar.py", ".gg-cal-page"),
+        ("generate_articles_index.py", ".gg-ai-page"),
+        ("generate_courses.py", ".gg-course-index-inner"),
+        ("generate_latest.py", ".gg-wire"),
+        ("generate_blog_index_page.py", ".gg-blog-index"),
+        ("generate_training_plan_pages.py", ".gg-tpp-page"),
+        ("generate_whitepaper_fueling.py", ".gg-wp-scroll-section"),
+        ("generate_consulting.py", ".gg-breadcrumb"),
+    ),
+)
+def test_remaining_default_page_families_use_1200px(source: str, selector: str):
+    text = (ROOT / "wordpress" / source).read_text()
+    rule = _rule(text.replace("{{", "{").replace("}}", "}"), selector)
+    assert re.search(r"max-width:\s*1200px", rule)
+
+
+def test_release_overlay_is_width_only_and_preserves_prose_caps():
+    css = (ROOT / "wordpress" / "desktop_width_override.css").read_text()
+    declarations = re.findall(r"\b([a-z-]+)\s*:", re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL))
+    assert set(declarations) == {"max-width"}
+
+    assert "max-width: 1200px !important" in _rule(css, ".gg-site-header-inner")
+    assert "max-width: none" in _rule(css, ".gg-tp-section.gg-tp-section-alt")
+    assert "max-width: none" in _rule(css, ".gg-tp-hero-title")
+    assert "max-width: 68ch" in _rule(css, ".gg-neo-brutalist-page .gg-prose")
+
+    expected_caps = {
+        ".gg-tp-hero-sub": "600px",
+        ".gg-tp-hero-bar": "550px",
+        ".gg-tp-delivery-terms": "700px",
+        ".gg-tp-pullquote p": "750px",
+        ".gg-tp-coaching-copy": "760px",
+        ".gg-tp-pricing-wrap": "500px",
+        ".gg-tp-deliverable-content p": "68ch",
+        ".gg-tp-step p": "68ch",
+    }
+    for selector, width in expected_caps.items():
+        assert f"max-width: {width}" in _rule(css, selector)

--- a/tests/test_site_content_width.py
+++ b/tests/test_site_content_width.py
@@ -16,6 +16,7 @@ from generate_coaching import build_coaching_css  # noqa: E402
 from generate_homepage import build_homepage_css  # noqa: E402
 from generate_neo_brutalist import get_page_css  # noqa: E402
 from generate_training_plans import build_training_css  # noqa: E402
+from generate_tire_guide import get_page_css as get_tire_guide_css  # noqa: E402
 from shared_footer import get_mega_footer_css  # noqa: E402
 from shared_header import get_site_header_css  # noqa: E402
 
@@ -68,6 +69,18 @@ def test_training_plan_page_widens_frame_without_stretching_copy():
     assert "max-width: 760px" in _rule(css, ".gg-tp-coaching-copy")
 
 
+def test_tire_guide_widens_data_frame_without_stretching_prose():
+    css = get_tire_guide_css()
+    assert "max-width: 1200px" in _rule(css, ".tg-container")
+    prose_group = """.tg-surface-box p,
+.tg-tire-tagline,
+.tg-tire-why,
+.tg-pressure-note,
+.tg-setup-item p,
+.tg-alt-card p"""
+    assert "max-width: 68ch" in _rule(css, prose_group)
+
+
 def test_coaching_reference_keeps_1200px_frame_and_68ch_prose():
     css = build_coaching_css()
     assert "max-width: 1200px" in _rule(css, ".gg-coach-inner")
@@ -108,6 +121,7 @@ def test_release_overlay_is_width_only_and_preserves_prose_caps():
     assert "max-width: none" in _rule(css, ".gg-tp-section.gg-tp-section-alt")
     assert "max-width: none" in _rule(css, ".gg-tp-hero-title")
     assert "max-width: 68ch" in _rule(css, ".gg-neo-brutalist-page .gg-prose")
+    assert "max-width: 1200px" in _rule(css, ".tg-container")
 
     expected_caps = {
         ".gg-tp-hero-sub": "600px",
@@ -121,3 +135,11 @@ def test_release_overlay_is_width_only_and_preserves_prose_caps():
     }
     for selector, width in expected_caps.items():
         assert f"max-width: {width}" in _rule(css, selector)
+
+    tire_prose_group = """.tg-surface-box p,
+.tg-tire-tagline,
+.tg-tire-why,
+.tg-pressure-note,
+.tg-setup-item p,
+.tg-alt-card p"""
+    assert "max-width: 68ch" in _rule(css, tire_prose_group)

--- a/web/training-plans.html
+++ b/web/training-plans.html
@@ -21,7 +21,7 @@
   font-family: 'Sometype Mono', monospace;
   color: #000;
   line-height: 1.6;
-  max-width: 900px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 0 1.5rem;
 }
@@ -260,6 +260,7 @@
   color: #333;
   margin-bottom: 0;
   line-height: 1.65;
+  max-width: 68ch;
 }
 
 .tp-deliverable-row:nth-child(odd) .tp-deliverable-content {
@@ -411,6 +412,7 @@
   color: #333;
   margin-bottom: 0;
   line-height: 1.65;
+  max-width: 68ch;
 }
 
 /* ================================================================

--- a/wordpress/desktop_width_override.css
+++ b/wordpress/desktop_width_override.css
@@ -1,0 +1,95 @@
+/* Width-only release overlay for already-built Gravel God pages.
+   Load after page CSS. Source values live in the corresponding generators. */
+.gg-site-header-inner,
+.gg-mega-footer-grid,
+.gg-mega-footer-legal,
+.gg-mega-footer-disclaimer,
+.gg-neo-brutalist-page,
+.gg-sticky-cta-inner,
+.gg-state-page,
+.gg-hub-page,
+.gg-series-page,
+.gg-vs-page,
+.gg-pr-page,
+.gg-insights-hero-inner,
+.gg-insights-section,
+#dimension-leaderboard,
+.gg-ins-rank,
+.gg-cal-page,
+.gg-ai-page,
+.gg-course-index-inner,
+.gg-wire,
+.gg-blog-index,
+.gg-tpp-page,
+.gg-wp-scroll-section,
+.gg-breadcrumb {
+  max-width: 1200px;
+}
+
+.gg-site-header-inner {
+  max-width: 1200px !important;
+}
+
+.gg-hp-hero-inner,
+.gg-hp-ladder-grid,
+.gg-hp-stats-inner,
+.gg-hp-content-grid,
+.gg-hp-latest-takes,
+.gg-hp-how-it-works,
+.gg-hp-coming-up,
+.gg-hp-training-cta-full,
+.gg-hp-guide,
+.gg-hp-featured-in,
+.gg-hp-testimonials,
+.gg-hp-email,
+.gg-tp-section,
+.gg-tp-section-alt > *,
+.gg-tp-hero {
+  max-width: 1200px;
+}
+
+.gg-tp-section.gg-tp-section-alt {
+  max-width: none;
+}
+
+.gg-tp-hero-title {
+  max-width: none;
+}
+
+/* The source defines these after the widened section frame. Reassert them
+   because this release overlay is appended after the existing page CSS. */
+.gg-tp-hero-sub {
+  max-width: 600px;
+}
+
+.gg-tp-hero-bar {
+  max-width: 550px;
+}
+
+.gg-tp-delivery-terms {
+  max-width: 700px;
+}
+
+.gg-tp-pullquote p {
+  max-width: 750px;
+}
+
+.gg-tp-coaching-copy {
+  max-width: 760px;
+}
+
+.gg-tp-pricing-wrap {
+  max-width: 500px;
+}
+
+.gg-tp-step p {
+  max-width: 68ch;
+}
+
+.gg-tp-deliverable-content p {
+  max-width: 68ch;
+}
+
+.gg-neo-brutalist-page .gg-prose {
+  max-width: 68ch;
+}

--- a/wordpress/desktop_width_override.css
+++ b/wordpress/desktop_width_override.css
@@ -22,7 +22,8 @@
 .gg-blog-index,
 .gg-tpp-page,
 .gg-wp-scroll-section,
-.gg-breadcrumb {
+.gg-breadcrumb,
+.tg-container {
   max-width: 1200px;
 }
 
@@ -91,5 +92,14 @@
 }
 
 .gg-neo-brutalist-page .gg-prose {
+  max-width: 68ch;
+}
+
+.tg-surface-box p,
+.tg-tire-tagline,
+.tg-tire-why,
+.tg-pressure-note,
+.tg-setup-item p,
+.tg-alt-card p {
   max-width: 68ch;
 }

--- a/wordpress/generate_articles_index.py
+++ b/wordpress/generate_articles_index.py
@@ -101,7 +101,7 @@ def generate_articles_index():
 * {{ margin: 0; padding: 0; box-sizing: border-box; border-radius: 0 !important; box-shadow: none !important; }}
 body {{ font-family: var(--gg-font-data); background: var(--gg-color-warm-paper); color: var(--gg-color-dark-brown); line-height: 1.6; }}
 
-.gg-ai-page {{ max-width: 960px; margin: 0 auto; padding: 0 20px; }}
+.gg-ai-page {{ max-width: 1200px; margin: 0 auto; padding: 0 20px; }}
 
 /* Hero */
 .gg-ai-hero {{

--- a/wordpress/generate_blog_index_page.py
+++ b/wordpress/generate_blog_index_page.py
@@ -127,7 +127,7 @@ def generate_blog_index_page(output_dir=None):
       color: var(--gg-dark-brown);
       line-height: 1.7;
     }}
-    .gg-blog-index {{ max-width: 1100px; margin: 0 auto; padding: 32px 24px; }}
+    .gg-blog-index {{ max-width: 1200px; margin: 0 auto; padding: 32px 24px; }}
 
     /* Hero */
     .gg-bi-hero {{

--- a/wordpress/generate_calendar.py
+++ b/wordpress/generate_calendar.py
@@ -210,7 +210,7 @@ body {{ margin: 0; background: var(--gg-color-warm-paper); }}
 *, *::before, *::after {{ border-radius: 0 !important; box-shadow: none !important; }}
 
 .gg-cal-page {{
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 0 24px;
   font-family: var(--gg-font-data);

--- a/wordpress/generate_consulting.py
+++ b/wordpress/generate_consulting.py
@@ -657,7 +657,7 @@ def build_consulting_css() -> str:
   font-family: var(--gg-font-data);
   font-size: var(--gg-font-size-2xs);
   color: var(--gg-color-secondary-brown);
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   letter-spacing: var(--gg-letter-spacing-wide);
 }}

--- a/wordpress/generate_courses.py
+++ b/wordpress/generate_courses.py
@@ -543,7 +543,7 @@ body:has(.gg-pwa-banner-show) .gg-course-chip{{bottom:96px}}
 
 /* ── Course Index ── */
 .gg-course-index{{padding:80px 24px 60px}}
-.gg-course-index-inner{{max-width:960px;margin:0 auto}}
+.gg-course-index-inner{{max-width:1200px;margin:0 auto}}
 .gg-course-index h1{{font-family:var(--gg-font-editorial,'Source Serif 4',Georgia,serif);font-size:clamp(2rem,4vw,2.8rem);color:var(--gg-color-dark-brown,#3a2e25);text-align:center;margin:0 0 12px}}
 .gg-course-index-subtitle{{font-family:var(--gg-font-editorial,'Source Serif 4',Georgia,serif);color:var(--gg-color-primary-brown,#59473c);text-align:center;margin:0 0 48px;font-size:1.1rem}}
 .gg-course-grid{{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:24px}}

--- a/wordpress/generate_homepage.py
+++ b/wordpress/generate_homepage.py
@@ -1332,7 +1332,7 @@ a { text-decoration: none; color: #178079; }
 
 /* ── Hero ─────────────────────────────────────────────────── */
 .gg-hp-hero { background: #f5efe6; padding: 64px 48px; border-bottom: 3px solid #3a2e25; }
-.gg-hp-hero-inner { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 64px; align-items: center; }
+.gg-hp-hero-inner { max-width: 1200px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 64px; align-items: center; }
 .gg-hp-hero-kicker { font-family: 'Sometype Mono', monospace; font-size: 10px; font-weight: 700; color: #9a7e0a; text-transform: uppercase; letter-spacing: 3px; margin-bottom: 16px; }
 .gg-hp-hero h1 { font-family: 'Source Serif 4', Georgia, serif; font-size: 48px; font-weight: 900; line-height: 1.05; margin-bottom: 12px; color: #3a2e25; }
 .gg-hp-hero-deck { font-size: 17px; font-weight: 300; color: #59473c; line-height: 1.7; margin-bottom: 20px; }
@@ -1395,7 +1395,7 @@ a { text-decoration: none; color: #178079; }
 /* ── Ladder strip BEGIN (tokens only — no hardcoded hex; see
    ladder-strip-spec.md) ── */
 .gg-hp-ladder { border-top: 1px solid var(--gg-color-dark-brown); border-bottom: 1px solid var(--gg-color-dark-brown); background: var(--gg-color-warm-paper); }
-.gg-hp-ladder-grid { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: repeat(3, 1fr); }
+.gg-hp-ladder-grid { max-width: 1200px; margin: 0 auto; display: grid; grid-template-columns: repeat(3, 1fr); }
 .gg-hp-ladder-cell { padding: 32px 28px; border-right: 1px solid var(--gg-color-tan); }
 .gg-hp-ladder-cell:last-child { border-right: none; }
 .gg-hp-ladder-num { display: block; font-family: 'Sometype Mono', monospace; font-size: 11px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--gg-color-tan); margin-bottom: 14px; }
@@ -1413,7 +1413,7 @@ a { text-decoration: none; color: #178079; }
 
 /* ── Stats stripe ───────────────────────────────────────── */
 .gg-hp-stats-stripe { background: #3a2e25; padding: 0 48px; }
-.gg-hp-stats-inner { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: repeat(5, 1fr); }
+.gg-hp-stats-inner { max-width: 1200px; margin: 0 auto; display: grid; grid-template-columns: repeat(5, 1fr); }
 .gg-hp-ss-item { text-align: center; padding: 20px 0; border-right: 2px solid #59473c; }
 .gg-hp-ss-item:last-child { border-right: none; }
 .gg-hp-ss-val { font-family: 'Sometype Mono', monospace; font-size: 24px; font-weight: 700; color: #9a7e0a; }
@@ -1425,7 +1425,7 @@ a { text-decoration: none; color: #178079; }
 .gg-hp-section-header--teal { border-bottom-color: #178079; }
 
 /* ── Content grid ───────────────────────────────────────── */
-.gg-hp-content-grid { max-width: 1080px; margin: 0 auto; padding: 48px; display: grid; grid-template-columns: 3fr 2fr; gap: 48px; box-sizing: border-box; }
+.gg-hp-content-grid { max-width: 1200px; margin: 0 auto; padding: 48px; display: grid; grid-template-columns: 3fr 2fr; gap: 48px; box-sizing: border-box; }
 .gg-hp-main-col, .gg-hp-sidebar { min-width: 0; overflow: hidden; }
 .gg-hp-sidebar-sticky { position: sticky; top: 24px; max-height: calc(100vh - 48px); overflow-y: auto; }
 .gg-hp-col-header { font-family: 'Sometype Mono', monospace; font-size: 10px; font-weight: 700; color: #9a7e0a; text-transform: uppercase; letter-spacing: 3px; padding-bottom: 12px; border-bottom: 3px solid #3a2e25; margin-bottom: 24px; }
@@ -1509,7 +1509,7 @@ a { text-decoration: none; color: #178079; }
 .gg-hp-badge-t4 { background: transparent; color: #5e6868; border: 1px solid #5e6868; }
 
 /* ── Latest Takes ───────────────────────────────────────── */
-.gg-hp-latest-takes { max-width: 1080px; margin: 32px auto 0; padding: 0 48px; border: 1px solid #d4c5b9; border-top: 2px solid #9a7e0a; box-sizing: border-box; }
+.gg-hp-latest-takes { max-width: 1200px; margin: 32px auto 0; padding: 0 48px; border: 1px solid #d4c5b9; border-top: 2px solid #9a7e0a; box-sizing: border-box; }
 .gg-hp-section-header--gold { border-bottom-color: #9a7e0a; }
 .gg-hp-take-carousel { display: flex; gap: 0; overflow-x: auto; scroll-snap-type: x mandatory; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
 .gg-hp-take-carousel::-webkit-scrollbar { display: none; }
@@ -1528,7 +1528,7 @@ a { text-decoration: none; color: #178079; }
 .gg-hp-take-cta .gg-hp-btn--primary:hover { background: #c9a92c; border-color: #c9a92c; }
 
 /* ── How it works ────────────────────────────────────────── */
-.gg-hp-how-it-works { background: #f5efe6; display: grid; grid-template-columns: repeat(3, 1fr); margin-top: 32px; border: 1px solid #d4c5b9; border-top: 2px solid #9a7e0a; max-width: 1080px; margin: 32px auto 0; }
+.gg-hp-how-it-works { background: #f5efe6; display: grid; grid-template-columns: repeat(3, 1fr); margin-top: 32px; border: 1px solid #d4c5b9; border-top: 2px solid #9a7e0a; max-width: 1200px; margin: 32px auto 0; }
 .gg-hp-step { padding: 36px 24px; border-right: 1px solid #d4c5b9; }
 .gg-hp-step:last-child { border-right: none; }
 .gg-hp-step-num { display: block; font-family: 'Sometype Mono', monospace; font-size: 36px; font-weight: 700; color: #9a7e0a; margin-bottom: 12px; }
@@ -1536,7 +1536,7 @@ a { text-decoration: none; color: #178079; }
 .gg-hp-step-desc { font-family: 'Source Serif 4', Georgia, serif; font-size: 14px; color: #7d695d; line-height: 1.7; }
 
 /* ── Coming Up (kept for compatibility) ─────────────────── */
-.gg-hp-coming-up { max-width: 1080px; margin: 32px auto 0; border: 1px solid #d4c5b9; }
+.gg-hp-coming-up { max-width: 1200px; margin: 32px auto 0; border: 1px solid #d4c5b9; }
 .gg-hp-cal-list { padding: 0; }
 .gg-hp-cal-item { display: flex; align-items: center; gap: 16px; padding: 14px 20px; border-bottom: 2px solid #d4c5b9; text-decoration: none; color: #3a2e25; transition: border-color var(--gg-ease), background-color var(--gg-ease); }
 .gg-hp-cal-item:last-child { border-bottom: none; }
@@ -1556,7 +1556,7 @@ a { text-decoration: none; color: #178079; }
 .gg-hp-cal-offseason a { color: #178079; font-weight: 700; }
 
 /* ── Training CTA (split card) ──────────────────────────── */
-.gg-hp-training-cta-full { max-width: 1080px; margin: 32px auto 0; padding: 0 48px; }
+.gg-hp-training-cta-full { max-width: 1200px; margin: 32px auto 0; padding: 0 48px; }
 .gg-hp-cta-card { display: grid; grid-template-columns: 1fr 1fr; border: 3px solid #3a2e25; }
 .gg-hp-cta-left { background: #1a1613; padding: 40px; display: flex; flex-direction: column; justify-content: center; }
 .gg-hp-cta-left h2 { font-size: 28px; font-weight: 900; color: #f5efe6; margin-bottom: 8px; }
@@ -1566,7 +1566,7 @@ a { text-decoration: none; color: #178079; }
 .gg-hp-cta-right { background: #d4c5b9; min-height: 200px; }
 
 /* ── Guide Preview ───────────────────────────────────────── */
-.gg-hp-guide { max-width: 1080px; margin: 32px auto 0; border: 1px solid #d4c5b9; }
+.gg-hp-guide { max-width: 1200px; margin: 32px auto 0; border: 1px solid #d4c5b9; }
 .gg-hp-guide-intro { padding: 20px; font-family: 'Source Serif 4', Georgia, serif; font-size: 14px; color: #3a2e25; line-height: 1.75; border-bottom: 2px solid #d4c5b9; }
 .gg-hp-guide-intro p { margin: 0; }
 .gg-hp-guide-grid { display: grid; grid-template-columns: repeat(2, 1fr); }
@@ -1583,7 +1583,7 @@ a { text-decoration: none; color: #178079; }
 .gg-hp-guide-cta { padding: 20px; text-align: center; background: #ede4d8; border-top: 2px solid #d4c5b9; }
 
 /* ── As Featured In ─────────────────────────────────────── */
-.gg-hp-featured-in { max-width: 1080px; margin: 32px auto 0; border: 1px solid #d4c5b9; background: #f5efe6; }
+.gg-hp-featured-in { max-width: 1200px; margin: 32px auto 0; border: 1px solid #d4c5b9; background: #f5efe6; }
 .gg-hp-feat-inner { display: flex; align-items: center; gap: 32px; padding: 32px 24px; }
 .gg-hp-feat-text { flex: 0 0 auto; max-width: 260px; }
 .gg-hp-feat-label { display: inline-block; font-family: 'Sometype Mono', monospace; font-size: 10px; font-weight: 700; letter-spacing: 4px; text-transform: uppercase; color: #9a7e0a; margin-bottom: 8px; }
@@ -1594,7 +1594,7 @@ a { text-decoration: none; color: #178079; }
 .gg-hp-feat-logo img { display: block; height: 56px; width: auto; }
 
 /* ── Testimonials ────────────────────────────────────────── */
-.gg-hp-testimonials { max-width: 1080px; margin: 32px auto 0; border: 1px solid #d4c5b9; border-top: 2px solid #9a7e0a; }
+.gg-hp-testimonials { max-width: 1200px; margin: 32px auto 0; border: 1px solid #d4c5b9; border-top: 2px solid #9a7e0a; }
 .gg-hp-test-grid { display: grid; grid-template-columns: repeat(2, 1fr); }
 .gg-hp-test-card { padding: 24px; border: 1px solid #d4c5b9; background: #f5efe6; }
 .gg-hp-test-quote { font-family: 'Source Serif 4', Georgia, serif; font-size: 14px; line-height: 1.75; color: #3a2e25; font-style: italic; margin: 0 0 16px; border-left: 3px solid #9a7e0a; padding-left: 16px; }
@@ -1607,7 +1607,7 @@ a { text-decoration: none; color: #178079; }
 .gg-hp-test-cta .gg-hp-btn--primary:hover { border-color: #9a7e0a; color: #fff; }
 
 /* ── Email capture ───────────────────────────────────────── */
-.gg-hp-email { background: #f5efe6; padding: 48px; border: 1px solid #d4c5b9; border-top: 2px solid #178079; max-width: 1080px; margin: 32px auto 0; }
+.gg-hp-email { background: #f5efe6; padding: 48px; border: 1px solid #d4c5b9; border-top: 2px solid #178079; max-width: 1200px; margin: 32px auto 0; }
 .gg-hp-email-inner { max-width: 560px; margin: 0 auto; text-align: center; }
 .gg-hp-email-label { display: inline-block; font-family: 'Sometype Mono', monospace; font-size: 10px; font-weight: 700; letter-spacing: 4px; text-transform: uppercase; color: #9a7e0a; margin-bottom: 12px; }
 .gg-hp-email-title { font-family: 'Source Serif 4', Georgia, serif; font-size: 28px; font-weight: 700; color: #3a2e25; margin-bottom: 12px; }

--- a/wordpress/generate_insights.py
+++ b/wordpress/generate_insights.py
@@ -1256,7 +1256,7 @@ def build_insights_css() -> str:
   border-bottom: 3px solid var(--gg-color-dark-brown);
 }}
 .gg-insights-hero-inner {{
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   text-align: center;
 }}
@@ -1309,7 +1309,7 @@ def build_insights_css() -> str:
 /* ── Sections ── */
 .gg-insights-section {{
   padding: var(--gg-spacing-2xl) var(--gg-spacing-xl);
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
 }}
 .gg-insights-section--alt {{
@@ -1995,7 +1995,7 @@ def build_insights_css() -> str:
    ══════════════════════════════════════════════════════════════ */
 #dimension-leaderboard {{
   padding: var(--gg-spacing-2xl) var(--gg-spacing-xl);
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
 }}
 .gg-ins-dim-controls {{
@@ -2209,7 +2209,7 @@ def build_insights_css() -> str:
    ══════════════════════════════════════════════════════════════ */
 .gg-ins-rank {{
   padding: var(--gg-spacing-2xl) var(--gg-spacing-xl);
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
 }}
 .gg-ins-rank-inner {{
@@ -2430,7 +2430,7 @@ def build_insights_css() -> str:
   font-family: var(--gg-font-data);
   font-size: var(--gg-font-size-2xs);
   color: var(--gg-color-secondary-brown);
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   letter-spacing: var(--gg-letter-spacing-wide);
 }}

--- a/wordpress/generate_latest.py
+++ b/wordpress/generate_latest.py
@@ -71,7 +71,7 @@ def render_page(intel: dict, race_index: list[dict], today: date | None = None) 
     events = flatten_events(intel, race_index, today)
     css = f"""<style>{get_tokens_css()}{get_font_face_css('/race/assets/fonts')}{get_site_header_css()}
 body{{margin:0;background:var(--gg-color-cream);color:var(--gg-color-dark-brown)}}
-.gg-wire{{max-width:1080px;margin:0 auto;padding:var(--gg-spacing-xl) var(--gg-spacing-md)}}
+.gg-wire{{max-width:1200px;margin:0 auto;padding:var(--gg-spacing-xl) var(--gg-spacing-md)}}
 .gg-wire h1,.gg-wire h2{{font-family:var(--gg-font-data);text-transform:uppercase}}
 .gg-wire h1{{font-size:clamp(2rem,8vw,5rem);margin:0;border-bottom:var(--gg-border-thick);padding-bottom:var(--gg-spacing-sm)}}
 .gg-wire-intro{{font-family:var(--gg-font-editorial);font-size:var(--gg-font-size-lg);margin:var(--gg-spacing-md) 0 var(--gg-spacing-xl)}}

--- a/wordpress/generate_neo_brutalist.py
+++ b/wordpress/generate_neo_brutalist.py
@@ -6171,7 +6171,7 @@ body {{ margin: 0; background: var(--gg-color-warm-paper); }}
 
 /* Page wrapper */
 .gg-neo-brutalist-page {{
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 0 20px;
   font-family: var(--gg-font-data);
@@ -6389,7 +6389,7 @@ body {{ margin: 0; background: var(--gg-color-warm-paper); }}
 .gg-neo-brutalist-page .gg-map-embed iframe {{ width: 100%; height: 500px; border: none; display: block; }}
 
 /* Prose — editorial font */
-.gg-neo-brutalist-page .gg-prose {{ font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-base); line-height: var(--gg-line-height-prose); color: var(--gg-color-dark-brown); }}
+.gg-neo-brutalist-page .gg-prose {{ max-width: 68ch; font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-base); line-height: var(--gg-line-height-prose); color: var(--gg-color-dark-brown); }}
 .gg-neo-brutalist-page .gg-prose p {{ margin-bottom: 14px; }}
 .gg-neo-brutalist-page .gg-prose p:last-child {{ margin-bottom: 0; }}
 
@@ -6698,7 +6698,7 @@ body {{ margin: 0; background: var(--gg-color-warm-paper); }}
 /* Sticky CTA */
 .gg-sticky-cta {{ position: fixed; bottom: 0; left: 0; right: 0; z-index: 200; background: var(--gg-color-near-black); border-top: 3px solid var(--gg-color-teal); padding: 12px 24px; transform: translateY(100%); transition: transform 0.3s ease; }}
 .gg-sticky-cta.is-visible {{ transform: translateY(0); }}
-.gg-sticky-cta-inner {{ max-width: 960px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 16px; }}
+.gg-sticky-cta-inner {{ max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 16px; }}
 .gg-sticky-cta-name {{ font-family: var(--gg-font-data); font-size: 13px; font-weight: 700; color: var(--gg-color-white); text-transform: uppercase; letter-spacing: 1px; }}
 .gg-sticky-cta .gg-btn {{ font-family: var(--gg-font-data); background: var(--gg-color-teal); color: var(--gg-color-white); border: var(--gg-border-width-subtle) solid var(--gg-color-teal); padding: var(--gg-spacing-xs) 20px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: var(--gg-letter-spacing-wider); text-decoration: none; cursor: pointer; }}
 .gg-sticky-cta .gg-btn:hover {{ background: var(--gg-color-dark-teal); border-color: var(--gg-color-dark-teal); }}

--- a/wordpress/generate_power_rankings.py
+++ b/wordpress/generate_power_rankings.py
@@ -180,7 +180,7 @@ body {{ margin: 0; background: var(--gg-color-warm-paper); }}
 *, *::before, *::after {{ border-radius: 0 !important; box-shadow: none !important; }}
 
 .gg-pr-page {{
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 0 24px;
   font-family: var(--gg-font-data);

--- a/wordpress/generate_series_hubs.py
+++ b/wordpress/generate_series_hubs.py
@@ -1441,7 +1441,7 @@ def build_hub_page(series: dict, race_lookup: dict, race_data: dict) -> str:
 {tokens}
 
 .gg-series-page {{
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 0 24px;
   font-family: var(--gg-font-data);

--- a/wordpress/generate_state_hubs.py
+++ b/wordpress/generate_state_hubs.py
@@ -599,7 +599,7 @@ body {{ margin: 0; background: var(--gg-color-warm-paper); }}
 *, *::before, *::after {{ border-radius: 0 !important; box-shadow: none !important; }}
 
 .gg-state-page {{
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 0 24px;
   font-family: var(--gg-font-data);

--- a/wordpress/generate_tier_hubs.py
+++ b/wordpress/generate_tier_hubs.py
@@ -234,7 +234,7 @@ def build_hub_page(tier: int, races: list, all_races: list) -> str:
 {tokens}
 
 .gg-hub-page {{
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 0 24px;
   font-family: var(--gg-font-data);

--- a/wordpress/generate_tire_guide.py
+++ b/wordpress/generate_tire_guide.py
@@ -820,9 +820,18 @@ a { color: var(--gg-color-teal); text-decoration: none; }
 a:hover { text-decoration: underline; }
 
 .tg-container {
-  max-width: 820px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 0 var(--gg-spacing-md);
+}
+
+.tg-surface-box p,
+.tg-tire-tagline,
+.tg-tire-why,
+.tg-pressure-note,
+.tg-setup-item p,
+.tg-alt-card p {
+  max-width: 68ch;
 }
 
 /* Header */

--- a/wordpress/generate_training_plan_pages.py
+++ b/wordpress/generate_training_plan_pages.py
@@ -602,7 +602,7 @@ def build_json_ld(rd: dict, qa: list, canonical: str) -> str:
 
 def build_css() -> str:
     return '''
-.gg-tpp-page { max-width: 1120px; margin: 0 auto; padding: 0 20px 60px; font-family: var(--gg-font-editorial); color: var(--gg-color-primary-brown); }
+.gg-tpp-page { max-width: 1200px; margin: 0 auto; padding: 0 20px 60px; font-family: var(--gg-font-editorial); color: var(--gg-color-primary-brown); }
 .gg-tpp-kicker { font-family: var(--gg-font-data); font-size: 11px; font-weight: 700; letter-spacing: 3px; color: var(--gg-color-secondary-brown); margin: 28px 0 8px; }
 .gg-tpp-hero h1 { font-family: var(--gg-font-data); font-size: clamp(26px, 5vw, 40px); text-transform: uppercase; letter-spacing: 0.03em; line-height: 1.15; margin: 0 0 10px; color: #000; }
 .gg-tpp-facts { font-family: var(--gg-font-data); font-size: 12px; letter-spacing: 1px; text-transform: uppercase; color: var(--gg-color-secondary-brown); margin: 0 0 16px; }

--- a/wordpress/generate_training_plans.py
+++ b/wordpress/generate_training_plans.py
@@ -439,7 +439,7 @@ def build_training_css() -> str:
   font-family: var(--gg-font-data);
   font-size: var(--gg-font-size-2xs);
   color: var(--gg-color-secondary-brown);
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   letter-spacing: var(--gg-letter-spacing-wide);
 }}
@@ -454,7 +454,7 @@ def build_training_css() -> str:
 /* ── Layout ── */
 .gg-tp-section {{
   padding: var(--gg-spacing-2xl) var(--gg-spacing-xl);
-  max-width: 900px;
+  max-width: 1200px;
   margin: 0 auto;
   border-bottom: var(--gg-border-standard);
 }}
@@ -465,7 +465,7 @@ def build_training_css() -> str:
   border-bottom-color: var(--gg-color-primary-brown);
 }}
 .gg-tp-section-alt > * {{
-  max-width: 900px;
+  max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
 }}
@@ -527,7 +527,7 @@ def build_training_css() -> str:
 /* ── Hero ── */
 .gg-tp-hero {{
   padding: var(--gg-spacing-2xl) var(--gg-spacing-xl) var(--gg-spacing-xl);
-  max-width: 900px;
+  max-width: 1200px;
   margin: 0 auto;
   border-bottom: var(--gg-border-standard);
 }}
@@ -537,7 +537,7 @@ def build_training_css() -> str:
   font-weight: var(--gg-font-weight-bold);
   color: var(--gg-color-near-black);
   margin: 0 0 var(--gg-spacing-lg) 0;
-  max-width: 700px;
+  max-width: none;
   text-transform: uppercase;
   letter-spacing: var(--gg-letter-spacing-wide);
   line-height: var(--gg-line-height-tight);
@@ -636,6 +636,7 @@ def build_training_css() -> str:
   color: var(--gg-color-primary-brown);
   margin: 0;
   line-height: var(--gg-line-height-prose);
+  max-width: 68ch;
 }}
 .gg-tp-deliverable-row:nth-child(odd) .gg-tp-deliverable-content {{
   background: var(--gg-color-white);
@@ -859,6 +860,7 @@ def build_training_css() -> str:
   color: var(--gg-color-primary-brown);
   margin: 0;
   line-height: var(--gg-line-height-prose);
+  max-width: 68ch;
 }}
 
 /* ── Pullquote / Rotating Reality Check ── */

--- a/wordpress/generate_vs_pages.py
+++ b/wordpress/generate_vs_pages.py
@@ -631,7 +631,7 @@ body {{ margin: 0; background: var(--gg-color-warm-paper); }}
 *, *::before, *::after {{ border-radius: 0 !important; box-shadow: none !important; }}
 
 .gg-vs-page {{
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 0 24px;
   font-family: var(--gg-font-data);

--- a/wordpress/generate_whitepaper_fueling.py
+++ b/wordpress/generate_whitepaper_fueling.py
@@ -1691,7 +1691,7 @@ def build_whitepaper_css() -> str:
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--gg-spacing-xl);
-  max-width: 1080px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: var(--gg-spacing-2xl) var(--gg-spacing-xl);
 }}

--- a/wordpress/mu-plugins/gg-header.php
+++ b/wordpress/mu-plugins/gg-header.php
@@ -78,7 +78,7 @@ header.site-header,
 /* ── Sticky Header ── */
 .gg-site-header { position: sticky !important; top: 0 !important; z-index: 900 !important; padding: 16px 24px !important; border-bottom: 2px solid #9a7e0a !important; background: #f5efe6 !important; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important; }
 .gg-site-header.gg-header-hidden { transform: translateY(-100%) !important; }
-.gg-site-header-inner { display: flex !important; align-items: center !important; justify-content: space-between !important; max-width: 960px !important; margin: 0 auto !important; }
+.gg-site-header-inner { display: flex !important; align-items: center !important; justify-content: space-between !important; max-width: 1200px !important; margin: 0 auto !important; }
 .gg-site-header-logo { display: block !important; }
 .gg-site-header-logo .gg-logo-mark { display: block !important; height: 46px !important; width: auto !important; fill: currentColor !important; color: #3a2e25 !important; }
 

--- a/wordpress/mu-plugins/gg-heading-normalizer.php
+++ b/wordpress/mu-plugins/gg-heading-normalizer.php
@@ -117,7 +117,7 @@ function gg_h1_normalizer_styles() {
         return;
     }
     echo '<style id="gg-heading-normalizer-css">'
-        . '.gg-auto-title-wrap{max-width:1100px;margin:0 auto;padding:32px 24px 16px}'
+        . '.gg-auto-title-wrap{max-width:1200px;margin:0 auto;padding:32px 24px 16px}'
         . '.gg-auto-title{margin:0;color:#3a2e25;font-family:"Source Serif 4",Georgia,serif;'
         . 'font-size:clamp(32px,5vw,64px);font-weight:700;line-height:1.05;letter-spacing:-.025em}'
         . '@media(max-width:600px){.gg-auto-title-wrap{padding:24px 20px 12px}}'

--- a/wordpress/shared_footer.py
+++ b/wordpress/shared_footer.py
@@ -76,7 +76,7 @@ def get_mega_footer_css() -> str:
     return """
 /* ── Mega Footer ───────────────────────────────────────── */
 .gg-mega-footer { background: var(--gg-color-dark-brown); border-top: var(--gg-border-gold); margin-top: var(--gg-spacing-xl); }
-.gg-mega-footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr 1fr; gap: var(--gg-spacing-lg); padding: var(--gg-spacing-2xl) var(--gg-spacing-xl); max-width: 960px; margin: 0 auto; }
+.gg-mega-footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr 1fr; gap: var(--gg-spacing-lg); padding: var(--gg-spacing-2xl) var(--gg-spacing-xl); max-width: 1200px; margin: 0 auto; }
 .gg-mega-footer-brand-title { font-family: var(--gg-font-data); font-size: var(--gg-font-size-sm); font-weight: var(--gg-font-weight-bold); letter-spacing: var(--gg-letter-spacing-ultra-wide); color: var(--gg-color-white); margin: 0 0 var(--gg-spacing-sm) 0; }
 .gg-mega-footer-brand-tagline { font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-xs); line-height: var(--gg-line-height-prose); color: var(--gg-color-tan); margin: 0; }
 .gg-mega-footer-heading { font-family: var(--gg-font-data); font-size: var(--gg-font-size-2xs); font-weight: var(--gg-font-weight-bold); letter-spacing: var(--gg-letter-spacing-ultra-wide); text-transform: uppercase; color: var(--gg-color-gold); margin: 0 0 var(--gg-spacing-md) 0; }
@@ -86,11 +86,11 @@ def get_mega_footer_css() -> str:
 .gg-mega-footer-newsletter-desc { font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-xs); color: var(--gg-color-tan); line-height: var(--gg-line-height-prose); margin: 0 0 var(--gg-spacing-md) 0; }
 .gg-mega-footer-subscribe { display: inline-block; padding: var(--gg-spacing-xs) var(--gg-spacing-lg); font-family: var(--gg-font-data); font-size: 11px; font-weight: var(--gg-font-weight-bold); letter-spacing: var(--gg-letter-spacing-wider); background: var(--gg-color-teal); color: var(--gg-color-white); text-decoration: none; border: var(--gg-border-width-standard) solid var(--gg-color-teal); transition: background-color var(--gg-transition-hover), border-color var(--gg-transition-hover); }
 .gg-mega-footer-subscribe:hover { background: transparent; border-color: var(--gg-color-teal); }
-.gg-mega-footer-legal { padding: var(--gg-spacing-md) var(--gg-spacing-xl); border-top: 1px solid var(--gg-color-primary-brown); text-align: center; font-family: var(--gg-font-data); font-size: var(--gg-font-size-2xs); color: var(--gg-color-secondary-brown); letter-spacing: var(--gg-letter-spacing-wide); max-width: 960px; margin: 0 auto; display: flex; justify-content: center; align-items: center; gap: var(--gg-spacing-md); flex-wrap: wrap; }
+.gg-mega-footer-legal { padding: var(--gg-spacing-md) var(--gg-spacing-xl); border-top: 1px solid var(--gg-color-primary-brown); text-align: center; font-family: var(--gg-font-data); font-size: var(--gg-font-size-2xs); color: var(--gg-color-secondary-brown); letter-spacing: var(--gg-letter-spacing-wide); max-width: 1200px; margin: 0 auto; display: flex; justify-content: center; align-items: center; gap: var(--gg-spacing-md); flex-wrap: wrap; }
 .gg-mega-footer-legal-links { display: flex; gap: var(--gg-spacing-md); }
 .gg-mega-footer-legal-links a { color: var(--gg-color-secondary-brown); text-decoration: none; transition: color var(--gg-transition-hover); }
 .gg-mega-footer-legal-links a:hover { color: var(--gg-color-tan); }
-.gg-mega-footer-disclaimer { padding: var(--gg-spacing-sm) var(--gg-spacing-xl) var(--gg-spacing-lg); max-width: 960px; margin: 0 auto; }
+.gg-mega-footer-disclaimer { padding: var(--gg-spacing-sm) var(--gg-spacing-xl) var(--gg-spacing-lg); max-width: 1200px; margin: 0 auto; }
 .gg-mega-footer-disclaimer p { font-family: var(--gg-font-editorial); font-size: var(--gg-font-size-2xs); color: var(--gg-color-secondary-brown); line-height: var(--gg-line-height-relaxed); margin: 0; text-align: center; }
 
 /* Tablet: 3-column */

--- a/wordpress/shared_header.py
+++ b/wordpress/shared_header.py
@@ -122,7 +122,7 @@ def get_site_header_css() -> str:
   transition: transform var(--gg-transition-hover);
 }
 .gg-site-header.gg-header-hidden { transform: translateY(-100%); }
-.gg-site-header-inner { display: flex; align-items: center; justify-content: space-between; max-width: 960px; margin: 0 auto; }
+.gg-site-header-inner { display: flex; align-items: center; justify-content: space-between; max-width: 1200px; margin: 0 auto; }
 .gg-site-header-logo { display: block; }
 .gg-site-header-logo .gg-logo-mark { display: block; height: 46px; width: auto; fill: currentColor; color: var(--gg-color-dark-brown); }
 .gg-site-header-nav { display: flex; gap: 24px; align-items: center; }


### PR DESCRIPTION
Desktop page shells still used 900–1080px limits despite the July design specification calling for a 1200px measure. Restore that measure across shared navigation, home/product/race pages, hubs and supporting page families. Let the training-plan headline use its available width while retaining existing narrow product components and capping editorial paragraphs at 68ch.

Validation: 563 core tests and 1,110 affected-family tests passed; final width/training tests passed; quick quality preflight passed. Browser checks covered five public page families at six viewport widths, preserving narrow product components and existing form behavior. The pre-existing Insights mobile overflow is unchanged and recorded separately.

Preserve live content and asset versions during publication by appending the reviewed, versioned width-only CSS to guarded current static files. WordPress chrome receives the corresponding CSS-only update. No copy, pricing, training logic, data, links or JavaScript behavior changes.

Design authority: `gravel-god-cycling/docs/world-class-sites-spec.md`, section 2. This implements the existing width direction without reopening the broader visual redesign.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout width changes with regression tests; no auth, data, or business-logic changes. Main risk is visual regression on wide viewports if overlay load order differs from expectations.
> 
> **Overview**
> **Restores the ratified 1200px desktop content measure** across shared chrome (header, footer, WordPress `gg-header.php`), homepage sections, hubs, race profiles, insights, calendar, and other generated page families—replacing prior 900–1080px shells.
> 
> **Readability is preserved** by capping editorial copy at **68ch** on race prose, tire guide, and training-plan deliverable/step paragraphs, while **training-plan hero titles** drop their width cap so headlines can use the wider frame. Narrow product UI caps (hero sub, pricing wrap, etc.) stay as-is.
> 
> Adds **`wordpress/desktop_width_override.css`**, a **max-width-only** overlay for already-published static HTML so live pages can widen without regenerating content. **`tests/test_site_content_width.py`** and updated header/footer/homepage tests lock the measure in; **`web/training-plans.html`** mirrors the same 1200px / 68ch rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdd21b21793cd19a79a815097b81aaab05ec4fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->