### PR TITLE
chore(parity): enable the purchase-terms marker

### DIFF
--- a/scripts/check_questionnaire_parity.py
+++ b/scripts/check_questionnaire_parity.py
@@ -30,8 +30,7 @@ CONTENT_MARKERS = [
     'gg-trust-strip',        # conversion trust strip (commit 6939db7c)
     'travelDatesGroup',      # travel-dates field (commit 72c6a741)
     '#178079',               # WCAG AA teal (color audit sprint)
-    # 'gg-purchase-terms',   # ADD after the Sep 2026 purchase-terms widget is pasted live —
-    #                        # preflight_quality hard-fails on drift and gates 3 deploy workflows
+    'gg-purchase-terms',     # purchase terms above the form (Sep 2026, funnel move 2; widget updated 2026-09-11)
 ]
 
 


### PR DESCRIPTION
The questionnaire Elementor widget (page 5017, widget 3f59420) was updated live on 2026-09-11 via WP-CLI (backup at ~/backups/5017-_elementor_data-20260911.json on SiteGround). Parity passes with the marker enabled; this turns the check on so future drift is caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df57KrhMyez9BwPVKRhbiT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only tightens an automated HTML parity check after live already passes; no runtime or auth changes.
> 
> **Overview**
> Turns on the **`gg-purchase-terms`** questionnaire parity canary in `scripts/check_questionnaire_parity.py`, which was previously commented out until the live Elementor widget matched the repo.
> 
> With the marker active, preflight/parity will **fail if the purchase-terms block is in the repo HTML but missing on** `gravelgodcycling.com/questionnaire/`, catching the same kind of silent drift that bypassed deploy for other markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34162b1297d8cbd1577b86d562b5a3ce1f8d3df7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->