### PR TITLE
fix(sequences): email attribution into the plan funnel, persistent unsubscribe, 24h delivery claim

### DIFF
--- a/docs/specs/friend-register-copy.md
+++ b/docs/specs/friend-register-copy.md
@@ -111,7 +111,7 @@ How's the training been going? Tell me your weekly hours and I'll give you my ho
 ### post_purchase · day 0 · purchase_welcome
 SUBJECT: got your questionnaire
 BODY:
-{greeting} got your questionnaire. I'm building around your course, your FTP, and the hours you actually have. You'll have it inside 48 hours.
+{greeting} got your questionnaire. I'm building around your course, your FTP, and the hours you actually have. You'll have it inside 24 hours.
 
 One thing: if anything about your life changes — schedule, knee, race date — just reply. The plan bends.
 

--- a/mission_control/services/sequence_engine.py
+++ b/mission_control/services/sequence_engine.py
@@ -455,11 +455,43 @@ def _render_template(template_name: str, enrollment: dict) -> str:
     return html.replace("{race_name}", "your race")
 
 
+_ENTRY_SURFACE_RE = re.compile(r"^[a-z_]{1,32}$")  # mirrors training-plans-form.js
+
+
+def entry_surface_for_sequence(sequence_id: str) -> str:
+    """Map a sequence id to the questionnaire's `src=` entry surface.
+
+    The questionnaire (web/training-plans-form.js) stamps `entry_surface` on
+    every GA4 event it sends but only accepts /^[a-z_]{1,32}$/, so the raw
+    sequence id (`nurture_v1`, digits) would be rejected and email arrivals
+    would read as 'external'. Strip brand prefix and version so all brands'
+    nurture tracks share one surface: email_nurture, email_welcome,
+    email_kit, email_countdown, email_debrief, email_winback, email_watch,
+    email_purchase, email_quiz.
+    """
+    base = re.sub(r"_v\d+$", "", sequence_id or "")
+    base = re.sub(r"^(road|xc)_", "", base)
+    aliases = {
+        "kit_delivery": "kit", "race_countdown_8": "countdown",
+        "race_countdown_16": "countdown", "race_debrief": "debrief",
+        "win_back": "winback", "race_watch": "watch",
+        "post_purchase": "purchase", "race_specific": "quiz",
+    }
+    surface = "email_" + aliases.get(base, base or "other")
+    surface = re.sub(r"[^a-z_]", "_", surface)[:32]
+    return surface if _ENTRY_SURFACE_RE.match(surface) else "email_other"
+
+
 def _inject_utm_params(
     html: str, sequence_id: str, variant: str, step_index: int,
     brand: str = "gravelgod",
 ) -> str:
-    """Append UTM tracking params to all brand-site links in HTML."""
+    """Append UTM tracking params to all brand-site links in HTML.
+
+    Questionnaire links additionally get `src=<entry surface>` (unless the
+    template already set one) so the plan funnel attributes arrivals to
+    email instead of 'external'. Fragments are preserved.
+    """
     from mission_control.config import BRAND_SEQUENCE_SENDERS
 
     sender = BRAND_SEQUENCE_SENDERS.get(brand, BRAND_SEQUENCE_SENDERS["gravelgod"])
@@ -469,11 +501,16 @@ def _inject_utm_params(
         "utm_campaign": sequence_id,
         "utm_content": f"{variant}_{step_index}",
     })
+    surface = entry_surface_for_sequence(sequence_id)
 
     def _add_utm(match: re.Match) -> str:
         url = match.group(1)
-        sep = "&" if "?" in url else "?"
-        return f'href="{url}{sep}{utm}"'
+        base, frag = (url.split("#", 1) + [""])[:2]
+        params = utm
+        if "/questionnaire" in base.split("?", 1)[0] and "src=" not in base:
+            params = f"src={surface}&{utm}"
+        sep = "&" if "?" in base else "?"
+        return f'href="{base}{sep}{params}{"#" + frag if frag else ""}"'
 
     return re.sub(
         r'href="(https://(?:gravelgodcycling|roadielabs|xcskilabs)\.com[^"]*)"',
@@ -711,7 +748,17 @@ def reset_enrollment(enrollment_id: str) -> bool:
 
 
 def unsubscribe(email: str) -> int:
-    """Pause all active enrollments for an email. Returns count paused."""
+    """Unsubscribe a contact from all marketing sequences. Returns the
+    number of enrollments changed.
+
+    Active enrollments become 'unsubscribed'. If the contact has NO active
+    enrollment (every sequence already completed or paused), one existing
+    marketing enrollment is still marked 'unsubscribed' so the enroll-time
+    guard (`status == unsubscribed`) keeps suppressing later lifecycle
+    enrollments (countdown, debrief, win-back). Before this, a
+    completed-only contact who clicked unsubscribe left no record and could
+    be re-enrolled — while the page told them they were unsubscribed.
+    """
     enrollments = db.select(
         "gg_sequence_enrollments",
         match={"contact_email": email},
@@ -721,8 +768,23 @@ def unsubscribe(email: str) -> int:
         if e["status"] == "active":
             db.update("gg_sequence_enrollments", {"status": "unsubscribed"}, {"id": e["id"]})
             count += 1
-
     if count:
         db.log_action("sequence_unsubscribed", "contact", email, f"Paused {count} enrollments")
-
-    return count
+        return count
+    if any(e.get("status") == "unsubscribed" for e in enrollments):
+        return 0  # already suppressed
+    marketing = [
+        e for e in enrollments
+        if (get_sequence(e.get("sequence_id") or "") or {}).get("trigger")
+        not in _POST_PURCHASE_TRIGGERS
+    ]
+    marketing.sort(key=lambda e: str(e.get("enrolled_at") or ""), reverse=True)
+    if not marketing:
+        return 0
+    marker = marketing[0]
+    db.update("gg_sequence_enrollments", {"status": "unsubscribed"}, {"id": marker["id"]})
+    db.log_action(
+        "sequence_unsubscribed", "contact", email,
+        f"No active enrollment; marked {marker.get('sequence_id')} "
+        f"(was {marker.get('status')}) as the suppression record")
+    return 1

--- a/mission_control/services/sequence_engine.py
+++ b/mission_control/services/sequence_engine.py
@@ -507,7 +507,10 @@ def _inject_utm_params(
         url = match.group(1)
         base, frag = (url.split("#", 1) + [""])[:2]
         params = utm
-        if "/questionnaire" in base.split("?", 1)[0] and "src=" not in base:
+        parts = urllib.parse.urlsplit(base)
+        is_questionnaire = parts.path.rstrip("/") == "/questionnaire"
+        has_src = "src" in urllib.parse.parse_qs(parts.query, keep_blank_values=True)
+        if is_questionnaire and not has_src:
             params = f"src={surface}&{utm}"
         sep = "&" if "?" in base else "?"
         return f'href="{base}{sep}{params}{"#" + frag if frag else ""}"'
@@ -625,9 +628,15 @@ def get_sequence_stats(sequence_id: str) -> dict:
     """Get aggregate stats for a sequence."""
     enrollments = db.select("gg_sequence_enrollments", match={"sequence_id": sequence_id})
 
+    def _is_completed(e: dict) -> bool:
+        # A completed enrollment that later became the contact's unsubscribe
+        # marker (see unsubscribe()) still completed its sequence.
+        return e["status"] == "completed" or (
+            e["status"] == "unsubscribed" and bool(e.get("completed_at")))
+
     total = len(enrollments)
     active = sum(1 for e in enrollments if e["status"] == "active")
-    completed = sum(1 for e in enrollments if e["status"] == "completed")
+    completed = sum(1 for e in enrollments if _is_completed(e))
     paused = sum(1 for e in enrollments if e["status"] == "paused")
 
     # Per-variant stats
@@ -637,7 +646,7 @@ def get_sequence_stats(sequence_id: str) -> dict:
         if v not in variant_stats:
             variant_stats[v] = {"total": 0, "completed": 0, "active": 0}
         variant_stats[v]["total"] += 1
-        if e["status"] == "completed":
+        if _is_completed(e):
             variant_stats[v]["completed"] += 1
         elif e["status"] == "active":
             variant_stats[v]["active"] += 1

--- a/mission_control/templates/emails/sequences/anti_pitch.html
+++ b/mission_control/templates/emails/sequences/anti_pitch.html
@@ -40,7 +40,7 @@
       <p>&bull; ZWO files for Zwift or your head unit, plus a PDF overview</p>
       <p>&bull; Pacing and fueling targets for your course</p>
       <p>&bull; Life blows up? Reply to the email and a human rebuilds the remaining weeks</p>
-      <p>&bull; Delivered in 48 hours</p>
+      <p>&bull; Delivered in 24 hours</p>
       <p>&bull; $15 per week of training, one payment, capped at $249 — a 12-week plan is $180</p>
     </div>
     <p>Two objections, answered honestly:</p>

--- a/mission_control/templates/emails/sequences/purchase_welcome.html
+++ b/mission_control/templates/emails/sequences/purchase_welcome.html
@@ -20,7 +20,7 @@
       <h1>Gravel God</h1>
     </div>
     <div class="body">
-      <p>{greeting} got your questionnaire. I'm building around your course, your FTP, and the hours you actually have. You'll have it inside 48 hours.</p>
+      <p>{greeting} got your questionnaire. I'm building around your course, your FTP, and the hours you actually have. You'll have it inside 24 hours.</p>
       <p>One thing: if anything about your life changes — schedule, knee, race date — just reply. The plan bends.</p>
       <p>— Matti</p>
     </div>

--- a/mission_control/templates/emails/sequences/repitch.html
+++ b/mission_control/templates/emails/sequences/repitch.html
@@ -19,7 +19,7 @@
     <p>A static plan handles the bad week by pretending it didn't happen. You come back, stare at a week that no longer fits your life, and quietly abandon the whole thing. (Ask me how I know.)</p>
     <p>With this one, you reply to an email and I rebuild the remaining weeks{{#race_name}} of your {race_name} plan{{/race_name}} around what actually happened. That's what you're paying for. There are no secret workouts — there's a plan that keeps fitting your life after your life misbehaves.</p>
     <p>One thing worth knowing while you decide: every week you wait comes off the front of the plan, and the front is where the base lives. You can't cram base in week eleven. People have tried like hell.</p>
-    <p>$15 per week of training, one payment, capped at $249. Delivered in 48 hours.</p>
+    <p>$15 per week of training, one payment, capped at $249. Delivered in 24 hours.</p>
     <p>If it's a no, it's a no — the free stuff doesn't care what you buy.</p>
     <p class="cta">If it's a yes: <a href="https://gravelgodcycling.com/products/training-plans/">BUILD MY PLAN &rarr;</a></p>
     <p>That's the last word on the plan. Next week: the funniest origin story in all of training science. It involves a napkin.</p>

--- a/mission_control/templates/emails/sequences/road_anti_pitch.html
+++ b/mission_control/templates/emails/sequences/road_anti_pitch.html
@@ -36,7 +36,7 @@
       <p>&bull; ZWO files for Zwift or a head unit, plus a PDF overview</p>
       <p>&bull; Pacing and fueling targets for the course</p>
       <p>&bull; Missed weeks: reply to an email; a human rebuilds the remaining weeks</p>
-      <p>&bull; Delivered inside 48 hours</p>
+      <p>&bull; Delivered inside 24 hours</p>
       <p>&bull; $15 per week of training. One payment. Capped at $249.</p>
     </div>
     <p>Two objections, answered:</p>

--- a/mission_control/templates/emails/sequences/road_purchase_welcome.html
+++ b/mission_control/templates/emails/sequences/road_purchase_welcome.html
@@ -20,7 +20,7 @@
       <h1>ROADIE LABS</h1>
     </div>
     <div class="body">
-      <p>{greeting} questionnaire received. The plan is being built from your course, your FTP, and your actual hours. Delivery inside 48 hours.</p>
+      <p>{greeting} questionnaire received. The plan is being built from your course, your FTP, and your actual hours. Delivery inside 24 hours.</p>
       <p>If anything changes — schedule, body, race date — reply. The plan gets rebuilt around it.</p>
       <p>— Matti</p>
     </div>

--- a/mission_control/templates/emails/sequences/road_repitch.html
+++ b/mission_control/templates/emails/sequences/road_repitch.html
@@ -18,7 +18,7 @@
     <p>An honest defect in our pricing: it pays you to wait. $15 per week of training means a plan bought 14 weeks out costs $210. The same decision made a month later costs $150. Waiting is $60 cheaper.</p>
     <p>What the $60 buys back: nothing. Weeks-to-race are a fixed stock. The weeks lost to waiting come off the front of the plan — the base weeks, where aerobic volume is built. Base does not compress, and no arrangement of the remaining weeks reconstructs it. Waiting does not lower the price. It lowers the plan.</p>
     <p>The $249 cap makes the same argument from the other side: it only engages on long runways. A 20-week plan costs the same as a 17-week one. The cap subsidizes starting early. It cannot subsidize a start that never happens.</p>
-    <p>Delivery is inside 48 hours. A plan bought today is training by the weekend.</p>
+    <p>Delivery is inside 24 hours. A plan bought today is training by the weekend.</p>
     <p>If the answer is no, the database does not care what you buy.</p>
     <p class="cta">If the answer is &ldquo;eventually&rdquo;: eventually is the expensive version of yes. <a href="https://roadielabs.com/training-plans/">BUILD THE PLAN &rarr;</a></p>
 {{^race_name}}    <p>Or reply with your race and the arithmetic gets done on your actual calendar first.</p>

--- a/mission_control/templates/emails/sequences/sober_pitch.html
+++ b/mission_control/templates/emails/sequences/sober_pitch.html
@@ -15,7 +15,7 @@
     <p>{greeting}</p>
     <p>This sequence contains two sales emails. This is the first; the second is a short follow-up in three days. After that, the topic is closed unless you raise it.</p>
     <p>What I sell is not workouts — workouts are free. It is the outcome: you get faster on the hours you actually have, the bike fits inside your life instead of competing with it, and you arrive at your race prepared instead of hopeful.</p>
-    <p>The mechanism is a custom training plan. Inputs: your race's actual course profile, your FTP, the hours you can genuinely train. Output: every workout from your start date to your start line, delivered within 48 hours, as files that load into Zwift or your head unit, with pacing and fueling for your course.</p>
+    <p>The mechanism is a custom training plan. Inputs: your race's actual course profile, your FTP, the hours you can genuinely train. Output: every workout from your start date to your start line, delivered within 24 hours, as files that load into Zwift or your head unit, with pacing and fueling for your course.</p>
     <p>$15 per week of training, one payment, capped at $249. A 12-week plan is $180. No subscription, no calls, no upsells.</p>
     <p>Who it is for: riders with a race on the calendar, fitting training around a job and a family — usually 6 to 12 real hours a week, which is exactly when structure matters most, because there is no room for wasted miles. Who it is not for: riders with no race planned. A plan needs a start line to point at.</p>
     <p><a href="https://gravelgodcycling.com/products/training-plans/">How it works</a></p>

--- a/mission_control/templates/emails/sequences/sober_repitch.html
+++ b/mission_control/templates/emails/sequences/sober_repitch.html
@@ -16,7 +16,7 @@
     <p>Second and final note about the training plan, as promised.</p>
     <p>The question worth deciding on: what happens when life interrupts training? Most plans are static documents. Miss a week and the document does not adjust — you either pretend the week happened or abandon the plan. Most people abandon the plan.</p>
     <p>This one comes with me attached. You reply to an email, and the remaining weeks get adjusted around what actually happened. The product is not the workouts — workouts are everywhere, free. The product is a plan that still fits on the day your circumstances change.</p>
-    <p>$249, once. Delivered in 48 hours. <a href="https://gravelgodcycling.com/products/training-plans/">How it works</a></p>
+    <p>$249, once. Delivered in 24 hours. <a href="https://gravelgodcycling.com/products/training-plans/">How it works</a></p>
     <p>The topic is now closed unless you raise it. Free material continues either way.</p>
     <p>— Matti</p>
     <div class="footer">Matti Rowe &middot; Gravel God Cycling &middot; <a href="https://gravelgodcycling.com">gravelgodcycling.com</a></div>

--- a/mission_control/tests/test_sequence_engine.py
+++ b/mission_control/tests/test_sequence_engine.py
@@ -1152,3 +1152,37 @@ class TestPersistentUnsubscribe:
         fake_db.store["gg_sequence_enrollments"].append(e)
         assert unsubscribe(email) == 0
         assert e["status"] == "completed"
+
+
+class TestEntrySurfaceNegatives:
+    def test_only_the_exact_questionnaire_path_is_tagged(self, fake_db):
+        from mission_control.services.sequence_engine import _inject_utm_params
+        html = ('<a href="https://gravelgodcycling.com/questionnaire-preview/">p</a>'
+                '<a href="https://gravelgodcycling.com/guide/questionnaire/">g</a>'
+                '<a href="https://gravelgodcycling.com/questionnaire">q</a>')
+        out = _inject_utm_params(html, "welcome_v1", "A", 0)
+        assert out.count("src=email_welcome") == 1
+        assert 'questionnaire?src=email_welcome&utm_source=' in out
+
+    def test_src_detection_uses_parsed_params_not_substrings(self, fake_db):
+        from mission_control.services.sequence_engine import _inject_utm_params
+        html = ('<a href="https://gravelgodcycling.com/questionnaire/?img_src=x">a</a>'
+                '<a href="https://gravelgodcycling.com/questionnaire/?%73rc=email_custom">b</a>')
+        out = _inject_utm_params(html, "welcome_v1", "A", 0)
+        first, second = out.split("</a>")[0], out.split("</a>")[1]
+        assert "src=email_welcome" in first          # img_src is not src
+        assert "src=email_welcome" not in second     # encoded src IS src
+
+
+class TestSuppressionKeepsCompletionStats:
+    def test_marker_row_still_counts_as_completed(self, fake_db):
+        from mission_control.services.sequence_engine import get_sequence_stats, unsubscribe
+        email = "stats@example.com"
+        e = make_enrollment(contact_email=email, status="completed", sequence_id="nurture_v1")
+        e["completed_at"] = "2026-09-01T00:00:00+00:00"
+        fake_db.store["gg_sequence_enrollments"].append(e)
+        before = get_sequence_stats("nurture_v1")["completed"]
+        assert unsubscribe(email) == 1 and e["status"] == "unsubscribed"
+        after = get_sequence_stats("nurture_v1")
+        assert after["completed"] == before
+        assert after["variants"][e["variant"]]["completed"] == 1

--- a/mission_control/tests/test_sequence_engine.py
+++ b/mission_control/tests/test_sequence_engine.py
@@ -1094,3 +1094,61 @@ class TestCustomerSuppression:
             if "Customer suppression" in l.get("details", "")
         ]
         assert len(suppression_logs) == 0
+
+
+class TestEntrySurfaceAttribution:
+    """Questionnaire links carry a valid `src=` so the plan funnel can see email."""
+
+    def test_surface_names_are_valid_and_brand_agnostic(self, fake_db):
+        from mission_control.services.sequence_engine import entry_surface_for_sequence as f
+        assert f("nurture_v1") == "email_nurture"
+        assert f("road_nurture_v1") == "email_nurture"
+        assert f("welcome_v1") == "email_welcome"
+        assert f("kit_delivery_v1") == "email_kit"
+        assert f("race_countdown_8_v1") == "email_countdown"
+        assert f("race_debrief_v1") == "email_debrief"
+        assert f("xc_win_back_v1") == "email_winback"
+        assert f("") == "email_other"
+        import re
+        for sid in ("nurture_v1", "race_countdown_16_v1", "post_purchase_v1", "weird-Seq 9"):
+            assert re.match(r"^[a-z_]{1,32}$", f(sid)), f(sid)
+
+    def test_questionnaire_link_gets_src_and_keeps_fragment(self, fake_db):
+        from mission_control.services.sequence_engine import _inject_utm_params
+        html = ('<a href="https://gravelgodcycling.com/questionnaire/?race=unbound-200#top">go</a>'
+                '<a href="https://gravelgodcycling.com/products/training-plans/">plans</a>')
+        out = _inject_utm_params(html, "nurture_v1", "A", 1)
+        assert 'href="https://gravelgodcycling.com/questionnaire/?race=unbound-200&src=email_nurture&utm_source=' in out
+        assert out.count("#top") == 1 and out.endswith('#top">go</a><a href="https://gravelgodcycling.com/products/training-plans/?utm_source=gravel_god&utm_medium=email&utm_campaign=nurture_v1&utm_content=A_1">plans</a>')
+        assert "src=" not in out.split("training-plans")[1]  # non-questionnaire links untouched
+
+    def test_template_supplied_src_is_respected(self, fake_db):
+        from mission_control.services.sequence_engine import _inject_utm_params
+        html = '<a href="https://roadielabs.com/questionnaire/?src=email_custom">go</a>'
+        out = _inject_utm_params(html, "road_welcome_v1", "A", 0, brand="roadielabs")
+        assert out.count("src=") == 1 and "src=email_custom" in out
+
+
+class TestPersistentUnsubscribe:
+    def test_completed_only_contact_gets_a_suppression_record(self, fake_db):
+        from mission_control.services.sequence_engine import enroll, unsubscribe
+        email = "done@example.com"
+        e1 = make_enrollment(contact_email=email, status="completed", sequence_id="nurture_v1")
+        e1["enrolled_at"] = "2026-08-01T00:00:00+00:00"
+        e2 = make_enrollment(contact_email=email, status="completed", sequence_id="kit_delivery_v1")
+        e2["enrolled_at"] = "2026-08-02T00:00:00+00:00"
+        fake_db.store["gg_sequence_enrollments"].extend([e1, e2])
+        assert unsubscribe(email) == 1
+        assert e2["status"] == "unsubscribed"  # newest marketing enrollment carries the marker
+        assert e1["status"] == "completed"
+        # ...and the enroll-time guard now holds for later lifecycle sequences
+        assert enroll(email, "Done", "race_debrief_v1", source="race_debrief") is None
+        assert unsubscribe(email) == 0  # idempotent
+
+    def test_post_purchase_only_contact_is_not_marked(self, fake_db):
+        from mission_control.services.sequence_engine import unsubscribe
+        email = "buyer@example.com"
+        e = make_enrollment(contact_email=email, status="completed", sequence_id="post_purchase_v1")
+        fake_db.store["gg_sequence_enrollments"].append(e)
+        assert unsubscribe(email) == 0
+        assert e["status"] == "completed"


### PR DESCRIPTION
Lead-nurture work, phase 1 (no-regret fixes). Diagnosis and design were reviewed adversarially by gpt-6-astra before building; the strategy question it raised (the voice model says "No broadcast ever pitches"; the largest lead source never receives a pitch) is held for Matti and NOT implemented here.

## Diagnosis (90 days)
- 255 enrollments; distinct leads by deal source: prep_kit_gate 85 of 118. Opens are healthy (51.5% overall). Clicks are the failure (6.1%; pitch emails 0–4%; the kit-delivery email 36%).
- Email → site over 90 days in GA4: 23 sessions, 5 questionnaire arrivals, 0 form starts, 0 purchases. The reply loop tables (gg_lead_conversations, gg_lead_messages) are empty in production and no send has reply_count > 0: replies are not being captured, so the friend-register conversion path is unmeasured.

## Changes
- **Attribution:** questionnaire links in sequence emails get `src=email_<surface>` via a sequence→surface map that satisfies the questionnaire's validator; fragments preserved; template-supplied `src` respected.
- **Persistent unsubscribe:** contacts with only completed/paused enrollments now get a suppression record so later lifecycle enrollments are blocked (verified gap: `unsubscribe()` returned 0 and wrote nothing).
- **Product fact:** "48 hours" → "24 hours" in 8 templates to match the live questionnaire and product page.

## Tests
`mission_control/tests/test_sequence_engine.py` + `test_brand_routing.py`: 104 passed (5 new).

## Not in this PR (needs Matti's call)
Whether to pilot a race-specific pitch for fresh prep-kit leads as a new sequence variant, or keep the no-pitch doctrine and fix the reply loop instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df57KrhMyez9BwPVKRhbiT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes marketing unsubscribe suppression and link rewriting on outbound email; mistakes could re-enroll opted-out contacts or mis-attribute funnel traffic, but scope is limited to sequence engine and templates.
> 
> **Overview**
> Fixes three lead-nurture gaps: **plan-funnel attribution**, **unsubscribe persistence**, and **delivery-time copy**.
> 
> **Questionnaire attribution:** Sequence emails now append a questionnaire-safe `src=email_<surface>` (mapped from sequence id via `entry_surface_for_sequence`) when UTM params are injected, unless the template already set `src`. Only exact `/questionnaire` paths are tagged; URL fragments and existing query params are preserved.
> 
> **Persistent unsubscribe:** If someone unsubscribes with no active enrollments, the newest marketing enrollment is flipped to `unsubscribed` so later lifecycle enrollments stay blocked. Post-purchase-only contacts are unchanged. Completion stats still count rows that finished the sequence before becoming the suppression marker (`completed_at` set).
> 
> **Copy:** Customer-facing **48 hours → 24 hours** for plan delivery in email templates and friend-register spec copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57e7f2b97e8c1d8b8ebee5594eb023e8decb2e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->