### PR TITLE
Simplify training-plan delivery copy

### DIFF
--- a/tests/test_training_plans.py
+++ b/tests/test_training_plans.py
@@ -144,16 +144,16 @@ class TestHero:
     def test_four_stats(self):
         hero = build_hero()
         assert "24 Hours" in hero
-        assert "Plan or Delivery Update" in hero
+        assert "Delivery" in hero
         assert "Matched" in hero
         assert "$2/day" in hero
         assert "5 min" in hero
 
-    def test_delivery_clock_and_blocker_are_visible(self):
+    def test_delivery_promise_is_simple_and_specific(self):
         hero = build_hero()
-        assert "payment, your complete questionnaire, and your TrainingPeaks connection" in hero
-        assert "specific blocker" in hero
-        assert "revised delivery time" in hero
+        assert "Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours." in hero
+        assert "24-hour clock" not in hero
+        assert "delivery update" not in hero.lower()
         assert "Same Day" not in hero
 
     def test_hours_claim_is_specific_without_overstating_the_science(self):
@@ -385,12 +385,11 @@ class TestPricing:
 
 
 class TestQuestionnaireReferenceContract:
-    def test_reference_matches_accepted_delivery_and_support_terms(self):
+    def test_reference_matches_delivery_and_support_terms(self):
         reference = (Path(__file__).parent.parent / "web" / "training-plans-questionnaire.html").read_text()
-        assert "Personally reviewed. Your plan or a delivery update within 24 hours." in reference
-        assert "payment, your complete questionnaire, and your TrainingPeaks connection" in reference
-        assert "specific blocker" in reference
-        assert "revised delivery time" in reference
+        assert "Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours." in reference
+        assert "24-hour clock" not in reference
+        assert "delivery update" not in reference.lower()
         assert "Email support and two plan adjustments" in reference
         assert "first rescale after the scheduled FTP test" in reference
         assert "Same-Day Delivery" not in reference

--- a/web/training-plans-questionnaire.html
+++ b/web/training-plans-questionnaire.html
@@ -571,15 +571,14 @@
   <div class="tp-questionnaire-hero">
     <h1>Build Your Plan</h1>
     <p>Five minutes. Be thorough. The plan is only as good as the data.
-    Personally reviewed. Your plan or a delivery update within 24 hours.</p>
-    <p>The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. If something prevents delivery, I will explain the specific blocker, what is needed, and give you a revised delivery time.</p>
+    Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours.</p>
   </div>
 
   <div class="gg-form-container">
     <div class="gg-form-header">
       <span class="gg-form-badge">Custom Training Plan</span>
       <h2>Build Your Plan</h2>
-      <p>Fill out this form and pay securely via Stripe. The 24-hour clock starts once payment, your complete questionnaire, and your TrainingPeaks connection are all in place.</p>
+      <p>Fill out this form and pay securely via Stripe.</p>
     </div>
 
     <form id="gg-training-form">
@@ -985,9 +984,9 @@
         <div class="gg-trust-badges">
           <span class="gg-trust-badge">7-Day Full Refund</span>
           <span class="gg-trust-badge">Secure Checkout via Stripe</span>
-          <span class="gg-trust-badge">Plan or Delivery Update in 24 Hours</span>
+          <span class="gg-trust-badge">Personally Reviewed Plan in 24 Hours</span>
         </div>
-        <p class="gg-trust-terms">The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I will deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time.</p>
+        <p class="gg-trust-terms">Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours.</p>
         <p class="gg-trust-terms">Email support and two plan adjustments are included during the dates covered by your plan for changes to your schedule, available training hours, or equipment. Correcting a plan that does not match your order does not use an adjustment. The first rescale after the scheduled FTP test is included separately. Weekly review and recurring changes are part of Coaching.</p>
       </div>
 

--- a/web/training-plans.html
+++ b/web/training-plans.html
@@ -970,7 +970,7 @@
     <div class="tp-hero-bar">
       <div class="tp-hero-bar-item">
         <strong>24 Hours</strong>
-        <span>Plan or Delivery Update</span>
+        <span>Delivery</span>
       </div>
       <div class="tp-hero-bar-item">
         <strong>Matched</strong>
@@ -985,7 +985,7 @@
         <span>To Start</span>
       </div>
     </div>
-    <p class="tp-delivery-terms">The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I will deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time.</p>
+    <p class="tp-delivery-terms">Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours.</p>
   </div>
 
   <!-- ============================================================
@@ -1118,7 +1118,7 @@
       <div class="tp-process-step">
         <div class="tp-process-num">04</div>
         <h4>You Train</h4>
-        <p>Plan or update within 24 hours</p>
+        <p>Delivered within 24 hours</p>
       </div>
     </div>
     <div class="tp-steps">
@@ -1153,10 +1153,7 @@
         <div class="tp-step-num">04</div>
         <div>
           <h3>Plan Drops Into Your Calendar</h3>
-          <p>The 24-hour clock starts when payment, your complete questionnaire,
-          and your TrainingPeaks connection are all in place. Within that window,
-          I deliver your personally reviewed plan in TrainingPeaks or email you
-          with the specific blocker, what is needed, and a revised delivery time.</p>
+          <p>Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours.</p>
         </div>
       </div>
     </div>
@@ -1222,9 +1219,9 @@
           <li>Race-optimized fueling plan</li>
           <li>Custom strength program</li>
           <li>Heat &amp; altitude protocols</li>
-          <li>Your plan or a delivery update within 24 hours</li>
+          <li>Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours</li>
         </ul>
-        <p class="tp-support-terms">The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I will deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time. Email support and two plan adjustments are included during the dates covered by your plan for changes to your schedule, available training hours, or equipment. Correcting a plan that does not match your order does not use an adjustment. The first rescale after the scheduled FTP test is included separately. Weekly review and recurring changes are part of Coaching.</p>
+        <p class="tp-support-terms">Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours. Email support and two plan adjustments are included during the dates covered by your plan for changes to your schedule, available training hours, or equipment. Correcting a plan that does not match your order does not use an adjustment. The first rescale after the scheduled FTP test is included separately. Weekly review and recurring changes are part of Coaching.</p>
         <div class="tp-pricing-cta">
           <a href="https://gravelgodcycling.com/training-plans/questionnaire/" class="tp-btn">Build My Plan</a>
         </div>

--- a/wordpress/generate_training_plans.py
+++ b/wordpress/generate_training_plans.py
@@ -67,12 +67,12 @@ def build_hero() -> str:
     <a href="#how-it-works" class="gg-tp-btn gg-tp-btn-secondary" data-cta="hero_how">See How It Works</a>
   </div>
   <div class="gg-tp-hero-bar">
-    <div class="gg-tp-hero-bar-item"><strong>24 Hours</strong><span>Plan or Delivery Update</span></div>
+    <div class="gg-tp-hero-bar-item"><strong>24 Hours</strong><span>Delivery</span></div>
     <div class="gg-tp-hero-bar-item"><strong>Matched</strong><span>Methodology</span></div>
     <div class="gg-tp-hero-bar-item"><strong>$2/day</strong><span>Less Than a Tube</span></div>
     <div class="gg-tp-hero-bar-item"><strong>5 min</strong><span>To Start</span></div>
   </div>
-  <p class="gg-tp-delivery-terms">The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I will deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time.</p>
+  <p class="gg-tp-delivery-terms">Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours.</p>
 </section>'''
 
 
@@ -248,7 +248,7 @@ def build_how_it_works() -> str:
         ("01", "Questionnaire", "5 min form"),
         ("02", "TrainingPeaks", "Connect account"),
         ("03", "Plan Built", "Matched to you"),
-        ("04", "You Train", "Plan or update within 24 hours"),
+        ("04", "You Train", "Delivered within 24 hours"),
     ]
     cards_html = ""
     for num, title, desc in process_cards:
@@ -266,7 +266,7 @@ def build_how_it_works() -> str:
         ("03", "I Build Your Plan",
          "Your intake hits the methodology engine. The training approach gets selected based on your profile. Polarized for the time-crunched. Pyramidal for the balanced. Block for the serious. Matched to your availability and ability."),
         ("04", "Plan Drops Into Your Calendar",
-         "The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time."),
+         "Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours."),
     ]
     steps_html = ""
     for num, title, desc in steps:
@@ -355,9 +355,9 @@ def build_pricing() -> str:
         <li>Race-optimized fueling plan</li>
         <li>Custom strength program</li>
         <li>Heat &amp; altitude protocols</li>
-        <li>Your plan or a delivery update within 24 hours</li>
+        <li>Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours</li>
       </ul>
-      <p class="gg-tp-support-terms">The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I will deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time. Email support and two plan adjustments are included during the dates covered by your plan for changes to your schedule, available training hours, or equipment. Correcting a plan that does not match your order does not use an adjustment. The first rescale after the scheduled FTP test is included separately. Weekly review and recurring changes are part of Coaching.</p>
+      <p class="gg-tp-support-terms">Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours. Email support and two plan adjustments are included during the dates covered by your plan for changes to your schedule, available training hours, or equipment. Correcting a plan that does not match your order does not use an adjustment. The first rescale after the scheduled FTP test is included separately. Weekly review and recurring changes are part of Coaching.</p>
       <div class="gg-tp-pricing-cta">
         <a href="{QUESTIONNAIRE_URL}" class="gg-tp-btn" data-cta="pricing_build">Build My Plan</a>
       </div>


### PR DESCRIPTION
Replace the conditional delivery language with the approved promise: “Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours.” The hero stat now reads “Delivery,” and the supporting product and questionnaire copy no longer exposes fulfillment prerequisites or fallback updates.

The source generator and the WordPress/Elementor reference markup stay aligned. No CSS, widths, fulfillment logic, payment flow, timers, or support-and-adjustment terms changed.

Validation:

- `python3 -m pytest tests/test_training_plans.py -q` — 113 passed
- `python3 wordpress/generate_training_plans.py --output-dir /tmp/gg-copy-cleanup-output`
- `python3 scripts/preflight_quality.py` — passed (existing environment warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change with no payment, fulfillment logic, or support terms modified; main caveat is softer public wording on delivery edge cases versus the removed fallback language.
> 
> **Overview**
> **Simplifies customer-facing delivery messaging** across the training plans landing page, questionnaire, and `generate_training_plans.py` so they all use one line: *"Your plan, personally reviewed and delivered in TrainingPeaks within 24 hours."*
> 
> The hero stat label changes from **"Plan or Delivery Update"** to **"Delivery"**, and how-it-works/pricing/trust copy drops the **24-hour clock** prerequisites (payment, questionnaire, TrainingPeaks) and **fallback "delivery update" / blocker** language. The questionnaire hero and Stripe intro are shortened accordingly; the trust badge becomes **"Personally Reviewed Plan in 24 Hours."** Email support and adjustment terms are unchanged.
> 
> Tests are updated to assert the new promise and forbid the removed phrases, including parity with `web/training-plans-questionnaire.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 502458c0e4eb60e307535a929471fee07cff9b54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->