### PR TITLE
feat(deploy): Markdown gate — race pages must ship with /race/{slug}.md

### DIFF
--- a/scripts/push_wordpress.py
+++ b/scripts/push_wordpress.py
@@ -1533,6 +1533,58 @@ def apply_prep_kit_gate(args) -> None:
         args.sync_prep_kits = True
 
 
+# Markdown gate (2026-09-09): every race page emits
+# <link rel="alternate" type="text/markdown" href="/race/{slug}.md">, so a race
+# page shipped without its Markdown mirror is a guaranteed 404 the weekly
+# link-check flags. 30 profiles drifted that way before anything caught it.
+# Same shape as the prep-kit gate: decided before any sync, refuses and names
+# the slugs, otherwise auto-adds --sync-markdown. --no-markdown-gate is the
+# only way past it.
+
+def markdown_gate(page_slugs, md_slugs, race_slugs):
+    """Pure gate decision, no filesystem or network. Returns (gated, missing)."""
+    gated = sorted(set(page_slugs) & set(race_slugs))
+    mds = set(md_slugs)
+    missing = [slug for slug in gated if slug not in mds]
+    return gated, missing
+
+
+def check_markdown_gate(pages_dir, markdown_dir, race_data_dir=None):
+    """Filesystem wrapper for markdown_gate(); returns (gated, missing)."""
+    pages_path = Path(pages_dir)
+    md_path = Path(markdown_dir)
+    race_path = Path(race_data_dir) if race_data_dir else RACE_DATA_DIR
+    pages = [f.stem for f in pages_path.glob("*.html") if f.stem not in ROOT_CANONICAL_SLUGS]
+    mds = [f.stem for f in md_path.glob("*.md")]
+    races = [f.stem for f in race_path.glob("*.json")]
+    return markdown_gate(pages, mds, races)
+
+
+def apply_markdown_gate(args) -> None:
+    """Enforce the Markdown gate on a parsed CLI namespace, before any sync runs.
+
+    No-op unless --sync-pages is requested (and --no-markdown-gate is not).
+    Exits 1 — having pushed nothing — if any race page about to ship has no
+    generated Markdown profile; otherwise turns --sync-markdown on so the
+    mirrors ship in this same deploy.
+    """
+    if not args.sync_pages or args.no_markdown_gate:
+        return
+    gated, missing = check_markdown_gate(args.pages_dir, args.markdown_dir)
+    if missing:
+        print(f"✗ MARKDOWN GATE: {len(missing)} of {len(gated)} race pages about to ship "
+              f"have no generated Markdown profile in {args.markdown_dir} — nothing was pushed.")
+        for slug in missing:
+            print(f"    {slug}  → /race/{slug}.md would 404")
+        print("  Fix: python3 scripts/generate_markdown_profiles.py, then re-run this deploy.")
+        print("  Escape hatch (ships the 404s knowingly): --no-markdown-gate")
+        sys.exit(1)
+    if gated and not args.sync_markdown:
+        print(f"  Markdown gate: {len(gated)} race pages ship with their Markdown mirrors — "
+              f"adding --sync-markdown to this deploy")
+        args.sync_markdown = True
+
+
 def sync_pages(pages_dir: str):
     """Upload race pages to /race/ on SiteGround via tar+ssh pipe.
 
@@ -4137,6 +4189,12 @@ if __name__ == "__main__":
              "race page's /prep-kit/ would 404, and auto-adds --sync-prep-kits"
     )
     parser.add_argument(
+        "--no-markdown-gate", action="store_true",
+        help="Escape hatch: ship race pages even when their Markdown mirrors are "
+             "missing or not synced. Default: --sync-pages refuses to push if any "
+             "race page's /race/{slug}.md would 404, and auto-adds --sync-markdown"
+    )
+    parser.add_argument(
         "--sync-plan-pages", action="store_true",
         help="Upload training-plan pages to /race/{slug}/training-plan/ via tar+ssh"
     )
@@ -4325,6 +4383,7 @@ if __name__ == "__main__":
 
     # Prep-kit gate (#122): decided BEFORE any sync runs so a refusal pushes nothing.
     apply_prep_kit_gate(args)
+    apply_markdown_gate(args)
 
     # Any sync returning falsy marks the whole run failed — a deploy that
     # half-happens must exit non-zero so CI cannot report silent success.

--- a/tests/test_markdown_deploy_gate.py
+++ b/tests/test_markdown_deploy_gate.py
@@ -1,0 +1,148 @@
+"""Markdown deploy gate: race pages must ship with their /race/{slug}.md mirror.
+
+Mirror of tests/test_prep_kit_deploy_gate.py. Every race page links
+<link rel="alternate" type="text/markdown" href="/race/{slug}.md">; 30 profiles
+shipped without the mirror before 2026-09-09 and the weekly link-check went red.
+"""
+import os
+import site
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import push_wordpress as pw
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestPureGate:
+    def test_all_present_means_nothing_missing(self):
+        gated, missing = pw.markdown_gate(["a", "b"], ["a", "b"], ["a", "b"])
+        assert gated == ["a", "b"] and missing == []
+
+    def test_non_race_pages_are_not_gated(self):
+        gated, missing = pw.markdown_gate(["a", "hub"], [], ["a"])
+        assert gated == ["a"] and missing == ["a"]
+
+    def test_missing_named_in_sorted_order(self):
+        gated, missing = pw.markdown_gate(["b", "a"], [], ["a", "b"])
+        assert gated == ["a", "b"] and missing == ["a", "b"]
+
+    def test_only_new_profiles_missing(self):
+        old, new = ["a", "b"], ["c", "d"]
+        gated, missing = pw.markdown_gate(old + new, old, old + new)
+        assert missing == new
+
+
+class TestFilesystemWrapper:
+    def test_reads_stems_and_ignores_root_canonical(self, tmp_path):
+        pages_dir, md_dir, race_dir = tmp_path / "output", tmp_path / "md", tmp_path / "race-data"
+        for d in (pages_dir, md_dir, race_dir):
+            d.mkdir()
+        for s in ("a", "b"):
+            (pages_dir / f"{s}.html").write_text("<html></html>")
+            (race_dir / f"{s}.json").write_text("{}")
+        (pages_dir / "about.html").write_text("<html></html>")
+        (md_dir / "a.md").write_text("# a")
+        gated, missing = pw.check_markdown_gate(pages_dir, md_dir, race_dir)
+        assert gated == ["a", "b"] and missing == ["b"]
+
+    def test_missing_markdown_dir_means_everything_missing(self, tmp_path):
+        pages_dir, race_dir = tmp_path / "output", tmp_path / "race-data"
+        pages_dir.mkdir(); race_dir.mkdir()
+        (pages_dir / "a.html").write_text("<html></html>")
+        (race_dir / "a.json").write_text("{}")
+        gated, missing = pw.check_markdown_gate(pages_dir, tmp_path / "nope", race_dir)
+        assert gated == ["a"] and missing == ["a"]
+
+
+class TestGateWiring:
+    @pytest.fixture
+    def tree(self, tmp_path, monkeypatch):
+        pages_dir = tmp_path / "output"
+        md_dir = tmp_path / "markdown"
+        race_dir = tmp_path / "race-data"
+        for d in (pages_dir, md_dir, race_dir):
+            d.mkdir(parents=True)
+        for s in ("a", "b"):
+            (pages_dir / f"{s}.html").write_text("<html></html>")
+            (race_dir / f"{s}.json").write_text("{}")
+        (md_dir / "a.md").write_text("# a")
+        monkeypatch.setattr(pw, "RACE_DATA_DIR", race_dir)
+        return pages_dir, md_dir
+
+    @staticmethod
+    def _args(pages_dir, md_dir, **overrides):
+        base = dict(sync_pages=True, sync_markdown=False, no_markdown_gate=False,
+                    pages_dir=str(pages_dir), markdown_dir=str(md_dir))
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def test_missing_mirror_exits_1_naming_the_slug(self, tree, capsys):
+        args = self._args(*tree)
+        with pytest.raises(SystemExit) as exc:
+            pw.apply_markdown_gate(args)
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "MARKDOWN GATE: 1 of 2 race pages" in out
+        assert "b  → /race/b.md would 404" in out
+        assert "generate_markdown_profiles.py" in out and "--no-markdown-gate" in out
+        assert args.sync_markdown is False
+
+    def test_mirrors_present_forces_markdown_sync_into_the_deploy(self, tree, capsys):
+        pages_dir, md_dir = tree
+        (md_dir / "b.md").write_text("# b")
+        args = self._args(pages_dir, md_dir)
+        pw.apply_markdown_gate(args)
+        assert args.sync_markdown is True
+        assert "adding --sync-markdown" in capsys.readouterr().out
+
+    def test_explicit_markdown_sync_is_left_alone(self, tree, capsys):
+        pages_dir, md_dir = tree
+        (md_dir / "b.md").write_text("# b")
+        args = self._args(pages_dir, md_dir, sync_markdown=True)
+        pw.apply_markdown_gate(args)
+        assert args.sync_markdown is True and "adding" not in capsys.readouterr().out
+
+    def test_escape_hatch_skips_the_gate(self, tree):
+        args = self._args(*tree, no_markdown_gate=True)
+        pw.apply_markdown_gate(args)
+        assert args.sync_markdown is False
+
+    def test_no_sync_pages_is_a_no_op(self, tree):
+        args = self._args(*tree, sync_pages=False)
+        pw.apply_markdown_gate(args)
+        assert args.sync_markdown is False
+
+
+class TestCliEndToEnd:
+    """Same two guards as test_prep_kit_deploy_gate: empty SSH creds + tmp HOME."""
+
+    def _run(self, tmp_path, *argv):
+        env = dict(os.environ)
+        env.update({"SSH_HOST": "", "SSH_USER": "", "WP_URL": "", "WP_USER": "", "WP_APP_PASSWORD": ""})
+        home = tmp_path / "home"
+        home.mkdir(exist_ok=True)
+        env["HOME"] = str(home)
+        env["PYTHONPATH"] = os.pathsep.join(
+            p for p in [site.getusersitepackages(), env.get("PYTHONPATH", "")] if p)
+        return subprocess.run(
+            [sys.executable, str(PROJECT_ROOT / "scripts" / "push_wordpress.py"), *argv],
+            capture_output=True, text=True, env=env, cwd=PROJECT_ROOT, timeout=60)
+
+    def test_race_page_with_kit_but_no_mirror_is_refused(self, tmp_path):
+        pages_dir = tmp_path / "output"
+        kit_dir = pages_dir / "prep-kit"
+        md_dir = tmp_path / "markdown"
+        kit_dir.mkdir(parents=True); md_dir.mkdir()
+        (pages_dir / "unbound-200.html").write_text("<html></html>")
+        (kit_dir / "unbound-200.html").write_text("<html></html>")
+        proc = self._run(tmp_path, "--sync-pages", "--pages-dir", str(pages_dir),
+                         "--prep-kit-dir", str(kit_dir), "--markdown-dir", str(md_dir))
+        assert proc.returncode == 1, proc.stdout + proc.stderr
+        assert "MARKDOWN GATE: 1 of 1 race pages" in proc.stdout
+        assert "unbound-200  → /race/unbound-200.md would 404" in proc.stdout
+        assert "Uploading" not in proc.stdout and "DEPLOY FAILED" not in proc.stdout

--- a/tests/test_prep_kit_deploy_gate.py
+++ b/tests/test_prep_kit_deploy_gate.py
@@ -193,10 +193,14 @@ class TestCliEndToEnd:
         kit_dir.mkdir(parents=True)
         (pages_dir / "unbound-200.html").write_text("<html></html>")
         (kit_dir / "unbound-200.html").write_text("<html></html>")
+        md_dir = tmp_path / "markdown"
+        md_dir.mkdir()
+        (md_dir / "unbound-200.md").write_text("# unbound")  # markdown gate satisfied
         proc = self._run(tmp_path, "--sync-pages", "--pages-dir", str(pages_dir),
-                         "--prep-kit-dir", str(kit_dir))
-        # Both steps were attempted (and both stopped at the credential check).
+                         "--prep-kit-dir", str(kit_dir), "--markdown-dir", str(md_dir))
+        # All three steps were attempted (and all stopped at the credential check).
         assert "adding --sync-prep-kits" in proc.stdout
-        assert "DEPLOY FAILED — 2 step(s): sync-pages, sync-prep-kits" in proc.stdout
+        assert "adding --sync-markdown" in proc.stdout
+        assert "DEPLOY FAILED — 3 step(s): sync-pages, sync-prep-kits, sync-markdown" in proc.stdout
         assert "Uploading" not in proc.stdout
         assert proc.returncode == 1


### PR DESCRIPTION
Follow-up to #122 / #334.

## Summary
- Every race page emits `<link rel="alternate" type="text/markdown" href="/race/{slug}.md">`, but nothing guaranteed the mirror existed on the server. 30 profiles drifted that way and `link-check.yml` was red for six weeks.
- Adds a Markdown gate with the same shape as the prep-kit gate: decided before any sync when `--sync-pages` is requested, refuses and names the slugs if any race page about to ship has no `web/markdown/{slug}.md`, otherwise auto-adds `--sync-markdown` so mirrors ship in the same deploy. `--no-markdown-gate` is the escape hatch.

## Verification
- `tests/test_markdown_deploy_gate.py` (new, mirrors the prep-kit gate tests incl. a real-CLI end-to-end refusal) + `tests/test_prep_kit_deploy_gate.py` (its end-to-end now satisfies both gates): 28 passed.
- Note: `web/markdown/` is generated (`scripts/generate_markdown_profiles.py`, needs SSH env for the training-guide inventory), so a `--sync-pages` deploy from a fresh checkout now refuses until it is generated. That is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df57KrhMyez9BwPVKRhbiT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-time safety checks only; no production runtime or auth changes, with an explicit opt-out flag.
> 
> **Overview**
> Adds a **Markdown deploy gate** parallel to the prep-kit gate so `--sync-pages` cannot publish race HTML without matching `/race/{slug}.md` mirrors that pages advertise via `rel="alternate"`.
> 
> When `--sync-pages` is set (and `--no-markdown-gate` is not), the gate runs **before any upload**: it compares race page slugs to generated files under `--markdown-dir` (default `web/markdown`) and `race-data` profiles. Missing mirrors **exit 1** with named slugs and a fix hint (`generate_markdown_profiles.py`); if all mirrors exist it **auto-enables `--sync-markdown`** for the same deploy. **`--no-markdown-gate`** is the intentional bypass.
> 
> New **`tests/test_markdown_deploy_gate.py`** covers pure logic, filesystem checks, `apply_markdown_gate`, and CLI refusal. **`test_prep_kit_deploy_gate.py`** now supplies markdown artifacts so its happy-path e2e exercises both gates (pages, prep-kits, markdown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8478f634ebec26743cab0af2e6a8b4e1fc631e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->