### PR TITLE
fix(deploy): sync_ab keeps previous hashed A/B bundles

### DIFF
--- a/scripts/push_wordpress.py
+++ b/scripts/push_wordpress.py
@@ -2565,14 +2565,17 @@ def sync_ab():
     remote_ab = f"{remote_base}/ab"
     remote_mu = f"{remote_base}/wp-content/mu-plugins"
 
-    # Create /ab/ directory and clean old hashed JS files
+    # Create /ab/. Old hashed bundles are KEPT: every static generator embeds
+    # the hash current at its own generation time, so a page not regenerated
+    # in this deploy (guide, tire, prep-kit, plan pages, …) still references
+    # the previous file. Deleting it 404'd the A/B script on those pages
+    # (2026-09-10 review). Prune by hand once no live page references a hash.
     try:
         subprocess.run(
             [
                 "ssh", "-i", str(SSH_KEY), "-p", port,
                 f"{user}@{host}",
-                f"mkdir -p {remote_ab} && chmod 755 {remote_ab} && "
-                f"rm -f {remote_ab}/gg-ab-tests.*.js",
+                f"mkdir -p {remote_ab} && chmod 755 {remote_ab}",
             ],
             check=True, capture_output=True, text=True, timeout=15,
         )


### PR DESCRIPTION
Flagged by the adversarial review of #341.

`sync_ab()` ran `rm -f /ab/gg-ab-tests.*.js` before uploading the new hashed bundle. Every static generator embeds the hash current at its own generation time (`brand_tokens.get_ab_js_filename`), so any static page not regenerated in the same deploy kept referencing a deleted file and the A/B script 404'd there. This keeps old bundles on the server; prune manually once nothing live references a hash.

Needed before deploying #341, whose `gg-ab-tests.js` change produces a new hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df57KrhMyez9BwPVKRhbiT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-script behavior change that fixes production 404s on A/B JS; no auth or data handling, with minor disk accumulation on `/ab/` until manual cleanup.
> 
> **Overview**
> **`sync_ab()` no longer deletes old `gg-ab-tests.*.js` files on the server** when preparing `/ab/` before upload.
> 
> Previously the SSH step ran `rm -f …/gg-ab-tests.*.js`, so only the newly uploaded hash survived. Static HTML still points at whatever hashed filename was baked in at generation time, so pages not rebuilt in the same deploy kept loading a removed bundle and the A/B script **404’d**. The deploy now only `mkdir`s and chmods `/ab/`; comments document keeping prior hashes until manual prune once nothing live references them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37e3b1294c268ca1b8a9f9d116c9bc3ef9e0092f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->