### PR TITLE
data: regenerate race-index.json from race-data (3 stale values)

### DIFF
--- a/web/race-index.json
+++ b/web/race-index.json
@@ -11466,7 +11466,7 @@
     "month": "August",
     "year": 2026,
     "distance_mi": 65,
-    "elevation_ft": 3500,
+    "elevation_ft": 2248,
     "tier": 3,
     "overall_score": 46,
     "scores": {
@@ -12039,7 +12039,7 @@
     "month": "September",
     "year": 2026,
     "distance_mi": 62,
-    "elevation_ft": 3000,
+    "elevation_ft": 3600,
     "tier": 4,
     "overall_score": 44,
     "scores": {
@@ -12841,7 +12841,7 @@
     "region": "Oceania",
     "month": "February",
     "year": 2027,
-    "distance_mi": 66,
+    "distance_mi": 60,
     "elevation_ft": 9022,
     "tier": 4,
     "overall_score": 43,


### PR DESCRIPTION
race-data moved without an index regeneration. The Sep 10 deploy pushed the regenerated index live; this syncs the repo copy. Two elevation values and one distance, races: gray-duck-grit great-otway-gravel-grind heathland-gravel 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df57KrhMyez9BwPVKRhbiT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only corrections in the race index with no application logic or security impact.
> 
> **Overview**
> Syncs **`web/race-index.json`** with the regenerated index from race-data so the repo matches what was already deployed (Sep 10).
> 
> **Heathland Gravel** `elevation_ft` is corrected from 3500 to **2248**. **Gray Duck Grit** elevation goes from 3000 to **3600**. **Great Otway Gravel Grind** distance is updated from 66 to **60** miles. No scoring or copy changes in this diff—only those three numeric fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2441700b873aa0c5b921b6da44d604bc0177712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->