### PR TITLE
fix(mission_control): order native funnel checkout before submit (#338)

### DIFF
--- a/mission_control/services/ga4.py
+++ b/mission_control/services/ga4.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 CACHE_TTL_HOURS = 4
 GA4_DATA_API_ROOT = "https://analyticsdata.googleapis.com"
 NATIVE_FUNNEL_SCHEMA = "ga4_native_ordered_funnel/v1"
-NATIVE_FUNNEL_CACHE_VERSION = "v1"
+NATIVE_FUNNEL_CACHE_VERSION = "v2"  # v2: checkout step moved before submit (#338)
 NATIVE_FUNNEL_METRICS = (
     "activeUsers",
     "funnelStepCompletionRate",
@@ -43,8 +43,13 @@ NATIVE_FUNNEL_STEPS = (
     {"key": "race_page_view", "name": "Race page view"},
     {"key": "race_cta", "name": "Race CTA"},
     {"key": "plan_form_start", "name": "Plan form start"},
-    {"key": "plan_form_submit", "name": "Plan form submit"},
+    # Checkout precedes submit on purpose: training-plans-form.js fires
+    # begin_checkout when the submit handler starts and tp_form_submit only
+    # after the API returns a checkout_url (just before the Stripe redirect).
+    # This is a CLOSED, ordered funnel, so the steps must match emission order
+    # or every real journey is dropped at the checkout step (#338).
     {"key": "training_plan_checkout", "name": "Training-plan checkout"},
+    {"key": "plan_form_submit", "name": "Plan form submit"},
     {"key": "training_plan_purchase", "name": "Training-plan purchase"},
 )
 _INTEGER_METRIC = re.compile(r"(?:0|[1-9][0-9]*)\Z")
@@ -240,12 +245,12 @@ def _native_funnel_request(start_date: str, end_date: str) -> dict:
         _funnel_and(_funnel_or(
             _funnel_event("form_start"), _funnel_event("tp_form_start")),
             form_path),
-        _funnel_and(_funnel_or(
-            _funnel_event("form_submit"), _funnel_event("tp_form_submit")),
-            form_path),
         _funnel_and(
             _funnel_event("begin_checkout"),
             _funnel_field("itemCategory", "training_plan", "EXACT")),
+        _funnel_and(_funnel_or(
+            _funnel_event("form_submit"), _funnel_event("tp_form_submit")),
+            form_path),
         _funnel_and(
             _funnel_event("purchase"),
             _funnel_field("itemCategory", "training_plan", "EXACT")),

--- a/tests/fixtures/ga4_native_closed_funnel.json
+++ b/tests/fixtures/ga4_native_closed_funnel.json
@@ -174,7 +174,7 @@
         {
           "dimensionValues": [
             {
-              "value": "4. Plan form submit"
+              "value": "4. Training-plan checkout"
             }
           ],
           "metricValues": [
@@ -251,7 +251,7 @@
         {
           "dimensionValues": [
             {
-              "value": "4. Plan form submit"
+              "value": "4. Training-plan checkout"
             }
           ],
           "metricValues": [

--- a/tests/test_ga4_service_events.py
+++ b/tests/test_ga4_service_events.py
@@ -269,8 +269,8 @@ def test_native_funnel_parses_captured_repeated_headers_and_preserves_absence(
     assert payload["dateRanges"] == [{"startDate": "2026-08-09", "endDate": "2026-09-07"}]
     assert payload["funnel"]["isOpenFunnel"] is False
     assert [step["name"] for step in payload["funnel"]["steps"]] == [
-        "Race page view", "Race CTA", "Plan form start", "Plan form submit",
-        "Training-plan checkout", "Training-plan purchase",
+        "Race page view", "Race CTA", "Plan form start", "Training-plan checkout",
+        "Plan form submit", "Training-plan purchase",
     ]
     assert "unifiedPagePathScreen" in json.dumps(payload)
     assert '"itemCategory"' in json.dumps(payload)
@@ -294,13 +294,13 @@ def test_native_funnel_parses_captured_repeated_headers_and_preserves_absence(
 def test_native_funnel_preserves_provider_zero_as_present(monkeypatch):
     body = _captured_response()
     table_row = {
-        "dimensionValues": [{"value": "5. Training-plan checkout"}],
+        "dimensionValues": [{"value": "5. Plan form submit"}],
         "metricValues": [
             {"value": "0"}, {"value": "0"}, {"value": "0"}, {"value": "0"},
         ],
     }
     visual_row = {
-        "dimensionValues": [{"value": "5. Training-plan checkout"}],
+        "dimensionValues": [{"value": "5. Plan form submit"}],
         "metricValues": [{"value": "0"}],
     }
     body["funnelTable"]["rows"].append(table_row)
@@ -464,7 +464,7 @@ def _valid_cached_funnel():
         },
         "provenance": {
             "cache_hit": False,
-            "request_version": "v1",
+            "request_version": "v2",
             "property_ref": "1f5aeb67e1f0",
             "response_kind": "analyticsData#runFunnelReport",
         },
@@ -572,7 +572,7 @@ def test_native_funnel_rejects_cached_malformed_metadata_and_refetches(monkeypat
         },
         "steps": [],
         "provenance": {
-            "request_version": "v1", "property_ref": "1f5aeb67e1f0",
+            "request_version": "v2", "property_ref": "1f5aeb67e1f0",
         },
     },
 ])


### PR DESCRIPTION
Closes #338.

## Summary
- `training-plans-form.js` fires `begin_checkout` when the submit handler starts and `tp_form_submit` only after the API returns a `checkout_url`. Mission Control's **closed, ordered** GA4 funnel had submit before checkout, so every real journey was dropped at the checkout step. The captured fixture shows it: `4601 → 186 → 10 → 2 → absent → absent`.
- Swap steps 4 and 5 in `NATIVE_FUNNEL_STEPS` and `_native_funnel_request()`, bump `NATIVE_FUNNEL_CACHE_VERSION` to `v2` so cached v1 reports are not reused.
- Fixture rows renamed to the new positions (same numbers; it remains a parser fixture, not a semantic capture).

## Verification
- `tests/test_ga4_service_events.py`: 32 passed.
- Live `get_ordered_funnel_report(days=30)` with the new order (period ending 2026-09-09): `2785 → 111 → 5 → 1 checkout → 1 submit → purchase absent`. Checkout is now present instead of dropped. Purchase stays absent because server-side purchases use the order-scoped fallback client id and cannot join browser steps (documented limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df57KrhMyez9BwPVKRhbiT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GA4 funnel definition and cache versioning for Mission Control analytics; no user-facing checkout flow, but reporting numbers and cache behavior change until v2 data is refetched.
> 
> **Overview**
> Fixes Mission Control’s **closed, ordered** GA4 training-plan funnel so step order matches how events are emitted on the site.
> 
> **Training-plan checkout** (`begin_checkout`) is now step 4 and **Plan form submit** (`tp_form_submit` / `form_submit`) is step 5, in both `NATIVE_FUNNEL_STEPS` and the `runFunnelReport` request built in `_native_funnel_request()`. Previously submit came before checkout, so real journeys failed the ordered funnel and checkout looked absent.
> 
> `NATIVE_FUNNEL_CACHE_VERSION` is bumped to **v2** so cached v1 funnel reports are not reused. Tests and the GA4 fixture are updated for the new step names/order and `request_version` v2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa5645d60e67cc59d755307816411f6f74eebe2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->