### PR TITLE
Pilot: add Endure custom-plan delivery receipt

### DIFF
--- a/tests/test_success_pages.py
+++ b/tests/test_success_pages.py
@@ -116,6 +116,19 @@ class TestGA4Tracking:
     def test_training_plan_product_type(self, all_pages):
         assert 'data-product-type="training_plan"' in all_pages["training-plans-success"]
 
+    def test_training_plan_success_supports_the_endure_pilot_receipt(self, all_pages):
+        page = all_pages["training-plans-success"]
+        assert 'data-delivery-copy="trainingpeaks"' in page
+        assert 'data-delivery-copy="endure" hidden' in page
+        assert "Your Endure Plan Is on the Way" in page
+        assert "Automatic device sync is not part of this pilot" in page
+        assert "Upload a\n        completed FIT or TCX file from Today" in page
+
+    def test_success_receipt_selects_delivery_copy_from_the_return_url(self, success_js):
+        assert "params.get('delivery') === 'endure'" in success_js
+        assert "copy.hidden = copy.getAttribute('data-delivery-copy') !== deliveryTarget" in success_js
+        assert "delivery_target: deliveryTarget" in success_js
+
     def test_coaching_product_type(self, all_pages):
         assert 'data-product-type="coaching"' in all_pages["coaching-welcome"]
 

--- a/wordpress/generate_success_pages.py
+++ b/wordpress/generate_success_pages.py
@@ -204,13 +204,21 @@ def build_success_js() -> str:
 (function() {
   var params = new URLSearchParams(window.location.search);
   var sessionId = params.get('session_id') || '';
+  var deliveryTarget = params.get('delivery') === 'endure'
+    ? 'endure'
+    : 'trainingpeaks';
   var productType = document.querySelector('[data-product-type]');
   var ptype = productType ? productType.getAttribute('data-product-type') : 'unknown';
+
+  document.querySelectorAll('[data-delivery-copy]').forEach(function(copy) {
+    copy.hidden = copy.getAttribute('data-delivery-copy') !== deliveryTarget;
+  });
 
   if (typeof gtag === 'function') {
     gtag('event', 'success_page_view', {
       product_type: ptype,
       session_id: sessionId,
+      delivery_target: deliveryTarget,
     });
   }
 
@@ -245,7 +253,8 @@ def build_success_js() -> str:
 
 def build_training_plan_success() -> str:
     """Content sections for training plan success page."""
-    hero = f"""
+    trainingpeaks = f"""
+  <div data-delivery-copy="trainingpeaks">
   <div class="gg-success-hero" data-product-type="training_plan">
     <div class="gg-success-check">&check;</div>
     <h1>Your Training Plan Is on the Way</h1>
@@ -281,6 +290,48 @@ def build_training_plan_success() -> str:
         workouts may feel easy. That's intentional.</p>
       </div>
     </div>
+  </div>
+  </div>"""
+
+    endure = """
+  <div data-delivery-copy="endure" hidden>
+  <div class="gg-success-hero" data-product-type="training_plan">
+    <div class="gg-success-check">&check;</div>
+    <h1>Your Endure Plan Is on the Way</h1>
+    <p>Payment confirmed. Matti will review the first training block before
+    it appears in your Endure account.</p>
+  </div>
+
+  <div class="gg-success-steps">
+    <h2>WHAT HAPPENS NEXT</h2>
+    <div class="gg-success-step">
+      <div class="gg-success-step-num">1</div>
+      <div class="gg-success-step-text">
+        <h3>Watch Your Email</h3>
+        <p>You will receive a secure Endure access link within 24 hours,
+        after the race, schedule, progression, and workouts are checked.</p>
+      </div>
+    </div>
+    <div class="gg-success-step">
+      <div class="gg-success-step-num">2</div>
+      <div class="gg-success-step-text">
+        <h3>Open Your First Block</h3>
+        <p>Endure works in your phone or computer browser; no mobile app is
+        required. Your training guide covers the full plan, while Endure opens
+        the first approved block for this pilot.</p>
+      </div>
+    </div>
+    <div class="gg-success-step">
+      <div class="gg-success-step-num">3</div>
+      <div class="gg-success-step-text">
+        <h3>Check In, Train, and Add Feedback</h3>
+        <p>Automatic device sync is not part of this pilot. Upload a
+        completed FIT or TCX file from Today, then add how the workout felt.
+        This purchase does not start ongoing coaching or automatic plan
+        changes.</p>
+      </div>
+    </div>
+  </div>
   </div>"""
 
     crosssell = f"""
@@ -306,7 +357,7 @@ def build_training_plan_success() -> str:
     <a href="mailto:gravelgodcoaching@gmail.com">gravelgodcoaching@gmail.com</a></p>
   </div>"""
 
-    return hero + steps + crosssell + support
+    return trainingpeaks + steps + endure + crosssell + support
 
 
 # ── Coaching Success ──────────────────────────────────────────


### PR DESCRIPTION
## Outcome
Adds the customer-facing success state for delivering a purchased custom plan through Endure.

## Included
- Endure-specific success receipt
- session and delivery query handling
- preserves the existing TrainingPeaks delivery path

## Evidence
- tests/test_success_pages.py: 85 passed, 1 skipped
- rebased onto current main before push
- no real Stripe charge performed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Customer-facing copy and client-side display toggling on a noindexed success page; purchase reporting still webhook-only.
> 
> **Overview**
> Adds an **Endure pilot** post-checkout receipt on the training plan success page while keeping the existing **TrainingPeaks** messaging as the default.
> 
> The page now embeds two `data-delivery-copy` blocks (TrainingPeaks and Endure, with Endure hidden initially). Success-page JS reads `?delivery=endure` on the return URL, shows the matching block, and sends **`delivery_target`** on the existing `success_page_view` GA4 event. Endure copy covers manual review, email access, browser-only use, FIT/TCX upload, and pilot limits (no auto sync / no ongoing coaching).
> 
> Tests lock in the dual HTML variants and the URL-driven copy selection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54469999313f408d90448f56b652beaae60a3f8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->