### PR TITLE
fix(legal): refund terms match the product promise

### DIFF
--- a/wordpress/generate_legal_pages.py
+++ b/wordpress/generate_legal_pages.py
@@ -110,7 +110,7 @@ def get_terms_content() -> str:
 <p>All training and coaching content is general fitness guidance. It is not medical advice. Consult a physician before starting any exercise program, especially if you have health conditions.</p>
 
 <h2>Payments &amp; Refunds</h2>
-<p>All payments are processed by Stripe. If you are unsatisfied with a training plan or consulting session, contact <a href="mailto:{CONTACT_EMAIL}">{CONTACT_EMAIL}</a> within 7 days. We handle refund requests on a case-by-case basis and aim to be fair.</p>
+<p>All payments are processed by Stripe. If you are not satisfied with a custom training plan, contact <a href="mailto:{CONTACT_EMAIL}">{CONTACT_EMAIL}</a> within 7 days of purchase for a full refund, no questions asked. For consulting sessions, contact us within 7 days; we handle those requests on a case-by-case basis and aim to be fair.</p>
 <p>Coaching subscriptions can be cancelled at any time. No refunds are issued for partially completed billing cycles.</p>
 
 <h2>Intellectual Property</h2>


### PR DESCRIPTION
The product page and the questionnaire promise a full refund within 7 days, no questions asked, for a custom training plan; the terms page said every refund was case-by-case. Aligns the terms page: training plans get the unconditional 7-day refund, consulting stays case-by-case. Flagged by the adversarial review of #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df57KrhMyez9BwPVKRhbiT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static legal copy only; no payment, auth, or application logic changes.
> 
> **Overview**
> Updates the **Payments & Refunds** section in generated Terms of Service so it matches the training-plan product promise.
> 
> **Custom training plans** are now described as eligible for a **full refund within 7 days of purchase, no questions asked** (via the contact email). **Consulting** keeps a **7-day window** but **case-by-case** handling. Coaching subscription cancellation language is unchanged.
> 
> This is a copy change in `get_terms_content()` inside `generate_legal_pages.py`; regenerating legal pages will publish the updated terms HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c95b961c2dda2451594f988beb872cc4473353. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->