### PR TITLE
Align remaining Gravel God custom plan promises

### DIFF
--- a/wordpress/generate_training_plan_pages.py
+++ b/wordpress/generate_training_plan_pages.py
@@ -540,13 +540,13 @@ def build_cta(rd: dict) -> str:
   <p>The free version of preparing for {name} is this page plus the
   <a href="/race/{slug}/prep-kit/" data-cta="tpp_cta_kit">prep kit</a>.
   The custom version is a plan built from your hours, your schedule, your
-  fitness markers, and this exact course &mdash; delivered to your
-  TrainingPeaks calendar the same day.</p>
+  fitness markers, and this exact course &mdash; personally reviewed and
+  delivered in TrainingPeaks within 24 hours.</p>
   <div class="gg-tpp-cta-row">
     <a href="{QUESTIONNAIRE_URL}?race={slug}" class="gg-btn" data-cta="tpp_footer_build" id="gg-tpp-footer-cta">BUILD MY PLAN &mdash; $15/WK</a>
     <a href="/race/{slug}/" class="gg-btn gg-btn--outline" data-cta="tpp_race_page">READ THE {name.upper()} REVIEW</a>
   </div>
-  <p class="gg-tpp-guarantee">7-day full refund. Same-day delivery. $249 cap.</p>
+  <p class="gg-tpp-guarantee">7-day full refund. Delivery within 24 hours. $249 cap.</p>
 </section>'''
 
 

--- a/wordpress/generate_training_plans.py
+++ b/wordpress/generate_training_plans.py
@@ -264,7 +264,7 @@ def build_how_it_works() -> str:
         ("02", "Connect on TrainingPeaks",
          "Attach to my TrainingPeaks Coach Account. This is how the plan gets to your calendar. Free TrainingPeaks account works fine."),
         ("03", "I Build Your Plan",
-         "Your intake hits the methodology engine. The training approach gets selected based on your profile. Polarized for the time-crunched. Pyramidal for the balanced. Block for the serious. Matched to your availability and ability."),
+         "I choose the training approach that fits your available time, experience, and race demands."),
         ("04", "Plan Drops Into Your Calendar",
          "The 24-hour clock starts when payment, your complete questionnaire, and your TrainingPeaks connection are all in place. Within that window, I deliver your personally reviewed plan in TrainingPeaks or email you with the specific blocker, what is needed, and a revised delivery time."),
     ]


### PR DESCRIPTION
The generated race-plan footer still promises same-day delivery, and one product-page step exposes the methodology engine. This aligns those remaining source strings with personal review and TrainingPeaks delivery within 24 hours, without touching the concurrent product-page release.

Validation: 24 focused tests passed; Python compilation and diff checks passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes in WordPress HTML generators; no pricing, fulfillment logic, or API behavior.
> 
> **Overview**
> Updates **generated marketing copy** so leftover custom-plan promises match the rest of the site: **personal review** and **TrainingPeaks delivery within 24 hours**, not same-day calendar drops or automated “methodology engine” language.
> 
> On race **`/training-plan/`** footers (`build_cta` in `generate_training_plan_pages.py`), the custom-plan blurb and guarantee line now say plans are **personally reviewed** and delivered **within 24 hours** instead of **same-day** TrainingPeaks calendar delivery.
> 
> On the main **training plans landing** (`generate_training_plans.py`), **How it works** step 03 drops polarized/pyramidal/block and “methodology engine” wording in favor of a coach-led line: the approach is chosen to fit **time, experience, and race demands**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46781dd6791cea8d9407a667220efe790076f464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->