### PR TITLE
fix(intel): scope legacy form_start/form_submit to /questionnaire/

### DIFF
--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -73,6 +73,14 @@ BRANDS = {
 # The deployed gravel form JS predates the tp_* rename — both generations
 # fire in the wild, so each stage counts the union (Jul 2026 investigation:
 # June was form_start 33 / form_submit 20 / purchase 2, invisible to tp_*-only queries).
+# form_start/form_submit are ALSO GA4 Enhanced Measurement auto-events fired by
+# every <form> on the site — chiefly the homepage race search (Sep 9 2026: 46 of
+# 49 form_submit over 28d were on "/"; tp_form_submit 2 = begin_checkout 2).
+# Counting them property-wide fabricates a "submits die before checkout" signal,
+# so the legacy pair is scoped to the questionnaire page (same rule as
+# funnel_report.py and the native funnel in mission_control/services/ga4.py).
+LEGACY_FORM_EVENTS = ["form_start", "form_submit"]
+LEGACY_FORM_PATH_PREFIX = "/questionnaire/"
 FUNNEL_STAGES = {
     "cta_click": ["cta_click"],
     "form_start": ["form_start", "tp_form_start"],
@@ -176,7 +184,8 @@ def _safe(fn):
 def collect_ga4(brand: str) -> dict:
     from google.analytics.data_v1beta import BetaAnalyticsDataClient
     from google.analytics.data_v1beta.types import (
-        DateRange, Dimension, Filter, FilterExpression, Metric, RunReportRequest,
+        DateRange, Dimension, Filter, FilterExpression, FilterExpressionList,
+        Metric, RunReportRequest,
     )
 
     creds = os.environ.get("GA4_CREDENTIALS", str(PROJECT_ROOT / "ga4-credentials.json"))
@@ -204,19 +213,43 @@ def collect_ga4(brand: str) -> dict:
             request_args["dimension_filter"] = dimension_filter
         return client.run_report(RunReportRequest(**request_args))
 
+    # Two event queries per window: custom events property-wide, and the
+    # legacy Enhanced-Measurement pair restricted to the questionnaire page.
+    custom_events = sorted(set(FUNNEL_EVENTS) - set(LEGACY_FORM_EVENTS))
     event_filter = FilterExpression(filter=Filter(
         field_name="eventName",
-        in_list_filter=Filter.InListFilter(values=sorted(FUNNEL_EVENTS)),
+        in_list_filter=Filter.InListFilter(values=custom_events),
     ))
+    legacy_filter = FilterExpression(and_group=FilterExpressionList(expressions=[
+        FilterExpression(filter=Filter(
+            field_name="eventName",
+            in_list_filter=Filter.InListFilter(values=sorted(LEGACY_FORM_EVENTS)),
+        )),
+        FilterExpression(filter=Filter(
+            field_name="pagePath",
+            string_filter=Filter.StringFilter(
+                value=LEGACY_FORM_PATH_PREFIX,
+                match_type=Filter.StringFilter.MatchType.BEGINS_WITH,
+            ),
+        )),
+    ]))
+
+    def event_counts(date_from, date_to):
+        counts = {}
+        for dim_filter in (event_filter, legacy_filter):
+            report = run(["eventCount"], ["eventName"], date_from=date_from,
+                         date_to=date_to, dimension_filter=dim_filter)
+            for r in report.rows:
+                name = r.dimension_values[0].value
+                counts[name] = counts.get(name, 0) + int(r.metric_values[0].value)
+        return counts
 
     totals = run(["sessions", "totalUsers", "screenPageViews"])
     t = totals.rows[0].metric_values if totals.rows else None
     week = run(["sessions"], date_from=week_ago, date_to=y)
     week_sessions = int(week.rows[0].metric_values[0].value) if week.rows else 0
 
-    events = run(["eventCount"], ["eventName"], dimension_filter=event_filter)
-    ev = {r.dimension_values[0].value: int(r.metric_values[0].value)
-          for r in events.rows}
+    ev = event_counts(y, y)
 
     pages = run(["screenPageViews"], ["pagePath"], limit=8)
     top_pages = [{"path": r.dimension_values[0].value,
@@ -227,12 +260,7 @@ def collect_ga4(brand: str) -> dict:
     m_ago = (date.today() - timedelta(days=28)).isoformat()
     agg = run(["sessions"], date_from=m_ago, date_to=y)
     sessions_28d = int(agg.rows[0].metric_values[0].value) if agg.rows else 0
-    ev28 = run(
-        ["eventCount"], ["eventName"], date_from=m_ago, date_to=y,
-        dimension_filter=event_filter,
-    )
-    ev28d = {r.dimension_values[0].value: int(r.metric_values[0].value)
-             for r in ev28.rows}
+    ev28d = event_counts(m_ago, y)
     funnel_28d = {stage: sum(ev28d.get(e, 0) for e in evs)
                   for stage, evs in FUNNEL_STAGES.items()}
 

--- a/tests/test_daily_intel.py
+++ b/tests/test_daily_intel.py
@@ -190,6 +190,10 @@ def test_collect_ga4_filters_both_event_queries_before_limit(monkeypatch):
         class InListFilter(Message):
             pass
 
+        class StringFilter(Message):
+            class MatchType:
+                BEGINS_WITH = "BEGINS_WITH"
+
     def row(name, count):
         return SimpleNamespace(
             dimension_values=[SimpleNamespace(value=name)],
@@ -204,9 +208,14 @@ def test_collect_ga4_filters_both_event_queries_before_limit(monkeypatch):
             dimensions = [item.name for item in request.dimensions]
             if dimensions == ["eventName"]:
                 self.event_requests.append(request)
-                if getattr(request, "dimension_filter", None):
-                    return SimpleNamespace(rows=[row("purchase", 2), row("refund", 7)])
-                return SimpleNamespace(rows=[row(f"unrelated_{i}", 1) for i in range(100)])
+                dim_filter = getattr(request, "dimension_filter", None)
+                if dim_filter is None:
+                    return SimpleNamespace(rows=[row(f"unrelated_{i}", 1) for i in range(100)])
+                if getattr(dim_filter, "and_group", None) is not None:
+                    # Legacy Enhanced-Measurement pair, questionnaire-scoped.
+                    return SimpleNamespace(rows=[row("form_submit", 3)])
+                return SimpleNamespace(rows=[row("purchase", 2), row("refund", 7),
+                                             row("tp_form_submit", 1)])
             return SimpleNamespace(rows=[])
 
     client = Client()
@@ -218,6 +227,7 @@ def test_collect_ga4_filters_both_event_queries_before_limit(monkeypatch):
         "Dimension": Message,
         "Filter": Filter,
         "FilterExpression": Message,
+        "FilterExpressionList": Message,
         "Metric": Message,
         "RunReportRequest": Message,
     }.items():
@@ -230,13 +240,29 @@ def test_collect_ga4_filters_both_event_queries_before_limit(monkeypatch):
 
     assert result["funnel"]["purchase"] == 2
     assert result["funnel"]["refund"] == 7
+    assert result["funnel"]["form_submit"] == 4  # 1 tp_form_submit + 3 scoped legacy
     assert result["funnel_28d"]["purchase"] == 2
     assert result["funnel_28d"]["refund"] == 7
-    assert len(client.event_requests) == 2
-    for request in client.event_requests:
+    assert result["funnel_28d"]["form_submit"] == 4
+    # Two windows (yesterday, 28d) x two filtered queries each.
+    assert len(client.event_requests) == 4
+    custom = [r for r in client.event_requests
+              if getattr(r.dimension_filter, "and_group", None) is None]
+    legacy = [r for r in client.event_requests
+              if getattr(r.dimension_filter, "and_group", None) is not None]
+    assert len(custom) == 2 and len(legacy) == 2
+    expected_custom = set(daily_intel.FUNNEL_EVENTS) - set(daily_intel.LEGACY_FORM_EVENTS)
+    for request in custom:
         event_filter = request.dimension_filter.filter
         assert event_filter.field_name == "eventName"
-        assert set(event_filter.in_list_filter.values) == set(daily_intel.FUNNEL_EVENTS)
+        assert set(event_filter.in_list_filter.values) == expected_custom
+    for request in legacy:
+        name_expr, path_expr = request.dimension_filter.and_group.expressions
+        assert name_expr.filter.field_name == "eventName"
+        assert set(name_expr.filter.in_list_filter.values) == set(daily_intel.LEGACY_FORM_EVENTS)
+        assert path_expr.filter.field_name == "pagePath"
+        assert path_expr.filter.string_filter.value == daily_intel.LEGACY_FORM_PATH_PREFIX
+        assert path_expr.filter.string_filter.match_type == "BEGINS_WITH"
 
 
 def test_load_trend_keeps_events_distinct_from_processing_records(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- daily_intel counted GA4 Enhanced-Measurement `form_start`/`form_submit` property-wide, so every homepage race search registered as a training-plan questionnaire submit. Sep 9 2026: 46 of 49 `form_submit` over 28d were on `/`; `tp_form_submit` 2 = `begin_checkout` 2. The reported "4 submits → 0 checkouts" gap and the 7.8% submit→purchase rate were measurement artifacts, not a wiring or flow gap.
- Split the event query in two: custom events property-wide, the legacy pair restricted to `pagePath BEGINS_WITH /questionnaire/` — the same scoping `funnel_report.py` and the mission_control native funnel already apply.

## Verification
- `tests/test_daily_intel.py` updated and green (28 passed); the filter test now asserts the questionnaire-scoped AND-group for the legacy pair.
- Live run of the patched `collect_ga4("gravelgod")` against the real property: yesterday `form_submit 0 / begin_checkout 0`; 28d `form_start 13 → form_submit 2 → begin_checkout 2 → purchase 4`.
- Full suite was still running locally at PR time; CI is the gate.

## Not in this PR
- begin_checkout client wiring verified correct: deployed `training-plans-form.js` is byte-identical to main and fires `begin_checkout` before `tp_form_submit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics measurement fix in the daily intel collector and tests only; no checkout, auth, or production runtime path changes beyond more accurate GA4 funnel numbers in reports.
> 
> **Overview**
> **Morning Intel GA4 funnel counts** no longer treat property-wide Enhanced Measurement `form_start`/`form_submit` as questionnaire submits (homepage race search was inflating submit totals and fake submit→checkout gaps).
> 
> `collect_ga4` now runs **two merged event queries** per window: custom funnel events property-wide, plus legacy `form_start`/`form_submit` only where `pagePath` begins with `/questionnaire/`—matching `funnel_report.py` and Mission Control’s native funnel. Funnel stages still union legacy and `tp_*` names.
> 
> Tests assert four filtered GA4 calls (yesterday + 28d × custom + legacy) and that `form_submit` sums scoped legacy counts with `tp_form_submit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f89df8e9be105673741599442eae63b33e831bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->