### PR TITLE
fix(intel): GA4 processing-lag guard + llms.txt host verification

### DIFF
--- a/scripts/aeo_weekly.py
+++ b/scripts/aeo_weekly.py
@@ -540,11 +540,55 @@ def check_llms_marker(brand: str, timeout: int = 20) -> dict[str, Any]:
         stripped = head.lstrip("﻿\n\r ")
 
     ok = stripped.startswith(marker)
+    if not ok and "sgcaptcha" in stripped.lower():
+        # The WAF challenged every HTTP attempt: the file is unverified, not
+        # broken. Read it from the host instead — the same SSH config the log
+        # collector uses — so a challenge window never renders as BROKEN.
+        host_head = _read_llms_head_via_ssh(brand)
+        if host_head is not None:
+            host_stripped = host_head.lstrip("\ufeff\n\r ")
+            return {
+                "status": "ok" if host_stripped.startswith(marker) else "displaced",
+                "marker": marker,
+                "first_line": host_head.splitlines()[0][:120] if host_head else "",
+                "verified_via": "ssh",
+            }
     return {
         "status": "ok" if ok else ("challenged" if "sgcaptcha" in stripped.lower() else "displaced"),
         "marker": marker,
         "first_line": head.splitlines()[0][:120] if head else "",
     }
+
+
+def _read_llms_head_via_ssh(brand: str, timeout: int = 30) -> str | None:
+    """Return the first 4 KB of the live llms.txt read on the host, or None.
+
+    None means "could not verify from the host" (no SSH config in this
+    environment, connection failure, file missing) — never a verdict.
+    """
+    try:
+        config = _ssh_config(brand)
+    except RuntimeError:
+        return None
+    domain = str(BRANDS[brand]["domain"])
+    command = [
+        "ssh",
+        "-i", config["key_path"],
+        "-p", config["port"],
+        "-o", "BatchMode=yes",
+        "-o", "ConnectTimeout=15",
+        "-o", "StrictHostKeyChecking=accept-new",
+        f"{config['user']}@{config['host']}",
+        "head", "-c", "4096", f"www/{domain}/public_html/llms.txt",
+    ]
+    try:
+        result = subprocess.run(
+            command, capture_output=True, text=True, timeout=timeout, check=False)
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0 or not result.stdout:
+        return None
+    return result.stdout
 
 
 def collect_weekly(now: datetime | None = None) -> dict[str, Any]:

--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -185,7 +185,7 @@ def collect_ga4(brand: str) -> dict:
     from google.analytics.data_v1beta import BetaAnalyticsDataClient
     from google.analytics.data_v1beta.types import (
         DateRange, Dimension, Filter, FilterExpression, FilterExpressionList,
-        Metric, RunReportRequest,
+        Metric, RunReportRequest, RunRealtimeReportRequest,
     )
 
     creds = os.environ.get("GA4_CREDENTIALS", str(PROJECT_ROOT / "ga4-credentials.json"))
@@ -249,21 +249,48 @@ def collect_ga4(brand: str) -> dict:
     week = run(["sessions"], date_from=week_ago, date_to=y)
     week_sessions = int(week.rows[0].metric_values[0].value) if week.rows else 0
 
-    # GA4 processing lag guard. This job runs at 12:00 UTC; GA4 often has not
+    # GA4 completeness guard. This job runs at 12:00 UTC; GA4 often has not
     # finished processing yesterday's late hours yet, so "yesterday" reads as
     # a collapse (Aug 31: 9 sessions, Sep 11: 6 sessions — both revised to
-    # ~120 within hours). If the hourly rows stop before 21:00 property time,
-    # the day is PROVISIONAL and must not be narrated as a traffic drop.
-    hours = run(["sessions"], ["dateHour"], limit=48)
-    populated = []
-    for r in hours.rows:
+    # ~120 within hours). If the hourly rows stop before 21:00 property time
+    # the day is PROVISIONAL: completeness unknown. Hourly rows alone cannot
+    # separate late processing from an outage, so a realtime probe is
+    # attached: active users in the last 30 minutes means the tag is live and
+    # late processing is the likely cause; zero means investigate. The next
+    # run re-reads the same date (see `revisions`) so the figure is closed.
+    yesterday_last_hour = None
+    yesterday_provisional = None
+    try:
+        hours = run(["sessions"], ["dateHour"], limit=48)
+        populated = []
+        for r in hours.rows:
+            try:
+                if int(r.metric_values[0].value) > 0:
+                    populated.append(int(r.dimension_values[0].value[-2:]))
+            except (TypeError, ValueError):
+                continue
+        yesterday_last_hour = max(populated) if populated else None
+        yesterday_provisional = yesterday_last_hour is None or yesterday_last_hour < 21
+    except Exception as e:  # never let the guard discard the rest of GA4
+        hourly_error = f"{type(e).__name__}: {e}"
+    else:
+        hourly_error = None
+    realtime_active_users = None
+    if yesterday_provisional:
         try:
-            if int(r.metric_values[0].value) > 0:
-                populated.append(int(r.dimension_values[0].value[-2:]))
-        except (TypeError, ValueError):
-            continue
-    yesterday_last_hour = max(populated) if populated else None
-    yesterday_provisional = yesterday_last_hour is None or yesterday_last_hour < 21
+            rt = client.run_realtime_report(RunRealtimeReportRequest(
+                property=f"properties/{prop}", metrics=[Metric(name="activeUsers")]))
+            realtime_active_users = int(rt.rows[0].metric_values[0].value) if rt.rows else 0
+        except Exception:
+            realtime_active_users = None
+    # The day before yesterday, re-read: closes yesterday's provisional figure
+    # in the next report (rendered as a revision when it moved).
+    d2 = (date.today() - timedelta(days=2)).isoformat()
+    try:
+        d2_report = run(["sessions"], date_from=d2, date_to=d2)
+        sessions_d2 = int(d2_report.rows[0].metric_values[0].value) if d2_report.rows else 0
+    except Exception:
+        sessions_d2 = None
 
     ev = event_counts(y, y)
 
@@ -295,6 +322,10 @@ def collect_ga4(brand: str) -> dict:
         "sessions_7d_avg": round(week_sessions / 7, 1),
         "yesterday_last_hour": yesterday_last_hour,
         "yesterday_provisional": yesterday_provisional,
+        "hourly_error": hourly_error,
+        "realtime_active_users": realtime_active_users,
+        "sessions_d2": sessions_d2,
+        "sessions_d2_date": d2,
         "funnel": {stage: sum(ev.get(e, 0) for e in evs)
                    for stage, evs in FUNNEL_STAGES.items()},
         "top_pages": top_pages,
@@ -618,6 +649,7 @@ def _collect_aeo(today: date | None = None) -> dict:
             "ga4_status": (current_brand.get("ga4") or {}).get("status", "error"),
             "logs_status": (current_brand.get("logs") or {}).get("status", "error"),
             "llms_serving_status": llms_serving.get("status", "unknown"),
+            "llms_serving_verified_via": llms_serving.get("verified_via", "http"),
             "llms_serving_first_line": llms_serving.get("first_line", ""),
             "llms_serving_error": llms_serving.get("error", ""),
             "ai_referral_sessions": ga4_sessions,
@@ -916,9 +948,22 @@ def render_report(collected: dict) -> str:
             if g.get("yesterday_provisional"):
                 last_hour = g.get("yesterday_last_hour")
                 ends = f"{int(last_hour):02d}:00" if isinstance(last_hour, int) else "no hourly rows"
+                rt = g.get("realtime_active_users")
+                if isinstance(rt, int) and rt > 0:
+                    cause = (f"tag is live ({rt} active users in the last 30 min); "
+                             "late processing is the usual cause")
+                elif rt == 0:
+                    cause = "realtime shows 0 active users — check tag and site, not only processing"
+                else:
+                    cause = "realtime probe unavailable; completeness unknown"
                 session_cell += (
-                    f" PROVISIONAL — GA4 hourly rows end at {ends}; "
-                    "late data still processing, recheck tomorrow")
+                    f" PROVISIONAL — GA4 hourly rows end at {ends}; {cause}; "
+                    "this date is re-read tomorrow")
+            revision = (collected.get("ga4_revisions") or {}).get(brand)
+            if revision:
+                session_cell += (
+                    f" · {revision['date']} revised to {revision['now']} "
+                    f"(reported {revision['reported']} yesterday)")
             event_totals = _event_totals_line(g.get("funnel") or {})
         else:
             session_cell = "unavailable"
@@ -1237,6 +1282,32 @@ def detect_tracking_regression(
     )
 
 
+def compute_ga4_revisions(collected: dict, prior_snapshots: list[dict]) -> dict:
+    """Re-read of the day before yesterday vs what yesterday's report said.
+
+    Yesterday's report showed D-2 as its "yesterday" (often provisional).
+    Today's collector re-reads D-2. When the figure moved by more than 20%,
+    surface the revision so a provisional collapse is closed on the record.
+    """
+    revisions = {}
+    prior = prior_snapshots[0] if prior_snapshots else None
+    if not isinstance(prior, dict):
+        return revisions
+    for brand, g in (collected.get("ga4") or {}).items():
+        if not isinstance(g, dict) or g.get("ok") is not True:
+            continue
+        now = g.get("sessions_d2")
+        pg = ((prior.get("ga4") or {}).get(brand) or {})
+        reported = pg.get("sessions") if pg.get("ok") is True else None
+        if not isinstance(now, int) or not isinstance(reported, int):
+            continue
+        if reported == 0 and now == 0:
+            continue
+        if abs(now - reported) > 0.2 * max(now, reported):
+            revisions[brand] = {"date": g.get("sessions_d2_date"), "reported": reported, "now": now}
+    return revisions
+
+
 def load_prior_snapshots(today: str, days: int = 2) -> list[dict]:
     """Load exact preceding calendar days; a missing day breaks consecutiveness."""
     snapshots = []
@@ -1291,10 +1362,12 @@ and customer fulfillment are unavailable without a separate provider reconciliat
 The factual report is already \
 rendered; do not repeat its sections or add new facts.
 
-A session count marked PROVISIONAL means GA4 has not finished processing that day \
-(hourly rows stop early). It is not a traffic drop, an uptime problem, or a tagging \
-failure; do not recommend site or tag checks for it and do not compare it to the 7-day \
-average. Say "provisional" and move on.
+A session count marked PROVISIONAL means GA4's hourly rows for that day stop early, so \
+completeness is unknown; do not compare it to the 7-day average or call it a drop. If the \
+cell says the tag is live, late processing is the likely cause: say "provisional" and \
+move on. If the cell says realtime shows 0 active users, that is the one case to \
+recommend a tag/site check. A "revised to" note means yesterday's provisional figure has \
+been re-read; report the revised number, not the old one.
 
 Measurement epochs in DATA mark analytics collection changes, not demand changes. If a \
 comparison straddles one, explicitly treat the apparent session jump and affected event \
@@ -1489,6 +1562,7 @@ def main() -> int:
     except Exception as e:
         tracking_issue = f"tracking-regression check crashed: {type(e).__name__}: {e}"
     collected["report_issues"] = [tracking_issue] if tracking_issue else []
+    collected["ga4_revisions"] = compute_ga4_revisions(collected, load_prior_snapshots(today, 1))
     trend = load_trend()
     deterministic_report = safe_render(collected)
 

--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -249,6 +249,22 @@ def collect_ga4(brand: str) -> dict:
     week = run(["sessions"], date_from=week_ago, date_to=y)
     week_sessions = int(week.rows[0].metric_values[0].value) if week.rows else 0
 
+    # GA4 processing lag guard. This job runs at 12:00 UTC; GA4 often has not
+    # finished processing yesterday's late hours yet, so "yesterday" reads as
+    # a collapse (Aug 31: 9 sessions, Sep 11: 6 sessions — both revised to
+    # ~120 within hours). If the hourly rows stop before 21:00 property time,
+    # the day is PROVISIONAL and must not be narrated as a traffic drop.
+    hours = run(["sessions"], ["dateHour"], limit=48)
+    populated = []
+    for r in hours.rows:
+        try:
+            if int(r.metric_values[0].value) > 0:
+                populated.append(int(r.dimension_values[0].value[-2:]))
+        except (TypeError, ValueError):
+            continue
+    yesterday_last_hour = max(populated) if populated else None
+    yesterday_provisional = yesterday_last_hour is None or yesterday_last_hour < 21
+
     ev = event_counts(y, y)
 
     pages = run(["screenPageViews"], ["pagePath"], limit=8)
@@ -277,6 +293,8 @@ def collect_ga4(brand: str) -> dict:
         "users": int(t[1].value) if t else 0,
         "pageviews": int(t[2].value) if t else 0,
         "sessions_7d_avg": round(week_sessions / 7, 1),
+        "yesterday_last_hour": yesterday_last_hour,
+        "yesterday_provisional": yesterday_provisional,
         "funnel": {stage: sum(ev.get(e, 0) for e in evs)
                    for stage, evs in FUNNEL_STAGES.items()},
         "top_pages": top_pages,
@@ -895,6 +913,12 @@ def render_report(collected: dict) -> str:
             sessions = _display(g.get("sessions"))
             avg = _display(g.get("sessions_7d_avg"))
             session_cell = f"{sessions} (vs {avg})"
+            if g.get("yesterday_provisional"):
+                last_hour = g.get("yesterday_last_hour")
+                ends = f"{int(last_hour):02d}:00" if isinstance(last_hour, int) else "no hourly rows"
+                session_cell += (
+                    f" PROVISIONAL — GA4 hourly rows end at {ends}; "
+                    "late data still processing, recheck tomorrow")
             event_totals = _event_totals_line(g.get("funnel") or {})
         else:
             session_cell = "unavailable"
@@ -1266,6 +1290,11 @@ establish payment or customer fulfillment. Provider payments, refunds, distinct 
 and customer fulfillment are unavailable without a separate provider reconciliation. \
 The factual report is already \
 rendered; do not repeat its sections or add new facts.
+
+A session count marked PROVISIONAL means GA4 has not finished processing that day \
+(hourly rows stop early). It is not a traffic drop, an uptime problem, or a tagging \
+failure; do not recommend site or tag checks for it and do not compare it to the 7-day \
+average. Say "provisional" and move on.
 
 Measurement epochs in DATA mark analytics collection changes, not demand changes. If a \
 comparison straddles one, explicitly treat the apparent session jump and affected event \

--- a/scripts/daily_intel.py
+++ b/scripts/daily_intel.py
@@ -285,7 +285,7 @@ def collect_ga4(brand: str) -> dict:
             realtime_active_users = None
     # The day before yesterday, re-read: closes yesterday's provisional figure
     # in the next report (rendered as a revision when it moved).
-    d2 = (date.today() - timedelta(days=2)).isoformat()
+    d2 = (date.fromisoformat(y) - timedelta(days=1)).isoformat()  # same clock as y
     try:
         d2_report = run(["sessions"], date_from=d2, date_to=d2)
         sessions_d2 = int(d2_report.rows[0].metric_values[0].value) if d2_report.rows else 0

--- a/tests/test_aeo_weekly.py
+++ b/tests/test_aeo_weekly.py
@@ -482,3 +482,28 @@ def test_fetch_does_not_accept_non_200_marker(monkeypatch):
     monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: response)
     with pytest.raises(OSError, match="HTTP status 202"):
         aeo_weekly._fetch_llms_head("https://example.test/llms.txt", 1)
+
+
+def test_check_llms_marker_verifies_from_host_when_challenge_never_clears(monkeypatch):
+    """A WAF challenge on every HTTP attempt is not a verdict: read the file over SSH."""
+    monkeypatch.setattr(aeo_weekly, "LLMS_CHALLENGE_BACKOFF", ())
+    monkeypatch.setattr(aeo_weekly, "_fetch_llms_head", lambda url, timeout: "<html><body>sgcaptcha</body></html>")
+    monkeypatch.setattr(aeo_weekly, "_read_llms_head_via_ssh", lambda brand, timeout=30: "# Gravel God Race Database\n\n> The definitive gravel race database.")
+    result = aeo_weekly.check_llms_marker("gravelgod")
+    assert result["status"] == "ok"
+    assert result["verified_via"] == "ssh"
+    assert result["first_line"].startswith("# Gravel God Race Database")
+
+
+def test_check_llms_marker_host_read_can_still_find_a_real_displacement(monkeypatch):
+    monkeypatch.setattr(aeo_weekly, "LLMS_CHALLENGE_BACKOFF", ())
+    monkeypatch.setattr(aeo_weekly, "_fetch_llms_head", lambda url, timeout: "sgcaptcha")
+    monkeypatch.setattr(aeo_weekly, "_read_llms_head_via_ssh", lambda brand, timeout=30: "# AIOSEO generated llms.txt")
+    result = aeo_weekly.check_llms_marker("gravelgod")
+    assert result["status"] == "displaced" and result["verified_via"] == "ssh"
+
+
+def test_read_llms_head_via_ssh_returns_none_without_ssh_config(monkeypatch):
+    for name in ("SSH_HOST", "SSH_USER", "SSH_KEY_PATH"):
+        monkeypatch.delenv(name, raising=False)
+    assert aeo_weekly._read_llms_head_via_ssh("gravelgod") is None

--- a/tests/test_aeo_weekly.py
+++ b/tests/test_aeo_weekly.py
@@ -140,6 +140,7 @@ def test_check_llms_marker_retries_through_sgcaptcha_then_succeeds(monkeypatch):
 
 
 def test_check_llms_marker_reports_challenged_when_challenge_never_clears(monkeypatch):
+    monkeypatch.setattr(aeo_weekly, "_read_llms_head_via_ssh", lambda brand, timeout=30: None)
     challenge_page = (
         '<html><head><link rel="icon" href="data:;">'
         '<meta http-equiv="refresh" content="0;/.well-known/sgcaptcha/?r=%2Fllms.txt&y">'

--- a/tests/test_daily_intel.py
+++ b/tests/test_daily_intel.py
@@ -206,6 +206,12 @@ def test_collect_ga4_filters_both_event_queries_before_limit(monkeypatch):
 
         def run_report(self, request):
             dimensions = [item.name for item in request.dimensions]
+            if dimensions == ["dateHour"]:
+                # Hourly rows stop at 03:00 — GA4 still processing yesterday.
+                return SimpleNamespace(rows=[
+                    SimpleNamespace(dimension_values=[SimpleNamespace(value=f"20260910{h:02d}")],
+                                    metric_values=[SimpleNamespace(value="3")])
+                    for h in range(0, 4)])
             if dimensions == ["eventName"]:
                 self.event_requests.append(request)
                 dim_filter = getattr(request, "dimension_filter", None)
@@ -241,6 +247,8 @@ def test_collect_ga4_filters_both_event_queries_before_limit(monkeypatch):
     assert result["funnel"]["purchase"] == 2
     assert result["funnel"]["refund"] == 7
     assert result["funnel"]["form_submit"] == 4  # 1 tp_form_submit + 3 scoped legacy
+    assert result["yesterday_last_hour"] == 3
+    assert result["yesterday_provisional"] is True
     assert result["funnel_28d"]["purchase"] == 2
     assert result["funnel_28d"]["refund"] == 7
     assert result["funnel_28d"]["form_submit"] == 4
@@ -685,3 +693,20 @@ def test_collect_mission_control_reads_newest_rows_past_the_1000_row_cap(monkeyp
     assert hot["new@example.com"]["opens"] == 1
     assert hot["new@example.com"]["clicks"] == 1
     assert hot["new@example.com"]["race"] == "The Rift"
+
+
+def test_render_marks_provisional_sessions_and_names_the_last_hour(collected):
+    from scripts import daily_intel
+    g = collected["ga4"]["gravelgod"]
+    g["yesterday_provisional"] = True
+    g["yesterday_last_hour"] = 3
+    report = daily_intel.render_report(collected)
+    assert "PROVISIONAL" in report and "end at 03:00" in report
+    g["yesterday_provisional"] = False
+    assert "PROVISIONAL" not in daily_intel.render_report(collected)
+
+
+def test_interpret_prompt_forbids_narrating_provisional_as_a_drop():
+    from scripts import daily_intel
+    assert "marked PROVISIONAL" in daily_intel.INTERPRET_PROMPT
+    assert "not a traffic drop" in daily_intel.INTERPRET_PROMPT

--- a/tests/test_daily_intel.py
+++ b/tests/test_daily_intel.py
@@ -204,6 +204,9 @@ def test_collect_ga4_filters_both_event_queries_before_limit(monkeypatch):
         def __init__(self):
             self.event_requests = []
 
+        def run_realtime_report(self, request):
+            return SimpleNamespace(rows=[SimpleNamespace(metric_values=[SimpleNamespace(value="2")])])
+
         def run_report(self, request):
             dimensions = [item.name for item in request.dimensions]
             if dimensions == ["dateHour"]:
@@ -236,6 +239,7 @@ def test_collect_ga4_filters_both_event_queries_before_limit(monkeypatch):
         "FilterExpressionList": Message,
         "Metric": Message,
         "RunReportRequest": Message,
+        "RunRealtimeReportRequest": Message,
     }.items():
         setattr(fake_types, name, value)
     monkeypatch.setitem(sys.modules, "google.analytics.data_v1beta", fake_api)
@@ -249,6 +253,8 @@ def test_collect_ga4_filters_both_event_queries_before_limit(monkeypatch):
     assert result["funnel"]["form_submit"] == 4  # 1 tp_form_submit + 3 scoped legacy
     assert result["yesterday_last_hour"] == 3
     assert result["yesterday_provisional"] is True
+    assert result["realtime_active_users"] == 2  # tag live → late processing likely
+    assert result["hourly_error"] is None
     assert result["funnel_28d"]["purchase"] == 2
     assert result["funnel_28d"]["refund"] == 7
     assert result["funnel_28d"]["form_submit"] == 4
@@ -695,18 +701,42 @@ def test_collect_mission_control_reads_newest_rows_past_the_1000_row_cap(monkeyp
     assert hot["new@example.com"]["race"] == "The Rift"
 
 
-def test_render_marks_provisional_sessions_and_names_the_last_hour(collected):
+def test_render_marks_provisional_sessions_and_separates_lag_from_outage(collected):
     from scripts import daily_intel
     g = collected["ga4"]["gravelgod"]
     g["yesterday_provisional"] = True
     g["yesterday_last_hour"] = 3
+    g["realtime_active_users"] = 2
     report = daily_intel.render_report(collected)
     assert "PROVISIONAL" in report and "end at 03:00" in report
+    assert "tag is live (2 active users" in report
+    g["realtime_active_users"] = 0
+    assert "realtime shows 0 active users" in daily_intel.render_report(collected)
+    g["realtime_active_users"] = None
+    assert "completeness unknown" in daily_intel.render_report(collected)
     g["yesterday_provisional"] = False
     assert "PROVISIONAL" not in daily_intel.render_report(collected)
+
+
+def test_render_shows_revision_of_yesterdays_provisional_figure(collected):
+    from scripts import daily_intel
+    collected["ga4_revisions"] = {"gravelgod": {"date": "2026-09-10", "reported": 6, "now": 121}}
+    report = daily_intel.render_report(collected)
+    assert "2026-09-10 revised to 121 (reported 6 yesterday)" in report
+
+
+def test_compute_ga4_revisions_only_when_the_figure_moved():
+    from scripts import daily_intel
+    collected = {"ga4": {"gravelgod": {"ok": True, "sessions_d2": 121, "sessions_d2_date": "2026-09-10"},
+                         "roadielabs": {"ok": True, "sessions_d2": 5, "sessions_d2_date": "2026-09-10"}}}
+    prior = [{"ga4": {"gravelgod": {"ok": True, "sessions": 6}, "roadielabs": {"ok": True, "sessions": 5}}}]
+    rev = daily_intel.compute_ga4_revisions(collected, prior)
+    assert rev == {"gravelgod": {"date": "2026-09-10", "reported": 6, "now": 121}}
+    assert daily_intel.compute_ga4_revisions(collected, []) == {}
 
 
 def test_interpret_prompt_forbids_narrating_provisional_as_a_drop():
     from scripts import daily_intel
     assert "marked PROVISIONAL" in daily_intel.INTERPRET_PROMPT
-    assert "not a traffic drop" in daily_intel.INTERPRET_PROMPT
+    assert "do not compare it to the 7-day average or call it a drop" in daily_intel.INTERPRET_PROMPT
+    assert "realtime shows 0 active users" in daily_intel.INTERPRET_PROMPT


### PR DESCRIPTION
Two systematic Morning Intel false alarms.

**1. "Sessions collapsed" at 06:00 MT.** The job runs at 12:00 UTC while GA4 is still processing yesterday's late hours, so a normal day reads as a collapse (Aug 31: 9 sessions, Sep 11: 6 — both revised to ~120 within hours) and the narrator recommends uptime/tagging checks. `collect_ga4` now reads yesterday's `dateHour` rows; if they stop before 21:00 property time the day is **PROVISIONAL**: the deterministic report says so with the last populated hour, and the narration prompt forbids reading a provisional day as a drop or recommending tag/site checks for it.

**2. `/llms.txt CAPTCHA-BLOCKED` under BROKEN.** When the WAF challenges every HTTP attempt, `check_llms_marker` now reads the first 4 KB from the host over the same SSH config the AEO log collector already uses and verifies the marker there (`verified_via: ssh`). `challenged` remains only when no SSH config is available (e.g. tests, local runs without keys).

**Verification:** `tests/test_daily_intel.py` + `tests/test_aeo_weekly.py`: 70 passed. Live: patched `collect_ga4` reads Sep 10 with hourly rows through 23:00 → not provisional; SSH head of `www/gravelgodcycling.com/public_html/llms.txt` returns our marker.

**Requires:** `SSH_KEY_PATH` / `RL_SSH_KEY_PATH` / `XC_SSH_KEY_PATH` in the `aeo-weekly.yml` environment — already present for log collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df57KrhMyez9BwPVKRhbiT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds GA4 realtime/hourly logic and production SSH reads for monitoring; failures are fail-soft but wrong SSH paths or provisional heuristics could mislabel health.
> 
> **Overview**
> Reduces two Morning Intel / AEO false alarms by changing how incomplete or blocked checks are interpreted.
> 
> **GA4 “session collapse” at the 12:00 UTC run:** `collect_ga4` now inspects yesterday’s hourly `dateHour` rows; if data stops before 21:00 the day is marked **PROVISIONAL**, with an optional realtime `activeUsers` probe to distinguish late GA4 processing from a dead tag. The report annotates session cells accordingly, `compute_ga4_revisions` compares a re-read of D-2 against the prior snapshot when counts move >20%, and the LLM prompt tells the narrator not to treat provisional counts as drops.
> 
> **`/llms.txt` under persistent WAF challenge:** When HTTP backoff still sees `sgcaptcha`, `check_llms_marker` reads the first 4KB of `llms.txt` on the host via SSH (same brand SSH config as log collection), sets `verified_via: ssh`, and only stays `challenged` if host verification is unavailable.
> 
> Tests cover SSH fallback, provisional rendering, revisions, and updated challenged-path behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521047d4dea12da4c81f1506c915953be8446ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->